### PR TITLE
Add Duolingo-style grammar quiz logic and UI integration

### DIFF
--- a/shared/types/index.ts
+++ b/shared/types/index.ts
@@ -147,10 +147,60 @@ export interface GrammarPattern {
   createdAt: string;
 }
 
+// ============ New Grammar Quiz Types (Duolingo-style) ============
+
+/**
+ * 新しい問題タイプ（デュオリンゴ式）
+ * - single_select: 1つの単語/フレーズを選択（旧choice）
+ * - word_tap: 空欄に入る単語をタップで選択（旧fill_blank）
+ * - sentence_build: 全単語を正しい順序に並べる（旧reorder）
+ */
+export type GrammarQuizType = 'single_select' | 'word_tap' | 'sentence_build';
+
+/**
+ * 旧問題タイプ（後方互換性のため保持）
+ */
+export type LegacyGrammarQuizType = 'fill_blank' | 'choice' | 'reorder';
+
+/**
+ * 単語オプション（ダミー含む）
+ * - word: 表示する単語
+ * - isCorrect: 正解かどうか
+ * - isDistractor: 類似単語のダミーかどうか（活用形違いなど）
+ */
+export interface WordOption {
+  word: string;
+  isCorrect: boolean;
+  isDistractor: boolean;
+}
+
+/**
+ * 新形式のクイズ問題構造（デュオリンゴ式）
+ */
+export interface GrammarQuizQuestionNew {
+  questionType: GrammarQuizType;
+  question: string;           // 問題文（空欄は _____ で表記）
+  questionJa?: string;        // 日本語訳/ヒント
+
+  // Single Select / Word Tap 用
+  wordOptions?: WordOption[]; // 選択肢（正解 + ダミー）
+  correctAnswer: string;      // 正解（単一単語 or 完全文）
+
+  // Sentence Build 用
+  sentenceWords?: string[];   // 正解の語順（配列）
+  extraWords?: string[];      // ダミー単語（難易度調整用）
+
+  explanation: string;        // 解説
+  grammarPoint?: string;      // この問題で問われる文法ポイント
+}
+
+/**
+ * 旧形式のクイズ問題（後方互換性のため保持）
+ */
 export interface GrammarQuizQuestion {
   id: string;
   patternId: string;
-  questionType: 'fill_blank' | 'choice' | 'reorder';
+  questionType: LegacyGrammarQuizType;
   question: string; // The question text
   questionJa?: string; // Japanese hint/translation
   correctAnswer: string;
@@ -159,6 +209,39 @@ export interface GrammarQuizQuestion {
   createdAt: string;
 }
 
+/**
+ * AIから返される旧形式のクイズ問題
+ */
+export interface AIGrammarQuizQuestionLegacy {
+  questionType: LegacyGrammarQuizType;
+  question: string;
+  questionJa?: string;
+  correctAnswer: string;
+  options?: string[];
+  explanation: string;
+}
+
+/**
+ * AIから返される新形式のクイズ問題
+ */
+export interface AIGrammarQuizQuestionNew {
+  questionType: GrammarQuizType;
+  question: string;
+  questionJa?: string;
+  wordOptions?: WordOption[];
+  correctAnswer: string;
+  sentenceWords?: string[];
+  extraWords?: string[];
+  explanation: string;
+  grammarPoint?: string;
+}
+
+// 型エイリアス: AIGrammarQuizQuestion は新形式を指す
+export type AIGrammarQuizQuestion = AIGrammarQuizQuestionNew;
+
+/**
+ * AIから返される文法パターン抽出結果（新形式）
+ */
 export interface AIGrammarExtraction {
   patternName: string;
   patternNameEn: string;
@@ -168,14 +251,22 @@ export interface AIGrammarExtraction {
   example: string;
   exampleJa: string;
   level: EikenGrammarLevel;
-  quizQuestions: {
-    questionType: 'fill_blank' | 'choice' | 'reorder';
-    question: string;
-    questionJa?: string;
-    correctAnswer: string;
-    options?: string[];
-    explanation: string;
-  }[];
+  quizQuestions: AIGrammarQuizQuestion[];
+}
+
+/**
+ * AIから返される旧形式の文法パターン（マイグレーション用）
+ */
+export interface AIGrammarExtractionLegacy {
+  patternName: string;
+  patternNameEn: string;
+  originalSentence: string;
+  explanation: string;
+  structure: string;
+  example: string;
+  exampleJa: string;
+  level: EikenGrammarLevel;
+  quizQuestions: AIGrammarQuizQuestionLegacy[];
 }
 
 export interface AIGrammarResponse {

--- a/src/app/grammar/[projectId]/page.tsx
+++ b/src/app/grammar/[projectId]/page.tsx
@@ -1,16 +1,16 @@
 'use client';
 
-import { useState, useEffect, use } from 'react';
+import { useState, useEffect, use, useMemo } from 'react';
 import Link from 'next/link';
 import {
   ArrowLeft,
   BookText,
-  ChevronRight,
-  Check,
   Play,
   Trash2,
 } from 'lucide-react';
-import type { AIGrammarExtraction } from '@/types';
+import type { AIGrammarExtraction, AIGrammarQuizQuestion } from '@/types';
+import { normalizeGrammarExtraction } from '@/lib/grammar';
+import { GrammarQuizContainer } from '@/components/grammar-quiz';
 
 export default function GrammarQuizPage({
   params,
@@ -27,15 +27,17 @@ export default function GrammarQuizPage({
   const [quizMode, setQuizMode] = useState(false);
   const [currentPatternIndex, setCurrentPatternIndex] = useState(0);
   const [currentQuestionIndex, setCurrentQuestionIndex] = useState(0);
-  const [selectedAnswer, setSelectedAnswer] = useState<string | null>(null);
-  const [showAnswer, setShowAnswer] = useState(false);
+  const [correctCount, setCorrectCount] = useState(0);
 
-  // Load patterns from sessionStorage
+  // Load patterns from sessionStorage and normalize to new format
   useEffect(() => {
     try {
       const data = sessionStorage.getItem(`grammar_patterns_${projectId}`);
       if (data) {
-        setPatterns(JSON.parse(data));
+        const rawPatterns = JSON.parse(data);
+        // Normalize any legacy format patterns to new format
+        const normalized = rawPatterns.map(normalizeGrammarExtraction);
+        setPatterns(normalized);
       }
     } catch (error) {
       console.error('Failed to load patterns:', error);
@@ -51,66 +53,75 @@ export default function GrammarQuizPage({
   };
 
   // Get all quiz questions flattened
-  const allQuestions = patterns.flatMap((pattern, patternIndex) =>
-    (pattern.quizQuestions || []).map((q, questionIndex) => ({
-      ...q,
-      patternName: pattern.patternName,
-      patternIndex,
-      questionIndex,
-    }))
-  );
+  const allQuestions = useMemo(() => {
+    return patterns.flatMap((pattern, patternIndex) =>
+      (pattern.quizQuestions || []).map((q, questionIndex) => ({
+        question: q as AIGrammarQuizQuestion,
+        patternName: pattern.patternName,
+        patternIndex,
+        questionIndex,
+      }))
+    );
+  }, [patterns]);
 
   const totalQuestions = allQuestions.length;
-  const currentQuestionNumber = currentPatternIndex * 10 + currentQuestionIndex + 1; // Approximation
 
-  // Quiz handlers
-  const currentPattern = patterns[currentPatternIndex];
-  const currentQuestion = currentPattern?.quizQuestions?.[currentQuestionIndex];
-
-  const handleStartQuiz = () => {
-    setCurrentPatternIndex(0);
-    setCurrentQuestionIndex(0);
-    setSelectedAnswer(null);
-    setShowAnswer(false);
-    setQuizMode(true);
-  };
-
-  const handleSelectAnswer = (answer: string) => {
-    if (showAnswer) return;
-    setSelectedAnswer(answer);
-    setShowAnswer(true);
-  };
-
-  const handleNextQuestion = () => {
-    const pattern = patterns[currentPatternIndex];
-    if (currentQuestionIndex + 1 < (pattern?.quizQuestions?.length || 0)) {
-      // Next question in same pattern
-      setCurrentQuestionIndex(prev => prev + 1);
-      setSelectedAnswer(null);
-      setShowAnswer(false);
-    } else if (currentPatternIndex + 1 < patterns.length) {
-      // Next pattern
-      setCurrentPatternIndex(prev => prev + 1);
-      setCurrentQuestionIndex(0);
-      setSelectedAnswer(null);
-      setShowAnswer(false);
-    } else {
-      // Quiz complete
-      setQuizMode(false);
-      setCurrentPatternIndex(0);
-      setCurrentQuestionIndex(0);
-      setSelectedAnswer(null);
-      setShowAnswer(false);
-    }
-  };
-
-  // Calculate current question number across all patterns
+  // Get current question number
   const getCurrentQuestionNumber = () => {
     let count = 0;
     for (let i = 0; i < currentPatternIndex; i++) {
       count += patterns[i]?.quizQuestions?.length || 0;
     }
     return count + currentQuestionIndex + 1;
+  };
+
+  // Get current question data
+  const currentQuestionData = useMemo(() => {
+    const currentPattern = patterns[currentPatternIndex];
+    const currentQuestion = currentPattern?.quizQuestions?.[currentQuestionIndex];
+    if (!currentQuestion) return null;
+
+    return {
+      question: currentQuestion as AIGrammarQuizQuestion,
+      patternName: currentPattern.patternName,
+    };
+  }, [patterns, currentPatternIndex, currentQuestionIndex]);
+
+  // Quiz handlers
+  const handleStartQuiz = () => {
+    setCurrentPatternIndex(0);
+    setCurrentQuestionIndex(0);
+    setCorrectCount(0);
+    setQuizMode(true);
+  };
+
+  const handleAnswer = (isCorrect: boolean) => {
+    if (isCorrect) {
+      setCorrectCount((prev) => prev + 1);
+    }
+  };
+
+  const handleNextQuestion = () => {
+    const pattern = patterns[currentPatternIndex];
+    if (currentQuestionIndex + 1 < (pattern?.quizQuestions?.length || 0)) {
+      // Next question in same pattern
+      setCurrentQuestionIndex((prev) => prev + 1);
+    } else if (currentPatternIndex + 1 < patterns.length) {
+      // Next pattern
+      setCurrentPatternIndex((prev) => prev + 1);
+      setCurrentQuestionIndex(0);
+    } else {
+      // Quiz complete
+      setQuizMode(false);
+      setCurrentPatternIndex(0);
+      setCurrentQuestionIndex(0);
+    }
+  };
+
+  const handleExitQuiz = () => {
+    setQuizMode(false);
+    setCurrentPatternIndex(0);
+    setCurrentQuestionIndex(0);
   };
 
   // Loading state
@@ -122,142 +133,22 @@ export default function GrammarQuizPage({
     );
   }
 
-  // Quiz mode render
-  if (quizMode && currentQuestion) {
-    const isCorrect = selectedAnswer === currentQuestion.correctAnswer;
-
+  // Quiz mode - use new GrammarQuizContainer with Duolingo-style UI
+  if (quizMode && currentQuestionData) {
     return (
-      <div className="min-h-screen bg-white flex flex-col">
-        {/* Header */}
-        <header className="sticky top-0 bg-white/95 backdrop-blur-sm z-40 border-b border-gray-100">
-          <div className="max-w-lg mx-auto px-4 py-3">
-            <div className="flex items-center gap-3">
-              <button
-                onClick={() => setQuizMode(false)}
-                className="p-2 hover:bg-gray-100 rounded-full transition-colors"
-              >
-                <ArrowLeft className="w-5 h-5 text-gray-600" />
-              </button>
-              <div>
-                <h1 className="font-semibold text-gray-900">{currentPattern.patternName}</h1>
-                <p className="text-sm text-gray-500">
-                  問題 {getCurrentQuestionNumber()} / {totalQuestions}
-                </p>
-              </div>
-            </div>
-          </div>
-        </header>
-
-        {/* Quiz content */}
-        <main className="flex-1 max-w-lg mx-auto px-4 py-6 w-full">
-          {/* Question */}
-          <div className="mb-6">
-            <p className="text-lg font-medium text-gray-900 mb-2">
-              {currentQuestion.question}
-            </p>
-            {currentQuestion.questionJa && (
-              <p className="text-sm text-gray-500">{currentQuestion.questionJa}</p>
-            )}
-          </div>
-
-          {/* Options */}
-          {currentQuestion.questionType === 'choice' && currentQuestion.options ? (
-            <div className="space-y-3 mb-6">
-              {currentQuestion.options.map((option, index) => {
-                let bgColor = 'bg-white hover:bg-gray-50';
-                let borderColor = 'border-gray-200';
-                let textColor = 'text-gray-900';
-
-                if (showAnswer) {
-                  if (option === currentQuestion.correctAnswer) {
-                    bgColor = 'bg-emerald-50';
-                    borderColor = 'border-emerald-300';
-                    textColor = 'text-emerald-800';
-                  } else if (option === selectedAnswer && !isCorrect) {
-                    bgColor = 'bg-red-50';
-                    borderColor = 'border-red-300';
-                    textColor = 'text-red-800';
-                  } else {
-                    bgColor = 'bg-gray-50';
-                    textColor = 'text-gray-400';
-                  }
-                }
-
-                return (
-                  <button
-                    key={index}
-                    onClick={() => handleSelectAnswer(option)}
-                    disabled={showAnswer}
-                    className={`w-full p-4 rounded-xl border-2 ${borderColor} ${bgColor} ${textColor} text-left transition-all disabled:cursor-default`}
-                  >
-                    {option}
-                  </button>
-                );
-              })}
-            </div>
-          ) : (
-            <div className="mb-6">
-              <input
-                type="text"
-                value={selectedAnswer || ''}
-                onChange={e => setSelectedAnswer(e.target.value)}
-                disabled={showAnswer}
-                placeholder="答えを入力..."
-                className="w-full px-4 py-3 border-2 border-gray-200 rounded-xl focus:border-blue-500 focus:outline-none disabled:bg-gray-50"
-              />
-              {!showAnswer && (
-                <button
-                  onClick={() => setShowAnswer(true)}
-                  disabled={!selectedAnswer}
-                  className="mt-3 w-full py-3 bg-blue-600 text-white rounded-xl font-medium hover:bg-blue-700 transition-colors disabled:opacity-50"
-                >
-                  回答する
-                </button>
-              )}
-            </div>
-          )}
-
-          {/* Answer feedback */}
-          {showAnswer && (
-            <div className="space-y-4">
-              <div className={`p-4 rounded-xl ${isCorrect ? 'bg-emerald-50' : 'bg-red-50'}`}>
-                <p className={`font-medium ${isCorrect ? 'text-emerald-800' : 'text-red-800'}`}>
-                  {isCorrect ? '正解!' : '不正解'}
-                </p>
-                {!isCorrect && (
-                  <p className="text-sm text-gray-600 mt-1">
-                    正解: {currentQuestion.correctAnswer}
-                  </p>
-                )}
-              </div>
-
-              <div className="p-4 bg-blue-50 rounded-xl">
-                <p className="text-sm text-blue-800">{currentQuestion.explanation}</p>
-              </div>
-
-              <button
-                onClick={handleNextQuestion}
-                className="w-full flex items-center justify-center gap-2 py-3 bg-blue-600 text-white rounded-xl font-medium hover:bg-blue-700 transition-colors"
-              >
-                {getCurrentQuestionNumber() < totalQuestions ? (
-                  <>
-                    次へ
-                    <ChevronRight className="w-5 h-5" />
-                  </>
-                ) : (
-                  <>
-                    <Check className="w-5 h-5" />
-                    完了
-                  </>
-                )}
-              </button>
-            </div>
-          )}
-        </main>
-      </div>
+      <GrammarQuizContainer
+        question={currentQuestionData.question}
+        patternName={currentQuestionData.patternName}
+        currentQuestionNumber={getCurrentQuestionNumber()}
+        totalQuestions={totalQuestions}
+        onAnswer={handleAnswer}
+        onNext={handleNextQuestion}
+        onExit={handleExitQuiz}
+      />
     );
   }
 
+  // List mode - show patterns and start button
   return (
     <div className="min-h-screen bg-white flex flex-col">
       {/* Header */}

--- a/src/components/grammar-quiz/ActionButton.tsx
+++ b/src/components/grammar-quiz/ActionButton.tsx
@@ -1,0 +1,51 @@
+'use client';
+
+import { motion } from 'framer-motion';
+import { ChevronRight, Check } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+interface ActionButtonProps {
+  label: string;
+  onClick: () => void;
+  disabled?: boolean;
+  variant?: 'primary' | 'success' | 'neutral';
+  showNextIcon?: boolean;
+  showCheckIcon?: boolean;
+  className?: string;
+}
+
+const variantStyles = {
+  primary: 'bg-blue-600 hover:bg-blue-700 text-white',
+  success: 'bg-emerald-600 hover:bg-emerald-700 text-white',
+  neutral: 'bg-gray-600 hover:bg-gray-700 text-white',
+};
+
+export function ActionButton({
+  label,
+  onClick,
+  disabled = false,
+  variant = 'primary',
+  showNextIcon = false,
+  showCheckIcon = false,
+  className,
+}: ActionButtonProps) {
+  return (
+    <motion.button
+      onClick={onClick}
+      disabled={disabled}
+      className={cn(
+        'w-full h-14 rounded-2xl font-semibold text-base',
+        'flex items-center justify-center gap-2',
+        'transition-colors duration-150',
+        'disabled:opacity-50 disabled:cursor-not-allowed',
+        variantStyles[variant],
+        className
+      )}
+      whileTap={disabled ? undefined : { scale: 0.98 }}
+    >
+      {showCheckIcon && <Check className="w-5 h-5" />}
+      {label}
+      {showNextIcon && <ChevronRight className="w-5 h-5" />}
+    </motion.button>
+  );
+}

--- a/src/components/grammar-quiz/AnswerArea.tsx
+++ b/src/components/grammar-quiz/AnswerArea.tsx
@@ -1,0 +1,98 @@
+'use client';
+
+import { motion, AnimatePresence } from 'framer-motion';
+import { cn } from '@/lib/utils';
+import { WordButton, WordButtonState } from './WordButton';
+
+export type AnswerAreaState = 'empty' | 'filled' | 'correct' | 'incorrect';
+
+interface AnswerAreaProps {
+  selectedWords: string[];
+  onWordRemove?: (word: string, index: number) => void;
+  state?: AnswerAreaState;
+  placeholder?: string;
+  disabled?: boolean;
+  className?: string;
+  correctAnswer?: string | string[];
+}
+
+const areaStyles: Record<AnswerAreaState, string> = {
+  empty: 'border-dashed border-gray-300 bg-gradient-to-br from-gray-50 to-gray-100',
+  filled: 'border-solid border-gray-300 bg-gradient-to-br from-gray-50 to-gray-100',
+  correct: 'border-solid border-emerald-400 bg-gradient-to-br from-emerald-50 to-emerald-100',
+  incorrect: 'border-solid border-red-400 bg-gradient-to-br from-red-50 to-red-100',
+};
+
+export function AnswerArea({
+  selectedWords,
+  onWordRemove,
+  state = 'empty',
+  placeholder = 'タップして単語を選択',
+  disabled = false,
+  className,
+  correctAnswer,
+}: AnswerAreaProps) {
+  const effectiveState = selectedWords.length === 0 ? 'empty' : state;
+
+  const getWordState = (word: string): WordButtonState => {
+    if (state === 'correct') return 'correct';
+    if (state === 'incorrect') {
+      // Check if this word is in the correct answer
+      const correctWords = Array.isArray(correctAnswer)
+        ? correctAnswer
+        : correctAnswer?.split(' ') || [];
+      const isCorrectWord = correctWords.includes(word);
+      return isCorrectWord ? 'correct' : 'incorrect';
+    }
+    return 'selected';
+  };
+
+  return (
+    <motion.div
+      className={cn(
+        'min-h-[80px] p-4 rounded-2xl border-2',
+        'flex flex-wrap items-center justify-center gap-3',
+        'transition-colors duration-200',
+        areaStyles[effectiveState],
+        className
+      )}
+      animate={{
+        x: state === 'incorrect' ? [0, -4, 4, -4, 4, 0] : 0,
+      }}
+      transition={{ duration: 0.4 }}
+    >
+      <AnimatePresence mode="popLayout">
+        {selectedWords.length === 0 ? (
+          <motion.p
+            key="placeholder"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            className="text-gray-400 text-sm select-none"
+          >
+            {placeholder}
+          </motion.p>
+        ) : (
+          selectedWords.map((word, index) => (
+            <motion.div
+              key={`${word}-${index}`}
+              initial={{ opacity: 0, scale: 0.8, y: 20 }}
+              animate={{ opacity: 1, scale: 1, y: 0 }}
+              exit={{ opacity: 0, scale: 0.8, y: -20 }}
+              transition={{ type: 'spring', stiffness: 500, damping: 30 }}
+            >
+              <WordButton
+                word={word}
+                state={getWordState(word)}
+                onClick={() => !disabled && onWordRemove?.(word, index)}
+                disabled={disabled || state === 'correct' || state === 'incorrect'}
+                showIcon={state === 'correct' || state === 'incorrect'}
+                layoutId={`word-${word}-${index}`}
+              />
+            </motion.div>
+          ))
+        )}
+      </AnimatePresence>
+    </motion.div>
+  );
+}

--- a/src/components/grammar-quiz/FeedbackPanel.tsx
+++ b/src/components/grammar-quiz/FeedbackPanel.tsx
@@ -1,0 +1,95 @@
+'use client';
+
+import { motion } from 'framer-motion';
+import { Check, X, Lightbulb } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+interface FeedbackPanelProps {
+  isCorrect: boolean;
+  correctAnswer: string;
+  userAnswer?: string;
+  explanation: string;
+  grammarPoint?: string;
+  className?: string;
+}
+
+export function FeedbackPanel({
+  isCorrect,
+  correctAnswer,
+  userAnswer,
+  explanation,
+  grammarPoint,
+  className,
+}: FeedbackPanelProps) {
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 20 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.3 }}
+      className={cn('space-y-4', className)}
+    >
+      {/* Result card */}
+      <div
+        className={cn(
+          'p-4 rounded-2xl border-2',
+          isCorrect
+            ? 'bg-emerald-50 border-emerald-200'
+            : 'bg-red-50 border-red-200'
+        )}
+      >
+        <div className="flex items-center gap-2 mb-2">
+          {isCorrect ? (
+            <>
+              <div className="p-1 bg-emerald-500 rounded-full">
+                <Check className="w-4 h-4 text-white" strokeWidth={3} />
+              </div>
+              <span className="font-semibold text-emerald-800">正解!</span>
+            </>
+          ) : (
+            <>
+              <div className="p-1 bg-red-500 rounded-full">
+                <X className="w-4 h-4 text-white" strokeWidth={3} />
+              </div>
+              <span className="font-semibold text-red-800">不正解</span>
+            </>
+          )}
+        </div>
+
+        {!isCorrect && (
+          <div className="space-y-2 mt-3">
+            {userAnswer && (
+              <div className="flex items-center gap-2">
+                <span className="text-sm text-gray-500">あなたの回答:</span>
+                <span className="text-sm font-medium text-red-700 line-through">
+                  {userAnswer}
+                </span>
+              </div>
+            )}
+            <div className="flex items-center gap-2">
+              <span className="text-sm text-gray-500">正解:</span>
+              <span className="text-sm font-medium text-emerald-700">
+                {correctAnswer}
+              </span>
+            </div>
+          </div>
+        )}
+      </div>
+
+      {/* Explanation card */}
+      <div className="p-4 rounded-2xl bg-blue-50 border-2 border-blue-200">
+        <div className="flex items-center gap-2 mb-2">
+          <Lightbulb className="w-5 h-5 text-blue-600" />
+          <span className="font-semibold text-blue-800">解説</span>
+        </div>
+        <p className="text-sm text-blue-800 leading-relaxed">{explanation}</p>
+        {grammarPoint && (
+          <div className="mt-3 pt-3 border-t border-blue-200">
+            <span className="text-xs text-blue-600 font-medium">
+              ポイント: {grammarPoint}
+            </span>
+          </div>
+        )}
+      </div>
+    </motion.div>
+  );
+}

--- a/src/components/grammar-quiz/GrammarQuizContainer.tsx
+++ b/src/components/grammar-quiz/GrammarQuizContainer.tsx
@@ -1,0 +1,320 @@
+'use client';
+
+import { useState, useCallback, useMemo } from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
+import { ArrowLeft } from 'lucide-react';
+import type { AIGrammarQuizQuestion, GrammarQuizType } from '@/types';
+import { ProgressBar } from './ProgressBar';
+import { QuestionDisplay } from './QuestionDisplay';
+import { AnswerArea, AnswerAreaState } from './AnswerArea';
+import { WordPool } from './WordPool';
+import { WordButton, WordButtonState } from './WordButton';
+import { FeedbackPanel } from './FeedbackPanel';
+import { ActionButton } from './ActionButton';
+
+interface GrammarQuizContainerProps {
+  question: AIGrammarQuizQuestion;
+  patternName: string;
+  currentQuestionNumber: number;
+  totalQuestions: number;
+  onAnswer: (isCorrect: boolean) => void;
+  onNext: () => void;
+  onExit: () => void;
+}
+
+export function GrammarQuizContainer({
+  question,
+  patternName,
+  currentQuestionNumber,
+  totalQuestions,
+  onAnswer,
+  onNext,
+  onExit,
+}: GrammarQuizContainerProps) {
+  // State
+  const [selectedWords, setSelectedWords] = useState<string[]>([]);
+  const [selectedOption, setSelectedOption] = useState<string | null>(null);
+  const [showResult, setShowResult] = useState(false);
+  const [isCorrect, setIsCorrect] = useState(false);
+
+  // Prepare word pool based on question type
+  const wordPool = useMemo(() => {
+    if (question.questionType === 'single_select') {
+      return question.wordOptions?.map((opt) => opt.word) || [];
+    }
+    if (question.questionType === 'word_tap') {
+      return question.wordOptions?.map((opt) => opt.word) || [];
+    }
+    if (question.questionType === 'sentence_build') {
+      const words = [...(question.sentenceWords || [])];
+      if (question.extraWords) {
+        words.push(...question.extraWords);
+      }
+      // Shuffle
+      return words.sort(() => Math.random() - 0.5);
+    }
+    return [];
+  }, [question]);
+
+  // Handle word selection (Word Tap / Sentence Build)
+  const handleWordSelect = useCallback((word: string) => {
+    if (showResult) return;
+    setSelectedWords((prev) => [...prev, word]);
+  }, [showResult]);
+
+  // Handle word removal from answer area
+  const handleWordRemove = useCallback((word: string, index: number) => {
+    if (showResult) return;
+    setSelectedWords((prev) => prev.filter((_, i) => i !== index));
+  }, [showResult]);
+
+  // Handle single select option
+  const handleOptionSelect = useCallback((option: string) => {
+    if (showResult) return;
+    setSelectedOption((prev) => (prev === option ? null : option));
+  }, [showResult]);
+
+  // Get user's answer string
+  const getUserAnswer = (): string => {
+    if (question.questionType === 'single_select') {
+      return selectedOption || '';
+    }
+    if (question.questionType === 'word_tap') {
+      return selectedWords.join(' ');
+    }
+    if (question.questionType === 'sentence_build') {
+      return selectedWords.join(' ');
+    }
+    return '';
+  };
+
+  // Check if answer is correct
+  const checkAnswer = (): boolean => {
+    const userAnswer = getUserAnswer().toLowerCase().trim();
+
+    if (question.questionType === 'sentence_build') {
+      const correctSentence = question.sentenceWords?.join(' ').toLowerCase().trim();
+      return userAnswer === correctSentence;
+    }
+
+    return userAnswer === question.correctAnswer.toLowerCase().trim();
+  };
+
+  // Handle submit
+  const handleSubmit = () => {
+    if (showResult) return;
+
+    const correct = checkAnswer();
+    setIsCorrect(correct);
+    setShowResult(true);
+    onAnswer(correct);
+  };
+
+  // Handle next question
+  const handleNext = () => {
+    setSelectedWords([]);
+    setSelectedOption(null);
+    setShowResult(false);
+    setIsCorrect(false);
+    onNext();
+  };
+
+  // Check if can submit
+  const canSubmit = () => {
+    if (question.questionType === 'single_select') {
+      return selectedOption !== null;
+    }
+    if (question.questionType === 'word_tap') {
+      return selectedWords.length > 0;
+    }
+    if (question.questionType === 'sentence_build') {
+      // All words must be placed (excluding extra distractor words)
+      const requiredCount = question.sentenceWords?.length || 0;
+      return selectedWords.length >= requiredCount;
+    }
+    return false;
+  };
+
+  // Get answer area state
+  const getAnswerAreaState = (): AnswerAreaState => {
+    if (!showResult) {
+      return selectedWords.length > 0 ? 'filled' : 'empty';
+    }
+    return isCorrect ? 'correct' : 'incorrect';
+  };
+
+  // Get single select option state
+  const getOptionState = (option: string): WordButtonState => {
+    if (showResult) {
+      if (option === question.correctAnswer) {
+        return 'correct';
+      }
+      if (option === selectedOption && !isCorrect) {
+        return 'incorrect';
+      }
+      return 'disabled';
+    }
+    if (option === selectedOption) {
+      return 'selected';
+    }
+    return 'default';
+  };
+
+  // Render question type specific UI
+  const renderQuestionUI = () => {
+    switch (question.questionType) {
+      case 'single_select':
+        return (
+          <div className="grid grid-cols-2 gap-3 px-4">
+            {wordPool.map((option, index) => (
+              <WordButton
+                key={`${option}-${index}`}
+                word={option}
+                state={getOptionState(option)}
+                onClick={() => handleOptionSelect(option)}
+                disabled={showResult}
+                showIcon={showResult}
+                className="w-full justify-center"
+              />
+            ))}
+          </div>
+        );
+
+      case 'word_tap':
+      case 'sentence_build':
+        return (
+          <>
+            {/* Answer Area */}
+            <div className="px-4">
+              <AnswerArea
+                selectedWords={selectedWords}
+                onWordRemove={handleWordRemove}
+                state={getAnswerAreaState()}
+                placeholder={
+                  question.questionType === 'word_tap'
+                    ? 'タップして単語を選択'
+                    : '単語をタップして文を作成'
+                }
+                disabled={showResult}
+                correctAnswer={
+                  question.questionType === 'sentence_build'
+                    ? question.sentenceWords
+                    : question.correctAnswer
+                }
+              />
+            </div>
+
+            {/* Divider */}
+            <div className="border-t border-gray-100 my-4" />
+
+            {/* Word Pool */}
+            <WordPool
+              words={wordPool}
+              selectedWords={selectedWords}
+              onWordSelect={handleWordSelect}
+              disabled={showResult}
+              correctAnswer={
+                question.questionType === 'sentence_build'
+                  ? question.sentenceWords
+                  : question.correctAnswer
+              }
+              showResult={showResult && !isCorrect}
+            />
+          </>
+        );
+
+      default:
+        return null;
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-white flex flex-col">
+      {/* Header */}
+      <header className="sticky top-0 bg-white/95 backdrop-blur-sm z-40 border-b border-gray-100">
+        <div className="max-w-lg mx-auto px-4 py-3">
+          <div className="flex items-center gap-3">
+            <button
+              onClick={onExit}
+              className="p-2 hover:bg-gray-100 rounded-full transition-colors"
+            >
+              <ArrowLeft className="w-5 h-5 text-gray-600" />
+            </button>
+            <div className="flex-1">
+              <h1 className="font-semibold text-gray-900 truncate">
+                {patternName}
+              </h1>
+              <p className="text-sm text-gray-500">
+                問題 {currentQuestionNumber} / {totalQuestions}
+              </p>
+            </div>
+          </div>
+        </div>
+        <ProgressBar current={currentQuestionNumber} total={totalQuestions} />
+      </header>
+
+      {/* Main content */}
+      <main className="flex-1 max-w-lg mx-auto w-full py-6 overflow-y-auto">
+        <AnimatePresence mode="wait">
+          <motion.div
+            key={`question-${currentQuestionNumber}`}
+            initial={{ opacity: 0, x: 20 }}
+            animate={{ opacity: 1, x: 0 }}
+            exit={{ opacity: 0, x: -20 }}
+            transition={{ duration: 0.2 }}
+          >
+            {/* Question */}
+            <div className="px-4 mb-6">
+              <QuestionDisplay
+                question={question.question}
+                questionJa={question.questionJa}
+              />
+            </div>
+
+            {/* Question-specific UI */}
+            {renderQuestionUI()}
+
+            {/* Feedback Panel */}
+            {showResult && (
+              <div className="px-4 mt-6">
+                <FeedbackPanel
+                  isCorrect={isCorrect}
+                  correctAnswer={
+                    question.questionType === 'sentence_build'
+                      ? question.sentenceWords?.join(' ') || ''
+                      : question.correctAnswer
+                  }
+                  userAnswer={getUserAnswer()}
+                  explanation={question.explanation}
+                  grammarPoint={question.grammarPoint}
+                />
+              </div>
+            )}
+          </motion.div>
+        </AnimatePresence>
+      </main>
+
+      {/* Action button */}
+      <div className="sticky bottom-0 bg-white/95 backdrop-blur-sm border-t border-gray-100 p-4 safe-area-bottom">
+        <div className="max-w-lg mx-auto">
+          {!showResult ? (
+            <ActionButton
+              label="回答する"
+              onClick={handleSubmit}
+              disabled={!canSubmit()}
+              variant="primary"
+            />
+          ) : (
+            <ActionButton
+              label={currentQuestionNumber < totalQuestions ? '次へ' : '完了'}
+              onClick={handleNext}
+              variant={isCorrect ? 'success' : 'neutral'}
+              showNextIcon={currentQuestionNumber < totalQuestions}
+              showCheckIcon={currentQuestionNumber >= totalQuestions}
+            />
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/grammar-quiz/ProgressBar.tsx
+++ b/src/components/grammar-quiz/ProgressBar.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+import { motion } from 'framer-motion';
+import { cn } from '@/lib/utils';
+
+interface ProgressBarProps {
+  current: number;
+  total: number;
+  className?: string;
+}
+
+export function ProgressBar({ current, total, className }: ProgressBarProps) {
+  const progress = total > 0 ? (current / total) * 100 : 0;
+
+  return (
+    <div className={cn('h-1 bg-gray-200 overflow-hidden', className)}>
+      <motion.div
+        className="h-full bg-emerald-500"
+        initial={{ width: 0 }}
+        animate={{ width: `${progress}%` }}
+        transition={{ duration: 0.3, ease: 'easeOut' }}
+      />
+    </div>
+  );
+}

--- a/src/components/grammar-quiz/QuestionDisplay.tsx
+++ b/src/components/grammar-quiz/QuestionDisplay.tsx
@@ -1,0 +1,33 @@
+'use client';
+
+import { cn } from '@/lib/utils';
+
+interface QuestionDisplayProps {
+  question: string;
+  questionJa?: string;
+  className?: string;
+}
+
+export function QuestionDisplay({
+  question,
+  questionJa,
+  className,
+}: QuestionDisplayProps) {
+  // Highlight blanks (_____)
+  const highlightedQuestion = question.replace(
+    /_____/g,
+    '<span class="inline-block min-w-[60px] border-b-2 border-emerald-400 text-emerald-600 font-semibold">_____</span>'
+  );
+
+  return (
+    <div className={cn('space-y-2', className)}>
+      <p
+        className="text-lg font-medium text-gray-900 leading-relaxed"
+        dangerouslySetInnerHTML={{ __html: highlightedQuestion }}
+      />
+      {questionJa && (
+        <p className="text-sm text-gray-500">{questionJa}</p>
+      )}
+    </div>
+  );
+}

--- a/src/components/grammar-quiz/WordButton.tsx
+++ b/src/components/grammar-quiz/WordButton.tsx
@@ -1,0 +1,94 @@
+'use client';
+
+import { motion } from 'framer-motion';
+import { Check, X } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+export type WordButtonState =
+  | 'default'
+  | 'hover'
+  | 'selected'
+  | 'disabled'
+  | 'correct'
+  | 'incorrect';
+
+interface WordButtonProps {
+  word: string;
+  state?: WordButtonState;
+  onClick?: () => void;
+  disabled?: boolean;
+  showIcon?: boolean;
+  className?: string;
+  layoutId?: string;
+}
+
+const stateStyles: Record<WordButtonState, string> = {
+  default: 'bg-white border-gray-200 text-gray-800 shadow-sm hover:bg-gray-50 hover:border-gray-300 hover:shadow-md active:scale-[0.97]',
+  hover: 'bg-gray-50 border-gray-300 text-gray-800 shadow-md',
+  selected: 'bg-emerald-50 border-emerald-400 text-emerald-700 shadow-sm',
+  disabled: 'bg-gray-100 border-gray-200 text-gray-400 cursor-not-allowed',
+  correct: 'bg-emerald-500 border-emerald-600 text-white shadow-sm',
+  incorrect: 'bg-red-500 border-red-600 text-white shadow-sm',
+};
+
+export function WordButton({
+  word,
+  state = 'default',
+  onClick,
+  disabled = false,
+  showIcon = false,
+  className,
+  layoutId,
+}: WordButtonProps) {
+  const isInteractive = state === 'default' || state === 'selected';
+  const effectiveDisabled = disabled || state === 'disabled';
+
+  return (
+    <motion.button
+      layoutId={layoutId}
+      onClick={effectiveDisabled ? undefined : onClick}
+      disabled={effectiveDisabled}
+      className={cn(
+        'inline-flex items-center justify-center gap-1.5',
+        'min-w-[60px] h-12 px-5',
+        'rounded-full border-2',
+        'text-base font-medium',
+        'transition-colors duration-150',
+        'select-none',
+        stateStyles[state],
+        className
+      )}
+      initial={false}
+      animate={{
+        scale: state === 'correct' ? [1, 1.05, 1] : 1,
+      }}
+      transition={{
+        scale: { duration: 0.3, ease: 'easeOut' },
+        layout: { type: 'spring', stiffness: 500, damping: 30 },
+      }}
+      whileTap={isInteractive ? { scale: 0.97 } : undefined}
+    >
+      {showIcon && state === 'correct' && (
+        <Check className="w-4 h-4" strokeWidth={3} />
+      )}
+      {showIcon && state === 'incorrect' && (
+        <X className="w-4 h-4" strokeWidth={3} />
+      )}
+      {word}
+    </motion.button>
+  );
+}
+
+// Shake animation for incorrect answers
+export function ShakingWordButton(props: WordButtonProps) {
+  return (
+    <motion.div
+      animate={{
+        x: props.state === 'incorrect' ? [0, -4, 4, -4, 4, -2, 2, 0] : 0,
+      }}
+      transition={{ duration: 0.4 }}
+    >
+      <WordButton {...props} />
+    </motion.div>
+  );
+}

--- a/src/components/grammar-quiz/WordPool.tsx
+++ b/src/components/grammar-quiz/WordPool.tsx
@@ -1,0 +1,85 @@
+'use client';
+
+import { motion, AnimatePresence } from 'framer-motion';
+import { cn } from '@/lib/utils';
+import { WordButton, WordButtonState } from './WordButton';
+
+interface WordPoolProps {
+  words: string[];
+  selectedWords: string[];
+  onWordSelect: (word: string) => void;
+  disabled?: boolean;
+  className?: string;
+  correctAnswer?: string | string[];
+  showResult?: boolean;
+}
+
+export function WordPool({
+  words,
+  selectedWords,
+  onWordSelect,
+  disabled = false,
+  className,
+  correctAnswer,
+  showResult = false,
+}: WordPoolProps) {
+  const getWordState = (word: string): WordButtonState => {
+    const isSelected = selectedWords.includes(word);
+
+    if (showResult) {
+      const correctWords = Array.isArray(correctAnswer)
+        ? correctAnswer
+        : correctAnswer?.split(' ') || [];
+      const isCorrectWord = correctWords.includes(word);
+
+      if (isCorrectWord && !isSelected) {
+        // Highlight correct answer that wasn't selected
+        return 'correct';
+      }
+      return 'disabled';
+    }
+
+    if (isSelected) {
+      return 'disabled';
+    }
+
+    return 'default';
+  };
+
+  return (
+    <div
+      className={cn(
+        'flex flex-wrap justify-center gap-3 p-4',
+        className
+      )}
+    >
+      <AnimatePresence>
+        {words.map((word, index) => {
+          const state = getWordState(word);
+          const isSelected = selectedWords.includes(word);
+
+          return (
+            <motion.div
+              key={`${word}-${index}`}
+              initial={{ opacity: 0, scale: 0.8 }}
+              animate={{
+                opacity: isSelected ? 0.4 : 1,
+                scale: 1,
+              }}
+              transition={{ type: 'spring', stiffness: 500, damping: 30 }}
+            >
+              <WordButton
+                word={word}
+                state={state}
+                onClick={() => onWordSelect(word)}
+                disabled={disabled || isSelected}
+                showIcon={showResult && state === 'correct'}
+                layoutId={`pool-${word}-${index}`}
+              />
+            </motion.div>
+          );
+        })}
+      </AnimatePresence>
+    </div>
+  );
+}

--- a/src/components/grammar-quiz/index.ts
+++ b/src/components/grammar-quiz/index.ts
@@ -1,0 +1,11 @@
+// Grammar Quiz Components - Duolingo-style word tap UI
+export { WordButton, ShakingWordButton } from './WordButton';
+export type { WordButtonState } from './WordButton';
+export { AnswerArea } from './AnswerArea';
+export type { AnswerAreaState } from './AnswerArea';
+export { WordPool } from './WordPool';
+export { ProgressBar } from './ProgressBar';
+export { QuestionDisplay } from './QuestionDisplay';
+export { FeedbackPanel } from './FeedbackPanel';
+export { ActionButton } from './ActionButton';
+export { GrammarQuizContainer } from './GrammarQuizContainer';

--- a/src/lib/grammar/index.ts
+++ b/src/lib/grammar/index.ts
@@ -1,0 +1,48 @@
+/**
+ * Grammar Quiz Module
+ * デュオリンゴ式文法クイズのロジックとフックをエクスポート
+ */
+
+// ユーティリティ関数
+export {
+  // Type Guards
+  isLegacyQuestionType,
+  isNewQuestionType,
+  isLegacyQuizQuestion,
+
+  // Migration
+  migrateQuizQuestion,
+  migrateGrammarExtraction,
+  normalizeGrammarExtraction,
+
+  // Quiz State Management
+  createInitialAnswerState,
+  selectWord,
+  deselectWord,
+  deselectWordAtIndex,
+  resetAnswerState,
+
+  // Validation
+  validateAnswer,
+  canSubmitAnswer,
+
+  // Helpers
+  shuffleArray,
+  getCorrectWordFromOptions,
+  getMaxSelectionCount,
+  getQuestionTypeLabel,
+
+  // Types
+  type AnswerState,
+  type ValidationResult,
+} from './quiz-utils';
+
+// React Hooks
+export {
+  useGrammarQuiz,
+  useSingleQuestion,
+  type UseGrammarQuizReturn,
+  type UseSingleQuestionReturn,
+  type QuizProgress,
+  type QuizPhase,
+} from './use-grammar-quiz';

--- a/src/lib/grammar/quiz-utils.ts
+++ b/src/lib/grammar/quiz-utils.ts
@@ -1,0 +1,447 @@
+/**
+ * Grammar Quiz Utilities
+ * デュオリンゴ式の文法クイズロジックを提供するユーティリティ関数
+ */
+
+import type {
+  AIGrammarQuizQuestion,
+  AIGrammarQuizQuestionLegacy,
+  AIGrammarExtraction,
+  AIGrammarExtractionLegacy,
+  GrammarQuizType,
+  LegacyGrammarQuizType,
+  WordOption,
+} from '@/types';
+
+// ============ Type Guards ============
+
+/**
+ * 旧形式の問題タイプかどうかを判定
+ */
+export function isLegacyQuestionType(
+  type: string
+): type is LegacyGrammarQuizType {
+  return ['fill_blank', 'choice', 'reorder'].includes(type);
+}
+
+/**
+ * 新形式の問題タイプかどうかを判定
+ */
+export function isNewQuestionType(type: string): type is GrammarQuizType {
+  return ['single_select', 'word_tap', 'sentence_build'].includes(type);
+}
+
+/**
+ * 旧形式のクイズ問題かどうかを判定
+ */
+export function isLegacyQuizQuestion(
+  question: AIGrammarQuizQuestion | AIGrammarQuizQuestionLegacy
+): question is AIGrammarQuizQuestionLegacy {
+  return isLegacyQuestionType(question.questionType);
+}
+
+// ============ Migration Functions ============
+
+/**
+ * 旧問題タイプから新問題タイプへのマッピング
+ */
+const QUESTION_TYPE_MAP: Record<LegacyGrammarQuizType, GrammarQuizType> = {
+  choice: 'single_select',
+  fill_blank: 'word_tap',
+  reorder: 'sentence_build',
+};
+
+/**
+ * 旧形式のクイズ問題を新形式に変換
+ */
+export function migrateQuizQuestion(
+  legacy: AIGrammarQuizQuestionLegacy
+): AIGrammarQuizQuestion {
+  const newType = QUESTION_TYPE_MAP[legacy.questionType];
+
+  const base: Omit<AIGrammarQuizQuestion, 'questionType'> = {
+    question: legacy.question,
+    questionJa: legacy.questionJa,
+    correctAnswer: legacy.correctAnswer,
+    explanation: legacy.explanation,
+  };
+
+  switch (legacy.questionType) {
+    case 'choice':
+      // choice → single_select
+      // 既存のoptionsをWordOption形式に変換
+      return {
+        ...base,
+        questionType: 'single_select',
+        wordOptions: (legacy.options || []).map((opt) => ({
+          word: opt,
+          isCorrect: opt === legacy.correctAnswer,
+          isDistractor: false, // 旧形式では区別がなかった
+        })),
+      };
+
+    case 'fill_blank':
+      // fill_blank → word_tap
+      // correctAnswerから単語オプションを生成
+      return {
+        ...base,
+        questionType: 'word_tap',
+        wordOptions: generateWordOptionsFromAnswer(
+          legacy.correctAnswer,
+          legacy.options
+        ),
+        grammarPoint: extractGrammarPointFromQuestion(legacy.question),
+      };
+
+    case 'reorder':
+      // reorder → sentence_build
+      // correctAnswerを単語配列に分割
+      return {
+        ...base,
+        questionType: 'sentence_build',
+        sentenceWords: splitSentenceIntoWords(legacy.correctAnswer),
+        extraWords: [], // 旧形式にはなかった
+      };
+
+    default:
+      // フォールバック: single_selectとして扱う
+      return {
+        ...base,
+        questionType: 'single_select',
+        wordOptions: (legacy.options || []).map((opt) => ({
+          word: opt,
+          isCorrect: opt === legacy.correctAnswer,
+          isDistractor: false,
+        })),
+      };
+  }
+}
+
+/**
+ * 旧形式の文法パターンを新形式に変換
+ */
+export function migrateGrammarExtraction(
+  legacy: AIGrammarExtractionLegacy
+): AIGrammarExtraction {
+  return {
+    ...legacy,
+    quizQuestions: legacy.quizQuestions.map(migrateQuizQuestion),
+  };
+}
+
+/**
+ * AIレスポンスが旧形式か新形式かを自動判定し、必要に応じて変換
+ */
+export function normalizeGrammarExtraction(
+  extraction: AIGrammarExtraction | AIGrammarExtractionLegacy
+): AIGrammarExtraction {
+  // 最初のクイズ問題の形式で判定
+  const firstQuestion = extraction.quizQuestions[0];
+  if (!firstQuestion) {
+    return extraction as AIGrammarExtraction;
+  }
+
+  if (isLegacyQuestionType(firstQuestion.questionType)) {
+    return migrateGrammarExtraction(extraction as AIGrammarExtractionLegacy);
+  }
+
+  return extraction as AIGrammarExtraction;
+}
+
+// ============ Quiz Logic Functions ============
+
+/**
+ * 回答エリアの選択状態を管理するための型
+ */
+export interface AnswerState {
+  selectedWords: string[]; // 選択された単語（順序保持）
+  availableWords: string[]; // 選択可能な単語（未選択のもの）
+}
+
+/**
+ * 初期状態を生成
+ */
+export function createInitialAnswerState(
+  question: AIGrammarQuizQuestion
+): AnswerState {
+  switch (question.questionType) {
+    case 'single_select':
+    case 'word_tap':
+      return {
+        selectedWords: [],
+        availableWords: shuffleArray(
+          (question.wordOptions || []).map((opt) => opt.word)
+        ),
+      };
+
+    case 'sentence_build': {
+      // 正解の単語 + ダミー単語をシャッフル
+      const allWords = [
+        ...(question.sentenceWords || []),
+        ...(question.extraWords || []),
+      ];
+      return {
+        selectedWords: [],
+        availableWords: shuffleArray(allWords),
+      };
+    }
+
+    default:
+      return {
+        selectedWords: [],
+        availableWords: [],
+      };
+  }
+}
+
+/**
+ * 単語を選択（プールから回答エリアへ移動）
+ */
+export function selectWord(state: AnswerState, word: string): AnswerState {
+  if (!state.availableWords.includes(word)) {
+    return state; // 利用可能でない単語は選択できない
+  }
+
+  return {
+    selectedWords: [...state.selectedWords, word],
+    availableWords: state.availableWords.filter((w) => w !== word),
+  };
+}
+
+/**
+ * 単語を選択解除（回答エリアからプールへ戻す）
+ */
+export function deselectWord(state: AnswerState, word: string): AnswerState {
+  const index = state.selectedWords.indexOf(word);
+  if (index === -1) {
+    return state; // 選択されていない単語は解除できない
+  }
+
+  return {
+    selectedWords: state.selectedWords.filter((_, i) => i !== index),
+    availableWords: [...state.availableWords, word],
+  };
+}
+
+/**
+ * 特定のインデックスの単語を選択解除
+ */
+export function deselectWordAtIndex(
+  state: AnswerState,
+  index: number
+): AnswerState {
+  const word = state.selectedWords[index];
+  if (!word) {
+    return state;
+  }
+  return deselectWord(state, word);
+}
+
+/**
+ * 全ての選択をリセット
+ */
+export function resetAnswerState(
+  question: AIGrammarQuizQuestion
+): AnswerState {
+  return createInitialAnswerState(question);
+}
+
+// ============ Answer Validation ============
+
+/**
+ * 回答の正誤判定結果
+ */
+export interface ValidationResult {
+  isCorrect: boolean;
+  userAnswer: string;
+  correctAnswer: string;
+  explanation: string;
+  grammarPoint?: string;
+}
+
+/**
+ * 回答を検証
+ */
+export function validateAnswer(
+  question: AIGrammarQuizQuestion,
+  state: AnswerState
+): ValidationResult {
+  const baseResult = {
+    explanation: question.explanation,
+    grammarPoint: question.grammarPoint,
+  };
+
+  switch (question.questionType) {
+    case 'single_select': {
+      // 1つだけ選択されているか確認
+      const userAnswer = state.selectedWords[0] || '';
+      return {
+        ...baseResult,
+        isCorrect: userAnswer === question.correctAnswer,
+        userAnswer,
+        correctAnswer: question.correctAnswer,
+      };
+    }
+
+    case 'word_tap': {
+      // 空欄に入れた単語が正解か確認
+      const userAnswer = state.selectedWords.join(' ');
+      return {
+        ...baseResult,
+        isCorrect: userAnswer === question.correctAnswer,
+        userAnswer,
+        correctAnswer: question.correctAnswer,
+      };
+    }
+
+    case 'sentence_build': {
+      // 並べた順序が正解と一致するか確認
+      const userAnswer = state.selectedWords.join(' ');
+      const correctAnswer = (question.sentenceWords || []).join(' ');
+      return {
+        ...baseResult,
+        isCorrect: userAnswer === correctAnswer,
+        userAnswer,
+        correctAnswer,
+      };
+    }
+
+    default:
+      return {
+        ...baseResult,
+        isCorrect: false,
+        userAnswer: '',
+        correctAnswer: question.correctAnswer,
+      };
+  }
+}
+
+/**
+ * 回答が確定可能かどうかを判定
+ */
+export function canSubmitAnswer(
+  question: AIGrammarQuizQuestion,
+  state: AnswerState
+): boolean {
+  switch (question.questionType) {
+    case 'single_select':
+      // 1つ選択されている
+      return state.selectedWords.length === 1;
+
+    case 'word_tap':
+      // 少なくとも1つ選択されている
+      return state.selectedWords.length > 0;
+
+    case 'sentence_build':
+      // 全ての正解単語が配置されている（ダミー単語は除く）
+      const requiredCount = question.sentenceWords?.length || 0;
+      return state.selectedWords.length === requiredCount;
+
+    default:
+      return false;
+  }
+}
+
+// ============ Helper Functions ============
+
+/**
+ * 配列をシャッフル（Fisher-Yates）
+ */
+export function shuffleArray<T>(array: T[]): T[] {
+  const result = [...array];
+  for (let i = result.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [result[i], result[j]] = [result[j], result[i]];
+  }
+  return result;
+}
+
+/**
+ * fill_blank の correctAnswer からWordOptionsを生成
+ * （旧形式マイグレーション用）
+ */
+function generateWordOptionsFromAnswer(
+  correctAnswer: string,
+  existingOptions?: string[]
+): WordOption[] {
+  // 既存のoptionsがあればそれを使う
+  if (existingOptions && existingOptions.length > 0) {
+    return existingOptions.map((opt) => ({
+      word: opt,
+      isCorrect: opt === correctAnswer,
+      isDistractor: opt !== correctAnswer,
+    }));
+  }
+
+  // なければ正解のみを返す（AIが新形式で生成する場合はwordOptionsが設定される）
+  return [
+    {
+      word: correctAnswer,
+      isCorrect: true,
+      isDistractor: false,
+    },
+  ];
+}
+
+/**
+ * 問題文から文法ポイントを抽出（簡易版）
+ */
+function extractGrammarPointFromQuestion(question: string): string | undefined {
+  // 括弧内のヒントを抽出 例: "She ___ (live)" → "live"
+  const match = question.match(/\(([^)]+)\)/);
+  return match ? match[1] : undefined;
+}
+
+/**
+ * 文を単語配列に分割
+ */
+function splitSentenceIntoWords(sentence: string): string[] {
+  // ピリオド、カンマ、疑問符などを単語から分離
+  return sentence
+    .replace(/([.,!?])/g, ' $1')
+    .split(/\s+/)
+    .filter((w) => w.length > 0);
+}
+
+/**
+ * WordOptionの配列から正解を取得
+ */
+export function getCorrectWordFromOptions(options: WordOption[]): string | null {
+  const correct = options.find((opt) => opt.isCorrect);
+  return correct?.word || null;
+}
+
+/**
+ * 問題タイプに応じた最大選択数を取得
+ */
+export function getMaxSelectionCount(
+  question: AIGrammarQuizQuestion
+): number {
+  switch (question.questionType) {
+    case 'single_select':
+      return 1;
+    case 'word_tap':
+      // 空欄の数をカウント（_____の数）
+      return (question.question.match(/_____/g) || []).length || 1;
+    case 'sentence_build':
+      return question.sentenceWords?.length || 0;
+    default:
+      return 1;
+  }
+}
+
+/**
+ * 問題タイプの日本語ラベルを取得
+ */
+export function getQuestionTypeLabel(type: GrammarQuizType): string {
+  switch (type) {
+    case 'single_select':
+      return '選択問題';
+    case 'word_tap':
+      return '穴埋め問題';
+    case 'sentence_build':
+      return '並べ替え問題';
+    default:
+      return '問題';
+  }
+}

--- a/src/lib/grammar/use-grammar-quiz.ts
+++ b/src/lib/grammar/use-grammar-quiz.ts
@@ -1,0 +1,299 @@
+'use client';
+
+/**
+ * Grammar Quiz React Hook
+ * デュオリンゴ式の文法クイズの状態管理を提供するカスタムフック
+ */
+
+import { useState, useCallback, useMemo } from 'react';
+import type { AIGrammarQuizQuestion, AIGrammarExtraction } from '@/types';
+import {
+  type AnswerState,
+  type ValidationResult,
+  createInitialAnswerState,
+  selectWord,
+  deselectWord,
+  deselectWordAtIndex,
+  validateAnswer,
+  canSubmitAnswer,
+  shuffleArray,
+  normalizeGrammarExtraction,
+} from './quiz-utils';
+
+// ============ Types ============
+
+export interface QuizProgress {
+  currentIndex: number;
+  totalCount: number;
+  correctCount: number;
+  wrongCount: number;
+}
+
+export type QuizPhase = 'answering' | 'feedback' | 'completed';
+
+export interface UseGrammarQuizReturn {
+  // 現在の状態
+  currentQuestion: AIGrammarQuizQuestion | null;
+  answerState: AnswerState;
+  phase: QuizPhase;
+  progress: QuizProgress;
+  lastResult: ValidationResult | null;
+
+  // アクション
+  selectWord: (word: string) => void;
+  deselectWord: (word: string) => void;
+  deselectWordAtIndex: (index: number) => void;
+  submitAnswer: () => void;
+  nextQuestion: () => void;
+  resetQuiz: () => void;
+
+  // 便利なゲッター
+  canSubmit: boolean;
+  isCorrect: boolean | null;
+  isCompleted: boolean;
+}
+
+// ============ Hook Implementation ============
+
+export function useGrammarQuiz(
+  patterns: AIGrammarExtraction[],
+  options?: {
+    shuffle?: boolean;
+    onComplete?: (progress: QuizProgress) => void;
+  }
+): UseGrammarQuizReturn {
+  const { shuffle = true, onComplete } = options || {};
+
+  // 全ての問題を抽出してフラット化
+  const allQuestions = useMemo(() => {
+    const normalized = patterns.map(normalizeGrammarExtraction);
+    const questions = normalized.flatMap((p) => p.quizQuestions);
+    return shuffle ? shuffleArray(questions) : questions;
+  }, [patterns, shuffle]);
+
+  // 状態
+  const [currentIndex, setCurrentIndex] = useState(0);
+  const [correctCount, setCorrectCount] = useState(0);
+  const [wrongCount, setWrongCount] = useState(0);
+  const [phase, setPhase] = useState<QuizPhase>('answering');
+  const [lastResult, setLastResult] = useState<ValidationResult | null>(null);
+
+  // 現在の問題
+  const currentQuestion = allQuestions[currentIndex] || null;
+
+  // 回答状態
+  const [answerState, setAnswerState] = useState<AnswerState>(() =>
+    currentQuestion ? createInitialAnswerState(currentQuestion) : { selectedWords: [], availableWords: [] }
+  );
+
+  // 単語を選択
+  const handleSelectWord = useCallback(
+    (word: string) => {
+      if (phase !== 'answering') return;
+      setAnswerState((prev) => selectWord(prev, word));
+    },
+    [phase]
+  );
+
+  // 単語を選択解除
+  const handleDeselectWord = useCallback(
+    (word: string) => {
+      if (phase !== 'answering') return;
+      setAnswerState((prev) => deselectWord(prev, word));
+    },
+    [phase]
+  );
+
+  // インデックスで選択解除
+  const handleDeselectWordAtIndex = useCallback(
+    (index: number) => {
+      if (phase !== 'answering') return;
+      setAnswerState((prev) => deselectWordAtIndex(prev, index));
+    },
+    [phase]
+  );
+
+  // 回答を確定
+  const handleSubmitAnswer = useCallback(() => {
+    if (!currentQuestion || phase !== 'answering') return;
+
+    const result = validateAnswer(currentQuestion, answerState);
+    setLastResult(result);
+
+    if (result.isCorrect) {
+      setCorrectCount((prev) => prev + 1);
+    } else {
+      setWrongCount((prev) => prev + 1);
+    }
+
+    setPhase('feedback');
+  }, [currentQuestion, answerState, phase]);
+
+  // 次の問題へ
+  const handleNextQuestion = useCallback(() => {
+    if (phase !== 'feedback') return;
+
+    const nextIndex = currentIndex + 1;
+
+    if (nextIndex >= allQuestions.length) {
+      setPhase('completed');
+      onComplete?.({
+        currentIndex: nextIndex,
+        totalCount: allQuestions.length,
+        correctCount: correctCount + (lastResult?.isCorrect ? 0 : 0), // Already counted
+        wrongCount: wrongCount + (lastResult?.isCorrect ? 0 : 0), // Already counted
+      });
+      return;
+    }
+
+    setCurrentIndex(nextIndex);
+    setPhase('answering');
+    setLastResult(null);
+
+    // 新しい問題の回答状態を初期化
+    const nextQuestion = allQuestions[nextIndex];
+    if (nextQuestion) {
+      setAnswerState(createInitialAnswerState(nextQuestion));
+    }
+  }, [phase, currentIndex, allQuestions, onComplete, correctCount, wrongCount, lastResult]);
+
+  // クイズをリセット
+  const handleResetQuiz = useCallback(() => {
+    setCurrentIndex(0);
+    setCorrectCount(0);
+    setWrongCount(0);
+    setPhase('answering');
+    setLastResult(null);
+
+    const firstQuestion = allQuestions[0];
+    if (firstQuestion) {
+      setAnswerState(createInitialAnswerState(firstQuestion));
+    }
+  }, [allQuestions]);
+
+  // 回答可能かどうか
+  const canSubmit = useMemo(() => {
+    if (!currentQuestion || phase !== 'answering') return false;
+    return canSubmitAnswer(currentQuestion, answerState);
+  }, [currentQuestion, answerState, phase]);
+
+  // 進捗
+  const progress: QuizProgress = useMemo(
+    () => ({
+      currentIndex,
+      totalCount: allQuestions.length,
+      correctCount,
+      wrongCount,
+    }),
+    [currentIndex, allQuestions.length, correctCount, wrongCount]
+  );
+
+  return {
+    // 状態
+    currentQuestion,
+    answerState,
+    phase,
+    progress,
+    lastResult,
+
+    // アクション
+    selectWord: handleSelectWord,
+    deselectWord: handleDeselectWord,
+    deselectWordAtIndex: handleDeselectWordAtIndex,
+    submitAnswer: handleSubmitAnswer,
+    nextQuestion: handleNextQuestion,
+    resetQuiz: handleResetQuiz,
+
+    // ゲッター
+    canSubmit,
+    isCorrect: lastResult?.isCorrect ?? null,
+    isCompleted: phase === 'completed',
+  };
+}
+
+// ============ Simplified Hook for Single Question ============
+
+export interface UseSingleQuestionReturn {
+  answerState: AnswerState;
+  phase: 'answering' | 'feedback';
+  result: ValidationResult | null;
+
+  selectWord: (word: string) => void;
+  deselectWord: (word: string) => void;
+  deselectWordAtIndex: (index: number) => void;
+  submitAnswer: () => void;
+  reset: () => void;
+
+  canSubmit: boolean;
+  isCorrect: boolean | null;
+}
+
+/**
+ * 単一の問題を扱うシンプルなフック
+ */
+export function useSingleQuestion(
+  question: AIGrammarQuizQuestion
+): UseSingleQuestionReturn {
+  const [answerState, setAnswerState] = useState<AnswerState>(() =>
+    createInitialAnswerState(question)
+  );
+  const [phase, setPhase] = useState<'answering' | 'feedback'>('answering');
+  const [result, setResult] = useState<ValidationResult | null>(null);
+
+  const handleSelectWord = useCallback(
+    (word: string) => {
+      if (phase !== 'answering') return;
+      setAnswerState((prev) => selectWord(prev, word));
+    },
+    [phase]
+  );
+
+  const handleDeselectWord = useCallback(
+    (word: string) => {
+      if (phase !== 'answering') return;
+      setAnswerState((prev) => deselectWord(prev, word));
+    },
+    [phase]
+  );
+
+  const handleDeselectWordAtIndex = useCallback(
+    (index: number) => {
+      if (phase !== 'answering') return;
+      setAnswerState((prev) => deselectWordAtIndex(prev, index));
+    },
+    [phase]
+  );
+
+  const handleSubmitAnswer = useCallback(() => {
+    if (phase !== 'answering') return;
+    const validationResult = validateAnswer(question, answerState);
+    setResult(validationResult);
+    setPhase('feedback');
+  }, [phase, question, answerState]);
+
+  const handleReset = useCallback(() => {
+    setAnswerState(createInitialAnswerState(question));
+    setPhase('answering');
+    setResult(null);
+  }, [question]);
+
+  const canSubmit = useMemo(() => {
+    if (phase !== 'answering') return false;
+    return canSubmitAnswer(question, answerState);
+  }, [question, answerState, phase]);
+
+  return {
+    answerState,
+    phase,
+    result,
+
+    selectWord: handleSelectWord,
+    deselectWord: handleDeselectWord,
+    deselectWordAtIndex: handleDeselectWordAtIndex,
+    submitAnswer: handleSubmitAnswer,
+    reset: handleReset,
+
+    canSubmit,
+    isCorrect: result?.isCorrect ?? null,
+  };
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -24,6 +24,15 @@ export type {
   GrammarQuizQuestion,
   AIGrammarExtraction,
   AIGrammarResponse,
+  // New Duolingo-style grammar quiz types
+  GrammarQuizType,
+  LegacyGrammarQuizType,
+  WordOption,
+  GrammarQuizQuestionNew,
+  AIGrammarQuizQuestionLegacy,
+  AIGrammarQuizQuestionNew,
+  AIGrammarQuizQuestion,
+  AIGrammarExtractionLegacy,
 } from '../../shared/types';
 
 // ============ Web-Specific Types ============


### PR DESCRIPTION
- Add new quiz types: single_select, word_tap, sentence_build
- Add WordOption interface with isDistractor flag
- Create quiz-utils.ts with state management and validation
- Create useGrammarQuiz and useSingleQuestion hooks
- Update AI prompt for Japanese questions and word-only options
- Integrate with UIUX team's grammar-quiz components