### PR TITLE
Add text-to-speech functionality to flashcard screens

### DIFF
--- a/mobile/src/components/home/InlineFlashcard.tsx
+++ b/mobile/src/components/home/InlineFlashcard.tsx
@@ -116,15 +116,15 @@ export function InlineFlashcard({ words }: InlineFlashcardProps) {
           {!isFlipped ? (
             // Front: English
             <View style={styles.cardContent}>
-              <Text style={styles.englishText} numberOfLines={3} adjustsFontSizeToFit minimumFontScale={0.5}>
-                {currentWord.english}
-              </Text>
               <TouchableOpacity
                 onPress={speakWord}
                 style={styles.speakButton}
               >
                 <Volume2 size={20} color={colors.gray[400]} />
               </TouchableOpacity>
+              <Text style={styles.englishText} numberOfLines={3} adjustsFontSizeToFit minimumFontScale={0.5}>
+                {currentWord.english}
+              </Text>
               <Text style={styles.hintText}>タップして意味を表示</Text>
             </View>
           ) : (
@@ -234,7 +234,7 @@ const styles = StyleSheet.create({
   },
   speakButton: {
     padding: 8,
-    marginTop: 12,
+    marginBottom: 12,
   },
   hintText: {
     fontSize: 13,

--- a/mobile/src/screens/FavoritesFlashcardScreen.tsx
+++ b/mobile/src/screens/FavoritesFlashcardScreen.tsx
@@ -20,7 +20,9 @@ import {
   Flag,
   Eye,
   EyeOff,
+  Volume2,
 } from 'lucide-react-native';
+import * as Speech from 'expo-speech';
 import { getRepository } from '../lib/db';
 import { useAuth } from '../hooks/use-auth';
 import { getGuestUserId, shuffleArray } from '../lib/utils';
@@ -328,6 +330,17 @@ export function FavoritesFlashcardScreen() {
           >
             {/* Front (English) */}
             <Animated.View style={[styles.card, styles.cardFront, frontAnimatedStyle]}>
+              {/* Voice button above the word */}
+              <TouchableOpacity
+                onPress={() => {
+                  if (currentWord?.english) {
+                    Speech.speak(currentWord.english, { language: 'en-US', rate: 0.9 });
+                  }
+                }}
+                style={styles.voiceButton}
+              >
+                <Volume2 size={24} color={colors.gray[400]} />
+              </TouchableOpacity>
               <View style={styles.cardTextContainer}>
                 <Text
                   style={styles.englishText}
@@ -482,6 +495,11 @@ const styles = StyleSheet.create({
   },
   cardFront: {
     backgroundColor: colors.white,
+  },
+  voiceButton: {
+    position: 'absolute',
+    top: 24,
+    padding: 8,
   },
   cardBack: {
     backgroundColor: colors.orange[500],


### PR DESCRIPTION
## Summary
Added text-to-speech capability to both the inline flashcard component and the favorites flashcard screen, allowing users to hear the pronunciation of English words.

## Key Changes
- **InlineFlashcard.tsx**: 
  - Reordered DOM elements to place the speak button before the text for better visual hierarchy
  - Changed `speakButton` margin from `marginTop: 12` to `marginBottom: 12` to properly space the button above the text
  
- **FavoritesFlashcardScreen.tsx**:
  - Added `expo-speech` import for text-to-speech functionality
  - Imported `Volume2` icon from lucide-react-native
  - Added a voice button above the English word on the front of the card
  - Button triggers speech synthesis with English (US) language at 0.9x rate
  - Styled the voice button as an absolutely positioned element at the top of the card

## Implementation Details
- Both screens now use the same text-to-speech approach via `expo-speech`
- Voice buttons are consistently styled with the `Volume2` icon in gray
- The speak functionality includes null-checking to ensure the word exists before attempting to speak
- Button positioning and spacing have been adjusted to maintain clean UI layout