### PR TITLE
Add expo-speech plugin for text-to-speech functionality

### DIFF
--- a/mobile/app.json
+++ b/mobile/app.json
@@ -42,7 +42,8 @@
     },
     "plugins": [
       "expo-camera",
-      "expo-image-picker"
+      "expo-image-picker",
+      "expo-speech"
     ],
     "extra": {
       "eas": {

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -20,6 +20,7 @@
     "expo-file-system": "^19.0.21",
     "expo-image-picker": "^17.0.10",
     "expo-linking": "^8.0.11",
+    "expo-speech": "~13.1.1",
     "expo-sqlite": "^16.0.10",
     "expo-status-bar": "~3.0.9",
     "lucide-react-native": "^0.563.0",


### PR DESCRIPTION
## Summary
This PR adds the `expo-speech` library to the mobile app, enabling text-to-speech capabilities.

## Changes
- Added `expo-speech` plugin to `app.json` configuration
- Added `expo-speech` (~13.1.1) dependency to `package.json`

## Details
The expo-speech library provides native text-to-speech functionality across iOS and Android platforms. This addition allows the app to synthesize and play audio from text input, which can be useful for accessibility features or audio feedback.