### PR TITLE
Rename sessionStorage key for existing project ID

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1039,7 +1039,7 @@ export default function HomePage() {
 
     // If adding to existing project, skip project name modal
     if (isAddingToExisting && currentProject) {
-      sessionStorage.setItem('scanvocab_project_id', currentProject.id);
+      sessionStorage.setItem('scanvocab_existing_project_id', currentProject.id);
       sessionStorage.removeItem('scanvocab_project_name');
       processImage(file);
     } else {


### PR DESCRIPTION
## Summary
Updated the sessionStorage key name for storing existing project IDs to be more descriptive and avoid potential naming conflicts.

## Changes
- Renamed `scanvocab_project_id` to `scanvocab_existing_project_id` in the project addition flow
- This change clarifies that the stored ID specifically refers to an existing project being added to, rather than a new project

## Details
The key rename improves code clarity by explicitly indicating that this sessionStorage entry is used when adding files to an existing project. This prevents confusion with other project ID references and makes the codebase more maintainable.