### PR TITLE
Fix login stuck in loading state after successful authentication

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,14 +1,13 @@
 'use client';
 
 import { useState, Suspense } from 'react';
-import { useRouter, useSearchParams } from 'next/navigation';
+import { useSearchParams } from 'next/navigation';
 import Link from 'next/link';
 import { Eye, EyeOff, Loader2 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { useAuth } from '@/hooks/use-auth';
 
 function LoginForm() {
-  const router = useRouter();
   const searchParams = useSearchParams();
   const redirect = searchParams.get('redirect') || '/';
   const { signIn } = useAuth();
@@ -27,7 +26,8 @@ function LoginForm() {
     const result = await signIn(email, password);
 
     if (result.success) {
-      router.push(redirect);
+      // Use hard navigation to ensure session state is fully refreshed
+      window.location.href = redirect;
     } else {
       setError(result.error || 'ログインに失敗しました');
       setLoading(false);


### PR DESCRIPTION
Changed from Next.js router.push() to window.location.href for post-login redirect. This ensures a full page reload that properly reflects the new session state, instead of soft navigation that may use cached page content.