### PR TITLE
Add HEIC/HEIF format rejection and improve error messaging

### DIFF
--- a/src/app/api/extract/route.ts
+++ b/src/app/api/extract/route.ts
@@ -87,6 +87,16 @@ export async function POST(request: NextRequest) {
       );
     }
 
+    // Reject unsupported image formats (HEIC/HEIF are not supported by OpenAI Vision API)
+    // This can happen when client-side HEIC conversion fails
+    if (image.startsWith('data:image/heic') || image.startsWith('data:image/heif')) {
+      console.error('Unsupported image format: HEIC/HEIF detected', { detectedType });
+      return NextResponse.json(
+        { success: false, error: 'HEIC/HEIF形式は対応していません。カメラアプリの設定で「互換性優先」を選択するか、スクリーンショットをお試しください。' },
+        { status: 400 }
+      );
+    }
+
     // ============================================
     // 3. CHECK & INCREMENT SCAN COUNT (SERVER-SIDE ENFORCEMENT)
     // ============================================

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1193,7 +1193,9 @@ export default function HomePage() {
       if (error instanceof Error) {
         // Make common errors more user-friendly
         if (error.message.includes('did not match the expected pattern')) {
-          errorMessage = '画像の読み込みに失敗しました。別の画像をお試しください。';
+          errorMessage = '画像データの処理に問題が発生しました。カメラ設定を「互換性優先」にするか、スクリーンショットをお試しください。';
+        } else if (error.message.includes('HEIC') || error.message.includes('HEIF')) {
+          errorMessage = error.message; // HEIC関連のエラーはそのまま表示
         } else {
           errorMessage = error.message;
         }


### PR DESCRIPTION
## Summary
This PR adds server-side validation to reject unsupported HEIC/HEIF image formats and improves error messaging to guide users toward compatible formats or workarounds.

## Key Changes
- **Server-side validation**: Added explicit check in the extract API route to reject HEIC/HEIF formats that aren't supported by OpenAI Vision API, with a helpful error message in Japanese
- **Improved error handling**: Enhanced client-side error message mapping to provide more actionable guidance:
  - Generic image processing errors now suggest changing camera settings to "互換性優先" (compatibility mode) or using screenshots
  - HEIC/HEIF-specific errors are passed through directly to the user
- **Better user guidance**: Error messages now explicitly suggest camera app settings adjustments and screenshot alternatives

## Implementation Details
- The HEIC/HEIF rejection happens after initial validation but before processing, preventing unnecessary API calls
- Error messages are localized in Japanese to match the application's language
- The solution handles cases where client-side HEIC conversion may fail, providing a fallback server-side check