### PR TITLE
Add project name editing and manual word addition features

### DIFF
--- a/src/app/scan/confirm/page.tsx
+++ b/src/app/scan/confirm/page.tsx
@@ -72,12 +72,21 @@ export default function ConfirmPage() {
           }
         }
       } catch {
+        showToast({
+          message: 'データの読み込みに失敗しました。もう一度スキャンしてください。',
+          type: 'error',
+        });
         router.push('/');
       }
     } else {
+      // Show a more helpful message instead of silently redirecting
+      showToast({
+        message: 'スキャンデータが見つかりません。もう一度スキャンしてください。',
+        type: 'error',
+      });
       router.push('/');
     }
-  }, [router]);
+  }, [router, showToast]);
 
   const handleToggleWord = (tempId: string) => {
     setWords((prev) =>
@@ -115,6 +124,20 @@ export default function ConfirmPage() {
         w.tempId === tempId ? { ...w, isEditing: false } : w
       )
     );
+  };
+
+  const handleAddManualWord = () => {
+    const newWord: EditableWord = {
+      english: '',
+      japanese: '',
+      distractors: [],
+      exampleSentence: '',
+      exampleSentenceJa: '',
+      tempId: `word-manual-${Date.now()}`,
+      isEditing: true,
+      isSelected: true,
+    };
+    setWords((prev) => [...prev, newWord]);
   };
 
   const handleSaveProject = async () => {
@@ -294,15 +317,24 @@ export default function ConfirmPage() {
           </div>
         )}
 
-        {/* Word count */}
+        {/* Word count and add button */}
         <div className="flex items-center justify-between mb-4">
           <h2 className="text-sm font-medium text-gray-500">
             抽出された単語
           </h2>
-          <span className={`text-sm font-medium ${showLimitWarning && excessCount > 0 ? 'text-red-600' : 'text-blue-600'}`}>
-            {selectedCount}語選択中
-            {!isPro && ` / 残り${availableSlots}語`}
-          </span>
+          <div className="flex items-center gap-3">
+            <span className={`text-sm font-medium ${showLimitWarning && excessCount > 0 ? 'text-red-600' : 'text-blue-600'}`}>
+              {selectedCount}語選択中
+              {!isPro && ` / 残り${availableSlots}語`}
+            </span>
+            <button
+              onClick={handleAddManualWord}
+              className="p-1.5 hover:bg-blue-100 rounded-full transition-colors text-blue-600"
+              title="手で入力"
+            >
+              <Plus className="w-5 h-5" />
+            </button>
+          </div>
         </div>
 
         {/* Word list */}


### PR DESCRIPTION
## Summary
This PR adds two new features to improve user experience: the ability to edit project names directly from the project selection sheet, and the ability to manually add words during the scan confirmation process.

## Key Changes

### Project Name Editing
- Added `EditProjectNameModal` component for editing project names with validation
- Implemented `handleEditProjectName` and `handleConfirmEditProjectName` handlers to manage the edit flow
- Added edit button (pencil icon) to each project in the ProjectSelectionSheet
- Updates project title in the UI and persists changes to the repository
- Shows success/error toast notifications for user feedback

### Manual Word Addition
- Added `handleAddManualWord` function to create new editable word entries
- Added "+" button next to word count in the confirm page to trigger manual word addition
- New words are created with empty fields and `isEditing: true` state for immediate editing
- Maintains selection state for newly added words

### Error Handling Improvements
- Enhanced error handling in the scan confirm page with user-friendly toast messages
- Added `showToast` to dependency array in useEffect to prevent stale closures
- Provides clear feedback when scan data is missing or fails to load

## Implementation Details
- The EditProjectNameModal follows the same pattern as the existing ProjectNameModal
- Input field auto-focuses when modal opens for better UX
- Submit button is disabled when name is unchanged or empty
- Manual words are assigned unique tempIds using timestamp to avoid conflicts
- All changes maintain consistency with existing UI patterns and styling