### PR TITLE
フラッシュカード: Swift版と同じレイアウトに統一

### DIFF
--- a/src/components/home/InlineFlashcard.tsx
+++ b/src/components/home/InlineFlashcard.tsx
@@ -1,12 +1,58 @@
 'use client';
 
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useMemo } from 'react';
 import { Icon } from '@/components/ui/Icon';
 import { shuffleArray } from '@/lib/utils';
 import type { Word } from '@/types';
 
 interface InlineFlashcardProps {
   words: Word[];
+}
+
+type MasteryInfo = {
+  level: number; // 0..3
+  label: string;
+  colorVar: string;
+};
+
+function getMasteryInfo(repetition: number): MasteryInfo {
+  if (repetition === 0) {
+    return { level: 0, label: '新規', colorVar: 'var(--color-muted)' };
+  }
+  if (repetition <= 2) {
+    return { level: 1, label: '学習中', colorVar: '#f59e0b' };
+  }
+  if (repetition <= 5) {
+    return { level: 2, label: '定着中', colorVar: 'var(--color-primary)' };
+  }
+  return { level: 3, label: 'マスター', colorVar: '#10b981' };
+}
+
+function HighlightedExample({ text, term }: { text: string; term: string }) {
+  const segments = useMemo(() => {
+    if (!term) return [{ text, highlight: false }];
+    const escaped = term.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const regex = new RegExp(`(${escaped})`, 'gi');
+    const parts = text.split(regex);
+    return parts.map((part) => ({
+      text: part,
+      highlight: part.toLowerCase() === term.toLowerCase(),
+    }));
+  }, [text, term]);
+
+  return (
+    <p className="text-sm leading-relaxed text-white/90">
+      {segments.map((seg, i) =>
+        seg.highlight ? (
+          <span key={i} className="font-bold text-white">
+            {seg.text}
+          </span>
+        ) : (
+          <span key={i}>{seg.text}</span>
+        )
+      )}
+    </p>
+  );
 }
 
 export function InlineFlashcard({ words }: InlineFlashcardProps) {
@@ -44,7 +90,7 @@ export function InlineFlashcard({ words }: InlineFlashcardProps) {
   const goToPrevious = (e?: React.MouseEvent) => {
     e?.stopPropagation();
     if (currentIndex > 0) {
-      setCurrentIndex(prev => prev - 1);
+      setCurrentIndex((prev) => prev - 1);
       setIsFlipped(false);
     }
   };
@@ -52,7 +98,7 @@ export function InlineFlashcard({ words }: InlineFlashcardProps) {
   const goToNext = (e?: React.MouseEvent) => {
     e?.stopPropagation();
     if (currentIndex < shuffledWords.length - 1) {
-      setCurrentIndex(prev => prev + 1);
+      setCurrentIndex((prev) => prev + 1);
       setIsFlipped(false);
     } else {
       // Loop back to beginning with reshuffle
@@ -67,6 +113,8 @@ export function InlineFlashcard({ words }: InlineFlashcardProps) {
       </div>
     );
   }
+
+  const mastery = getMasteryInfo(currentWord.repetition ?? 0);
 
   return (
     <div className="card p-4 bg-[var(--color-primary-light)]">
@@ -86,7 +134,7 @@ export function InlineFlashcard({ words }: InlineFlashcardProps) {
 
       {/* Flashcard */}
       <div
-        className="bg-[var(--color-surface)] rounded-2xl min-h-[160px] shadow-soft mb-4 relative cursor-pointer select-none"
+        className="rounded-2xl min-h-[220px] shadow-soft mb-4 relative cursor-pointer select-none overflow-hidden"
         onClick={(e) => {
           const rect = e.currentTarget.getBoundingClientRect();
           const x = e.clientX - rect.left;
@@ -98,39 +146,115 @@ export function InlineFlashcard({ words }: InlineFlashcardProps) {
           } else if (x > third * 2) {
             goToNext();
           } else {
-            setIsFlipped(prev => !prev);
+            setIsFlipped((prev) => !prev);
           }
         }}
       >
-        <div className="p-6 flex items-center justify-center min-h-[160px]">
-          {!isFlipped ? (
-            // Front: English
-            <div className="text-center">
-              <div className="flex items-center justify-center mb-2 h-[20px]">
-                <button
-                  onClick={speakWord}
-                  className="p-1 hover:bg-[var(--color-primary-light)] rounded-full transition-colors"
-                  aria-label="発音を聞く"
-                >
-                  <Icon name="volume_up" size={20} className="text-[var(--color-muted)]" />
-                </button>
-              </div>
+        {!isFlipped ? (
+          // Front: English + pronunciation + POS + mastery
+          <div className="bg-[var(--color-surface)] p-6 flex flex-col items-center justify-center min-h-[220px]">
+            {/* Mastery dots */}
+            <div className="flex items-center gap-1 mb-3">
+              {[0, 1, 2, 3].map((i) => (
+                <span
+                  key={i}
+                  className="block w-1.5 h-1.5 rounded-full"
+                  style={{
+                    backgroundColor:
+                      i <= mastery.level ? mastery.colorVar : 'var(--color-border)',
+                  }}
+                />
+              ))}
+              <span
+                className="ml-1.5 text-[10px] font-medium"
+                style={{ color: mastery.colorVar }}
+              >
+                {mastery.label}
+              </span>
+            </div>
+
+            <div className="flex items-center justify-center gap-2">
               <h2 className="text-3xl font-bold text-[var(--color-foreground)] tracking-tight">
                 {currentWord.english}
               </h2>
-              <p className="text-sm text-[var(--color-muted)] mt-3">タップして意味を表示</p>
+              <button
+                onClick={speakWord}
+                className="p-1 hover:bg-[var(--color-primary-light)] rounded-full transition-colors"
+                aria-label="発音を聞く"
+              >
+                <Icon name="volume_up" size={20} className="text-[var(--color-muted)]" />
+              </button>
             </div>
-          ) : (
-            // Back: Japanese
-            <div className="text-center">
-              <p className="text-sm text-[var(--color-muted)] mb-2 h-[20px] flex items-center justify-center">{currentWord.english}</p>
-              <h2 className="text-2xl font-bold text-[var(--color-foreground)]">
-                {currentWord.japanese}
-              </h2>
-              <p className="text-sm text-[var(--color-muted)] mt-3">タップして英語を表示</p>
+
+            {/* Pronunciation */}
+            {currentWord.pronunciation && (
+              <p className="mt-2 font-mono text-sm text-[var(--color-muted)]">
+                {currentWord.pronunciation}
+              </p>
+            )}
+
+            {/* Part of speech tags */}
+            {currentWord.partOfSpeechTags && currentWord.partOfSpeechTags.length > 0 && (
+              <div className="mt-3 flex flex-wrap items-center justify-center gap-1.5">
+                {currentWord.partOfSpeechTags.map((tag) => (
+                  <span
+                    key={tag}
+                    className="px-2 py-0.5 text-[11px] font-medium rounded-full bg-[var(--color-primary)]/12 text-[var(--color-primary)]"
+                  >
+                    {tag}
+                  </span>
+                ))}
+              </div>
+            )}
+
+            <p className="text-xs text-[var(--color-muted)] mt-4">タップして裏面を見る</p>
+          </div>
+        ) : (
+          // Back: Japanese + example sentence + translation
+          <div
+            className="p-6 flex flex-col min-h-[220px] text-white"
+            style={{
+              background:
+                'linear-gradient(135deg, var(--color-primary) 0%, color-mix(in srgb, var(--color-primary) 85%, black) 100%)',
+            }}
+          >
+            <div className="flex flex-col items-center text-center mb-4">
+              <h2 className="text-2xl font-bold">{currentWord.japanese}</h2>
+              <p className="mt-1 text-sm text-white/60">{currentWord.english}</p>
+              {currentWord.pronunciation && (
+                <p className="mt-0.5 font-mono text-xs text-white/50">
+                  {currentWord.pronunciation}
+                </p>
+              )}
             </div>
-          )}
-        </div>
+
+            {/* Example sentence */}
+            {currentWord.exampleSentence ? (
+              <div className="rounded-xl bg-white/10 p-3.5">
+                <p className="text-[10px] font-bold uppercase tracking-[1.5px] text-white/50 mb-2">
+                  例文
+                </p>
+                <HighlightedExample
+                  text={currentWord.exampleSentence}
+                  term={currentWord.english}
+                />
+                {currentWord.exampleSentenceJa && (
+                  <p className="mt-1.5 text-xs text-white/60 leading-relaxed">
+                    {currentWord.exampleSentenceJa}
+                  </p>
+                )}
+              </div>
+            ) : (
+              <div className="rounded-xl bg-white/10 p-3.5 text-center">
+                <p className="text-xs text-white/60">例文はまだありません</p>
+              </div>
+            )}
+
+            <p className="text-xs text-white/60 mt-auto pt-3 text-center">
+              タップして英語を表示
+            </p>
+          </div>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
表面に発音記号・品詞タグ・習得度を、裏面に例文とその和訳を表示するよう
InlineFlashcard を更新。iOS ネイティブ版 (FlashcardCardView.swift) のデザイン を参考に、習得度ドット、POS チップ、例文カードを追加。

https://claude.ai/code/session_01WbPtXN6xBb4u7ZyonpvFmD