### PR TITLE
単語一覧の英単語・訳の文字を1.2倍に拡大

### DIFF
--- a/src/app/project/[id]/page.tsx
+++ b/src/app/project/[id]/page.tsx
@@ -1488,7 +1488,7 @@ export default function ProjectDetailPage() {
                         </td>
                         <td className="px-2 py-2.5 whitespace-nowrap">
                           <span className="inline-flex items-center gap-1">
-                            <span className="text-base font-bold text-[var(--color-foreground)]">{word.english}</span>
+                            <span className="text-[19.2px] leading-[24px] font-bold text-[var(--color-foreground)]">{word.english}</span>
                             {word.isFavorite && (
                               <Icon
                                 name="flag"
@@ -1513,7 +1513,7 @@ export default function ProjectDetailPage() {
                         <td className="w-10 px-1 py-2.5 text-center text-xs font-bold text-[var(--color-muted)]">
                           {posLabel(word.partOfSpeechTags) || '—'}
                         </td>
-                        <td className="px-2 py-2.5 text-xs text-[var(--color-muted)] whitespace-nowrap" title={word.japanese}>
+                        <td className="px-2 py-2.5 text-[14.4px] leading-[16px] text-[var(--color-muted)] whitespace-nowrap" title={word.japanese}>
                           {word.japanese}
                         </td>
                         {(project?.customColumns ?? []).map((col) => {

--- a/src/components/home/WordList.tsx
+++ b/src/components/home/WordList.tsx
@@ -244,7 +244,7 @@ function WordItem({
       >
         <div className="w-max max-w-none">
           <div className="flex items-center gap-1.5">
-            <span className="font-semibold text-[var(--color-foreground)] whitespace-nowrap">{word.english}</span>
+            <span className="font-semibold text-[var(--color-foreground)] whitespace-nowrap text-[19.2px] leading-[24px]">{word.english}</span>
             {word.isFavorite && (
               <Icon
                 name="flag"
@@ -255,7 +255,7 @@ function WordItem({
               />
             )}
           </div>
-          <p className="text-sm text-[var(--color-muted)] whitespace-nowrap" title={word.japanese}>{word.japanese}</p>
+          <p className="text-[16.8px] leading-[20px] text-[var(--color-muted)] whitespace-nowrap" title={word.japanese}>{word.japanese}</p>
           {showProjectName && word.projectTitle && (
             <p className="text-xs text-[var(--color-primary)] mt-1 whitespace-nowrap">{word.projectTitle}</p>
           )}


### PR DESCRIPTION
枠の高さは変えずに文字だけを大きくするため、line-heightを
元のサイズに固定しつつfont-sizeを1.2倍に設定。

- WordList カード: 英単語 16px→19.2px、訳 14px→16.8px
- プロジェクト詳細テーブル: 英単語 16px→19.2px、訳 12px→14.4px

https://claude.ai/code/session_01FogwFVLfyzHpojtiDQMkLb