### PR TITLE
単語一覧の文字拡大: scale変換で枠サイズを完全に維持

### DIFF
--- a/src/app/project/[id]/page.tsx
+++ b/src/app/project/[id]/page.tsx
@@ -1488,7 +1488,7 @@ export default function ProjectDetailPage() {
                         </td>
                         <td className="px-2 py-2.5 whitespace-nowrap">
                           <span className="inline-flex items-center gap-1">
-                            <span className="text-[19.2px] leading-[24px] font-bold text-[var(--color-foreground)]">{word.english}</span>
+                            <span className="text-base font-bold text-[var(--color-foreground)] inline-block origin-left scale-[1.2]">{word.english}</span>
                             {word.isFavorite && (
                               <Icon
                                 name="flag"
@@ -1513,8 +1513,8 @@ export default function ProjectDetailPage() {
                         <td className="w-10 px-1 py-2.5 text-center text-xs font-bold text-[var(--color-muted)]">
                           {posLabel(word.partOfSpeechTags) || '—'}
                         </td>
-                        <td className="px-2 py-2.5 text-[14.4px] leading-[16px] text-[var(--color-muted)] whitespace-nowrap" title={word.japanese}>
-                          {word.japanese}
+                        <td className="px-2 py-2.5 text-xs text-[var(--color-muted)] whitespace-nowrap" title={word.japanese}>
+                          <span className="inline-block origin-left scale-[1.2]">{word.japanese}</span>
                         </td>
                         {(project?.customColumns ?? []).map((col) => {
                           const value = word.customSections?.find((s) => s.id === col.id)?.content ?? '';

--- a/src/components/home/WordList.tsx
+++ b/src/components/home/WordList.tsx
@@ -244,7 +244,7 @@ function WordItem({
       >
         <div className="w-max max-w-none">
           <div className="flex items-center gap-1.5">
-            <span className="font-semibold text-[var(--color-foreground)] whitespace-nowrap text-[19.2px] leading-[24px]">{word.english}</span>
+            <span className="font-semibold text-[var(--color-foreground)] whitespace-nowrap inline-block origin-left scale-[1.2]">{word.english}</span>
             {word.isFavorite && (
               <Icon
                 name="flag"
@@ -255,7 +255,7 @@ function WordItem({
               />
             )}
           </div>
-          <p className="text-[16.8px] leading-[20px] text-[var(--color-muted)] whitespace-nowrap" title={word.japanese}>{word.japanese}</p>
+          <p className="text-sm text-[var(--color-muted)] whitespace-nowrap" title={word.japanese}><span className="inline-block origin-left scale-[1.2]">{word.japanese}</span></p>
           {showProjectName && word.projectTitle && (
             <p className="text-xs text-[var(--color-primary)] mt-1 whitespace-nowrap">{word.projectTitle}</p>
           )}


### PR DESCRIPTION
前回のfont-size指定では枠の高さが変わってしまっていたため、
CSS transform: scale(1.2) を使うように変更。
レイアウトボックスは元のサイズのまま、見た目だけ1.2倍になる。

origin-left により左揃えを維持。

https://claude.ai/code/session_01FogwFVLfyzHpojtiDQMkLb