### PR TITLE
単語一覧の文字拡大: コンテナ高さを固定して枠膨張を防止

### DIFF
--- a/src/app/project/[id]/page.tsx
+++ b/src/app/project/[id]/page.tsx
@@ -1487,8 +1487,8 @@ export default function ProjectDetailPage() {
                           />
                         </td>
                         <td className="px-2 py-2.5 whitespace-nowrap">
-                          <span className="inline-flex items-center gap-1">
-                            <span className="text-base font-bold text-[var(--color-foreground)] inline-block origin-left scale-[1.2]">{word.english}</span>
+                          <span className="inline-flex items-center gap-1 h-6 overflow-visible align-middle">
+                            <span className="text-base font-bold text-[var(--color-foreground)] inline-block origin-left scale-[1.2] leading-none">{word.english}</span>
                             {word.isFavorite && (
                               <Icon
                                 name="flag"
@@ -1514,7 +1514,7 @@ export default function ProjectDetailPage() {
                           {posLabel(word.partOfSpeechTags) || '—'}
                         </td>
                         <td className="px-2 py-2.5 text-xs text-[var(--color-muted)] whitespace-nowrap" title={word.japanese}>
-                          <span className="inline-block origin-left scale-[1.2]">{word.japanese}</span>
+                          <span className="inline-block origin-left scale-[1.2] leading-none align-middle">{word.japanese}</span>
                         </td>
                         {(project?.customColumns ?? []).map((col) => {
                           const value = word.customSections?.find((s) => s.id === col.id)?.content ?? '';

--- a/src/components/home/WordList.tsx
+++ b/src/components/home/WordList.tsx
@@ -243,8 +243,8 @@ function WordItem({
         style={{ scrollbarWidth: 'thin' }}
       >
         <div className="w-max max-w-none">
-          <div className="flex items-center gap-1.5">
-            <span className="font-semibold text-[var(--color-foreground)] whitespace-nowrap inline-block origin-left scale-[1.2]">{word.english}</span>
+          <div className="flex items-center gap-1.5 h-6 overflow-visible">
+            <span className="font-semibold text-[var(--color-foreground)] whitespace-nowrap inline-block origin-left scale-[1.2] leading-none">{word.english}</span>
             {word.isFavorite && (
               <Icon
                 name="flag"
@@ -255,7 +255,7 @@ function WordItem({
               />
             )}
           </div>
-          <p className="text-sm text-[var(--color-muted)] whitespace-nowrap" title={word.japanese}><span className="inline-block origin-left scale-[1.2]">{word.japanese}</span></p>
+          <p className="text-sm text-[var(--color-muted)] whitespace-nowrap h-5 overflow-visible" title={word.japanese}><span className="inline-block origin-left scale-[1.2] leading-none">{word.japanese}</span></p>
           {showProjectName && word.projectTitle && (
             <p className="text-xs text-[var(--color-primary)] mt-1 whitespace-nowrap">{word.projectTitle}</p>
           )}


### PR DESCRIPTION
inline-block + scale だけでは親のline-heightが
変わってしまっていたため、テキスト行のコンテナに
明示的な固定高さ (h-6 / h-5) と leading-none を追加。
overflow-visible で拡大されたグリフは描画される。

- WordList: 英単語行 h-6, 訳行 h-5
- プロジェクト詳細テーブル: 英単語spanラッパー h-6, 訳と英単語の本体に leading-none + align-middle

これで枠（カード/行）の高さは元のサイズで完全に固定される。

https://claude.ai/code/session_01FogwFVLfyzHpojtiDQMkLb