### PR TITLE
Revert claude/enlarge-word-text-93lEL changes from main

### DIFF
--- a/src/app/project/[id]/page.tsx
+++ b/src/app/project/[id]/page.tsx
@@ -1514,8 +1514,8 @@ export default function ProjectDetailPage() {
                           />
                         </td>
                         <td className="px-2 py-2.5 whitespace-nowrap">
-                          <span className="inline-flex items-center gap-1 h-6 overflow-visible align-middle">
-                            <span className="text-base font-bold text-[var(--color-foreground)] inline-block origin-left scale-[1.2] leading-none">{word.english}</span>
+                          <span className="inline-flex items-center gap-1">
+                            <span className="text-base font-bold text-[var(--color-foreground)]">{word.english}</span>
                             {word.isFavorite && (
                               <Icon
                                 name="flag"
@@ -1541,7 +1541,7 @@ export default function ProjectDetailPage() {
                           {posLabel(word.partOfSpeechTags) || '—'}
                         </td>
                         <td className="px-2 py-2.5 text-xs text-[var(--color-muted)] whitespace-nowrap" title={word.japanese}>
-                          <span className="inline-block origin-left scale-[1.2] leading-none align-middle">{word.japanese}</span>
+                          {word.japanese}
                         </td>
                         {(project?.customColumns ?? []).map((col) => {
                           const rawValue = word.customSections?.find((s) => s.id === col.id)?.content ?? '';

--- a/src/components/home/WordList.tsx
+++ b/src/components/home/WordList.tsx
@@ -243,8 +243,8 @@ function WordItem({
         style={{ scrollbarWidth: 'thin' }}
       >
         <div className="w-max max-w-none">
-          <div className="flex items-center gap-1.5 h-6 overflow-visible">
-            <span className="font-semibold text-[var(--color-foreground)] whitespace-nowrap inline-block origin-left scale-[1.2] leading-none">{word.english}</span>
+          <div className="flex items-center gap-1.5">
+            <span className="font-semibold text-[var(--color-foreground)] whitespace-nowrap">{word.english}</span>
             {word.isFavorite && (
               <Icon
                 name="flag"
@@ -255,7 +255,7 @@ function WordItem({
               />
             )}
           </div>
-          <p className="text-sm text-[var(--color-muted)] whitespace-nowrap h-5 overflow-visible" title={word.japanese}><span className="inline-block origin-left scale-[1.2] leading-none">{word.japanese}</span></p>
+          <p className="text-sm text-[var(--color-muted)] whitespace-nowrap" title={word.japanese}>{word.japanese}</p>
           {showProjectName && word.projectTitle && (
             <p className="text-xs text-[var(--color-primary)] mt-1 whitespace-nowrap">{word.projectTitle}</p>
           )}


### PR DESCRIPTION
PR #65, #67, #68 でマージされた単語一覧の文字拡大変更を全て元に戻す:
- a9bd628: 英単語・訳の文字を1.2倍に拡大
- 1d5934a: scale変換で枠サイズを完全に維持
- dd66d8e: コンテナ高さを固定して枠膨張を防止

src/app/project/[id]/page.tsx と src/components/home/WordList.tsx を変更前の状態に戻した。

https://claude.ai/code/session_01L5vsYDCnaqLtr6B2qPxeZw