### PR TITLE
プロパティ名のフォントサイズを1.2倍に拡大

### DIFF
--- a/src/app/project/[id]/page.tsx
+++ b/src/app/project/[id]/page.tsx
@@ -1427,7 +1427,7 @@ export default function ProjectDetailPage() {
               >
                 <table className="border-collapse" style={{ width: 'max-content', minWidth: '100%' }}>
                   <thead>
-                    <tr className="border-b border-[var(--color-border)] text-[0.65rem] text-[var(--color-muted)]">
+                    <tr className="border-b border-[var(--color-border)] text-[0.78rem] text-[var(--color-muted)]">
                       {selectMode && (
                         <th className="w-8 py-2 text-center">
                           <button type="button" onClick={handleSelectAll} className="inline-flex items-center justify-center">


### PR DESCRIPTION
プロジェクト詳細テーブルのカラムヘッダ (単語/A/P/品詞/訳/カスタム列) を
text-[0.65rem] → text-[0.78rem] に変更。

https://claude.ai/code/session_01L5vsYDCnaqLtr6B2qPxeZw