### PR TITLE
FAB 押下時に名前/説明入力モーダルを挟むように

### DIFF
--- a/src/components/home/BlankProjectModal.tsx
+++ b/src/components/home/BlankProjectModal.tsx
@@ -1,0 +1,109 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import { Button } from '@/components/ui';
+
+interface BlankProjectModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onConfirm: (name: string, description?: string) => void | Promise<void>;
+  isSubmitting?: boolean;
+}
+
+/**
+ * Lightweight creation modal used by the bottom-nav FAB. Unlike the
+ * full ProjectNameModal (which also handles icon upload and is used in
+ * the scan flow), this one only collects a name and optional description
+ * so the user gets a quick "from-blank" creation experience.
+ */
+export function BlankProjectModal({
+  isOpen,
+  onClose,
+  onConfirm,
+  isSubmitting,
+}: BlankProjectModalProps) {
+  const [name, setName] = useState('');
+  const [description, setDescription] = useState('');
+  const nameInputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (isOpen) {
+      setName('');
+      setDescription('');
+      setTimeout(() => nameInputRef.current?.focus(), 80);
+    }
+  }, [isOpen]);
+
+  if (!isOpen) return null;
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    const trimmedName = name.trim();
+    if (!trimmedName) return;
+    const trimmedDescription = description.trim();
+    void onConfirm(trimmedName, trimmedDescription.length > 0 ? trimmedDescription : undefined);
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-[100] flex items-center justify-center bg-black/50 p-4"
+      onClick={onClose}
+    >
+      <div
+        className="relative w-full max-w-sm rounded-2xl bg-[var(--color-surface)] p-6 shadow-2xl animate-fade-in-up"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <h2 className="mb-4 text-center text-lg font-bold text-[var(--color-foreground)]">
+          新しい単語帳
+        </h2>
+        <form onSubmit={handleSubmit}>
+          <div className="mb-4">
+            <label className="mb-1.5 block text-sm font-medium text-[var(--color-muted)]">
+              名前
+            </label>
+            <input
+              ref={nameInputRef}
+              type="text"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="例: 英語テスト対策"
+              maxLength={50}
+              className="w-full rounded-[var(--radius-lg)] border border-[var(--color-border)] bg-[var(--color-surface)] px-4 py-3 text-base text-[var(--color-foreground)] transition-colors focus:border-[var(--color-primary)] focus:outline-none"
+            />
+          </div>
+          <div className="mb-5">
+            <label className="mb-1.5 block text-sm font-medium text-[var(--color-muted)]">
+              説明 <span className="text-xs text-[var(--color-muted)]">(任意)</span>
+            </label>
+            <textarea
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              placeholder="この単語帳の目的やメモ"
+              rows={3}
+              maxLength={300}
+              className="w-full resize-none rounded-[var(--radius-lg)] border border-[var(--color-border)] bg-[var(--color-surface)] px-4 py-3 text-sm text-[var(--color-foreground)] transition-colors focus:border-[var(--color-primary)] focus:outline-none"
+            />
+          </div>
+          <div className="flex gap-3">
+            <Button
+              type="button"
+              variant="secondary"
+              onClick={onClose}
+              disabled={isSubmitting}
+              className="flex-1"
+            >
+              キャンセル
+            </Button>
+            <Button
+              type="submit"
+              disabled={!name.trim() || isSubmitting}
+              className="flex-1"
+            >
+              {isSubmitting ? '作成中...' : '作成'}
+            </Button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/src/components/ui/bottom-nav.tsx
+++ b/src/components/ui/bottom-nav.tsx
@@ -8,6 +8,7 @@ import { cn, getGuestUserId } from '@/lib/utils';
 import { useAuth } from '@/hooks/use-auth';
 import { useToast } from '@/components/ui/toast';
 import { getRepository } from '@/lib/db';
+import { BlankProjectModal } from '@/components/home/BlankProjectModal';
 
 interface NavItem {
   href: string;
@@ -48,6 +49,7 @@ export function BottomNav() {
   const router = useRouter();
   const { user, subscription, wasPro } = useAuth();
   const { showToast } = useToast();
+  const [modalOpen, setModalOpen] = useState(false);
   const [creating, setCreating] = useState(false);
 
   const isActive = (item: NavItem) => {
@@ -59,7 +61,7 @@ export function BottomNav() {
     return pathname === item.href;
   };
 
-  const handleCreateBlankProject = async () => {
+  const handleConfirmCreate = async (name: string, description?: string) => {
     if (creating) return;
     setCreating(true);
     try {
@@ -68,13 +70,16 @@ export function BottomNav() {
       const userId = user?.id || getGuestUserId();
       const created = await repository.createProject({
         userId,
-        title: '無題の単語帳',
+        title: name,
+        description,
         sourceLabels: [],
       });
+      setModalOpen(false);
       router.push(`/project/${created.id}`);
     } catch (error) {
       console.error('Failed to create blank project:', error);
       showToast({ message: '単語帳の作成に失敗しました', type: 'error' });
+    } finally {
       setCreating(false);
     }
   };
@@ -107,16 +112,23 @@ export function BottomNav() {
           })}
         </div>
       </nav>
-      {/* FAB - creates a blank Notion-style flashcard instantly */}
+      {/* FAB — opens a name + description dialog before creating the project. */}
       <button
         type="button"
-        onClick={handleCreateBlankProject}
-        disabled={creating}
-        className="fab lg:hidden active:scale-95 transition-transform disabled:opacity-60"
+        onClick={() => setModalOpen(true)}
+        className="fab lg:hidden active:scale-95 transition-transform"
         aria-label="新規単語帳を作成"
       >
-        <Icon name={creating ? 'progress_activity' : 'add'} size={28} className={creating ? 'animate-spin' : ''} />
+        <Icon name="add" size={28} />
       </button>
+      <BlankProjectModal
+        isOpen={modalOpen}
+        onClose={() => {
+          if (!creating) setModalOpen(false);
+        }}
+        onConfirm={handleConfirmCreate}
+        isSubmitting={creating}
+      />
     </>
   );
 }


### PR DESCRIPTION
DB への空プロジェクト即時書き込みを防ぐため、BottomNav の FAB は
押下直後に BlankProjectModal を表示する方式に変更。

- BlankProjectModal: 名前 (必須) と説明 (任意) を入力する小型の フローティングダイアログ。キャンセル / 作成 の 2 ボタン
- bottom-nav: クリックで modalOpen = true、モーダルの onConfirm で初めて repository.createProject(...) を呼んで /project/:id へ遷移
- 作成中は disabled + 「作成中...」表示にして重複クリックを防止
- ProjectNameModal (スキャン側) は触らない

https://claude.ai/code/session_013Rq7jrttAxmnUBgbGhTg8w