### PR TITLE
PC版でヘッダが中央カラムに留まる問題を修正

### DIFF
--- a/src/app/project/[id]/page.tsx
+++ b/src/app/project/[id]/page.tsx
@@ -1263,7 +1263,7 @@ export default function ProjectDetailPage() {
     <>
       <div className="min-h-screen bg-[var(--color-background)] pb-28 lg:pb-[calc(20vh+5rem)]" style={contentVisible ? undefined : { visibility: 'hidden' }}>
         <div
-          className="project-detail-header-safe-top z-[50] sticky top-0"
+          className="project-detail-header-safe-top z-[50] sticky top-0 min-[1360px]:-mx-[200px] min-[1360px]:px-[200px] min-[1600px]:-mx-[208px] min-[1600px]:px-[208px]"
           style={{ background: headerBackground }}
         >
           <div

--- a/src/app/share/[shareId]/page.tsx
+++ b/src/app/share/[shareId]/page.tsx
@@ -322,7 +322,7 @@ export default function SharedProjectPage() {
       <div className="min-h-screen bg-[var(--color-background)] pb-28 lg:pb-8">
         {/* Dynamic color header */}
         <div
-          className="project-detail-header-safe-top z-[50] sticky top-0"
+          className="project-detail-header-safe-top z-[50] sticky top-0 min-[1360px]:-mx-[200px] min-[1360px]:px-[200px] min-[1600px]:-mx-[208px] min-[1600px]:px-[208px]"
           style={{ backgroundColor: headerFrom, background: `linear-gradient(135deg, ${headerFrom}, ${headerTo})` }}
         >
           <div className="max-w-lg lg:max-w-xl mx-auto px-5 pt-4 pb-5">


### PR DESCRIPTION
DesktopAdFrame が min-[1360px] 以降で 3カラムグリッド
(160px | 1fr | 160px) を組むため、stickyヘッダの背景色が
中央カラム幅で途切れていた。水平方向にネガティブマージン＋
対応するパディングを足し、メインエリア全幅まで背景を広げつつ
中身の位置は維持する。