### PR TITLE
fix(#86): 手動追加単語を開くと「単語が見つかりません」と表示される問題

### DIFF
--- a/src/app/project/[id]/page.tsx
+++ b/src/app/project/[id]/page.tsx
@@ -2048,6 +2048,13 @@ export default function ProjectDetailPage() {
           <WordDetailView
             key={openWordId}
             wordId={openWordId}
+            // Pass the already-loaded row from the parent list state so the
+            // modal can render instantly AND survive repository-backend
+            // mismatches (e.g. manually added words written via one repo but
+            // read by another). Without this, the async getWord in the modal
+            // could return undefined for a word that actually exists, causing
+            // "単語が見つかりません" to flash.
+            initialWord={words.find((w) => w.id === openWordId) ?? null}
             onClose={handleCloseWordModal}
             variant="modal"
             onWordUpdated={handleWordUpdatedFromModal}

--- a/src/components/word/WordDetailView.tsx
+++ b/src/components/word/WordDetailView.tsx
@@ -60,6 +60,16 @@ export interface WordDetailViewProps {
   variant?: 'page' | 'modal';
   /** Called after any successful write (favorite toggle, vocab type cycle, save edit). */
   onWordUpdated?: (word: Word) => void;
+  /**
+   * Optional pre-known word object. When opened from the project list we already
+   * have the full word in the parent's state (including freshly manually added
+   * words that are not yet reflected in the home-cache snapshot and may not
+   * live in the same repository backend the modal reads from). Passing it here
+   * lets the modal render instantly with the correct data AND prevents the
+   * async repository reload from clobbering the UI with a "word not found"
+   * state when the repositories disagree about where the word is stored.
+   */
+  initialWord?: Word | null;
 }
 
 export function WordDetailView({
@@ -67,6 +77,7 @@ export function WordDetailView({
   onClose,
   variant = 'page',
   onWordUpdated,
+  initialWord: initialWordFromProps,
 }: WordDetailViewProps) {
   const isModal = variant === 'modal';
 
@@ -75,10 +86,23 @@ export function WordDetailView({
   const wasPro = subscription?.plan === 'pro' && subscriptionStatus !== 'active';
   const repository = useMemo(() => getRepository(subscriptionStatus, wasPro), [subscriptionStatus, wasPro]);
 
-  // Seed initial word from the in-memory list cache (when opened from project page)
-  // so the modal renders immediately without a spinner flash.
-  const initialWord = useMemo(() => findCachedWord(wordId), [wordId]);
+  // Seed initial word from the explicit prop first (passed by the project
+  // page with the word already in its state), then fall back to the global
+  // in-memory list cache so direct-link opens from /word/[id] still get an
+  // instant render when possible.
+  const initialWord = useMemo(
+    () => initialWordFromProps ?? findCachedWord(wordId),
+    [wordId, initialWordFromProps],
+  );
   const [word, setWord] = useState<Word | null>(initialWord);
+  // Keep the latest known word accessible to async effects without having
+  // to depend on the `word` state (which would retrigger the load effect on
+  // every update). This lets the repository-reload effect fall back to the
+  // most recent word we actually showed when the lookup misses.
+  const latestWordRef = useRef<Word | null>(initialWord);
+  useEffect(() => {
+    latestWordRef.current = word;
+  }, [word]);
   const [projectCustomColumns, setProjectCustomColumns] = useState<CustomColumn[]>([]);
   const [loading, setLoading] = useState(initialWord === null);
 
@@ -122,9 +146,18 @@ export function WordDetailView({
     let cancelled = false;
     (async () => {
       try {
-        const w = await repository.getWord(wordId);
+        const fetched = await repository.getWord(wordId);
         if (cancelled) return;
-        setWord(w ?? null);
+
+        // If the repository lookup misses but we already have a word we
+        // previously showed (from the initialWord prop or an earlier
+        // successful load), keep showing it. Overwriting with null here
+        // is what triggered "単語が見つかりません" for manually added
+        // words when the parent wrote through a different repository
+        // backend than the modal reads from (e.g. remote-only vs. local
+        // IndexedDB).
+        const w: Word | null = fetched ?? latestWordRef.current ?? null;
+        setWord(w);
 
         // Load project-level custom columns. The word's own customSections hold
         // the per-word values; we synthesize placeholder sections for any


### PR DESCRIPTION
WordDetailView は開くたびに getRepository(subscriptionStatus, wasPro) から独立してリポジトリを解決し、getWord が undefined を返すと即座に
word state を null に上書きしていた。一方、project/[id]/page.tsx の handleSaveManualWord は mutationRepository (Pro なら hybrid、 そうでなければ Phase 2 の activeRepository) を経由して書き込む。
両者の backing store が食い違うケース (例: wasPro → free 降格後に
remote にしか単語が無い、あるいは旧 Pro データがリモートに残っている
free ユーザー) では、モーダル側の localRepository.getWord が undefined を返し、直前に追加したはずの単語が「単語が見つかりません」と表示されて
しまっていた。

修正:
- WordDetailView に initialWord プロップを追加し、親の words state に 既に存在する行をそのまま渡せるようにする
- リポジトリ reload で fetched が undefined だった場合は latestWordRef 経由で直前に表示していた word を保持し、null への上書きを抑止
- project/[id]/page.tsx のモーダルマウント部で words.find() の結果を initialWord として渡し、手動追加直後のクリックでも確実に単語が 表示されるようにする

これにより、ユーザーは手動追加した単語を一覧からタップした際に、
例文・例文訳の追加などの編集フローへ問題なく進めるようになる。

Closes #86

https://claude.ai/code/session_01XFZ1W1NQRbo2uBtKT3Y1Lm