### PR TITLE
Fix iOS overscroll: prevent background color bleed and header disappe…

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -105,11 +105,17 @@
   -webkit-tap-highlight-color: transparent;
 }
 
+html {
+  background-color: var(--color-background);
+  overscroll-behavior-y: none;
+}
+
 body {
   background-color: var(--color-background);
   color: var(--color-foreground);
   font-family: var(--font-body);
   min-height: 100dvh;
+  overscroll-behavior-y: none;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   padding-top: constant(safe-area-inset-top);


### PR DESCRIPTION
…aring

Add background-color and overscroll-behavior-y: none to html element, and overscroll-behavior-y: none to body. This prevents the iOS rubber-band bounce effect that was causing the bottom nav to disappear and exposing non-white background when scrolling past page boundaries.

Fixes #97

https://claude.ai/code/session_01RPzcJZB7BPqtv9nQk5CyjT