### PR TITLE
feat: 文章ブロックの枠囲み化と編集ボタン経由の編集

### DIFF
--- a/src/components/project/RichTextBlock.tsx
+++ b/src/components/project/RichTextBlock.tsx
@@ -221,31 +221,52 @@ export function RichTextBlock({
   }, [html, wordHighlightMap, aiMatches]);
 
   return (
-    <div className="group relative lg:pl-7">
+    <div className="group relative">
       {/* Rounded frame container */}
-      <div className="rounded-2xl border border-[var(--color-border)] bg-[var(--color-surface)] p-4">
-        {/* Toolbar row: formatting tools (edit mode) or edit button (view mode) */}
-        <div className="mb-3 flex items-center justify-between">
-          {mode === 'edit' ? (
-            <div className="flex gap-1 rounded-lg border border-[var(--color-border)] bg-[var(--color-surface-secondary)] p-1">
-              <ToolbarButton label="見出し" onClick={() => exec('formatBlock', '<h2>')}>
-                <Icon name="title" size={16} />
-              </ToolbarButton>
-              <ToolbarButton label="本文" onClick={() => exec('formatBlock', '<p>')}>
-                <Icon name="notes" size={16} />
-              </ToolbarButton>
-              <ToolbarButton label="リスト" onClick={() => exec('insertUnorderedList')}>
-                <Icon name="format_list_bulleted" size={16} />
-              </ToolbarButton>
-              <ToolbarButton label="太字" onClick={() => exec('bold')}>
-                <Icon name="format_bold" size={16} />
-              </ToolbarButton>
+      <div className="relative rounded-2xl border border-[var(--color-border)] bg-[var(--color-surface)] p-4">
+        {mode === 'edit' ? (
+          <>
+            {/* Inline toolbar in edit mode */}
+            <div className="mb-3 flex items-center justify-between">
+              <div className="flex gap-1 rounded-lg border border-[var(--color-border)] bg-[var(--color-surface-secondary)] p-1">
+                <ToolbarButton label="見出し" onClick={() => exec('formatBlock', '<h2>')}>
+                  <Icon name="title" size={16} />
+                </ToolbarButton>
+                <ToolbarButton label="本文" onClick={() => exec('formatBlock', '<p>')}>
+                  <Icon name="notes" size={16} />
+                </ToolbarButton>
+                <ToolbarButton label="リスト" onClick={() => exec('insertUnorderedList')}>
+                  <Icon name="format_list_bulleted" size={16} />
+                </ToolbarButton>
+                <ToolbarButton label="太字" onClick={() => exec('bold')}>
+                  <Icon name="format_bold" size={16} />
+                </ToolbarButton>
+              </div>
+              <button
+                type="button"
+                onMouseDown={(e) => {
+                  e.preventDefault();
+                  onDelete();
+                }}
+                aria-label="ブロックを削除"
+                className="flex h-7 w-7 items-center justify-center rounded-full text-[var(--color-muted)] transition-colors hover:bg-[var(--color-surface-secondary)] hover:text-[var(--color-foreground)]"
+              >
+                <Icon name="close" size={16} />
+              </button>
             </div>
-          ) : (
-            <div /> /* spacer */
-          )}
-          <div className="flex items-center gap-1">
-            {mode === 'view' && (
+            <div
+              ref={editorRef}
+              contentEditable
+              suppressContentEditableWarning
+              data-placeholder="本文を入力..."
+              className="rich-text-block text-[var(--color-foreground)] outline-none"
+              onBlur={handleBlur}
+            />
+          </>
+        ) : (
+          <>
+            {/* Floating action buttons in view mode — no vertical space consumed */}
+            <div className="absolute top-3 right-3 flex items-center gap-1">
               <button
                 type="button"
                 onClick={() => setMode('edit')}
@@ -254,46 +275,34 @@ export function RichTextBlock({
               >
                 <Icon name="edit" size={16} />
               </button>
-            )}
-            <button
-              type="button"
-              onMouseDown={(e) => {
-                e.preventDefault();
-                onDelete();
-              }}
-              aria-label="ブロックを削除"
-              className="flex h-7 w-7 items-center justify-center rounded-full text-[var(--color-muted)] transition-colors hover:bg-[var(--color-surface-secondary)] hover:text-[var(--color-foreground)]"
-            >
-              <Icon name="close" size={16} />
-            </button>
-          </div>
-        </div>
-
-        {mode === 'edit' ? (
-          <div
-            ref={editorRef}
-            contentEditable
-            suppressContentEditableWarning
-            data-placeholder="本文を入力..."
-            className="rich-text-block text-[var(--color-foreground)] outline-none"
-            onBlur={handleBlur}
-          />
-        ) : (
-          <div
-            data-placeholder="本文を入力..."
-            className="rich-text-block text-[var(--color-foreground)]"
-            onClick={(e) => {
-              const target = e.target as HTMLElement | null;
-              if (target) {
-                const span = target.closest('[data-merken-word-id]');
-                if (span) {
-                  const wid = span.getAttribute('data-merken-word-id');
-                  if (wid && onOpenWord) onOpenWord(wid);
+              <button
+                type="button"
+                onMouseDown={(e) => {
+                  e.preventDefault();
+                  onDelete();
+                }}
+                aria-label="ブロックを削除"
+                className="flex h-7 w-7 items-center justify-center rounded-full text-[var(--color-muted)] transition-colors hover:bg-[var(--color-surface-secondary)] hover:text-[var(--color-foreground)]"
+              >
+                <Icon name="close" size={16} />
+              </button>
+            </div>
+            <div
+              data-placeholder="本文を入力..."
+              className="rich-text-block text-[var(--color-foreground)]"
+              onClick={(e) => {
+                const target = e.target as HTMLElement | null;
+                if (target) {
+                  const span = target.closest('[data-merken-word-id]');
+                  if (span) {
+                    const wid = span.getAttribute('data-merken-word-id');
+                    if (wid && onOpenWord) onOpenWord(wid);
+                  }
                 }
-              }
-            }}
-            dangerouslySetInnerHTML={{ __html: highlightedHtml }}
-          />
+              }}
+              dangerouslySetInnerHTML={{ __html: highlightedHtml }}
+            />
+          </>
         )}
       </div>
     </div>

--- a/src/components/project/RichTextBlock.tsx
+++ b/src/components/project/RichTextBlock.tsx
@@ -220,87 +220,82 @@ export function RichTextBlock({
     return highlightWordsInHtml(html, wordHighlightMap ?? new Map(), aiMatches);
   }, [html, wordHighlightMap, aiMatches]);
 
-  const handleViewMouseDown = (e: React.MouseEvent<HTMLDivElement>) => {
-    const target = e.target as HTMLElement | null;
-    if (target) {
-      const span = target.closest('[data-merken-word-id]');
-      if (span) {
-        // Clicked a highlighted word → open the word modal, do NOT enter edit mode.
-        e.preventDefault();
-        e.stopPropagation();
-        const wid = span.getAttribute('data-merken-word-id');
-        if (wid && onOpenWord) onOpenWord(wid);
-        return;
-      }
-    }
-    // Otherwise, switch to edit mode. Prevent the default mousedown so
-    // the incoming click doesn't steal the caret placement; the effect
-    // that runs after mode change will focus the editor and place the
-    // caret at the end.
-    e.preventDefault();
-    setMode('edit');
-  };
-
   return (
     <div className="group relative lg:pl-7">
-      {/* Floating toolbar shown while the editor has focus. */}
-      {mode === 'edit' && (
-        <div className="absolute -top-9 left-0 z-10 flex gap-1 rounded-lg border border-[var(--color-border)] bg-[var(--color-surface)] p-1 shadow-sm lg:left-7">
-          <ToolbarButton label="見出し" onClick={() => exec('formatBlock', '<h2>')}>
-            <Icon name="title" size={16} />
-          </ToolbarButton>
-          <ToolbarButton label="本文" onClick={() => exec('formatBlock', '<p>')}>
-            <Icon name="notes" size={16} />
-          </ToolbarButton>
-          <ToolbarButton label="リスト" onClick={() => exec('insertUnorderedList')}>
-            <Icon name="format_list_bulleted" size={16} />
-          </ToolbarButton>
-          <ToolbarButton label="太字" onClick={() => exec('bold')}>
-            <Icon name="format_bold" size={16} />
-          </ToolbarButton>
+      {/* Rounded frame container */}
+      <div className="rounded-2xl border border-[var(--color-border)] bg-[var(--color-surface)] p-4">
+        {/* Toolbar row: formatting tools (edit mode) or edit button (view mode) */}
+        <div className="mb-3 flex items-center justify-between">
+          {mode === 'edit' ? (
+            <div className="flex gap-1 rounded-lg border border-[var(--color-border)] bg-[var(--color-surface-secondary)] p-1">
+              <ToolbarButton label="見出し" onClick={() => exec('formatBlock', '<h2>')}>
+                <Icon name="title" size={16} />
+              </ToolbarButton>
+              <ToolbarButton label="本文" onClick={() => exec('formatBlock', '<p>')}>
+                <Icon name="notes" size={16} />
+              </ToolbarButton>
+              <ToolbarButton label="リスト" onClick={() => exec('insertUnorderedList')}>
+                <Icon name="format_list_bulleted" size={16} />
+              </ToolbarButton>
+              <ToolbarButton label="太字" onClick={() => exec('bold')}>
+                <Icon name="format_bold" size={16} />
+              </ToolbarButton>
+            </div>
+          ) : (
+            <div /> /* spacer */
+          )}
+          <div className="flex items-center gap-1">
+            {mode === 'view' && (
+              <button
+                type="button"
+                onClick={() => setMode('edit')}
+                aria-label="編集"
+                className="flex h-7 w-7 items-center justify-center rounded-full text-[var(--color-muted)] transition-colors hover:bg-[var(--color-surface-secondary)] hover:text-[var(--color-foreground)]"
+              >
+                <Icon name="edit" size={16} />
+              </button>
+            )}
+            <button
+              type="button"
+              onMouseDown={(e) => {
+                e.preventDefault();
+                onDelete();
+              }}
+              aria-label="ブロックを削除"
+              className="flex h-7 w-7 items-center justify-center rounded-full text-[var(--color-muted)] transition-colors hover:bg-[var(--color-surface-secondary)] hover:text-[var(--color-foreground)]"
+            >
+              <Icon name="close" size={16} />
+            </button>
+          </div>
         </div>
-      )}
 
-      {mode === 'edit' ? (
-        <div
-          ref={editorRef}
-          contentEditable
-          suppressContentEditableWarning
-          data-placeholder="本文を入力..."
-          className="rich-text-block text-[var(--color-foreground)] outline-none"
-          onBlur={handleBlur}
-        />
-      ) : (
-        <div
-          role="textbox"
-          aria-label="リッチテキストブロック"
-          tabIndex={0}
-          data-placeholder="本文を入力..."
-          className="rich-text-block cursor-text text-[var(--color-foreground)] outline-none"
-          onMouseDown={handleViewMouseDown}
-          onKeyDown={(e) => {
-            if (e.key === 'Enter' || e.key === ' ') {
-              e.preventDefault();
-              setMode('edit');
-            }
-          }}
-          dangerouslySetInnerHTML={{ __html: highlightedHtml }}
-        />
-      )}
-
-      {/* Delete handle — always mounted inside the group, toggled via CSS so
-          moving the pointer onto it doesn't exit the hover area. */}
-      <button
-        type="button"
-        onMouseDown={(e) => {
-          e.preventDefault();
-          onDelete();
-        }}
-        aria-label="ブロックを削除"
-        className="absolute left-0 top-0 hidden h-6 w-6 items-center justify-center rounded text-[var(--color-muted)] opacity-0 transition-opacity hover:bg-[var(--color-surface-secondary)] hover:text-[var(--color-foreground)] group-hover:opacity-100 lg:flex"
-      >
-        <Icon name="close" size={14} />
-      </button>
+        {mode === 'edit' ? (
+          <div
+            ref={editorRef}
+            contentEditable
+            suppressContentEditableWarning
+            data-placeholder="本文を入力..."
+            className="rich-text-block text-[var(--color-foreground)] outline-none"
+            onBlur={handleBlur}
+          />
+        ) : (
+          <div
+            data-placeholder="本文を入力..."
+            className="rich-text-block text-[var(--color-foreground)]"
+            onClick={(e) => {
+              const target = e.target as HTMLElement | null;
+              if (target) {
+                const span = target.closest('[data-merken-word-id]');
+                if (span) {
+                  const wid = span.getAttribute('data-merken-word-id');
+                  if (wid && onOpenWord) onOpenWord(wid);
+                }
+              }
+            }}
+            dangerouslySetInnerHTML={{ __html: highlightedHtml }}
+          />
+        )}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- 文章（RichTextBlock）コンポーネントのコンテンツを丸みのある枠線（`rounded-2xl border`）で囲むように変更
- テキストをタップして直接編集モードに入る動作を廃止し、編集ボタン（鉛筆アイコン）経由でのみ編集できるように改良
- 削除ボタンとフォーマットツールバーを枠内に統合し、UIを整理

## Test plan
- [ ] プロジェクトページで文章ブロックが丸みのある枠で表示されることを確認
- [ ] 文章テキストをタップしても編集モードに入らないことを確認
- [ ] 編集ボタン（鉛筆アイコン）をタップすると編集モードに入ることを確認
- [ ] 編集モードでフォーマットツールバー（見出し・本文・リスト・太字）が正常に動作することを確認
- [ ] ハイライトされた単語をタップすると単語詳細が開くことを確認
- [ ] 削除ボタンでブロックが削除できることを確認

Closes #102

https://claude.ai/code/session_01FhJDQwyzzoBCEewJbSjEfQ