### PR TITLE
fix: 共有単語帳で長い英単語がA/Pバッジに重ならないよう省略表示を修正

### DIFF
--- a/src/app/share/[shareId]/page.tsx
+++ b/src/app/share/[shareId]/page.tsx
@@ -522,8 +522,8 @@ export default function SharedProjectPage() {
                             </span>
                           </td>
                         )}
-                        <td className="px-2 py-2.5 max-w-0">
-                          <span className="inline-flex items-center gap-1 min-w-0">
+                        <td className="px-2 py-2.5 max-w-0 overflow-hidden">
+                          <span className="flex items-center gap-1 min-w-0">
                             <span className="text-sm font-medium text-[var(--color-foreground)] truncate">{word.english}</span>
                           </span>
                         </td>


### PR DESCRIPTION
単語セルにoverflow-hiddenを追加し、inline-flexをflexに変更することで
truncateクラスが正しく機能し、長い単語が「...」で省略されるようにした

Fixes #104

https://claude.ai/code/session_01HnrEywiAy9mgjgyysLWirj