### PR TITLE
fix: クイズ画面で次へボタンを例文の直下に配置（隙間・スクロール問題を解消）

### DIFF
--- a/src/app/quiz/[projectId]/page.tsx
+++ b/src/app/quiz/[projectId]/page.tsx
@@ -1121,7 +1121,7 @@ export default function QuizPage() {
         </header>
 
         <main className="flex-1 flex flex-col min-h-0 w-full overflow-y-auto">
-          <div className="mx-auto w-full max-w-lg px-6 flex flex-col flex-1 min-h-0">
+          <div className="mx-auto w-full max-w-lg px-6 flex flex-col">
           {/* Mode badges - iOS style */}
           <div className="flex items-center justify-center gap-2 mb-2 flex-shrink-0">
             <span
@@ -1214,41 +1214,37 @@ export default function QuizPage() {
             </div>
           )}
 
-          {/* Example sentence after answering */}
+          {/* Example sentence + next button after answering */}
           {isRevealed && currentQuestion && (
-            <div className="w-full mt-4 flex-shrink-0">
-              {currentQuestion.word.exampleSentence && (
-                <div className="card p-4 space-y-2">
-                  <div className="flex items-center gap-1.5 text-xs text-[var(--color-muted)] font-semibold">
-                    <Icon name="format_quote" size={14} />
-                    例文
+            <>
+              <div className="w-full mt-4">
+                {currentQuestion.word.exampleSentence && (
+                  <div className="card p-4 space-y-2">
+                    <div className="flex items-center gap-1.5 text-xs text-[var(--color-muted)] font-semibold">
+                      <Icon name="format_quote" size={14} />
+                      例文
+                    </div>
+                    <p className="text-sm text-[var(--color-foreground)] leading-relaxed">{currentQuestion.word.exampleSentence}</p>
+                    {currentQuestion.word.exampleSentenceJa && (
+                      <p className="text-xs text-[var(--color-muted)] leading-relaxed">{currentQuestion.word.exampleSentenceJa}</p>
+                    )}
                   </div>
-                  <p className="text-sm text-[var(--color-foreground)] leading-relaxed">{currentQuestion.word.exampleSentence}</p>
-                  {currentQuestion.word.exampleSentenceJa && (
-                    <p className="text-xs text-[var(--color-muted)] leading-relaxed">{currentQuestion.word.exampleSentenceJa}</p>
-                  )}
-                </div>
-              )}
-            </div>
+                )}
+              </div>
+              <div className="w-full mt-4 safe-area-bottom">
+                <button
+                  onClick={moveToNext}
+                  disabled={isTransitioning}
+                  className="w-full flex items-center justify-center gap-2 py-4 rounded-xl bg-[var(--color-foreground)] text-white font-bold text-base disabled:opacity-50"
+                >
+                  次へ
+                  <Icon name="chevron_right" size={20} />
+                </button>
+              </div>
+            </>
           )}
           </div>
         </main>
-
-        {/* Bottom next button */}
-        {isRevealed && (
-          <div className="flex-shrink-0 bg-[var(--color-background)] pt-3 pb-6 safe-area-bottom w-full">
-            <div className="mx-auto w-full max-w-lg px-6">
-              <button
-                onClick={moveToNext}
-                disabled={isTransitioning}
-                className="w-full flex items-center justify-center gap-2 py-4 rounded-xl bg-[var(--color-foreground)] text-white font-bold text-base disabled:opacity-50"
-              >
-                次へ
-                <Icon name="chevron_right" size={20} />
-              </button>
-            </div>
-          </div>
-        )}
       </div>
     </QuizDesktopViewport>
   );


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- 例文と次へボタンの間に生じる大きな隙間を解消
- 次へボタンをスクロール領域の**外**（画面最下部固定）から、スクロール領域**内**のコンテンツフローへ移動
- 例文の直下に次へボタンが表示されるため、スクロールせずにタップできる

## 原因

以前のレイアウト：
```
<main overflow-y-auto flex-1>         ← スクロール領域
  <div flex-1 min-h-0>               ← viewport を埋め尽くす
    選択肢 + 例文                     ← 上部に表示
  </div>
</main>
[次へボタン] ← main の外、画面最下部固定  ← 大きな隙間が発生
```

例文が viewport の中央付近に表示されると、次へボタンとの間に画面の残り空間が全て隙間として現れていた。

## 変更後

```
<main overflow-y-auto>               ← スクロール領域
  <div>                              ← コンテンツサイズに合わせる（flex-1 除去）
    選択肢
    例文
    [次へボタン]                      ← 例文の直下に配置
  </div>
</main>
```

## Test plan

- [ ] 回答後、例文の直下に次へボタンが表示されること
- [ ] スクロール不要で次へボタンをタップできること
- [ ] 例文がない場合、選択肢の直下に次へボタンが表示されること
- [ ] コンテンツが長い場合でも、スクロールすれば例文と次へボタンが確認できること
- [ ] Active vocab（タイプ入力）モードでも同様に動作すること

https://claude.ai/code/session_01385iWRkuUC18Fr36jsfTw1
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01385iWRkuUC18Fr36jsfTw1)_