### PR TITLE
feat(home): replace correction empty state with SolidEmpty + scan button

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import Link from 'next/link';
 import { Icon } from '@/components/ui/Icon';
 import { SolidEmpty, SolidPanel } from '@/components/redesign/SolidPage';
+import { ScanCaptureModal } from '@/components/home/ScanCaptureModal';
 import { useAuth } from '@/hooks/use-auth';
 import { getDb, getRepository } from '@/lib/db';
 import { localRepository } from '@/lib/db/local-repository';
@@ -123,6 +124,7 @@ export default function HomePage() {
   const [error, setError] = useState<string | null>(null);
   const [correctionItems, setCorrectionItems] = useState<HistoryItem[]>([]);
   const [correctionLoading, setCorrectionLoading] = useState(false);
+  const [correctionScanOpen, setCorrectionScanOpen] = useState(false);
   const [pendingScans, setPendingScans] = useState<{ id: string; project_title: string }[]>([]);
   const loadHomeRef = useRef<() => Promise<void>>(() => Promise.resolve());
 
@@ -374,16 +376,21 @@ export default function HomePage() {
             <Icon name="progress_activity" size={18} className="animate-spin" />
           </div>
         ) : correctionItems.length === 0 ? (
-          <Link href="/correction" className="block">
-            <SolidPanel className="!rounded-[14px] !shadow-[3px_4px_0_var(--color-accent)]" faceClassName="!p-3 min-h-[88px]">
-              <div className="flex items-center gap-1.5 text-[var(--color-accent)]">
-                <Icon name="edit_note" size={16} />
-                <span className="font-mono text-[11px] font-bold tracking-[0.04em]">CORRECTION</span>
-              </div>
-              <div className="mt-1.5 text-[15px] font-bold leading-[1.35] text-[var(--solid-ink)]">英作文の添削</div>
-              <div className="mt-[3px] text-[11px] leading-[1.45] text-[var(--color-muted)]">Pro向けAI添削に接続済み</div>
-            </SolidPanel>
-          </Link>
+          <SolidEmpty
+            icon="edit_note"
+            title="添削はまだありません"
+            description="スキャンで最初の添削を作成しましょう。"
+            action={
+              <button
+                type="button"
+                onClick={() => setCorrectionScanOpen(true)}
+                className="solid-link-primary"
+              >
+                <Icon name="add_a_photo" size={16} />
+                新規スキャン
+              </button>
+            }
+          />
         ) : (
           <div className="flex flex-col gap-2.5">
             {correctionItems.slice(0, 3).map((item) => (
@@ -417,6 +424,12 @@ export default function HomePage() {
           </div>
         )}
       </div>
+
+      <ScanCaptureModal
+        isOpen={correctionScanOpen}
+        onClose={() => setCorrectionScanOpen(false)}
+        defaultMode="correction"
+      />
     </div>
   );
 }

--- a/src/components/home/ScanCaptureModal.tsx
+++ b/src/components/home/ScanCaptureModal.tsx
@@ -11,6 +11,7 @@ import type { ExtractMode } from '@/app/api/extract/route';
 interface ScanCaptureModalProps {
   isOpen: boolean;
   onClose: () => void;
+  defaultMode?: TopMode;
 }
 
 type TopMode = 'vocab' | 'correction' | 'parser';
@@ -59,10 +60,10 @@ function subToExtractMode(sub: SubOption): ExtractMode {
   return 'all';
 }
 
-export function ScanCaptureModal({ isOpen, onClose }: ScanCaptureModalProps) {
+export function ScanCaptureModal({ isOpen, onClose, defaultMode }: ScanCaptureModalProps) {
   const router = useRouter();
   const { isPro } = useAuth();
-  const [activeMode, setActiveMode] = useState<TopMode>('vocab');
+  const [activeMode, setActiveMode] = useState<TopMode>(defaultMode ?? 'vocab');
   const [activeSub, setActiveSub] = useState<SubOption>('all');
   const [processing, setProcessing] = useState(false);
   const [errorMsg, setErrorMsg] = useState<string | null>(null);

--- a/src/lib/ai/correction-parser.ts
+++ b/src/lib/ai/correction-parser.ts
@@ -10,15 +10,15 @@ export const correctionIssueSchema = z.object({
   to: z.string().trim().min(1).max(160),
   why: z.string().trim().min(1).max(300),
   severity: z.enum(['low', 'medium', 'high']).default('medium'),
-  vocabularyCandidateId: z.string().trim().max(80).optional(),
+  vocabularyCandidateId: z.string().trim().max(80).nullish().transform(v => v ?? undefined),
 }).strict();
 
 export const correctionWordCandidateSchema = z.object({
   id: z.string().trim().min(1).max(80),
   english: z.string().trim().min(1).max(120),
   japanese: z.string().trim().min(1).max(200),
-  sourceIssueId: z.string().trim().max(80).optional(),
-  exampleSentence: z.string().trim().max(300).optional(),
+  sourceIssueId: z.string().trim().max(80).nullish().transform(v => v ?? undefined),
+  exampleSentence: z.string().trim().max(300).nullish().transform(v => v ?? undefined),
 }).strict();
 
 export const correctionResultSchema = z.object({


### PR DESCRIPTION
## Summary

- 添削セクションに添削履歴がない場合、既存のプロモカードの代わりに `SolidEmpty` コンポーネントで空状態を表示
- 「添削はまだありません」（太字タイトル）＋「スキャンで最初の添削を作成しましょう。」の説明文
- 「新規スキャン」ボタンを配置 — タップすると `ScanCaptureModal` が添削モードで開く
- `ScanCaptureModal` に `defaultMode` prop を追加（`'vocab' | 'correction' | 'parser'`）

## Test Plan

- [ ] 添削履歴がない状態でホームを開き、「添削はまだありません」の空状態が表示される
- [ ] 「新規スキャン」ボタンをタップすると、添削モードが選択済みの状態でスキャンモーダルが開く
- [ ] 添削履歴がある場合は従来通り履歴カードが表示される

https://claude.ai/code/session_01WLHxn9u3EAsPnEaFu2o7yY

---
_Generated by [Claude Code](https://claude.ai/code/session_01WLHxn9u3EAsPnEaFu2o7yY)_