### PR TITLE
Align project search/filter row with neo-brutalist UI style

### DIFF
--- a/src/app/project/[id]/page.tsx
+++ b/src/app/project/[id]/page.tsx
@@ -492,60 +492,63 @@ export default function ProjectPage() {
         </div>
       </div>
 
-      <div className="flex items-center justify-between px-5 pb-2">
-        <div className="flex gap-1.5">
-          <label className="sr-only" htmlFor="project-word-search">単語を検索</label>
+      <div className="flex items-center gap-2 px-5 pb-2">
+        <label
+          htmlFor="project-word-search"
+          className="flex min-w-0 flex-1 items-center gap-1.5 rounded-full border-[1.25px] border-[var(--solid-ink)] bg-white px-3 py-[7px] text-[var(--color-muted)] shadow-[2px_2px_0_var(--solid-ink)]"
+        >
+          <Icon name="search" size={14} />
+          <span className="sr-only">単語を検索</span>
           <input
             id="project-word-search"
+            type="search"
             value={query}
             onChange={(event) => setQuery(event.target.value)}
             placeholder="単語を検索"
-            className="w-[130px] rounded-full border-[1.25px] border-[var(--color-border)] bg-white px-3 py-1.5 text-[12px] text-[var(--solid-ink)] outline-none placeholder:text-[var(--color-muted)]"
+            className="min-w-0 flex-1 bg-transparent text-[12px] text-[var(--solid-ink)] outline-none placeholder:text-[var(--color-muted)]"
           />
-        </div>
-        <div className="flex items-center gap-1.5">
-          {(wordFilterActive || query) && (
-            <span className="font-mono text-[11px] tabular-nums text-[var(--color-muted)]">
-              {filteredWords.length}/{counts.total}
-            </span>
-          )}
-          <button
-            type="button"
-            onClick={() => setWordShowFilterSheet(true)}
-            aria-label="フィルタ"
-            className={`inline-flex h-[30px] w-[30px] items-center justify-center rounded-full border-[1.25px] transition-colors ${
-              wordFilterActive
-                ? 'border-[var(--solid-ink)] bg-[var(--solid-ink)] text-white'
-                : 'border-[var(--color-border)] bg-white text-[var(--color-muted)]'
-            }`}
-          >
-            <Icon name="filter_list" size={15} />
-          </button>
-          <button
-            type="button"
-            onClick={() => setWordShowSortSheet(true)}
-            aria-label="並べ替え"
-            className={`inline-flex h-[30px] w-[30px] items-center justify-center rounded-full border-[1.25px] transition-colors ${
-              wordSortOrder !== 'createdAsc'
-                ? 'border-[var(--solid-ink)] bg-[var(--solid-ink)] text-white'
-                : 'border-[var(--color-border)] bg-white text-[var(--color-muted)]'
-            }`}
-          >
-            <Icon name="swap_vert" size={15} />
-          </button>
-          <button
-            type="button"
-            onClick={() => { setSelectMode((v) => !v); setSelectedWordIds(new Set()); }}
-            aria-label="選択"
-            className={`inline-flex h-[30px] w-[30px] items-center justify-center rounded-full border-[1.25px] transition-colors ${
-              selectMode
-                ? 'border-[var(--solid-ink)] bg-[var(--solid-ink)] text-white'
-                : 'border-[var(--color-border)] bg-white text-[var(--color-muted)]'
-            }`}
-          >
-            <Icon name="check_box" size={15} />
-          </button>
-        </div>
+        </label>
+        {(wordFilterActive || query) && (
+          <span className="shrink-0 font-mono text-[11px] tabular-nums text-[var(--color-muted)]">
+            {filteredWords.length}/{counts.total}
+          </span>
+        )}
+        <button
+          type="button"
+          onClick={() => setWordShowFilterSheet(true)}
+          aria-label="フィルタ"
+          className={`inline-flex h-[32px] w-[32px] shrink-0 items-center justify-center rounded-full border-[1.25px] border-[var(--solid-ink)] shadow-[2px_2px_0_var(--solid-ink)] transition-all duration-100 active:translate-x-px active:translate-y-px active:shadow-none ${
+            wordFilterActive
+              ? 'bg-[var(--solid-ink)] text-white'
+              : 'bg-white text-[var(--solid-ink)]'
+          }`}
+        >
+          <Icon name="filter_list" size={15} />
+        </button>
+        <button
+          type="button"
+          onClick={() => setWordShowSortSheet(true)}
+          aria-label="並べ替え"
+          className={`inline-flex h-[32px] w-[32px] shrink-0 items-center justify-center rounded-full border-[1.25px] border-[var(--solid-ink)] shadow-[2px_2px_0_var(--solid-ink)] transition-all duration-100 active:translate-x-px active:translate-y-px active:shadow-none ${
+            wordSortOrder !== 'createdAsc'
+              ? 'bg-[var(--solid-ink)] text-white'
+              : 'bg-white text-[var(--solid-ink)]'
+          }`}
+        >
+          <Icon name="swap_vert" size={15} />
+        </button>
+        <button
+          type="button"
+          onClick={() => { setSelectMode((v) => !v); setSelectedWordIds(new Set()); }}
+          aria-label="選択"
+          className={`inline-flex h-[32px] w-[32px] shrink-0 items-center justify-center rounded-full border-[1.25px] border-[var(--solid-ink)] shadow-[2px_2px_0_var(--solid-ink)] transition-all duration-100 active:translate-x-px active:translate-y-px active:shadow-none ${
+            selectMode
+              ? 'bg-[var(--solid-ink)] text-white'
+              : 'bg-white text-[var(--solid-ink)]'
+          }`}
+        >
+          <Icon name="check_box" size={15} />
+        </button>
       </div>
 
       <div className="flex flex-col gap-2 px-4 pb-[160px]">


### PR DESCRIPTION
## Summary

`/project/[id]` の単語検索 input と同じ行にある 3 つのアイコンボタン（フィルタ・並べ替え・選択）が、ページ内の他の要素（ヘッダーボタン・クイズ/カードボタン・単語行など）が採用している「太めの solid-ink ボーダー + `2px 2px 0` のオフセット影」の Neo-brutalist デザインから外れた、薄い `--color-border` のフラットなデザインになっており違和感がありました。これを他のコンポーネントと揃えました。

### Changes (`src/app/project/[id]/page.tsx`)

- 検索 input をアイコン付きの `<label>` ラッパーで包み、`border-[var(--solid-ink)]` + `shadow-[2px_2px_0_var(--solid-ink)]` を適用し、横幅も flex-1 で柔軟に伸びるように変更
- 検索アイコン（`Icon name="search"`）を追加（`/projects` ページのスタイルと同様）
- フィルタ／並べ替え／選択ボタンのボーダーを `--color-border` から `--solid-ink` に統一し、`shadow-[2px_2px_0_var(--solid-ink)]` と `active:translate-x-px active:translate-y-px active:shadow-none` のプレス効果を追加
- ボタンサイズを 30×30 → 32×32 に微増し、影込みでも視覚バランスが取れるように
- 非アクティブ時のアイコン色を `--color-muted` から `--solid-ink` へ（他のボタンと統一）
- レイアウトを `justify-between` から `gap-2` に変更し、検索バーが行の余白を埋めるように

機能（検索フィルタ、フィルター/並べ替えシート、選択モード切り替え、件数表示など）には変更なし。

## Test plan

- [ ] `/project/[id]` を開き、検索バー＋3 ボタンが他のボタン群（クイズ／カード／ヘッダー戻るボタン／単語カード）と同じ Neo-brutalist スタイルで表示されることを目視確認
- [ ] 検索 input にフォーカスして文字入力できること、placeholder の単語を検索が表示されること
- [ ] 各ボタンを押して active 時の translate アニメーションが効くこと
- [ ] フィルタ/並べ替え/選択それぞれをアクティブにして、ボタンが反転（黒背景 + 白アイコン）になること
- [ ] フィルタ or 検索クエリが効いている時に件数 (`n/total`) が表示されること
- [ ] モバイル幅でもレイアウトが崩れないこと

https://claude.ai/code/session_012wdRJg23dnTjYgz5jcAm7a

---
_Generated by [Claude Code](https://claude.ai/code/session_012wdRJg23dnTjYgz5jcAm7a)_