### PR TITLE
feat(project): 単語追加ボタンに「スキャン/手動」選択ポップオーバーを追加

### DIFF
--- a/src/app/project/[id]/page.tsx
+++ b/src/app/project/[id]/page.tsx
@@ -68,6 +68,7 @@ export default function ProjectPage() {
   const [selectedWord, setSelectedWord] = useState<Word | null>(null);
 
   const [showManualWordModal, setShowManualWordModal] = useState(false);
+  const [addMenuOpen, setAddMenuOpen] = useState(false);
   const [manualWordEnglish, setManualWordEnglish] = useState('');
   const [manualWordJapanese, setManualWordJapanese] = useState('');
   const [manualWordPartOfSpeech, setManualWordPartOfSpeech] = useState('');
@@ -625,12 +626,50 @@ export default function ProjectPage() {
           <div className="pointer-events-none absolute inset-0 rounded-[10px] bg-[var(--solid-ink)]" style={{ transform: 'translate(2px, 2px)' }} />
           <button
             type="button"
-            onClick={() => setShowManualWordModal(true)}
+            onClick={() => setAddMenuOpen((open) => !open)}
             aria-label="単語を追加"
+            aria-haspopup="menu"
+            aria-expanded={addMenuOpen}
             className="relative flex h-full w-full items-center justify-center rounded-[10px] border-[1.25px] border-[var(--solid-ink)] bg-white text-[var(--solid-ink)] transition-all duration-100 active:translate-x-px active:translate-y-px"
           >
             <Icon name="add" size={20} />
           </button>
+          {addMenuOpen && (
+            <>
+              <button
+                type="button"
+                className="fixed inset-0 z-20 cursor-default bg-transparent"
+                aria-label="メニューを閉じる"
+                onClick={() => setAddMenuOpen(false)}
+              />
+              <div
+                role="menu"
+                className="absolute right-0 top-[52px] z-30 w-[180px] overflow-hidden rounded-[14px] border-[1.25px] border-[var(--solid-ink)] bg-white shadow-[3px_4px_0_var(--solid-ink)]"
+              >
+                <MenuButton
+                  icon="photo_camera"
+                  label="スキャンで追加"
+                  onClick={() => {
+                    setAddMenuOpen(false);
+                    try {
+                      sessionStorage.setItem('scanvocab_existing_project_id', projectId);
+                    } catch {
+                      /* ignore */
+                    }
+                    router.push('/scan');
+                  }}
+                />
+                <MenuButton
+                  icon="edit"
+                  label="手で入力"
+                  onClick={() => {
+                    setAddMenuOpen(false);
+                    setShowManualWordModal(true);
+                  }}
+                />
+              </div>
+            </>
+          )}
         </div>
       </div>
 


### PR DESCRIPTION
## Summary
PR #128 / #129 のフォローアップです。`d8d4cff06453a7eb3d91ee1ccd64c97e65971e73` 以前の挙動に倣い、追加ボタン（プラスアイコン）を押した際に「スキャンで追加 / 手で入力」を選べるようにしました。表示形式は右上「...」メニューと同じ小ウィンドウ（border-[1.25px] solid-ink + 影 + `MenuButton`）で、ボタンのすぐ下にポップオーバーとして展開します。

### 変更点
- `addMenuOpen` ステートを追加。プラスボタン押下で popover をトグル
- popover の上部に外側クリック閉じ用の透明な fixed inset-0 ボタン（z-20）
- メニュー本体は `absolute right-0 top-[52px] z-30 w-[180px]` でボタン直下に配置
- 「スキャンで追加」: `sessionStorage.setItem('scanvocab_existing_project_id', projectId)` を経由して `/scan` に遷移（既存の単語帳に追記される既存フローを利用）
- 「手で入力」: 既存の `ManualWordModal` を開く

## Test plan
- [ ] プラスボタンを押すと、ボタン直下に小ウィンドウのメニューが現れる
- [ ] メニュー外をタップするとメニューが閉じる
- [ ] 「スキャンで追加」を選ぶと `/scan` へ遷移し、保存時にこの単語帳へ追記される
- [ ] 「手で入力」を選ぶと従来通り単語追加モーダルが開く
- [ ] `npm run lint` / `tsc --noEmit` が通る

https://claude.ai/code/session_01AJacL3do9QdqJ8UCv6LHrP

---
_Generated by [Claude Code](https://claude.ai/code/session_01AJacL3do9QdqJ8UCv6LHrP)_