### PR TITLE
feat(project): スキャン追加を /scan 遷移ではなくページ内ボトムシートに

### DIFF
--- a/src/app/project/[id]/page.tsx
+++ b/src/app/project/[id]/page.tsx
@@ -6,6 +6,7 @@ import Link from 'next/link';
 import { Icon } from '@/components/ui/Icon';
 import { useToast } from '@/components/ui/toast';
 import { WordLimitModal } from '@/components/limits';
+import { ScanCaptureModal } from '@/components/home/ScanCaptureModal';
 import { ProjectShareSheet } from '@/components/project/ProjectShareSheet';
 import { VocabularyTypeButton } from '@/components/project/VocabularyTypeButton';
 import { WordFilterSheet, WordSortSheet } from '@/components/project/WordListSheets';
@@ -68,6 +69,7 @@ export default function ProjectPage() {
   const [selectedWord, setSelectedWord] = useState<Word | null>(null);
 
   const [showManualWordModal, setShowManualWordModal] = useState(false);
+  const [showScanCaptureModal, setShowScanCaptureModal] = useState(false);
   const [addMenuOpen, setAddMenuOpen] = useState(false);
   const [manualWordEnglish, setManualWordEnglish] = useState('');
   const [manualWordJapanese, setManualWordJapanese] = useState('');
@@ -651,12 +653,7 @@ export default function ProjectPage() {
                   label="スキャンで追加"
                   onClick={() => {
                     setAddMenuOpen(false);
-                    try {
-                      sessionStorage.setItem('scanvocab_existing_project_id', projectId);
-                    } catch {
-                      /* ignore */
-                    }
-                    router.push('/scan');
+                    setShowScanCaptureModal(true);
                   }}
                 />
                 <MenuButton
@@ -796,6 +793,12 @@ export default function ProjectPage() {
         isOpen={showWordLimitModal}
         onClose={() => setShowWordLimitModal(false)}
         currentCount={totalWordCount}
+      />
+
+      <ScanCaptureModal
+        isOpen={showScanCaptureModal}
+        onClose={() => setShowScanCaptureModal(false)}
+        targetProjectId={projectId}
       />
 
       <ProjectShareSheet

--- a/src/components/home/ScanCaptureModal.tsx
+++ b/src/components/home/ScanCaptureModal.tsx
@@ -12,6 +12,11 @@ interface ScanCaptureModalProps {
   isOpen: boolean;
   onClose: () => void;
   defaultMode?: TopMode;
+  /**
+   * If set, the scan results will be appended to this existing project
+   * instead of creating a new one.
+   */
+  targetProjectId?: string;
 }
 
 type TopMode = 'vocab' | 'correction' | 'parser';
@@ -60,7 +65,7 @@ function subToExtractMode(sub: SubOption): ExtractMode {
   return 'all';
 }
 
-export function ScanCaptureModal({ isOpen, onClose, defaultMode }: ScanCaptureModalProps) {
+export function ScanCaptureModal({ isOpen, onClose, defaultMode, targetProjectId }: ScanCaptureModalProps) {
   const router = useRouter();
   const { isPro } = useAuth();
   const [activeMode, setActiveMode] = useState<TopMode>(defaultMode ?? 'vocab');
@@ -111,6 +116,9 @@ export function ScanCaptureModal({ isOpen, onClose, defaultMode }: ScanCaptureMo
         formData.append('image', file);
         formData.append('projectTitle', `スキャン ${dateLabel}`);
         formData.append('scanMode', subToExtractMode(activeSub));
+        if (targetProjectId) {
+          formData.append('targetProjectId', targetProjectId);
+        }
 
         const res = await fetch('/api/scan-jobs', {
           method: 'POST',
@@ -140,7 +148,11 @@ export function ScanCaptureModal({ isOpen, onClose, defaultMode }: ScanCaptureMo
       sessionStorage.setItem('scanvocab_lexicon_entries', JSON.stringify(result.lexiconEntries ?? []));
       sessionStorage.removeItem('scanvocab_project_name');
       sessionStorage.removeItem('scanvocab_project_icon');
-      sessionStorage.removeItem('scanvocab_existing_project_id');
+      if (targetProjectId) {
+        sessionStorage.setItem('scanvocab_existing_project_id', targetProjectId);
+      } else {
+        sessionStorage.removeItem('scanvocab_existing_project_id');
+      }
       onClose();
       router.replace('/scan/confirm');
     } catch (err) {


### PR DESCRIPTION
## Summary
PR #130 のフォローアップ。「スキャンで追加」ボタンを選んだ際に `/scan` へ遷移していたのをやめ、`d8d4cff06453a7eb3d91ee1ccd64c97e65971e73` 以前と同様に**現在の単語帳ページ上にスキャンモード選択画面（新UIのボトムシート）を被せて表示**するように変更しました。

### 実装
- `src/components/home/ScanCaptureModal.tsx` に `targetProjectId?: string` プロップを追加
  - Pro バックグラウンドフロー: `scan-jobs` API に `targetProjectId` フォームフィールドを送信（API 側は既に対応済み）。既存の単語帳に追記される
  - Free フロー: `scanvocab_existing_project_id` を sessionStorage にセットして `/scan/confirm` を開く（既存ロジックが残りの処理を担当）
- `src/app/project/[id]/page.tsx`:
  - `showScanCaptureModal` ステートを追加
  - 「スキャンで追加」ボタンで `/scan` への `router.push` を廃止し、モーダルを開くだけに変更
  - `<ScanCaptureModal targetProjectId={projectId} />` を JSX に追加

## Test plan
- [ ] プラスボタン → 「スキャンで追加」を押すと、ページ遷移せずボトムシートが現れる
- [ ] ボトムシートで抽出オプションを選び「カメラで撮影」/「写真から選ぶ」が動作する
- [ ] Free アカウントで撮影 → `/scan/confirm` に遷移し、保存すると現在の単語帳に追記される
- [ ] Pro アカウントで撮影 → ボトムシートが閉じ、バックグラウンドジョブが現在の単語帳に追記される
- [ ] `npm run lint` / `tsc --noEmit` がエラーなく通る

https://claude.ai/code/session_01AJacL3do9QdqJ8UCv6LHrP

---
_Generated by [Claude Code](https://claude.ai/code/session_01AJacL3do9QdqJ8UCv6LHrP)_