### PR TITLE
fix(home): 下端paddingを他ページと統一して挙動差を解消

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -262,7 +262,7 @@ export default function HomePage() {
   const visibleProjects = projects.slice(0, 3);
 
   return (
-    <div className="relative min-h-screen bg-[var(--color-background)] pb-[150px] pt-3 font-[var(--font-body)] lg:pt-4">
+    <div className="relative min-h-screen bg-[var(--color-background)] pb-[110px] pt-3 font-[var(--font-body)] lg:pt-4">
       <div className="flex items-center justify-between px-[18px] pb-4 pt-2 lg:hidden">
         <div className="font-display text-[26px] font-black leading-none tracking-[0.1em] text-[var(--solid-ink)]">
           MERKEN
@@ -376,7 +376,7 @@ export default function HomePage() {
         </div>
       </div>
 
-      <div className="px-[18px] pb-[150px]">
+      <div className="px-[18px]">
         {correctionLoading ? (
           <div className="flex items-center justify-center py-6 text-[var(--color-muted)]">
             <Icon name="progress_activity" size={18} className="animate-spin" />


### PR DESCRIPTION
## Summary
- ホームページ (`src/app/page.tsx`) は最外ラッパー (L265) とセクション末尾の内側div (L379) の両方に `pb-[150px]` を持っていたため、下端に約300pxの余白が出来ていた
- 共有/進歩(統計)/アカウント(設定) は `pb-[110px]` 一回のみで固定ボトムナビ高に合わせ込まれており、ホームだけ画面下端到達時の挙動が他ページと異なって見える原因になっていた
- 最外ラッパーを `pb-[110px]` に揃え、内側の重複 padding は削除

## Test plan
- [ ] ホーム画面で下端までスクロールし、ボトムナビとコンテンツ末尾の間隔が共有/進歩/アカウントと同等であること
- [ ] iOS Safari でセーフエリア（ホームインジケータ）と被らないこと
- [ ] PC (lg) レイアウトで余分な空白が出ていないこと

https://claude.ai/code/session_01SagEz6QaK5GouYu48WVfxp

---
_Generated by [Claude Code](https://claude.ai/code/session_01SagEz6QaK5GouYu48WVfxp)_