### PR TITLE
fix(scan): targetProjectId 指定時は添削モードを非表示にする

### DIFF
--- a/src/components/home/ScanCaptureModal.tsx
+++ b/src/components/home/ScanCaptureModal.tsx
@@ -68,7 +68,7 @@ function subToExtractMode(sub: SubOption): ExtractMode {
 export function ScanCaptureModal({ isOpen, onClose, defaultMode, targetProjectId }: ScanCaptureModalProps) {
   const router = useRouter();
   const { isPro } = useAuth();
-  const [activeMode, setActiveMode] = useState<TopMode>(defaultMode ?? 'vocab');
+  const [activeMode, setActiveMode] = useState<TopMode>(targetProjectId ? 'vocab' : (defaultMode ?? 'vocab'));
   const [activeSub, setActiveSub] = useState<SubOption>('all');
   const [processing, setProcessing] = useState(false);
   const [errorMsg, setErrorMsg] = useState<string | null>(null);
@@ -229,8 +229,8 @@ export function ScanCaptureModal({ isOpen, onClose, defaultMode, targetProjectId
             </button>
           </div>
 
-          {/* 3 top-level modes */}
-          <div className="mb-3 flex flex-col gap-[7px]">
+          {/* Top-level modes (hidden when scanning into an existing word book) */}
+          {!targetProjectId && <div className="mb-3 flex flex-col gap-[7px]">
             {MODES.map(m => {
               const active = m.k === activeMode;
               return (
@@ -274,7 +274,7 @@ export function ScanCaptureModal({ isOpen, onClose, defaultMode, targetProjectId
                 </button>
               );
             })}
-          </div>
+          </div>}
 
           {/* Sub-options (vocab only) */}
           {activeMode === 'vocab' && (


### PR DESCRIPTION
## Summary
PR #131 のフォローアップ。`ScanCaptureModal` を `targetProjectId` 付きで開いた際に、ユーザーが「添削」モードを選べてしまう問題を修正しました。添削を選ぶと画像が `/api/correction/scan` に送られ `/correction/result?id=...` へ遷移するため、**開いていた単語帳には何も追加されない**動線になっていました。

### 変更
- `targetProjectId` が指定されているとき、`activeMode` の初期値を強制的に `'vocab'` に設定
- 同時に、トップレベルの「単語帳 / 添削」モード選択 UI を非表示にする

これにより、単語帳ページから開いたスキャンは vocab 一択になり、誤って添削に切り替わる事故を防げます。

## Test plan
- [ ] 単語帳ページの ＋ボタン → 「スキャンで追加」でモーダルを開いた際、トップレベルのモード切替（単語帳/添削）が表示されない
- [ ] 抽出オプション（丸囲み/英検/熟語/すべての単語）と画像取込ボタンは従来どおり動作する
- [ ] ホーム画面など `targetProjectId` 未指定で開いた場合は、従来どおりモード切替が表示される
- [ ] `npm run lint` / `tsc --noEmit` がエラーなく通る

https://claude.ai/code/session_01AJacL3do9QdqJ8UCv6LHrP

---
_Generated by [Claude Code](https://claude.ai/code/session_01AJacL3do9QdqJ8UCv6LHrP)_