### PR TITLE
fix(quiz): 進捗バーが間違い後に正解しても赤いままになるバグを修正

### DIFF
--- a/src/app/quiz/[projectId]/page.tsx
+++ b/src/app/quiz/[projectId]/page.tsx
@@ -41,6 +41,7 @@ interface QuizPersistState {
   selectedIndex: number | null;
   isRevealed: boolean;
   results: { correct: number; total: number };
+  answerResults?: (boolean | null)[];
   questionCount: number;
   quizDirection: 'en-to-ja' | 'ja-to-en';
   timestamp: number;
@@ -156,6 +157,7 @@ export default function QuizPage() {
   const [selectedIndex, setSelectedIndex] = useState<number | null>(null);
   const [isRevealed, setIsRevealed] = useState(false);
   const [results, setResults] = useState<{ correct: number; total: number }>({ correct: 0, total: 0 });
+  const [answerResults, setAnswerResults] = useState<(boolean | null)[]>([]);
   const [isComplete, setIsComplete] = useState(false);
   const [loading, setLoading] = useState(true);
   const [distractorError, setDistractorError] = useState<string | null>(null);
@@ -183,11 +185,11 @@ export default function QuizPage() {
   const saveQuizState = useCallback(() => {
     if (questions.length === 0 || !questionCount) return;
     const state: QuizPersistState = {
-      questions, currentIndex, selectedIndex, isRevealed, results, questionCount, quizDirection,
+      questions, currentIndex, selectedIndex, isRevealed, results, answerResults, questionCount, quizDirection,
       timestamp: Date.now(),
     };
     try { sessionStorage.setItem(storageKey, JSON.stringify(state)); } catch { /* ignore */ }
-  }, [questions, currentIndex, selectedIndex, isRevealed, results, questionCount, quizDirection, storageKey]);
+  }, [questions, currentIndex, selectedIndex, isRevealed, results, answerResults, questionCount, quizDirection, storageKey]);
 
   const clearQuizState = useCallback(() => {
     try { sessionStorage.removeItem(storageKey); } catch { /* ignore */ }
@@ -204,7 +206,7 @@ export default function QuizPage() {
 
   useEffect(() => {
     if (questions.length > 0 && questionCount && !isComplete) saveQuizState();
-  }, [questions, currentIndex, selectedIndex, isRevealed, results, questionCount, quizDirection, isComplete, saveQuizState]);
+  }, [questions, currentIndex, selectedIndex, isRevealed, results, answerResults, questionCount, quizDirection, isComplete, saveQuizState]);
 
   useEffect(() => {
     const handleVisibilityChange = () => {
@@ -336,6 +338,11 @@ export default function QuizPage() {
         setSelectedIndex(state.selectedIndex);
         setIsRevealed(state.isRevealed);
         setResults(state.results);
+        setAnswerResults(
+          Array.isArray(state.answerResults) && state.answerResults.length === restoredQuestions.length
+            ? state.answerResults
+            : Array.from({ length: restoredQuestions.length }, () => null)
+        );
         setQuestionCount(restoredCount);
         setQuizDirection(state.quizDirection);
         setAllWords(restoredQuestions.map(q => q.word));
@@ -488,6 +495,11 @@ export default function QuizPage() {
     const isCorrect = index === currentQuestion.correctIndex;
     const word = currentQuestion.word;
     setResults((prev) => ({ correct: prev.correct + (isCorrect ? 1 : 0), total: prev.total + 1 }));
+    setAnswerResults((prev) => {
+      const next = prev.length === questions.length ? [...prev] : Array.from({ length: questions.length }, (_, i) => prev[i] ?? null);
+      next[currentIndex] = isCorrect;
+      return next;
+    });
     if (isCorrect) recordCorrectAnswer(false);
     else recordWrongAnswer(word.id, word.english, word.japanese, reviewMode ? word.projectId : projectId, word.distractors);
     recordActivity();
@@ -509,6 +521,11 @@ export default function QuizPage() {
     setIsRevealed(true);
     const word = currentQuestion.word;
     setResults((prev) => ({ correct: prev.correct + (isCorrect ? 1 : 0), total: prev.total + 1 }));
+    setAnswerResults((prev) => {
+      const next = prev.length === questions.length ? [...prev] : Array.from({ length: questions.length }, (_, i) => prev[i] ?? null);
+      next[currentIndex] = isCorrect;
+      return next;
+    });
     if (isCorrect) recordCorrectAnswer(false);
     else recordWrongAnswer(word.id, word.english, word.japanese, reviewMode ? word.projectId : projectId, word.distractors);
     recordActivity();
@@ -543,7 +560,7 @@ export default function QuizPage() {
     if (allWords.some((w) => needsDistractors(w))) await startQuizWithDistractors(allWords, count);
     else setQuestions(generateQuestions(allWords, count, quizDirection));
     setCurrentIndex(0); setSelectedIndex(null); setIsRevealed(false);
-    setResults({ correct: 0, total: 0 }); setIsComplete(false);
+    setResults({ correct: 0, total: 0 }); setAnswerResults([]); setIsComplete(false);
   };
 
   const handleSelectCount = async (count: number) => {
@@ -678,7 +695,6 @@ export default function QuizPage() {
 
   /* ---------- Main quiz screen (DS style) ---------- */
   const total = questions.length;
-  const correctSoFar = results.correct;
 
   return (
     <div className="fixed inset-0 z-30 flex flex-col overflow-hidden bg-[var(--color-background)] font-[var(--font-body)] lg:left-[280px]">
@@ -699,9 +715,11 @@ export default function QuizPage() {
                 style={{
                   background:
                     i < currentIndex
-                      ? i < correctSoFar
+                      ? answerResults[i] === true
                         ? 'var(--color-success)'
-                        : 'var(--color-error)'
+                        : answerResults[i] === false
+                          ? 'var(--color-error)'
+                          : 'rgba(26,26,26,0.1)'
                       : i === currentIndex
                         ? 'var(--solid-ink)'
                         : 'rgba(26,26,26,0.1)',


### PR DESCRIPTION
## Summary

クイズ画面上部の進捗バーで、1問でも間違えるとそれ以降の正解問題まで赤く表示されてしまうバグを修正しました。

## 原因

`src/app/quiz/[projectId]/page.tsx` の進捗バー描画ロジックが「正答数のカウント」(`correctSoFar = results.correct`) を用いて全問題の色を決定していました。

```tsx
i < currentIndex
  ? i < correctSoFar
    ? 'var(--color-success)'  // 緑
    : 'var(--color-error)'    // 赤
  : ...
```

この実装は「最初のN問が正解」と暗黙に仮定しているため、例えば「Q0=不正解, Q1=正解」の状態（`correctSoFar=1`）では:
- Q0: `0 < 1` → 緑（誤）
- Q1: `1 < 1` → 赤（誤）

となり、正解した問題まで赤くなる現象が発生していました。

## 修正内容

- 問題ごとの正誤を保持する `answerResults: (boolean | null)[]` を新規 state として追加
- `handleSelect` / `handleTypeInSubmit` で `answerResults[currentIndex]` を更新
- 進捗バーの色判定を `answerResults[i]` ベースに変更
- セッションストレージへの永続化 (`QuizPersistState`)・復元・リスタート時のリセットにも反映

## Test plan

- [ ] 1問目でわざと間違える → 1問目のセルが赤になる
- [ ] 2問目で正解 → 2問目のセルが緑、1問目は赤のまま
- [ ] 3問目以降で正解しても緑表示が維持される（赤に塗り替わらない）
- [ ] タイプイン形式のクイズでも同様に動作する
- [ ] クイズ中にタブを切り替えて戻ってきても色が保持される（永続化の確認）
- [ ] 「もう一度」(Restart) で進捗バーがリセットされる

https://claude.ai/code/session_013cRsSZXMT84sFSu7Kha75L

---
_Generated by [Claude Code](https://claude.ai/code/session_013cRsSZXMT84sFSu7Kha75L)_