### PR TITLE
[codex] Retire dead AI DB artifacts

### DIFF
--- a/supabase/migrations/20260506120000_retire_dead_ai_db_artifacts.sql
+++ b/supabase/migrations/20260506120000_retire_dead_ai_db_artifacts.sql
@@ -1,0 +1,5 @@
+-- Retire database artifacts that only supported removed dead AI APIs.
+-- The active embedding rebuild/manual lexicon-resolution paths are intentionally left intact.
+
+DROP TABLE IF EXISTS public.word_similar_cache;
+DROP TABLE IF EXISTS public.lexicon_enrichment_jobs;


### PR DESCRIPTION
## Summary
- Adds a focused Supabase migration to retire DB artifacts used only by removed dead AI API paths.
- Drops `public.word_similar_cache` and `public.lexicon_enrichment_jobs` idempotently.
- Leaves embedding infrastructure and retired override columns untouched for separate decisions.

## Validation
- `rg -n "lexicon_enrichment_jobs|word_similar_cache" src scripts shared mobile ios-native` returned no runtime code references.
- `npm run test:security:routes`
- `npm test`
- `npm run lint` (0 errors, existing warnings only)

## Supabase rollout note
Do not use `supabase db push` for this repo state because remote migration history has drift. Apply this SQL directly after the dead API removal is deployed, then mark `20260506120000` as applied in migration history.
