### PR TITLE
feat(home): 復習未到来時に「習得できてない順」の学習 CTA を表示

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -278,8 +278,15 @@ export default function HomePage() {
   }, [authLoading, user, isPro]);
 
   const { dueCount, completedToday, streakDays, totalWords, mastered, review, newW } = stats;
+  const unmasteredCount = newW + review;
   const goalTotal = dueCount + completedToday;
   const goalProgress = goalTotal > 0 ? Math.round((completedToday / goalTotal) * 100) : 0;
+  const dailyLearnTarget = Math.min(unmasteredCount, 10);
+  const learnProgress = dailyLearnTarget > 0
+    ? Math.min(100, Math.round((completedToday / dailyLearnTarget) * 100))
+    : 0;
+  const goalState: 'review' | 'learn' | 'empty' =
+    dueCount > 0 ? 'review' : totalWords === 0 ? 'empty' : 'learn';
   const visibleProjects = projects.slice(0, 3);
 
   return (
@@ -307,32 +314,87 @@ export default function HomePage() {
       )}
 
       <div className="grid grid-cols-2 gap-2.5 px-[18px] pb-3.5">
-        <Link href={dueCount > 0 ? '/quiz/all?review=1&from=/' : '/projects'} className="block">
-          <SolidPanel className="!rounded-2xl" faceClassName="!p-3 min-h-[120px]">
-            <div className="font-mono text-[10px] font-semibold uppercase tracking-[0.02em] text-[var(--color-muted)]">
-              TODAY&apos;S GOAL
-            </div>
-            <div className="mt-0.5 text-[10px] text-[var(--color-muted)]">今日の目標</div>
-            <div className="mt-2 flex items-baseline gap-1">
-              <span className="font-display text-[30px] font-extrabold tabular-nums leading-none text-[var(--solid-ink)]">
-                {dueCount}
-              </span>
-              <span className="text-sm font-bold text-[var(--solid-ink)]">語</span>
-            </div>
-            <div className="mt-0.5 text-[11px] tabular-nums text-[var(--color-muted)]">
-              {completedToday} / {goalTotal} 完了
-            </div>
-            <div className="mt-2.5 h-[5px] overflow-hidden rounded-full bg-[rgba(26,26,26,0.08)]">
-              <div className="h-full bg-[var(--color-accent)]" style={{ width: `${goalProgress}%` }} />
-            </div>
-            <div className="mt-3 flex items-center gap-[3px] text-[var(--solid-ink)]">
-              <span className="text-[13px] font-bold">復習を始める</span>
-              <span className="inline-flex text-[var(--color-accent)]">
-                <Icon name="chevron_right" size={12} />
-              </span>
-            </div>
-          </SolidPanel>
-        </Link>
+        {goalState === 'empty' ? (
+          <button type="button" onClick={() => setVocabScanOpen(true)} className="block text-left">
+            <SolidPanel className="!rounded-2xl" faceClassName="!p-3 min-h-[120px]">
+              <div className="font-mono text-[10px] font-semibold uppercase tracking-[0.02em] text-[var(--color-muted)]">
+                TODAY&apos;S GOAL
+              </div>
+              <div className="mt-0.5 text-[10px] text-[var(--color-muted)]">今日の目標</div>
+              <div className="mt-2 flex items-center gap-1.5">
+                <span className="inline-flex text-[var(--solid-ink)]">
+                  <Icon name="photo_camera" size={26} />
+                </span>
+                <span className="font-display text-[18px] font-extrabold leading-tight text-[var(--solid-ink)]">
+                  最初のスキャン
+                </span>
+              </div>
+              <div className="mt-1 text-[11px] leading-snug text-[var(--color-muted)]">
+                ノートを撮って単語を登録しよう
+              </div>
+              <div className="mt-3.5 flex items-center gap-[3px] text-[var(--solid-ink)]">
+                <span className="text-[13px] font-bold">スキャンを開始</span>
+                <span className="inline-flex text-[var(--color-accent)]">
+                  <Icon name="chevron_right" size={12} />
+                </span>
+              </div>
+            </SolidPanel>
+          </button>
+        ) : goalState === 'learn' ? (
+          <Link href="/quiz/all?learn=1&from=/" className="block">
+            <SolidPanel className="!rounded-2xl" faceClassName="!p-3 min-h-[120px]">
+              <div className="font-mono text-[10px] font-semibold uppercase tracking-[0.02em] text-[var(--color-muted)]">
+                TODAY&apos;S GOAL
+              </div>
+              <div className="mt-0.5 text-[10px] text-[var(--color-muted)]">今日の目標</div>
+              <div className="mt-2 flex items-baseline gap-1">
+                <span className="font-display text-[30px] font-extrabold tabular-nums leading-none text-[var(--solid-ink)]">
+                  {unmasteredCount}
+                </span>
+                <span className="text-sm font-bold text-[var(--solid-ink)]">語</span>
+              </div>
+              <div className="mt-0.5 text-[11px] tabular-nums text-[var(--color-muted)]">
+                未習得 ・ 本日 {completedToday} 語学習
+              </div>
+              <div className="mt-2.5 h-[5px] overflow-hidden rounded-full bg-[rgba(26,26,26,0.08)]">
+                <div className="h-full bg-[var(--color-accent)]" style={{ width: `${learnProgress}%` }} />
+              </div>
+              <div className="mt-3 flex items-center gap-[3px] text-[var(--solid-ink)]">
+                <span className="text-[13px] font-bold">学習を始める</span>
+                <span className="inline-flex text-[var(--color-accent)]">
+                  <Icon name="chevron_right" size={12} />
+                </span>
+              </div>
+            </SolidPanel>
+          </Link>
+        ) : (
+          <Link href="/quiz/all?review=1&from=/" className="block">
+            <SolidPanel className="!rounded-2xl" faceClassName="!p-3 min-h-[120px]">
+              <div className="font-mono text-[10px] font-semibold uppercase tracking-[0.02em] text-[var(--color-muted)]">
+                TODAY&apos;S GOAL
+              </div>
+              <div className="mt-0.5 text-[10px] text-[var(--color-muted)]">今日の目標</div>
+              <div className="mt-2 flex items-baseline gap-1">
+                <span className="font-display text-[30px] font-extrabold tabular-nums leading-none text-[var(--solid-ink)]">
+                  {dueCount}
+                </span>
+                <span className="text-sm font-bold text-[var(--solid-ink)]">語</span>
+              </div>
+              <div className="mt-0.5 text-[11px] tabular-nums text-[var(--color-muted)]">
+                {completedToday} / {goalTotal} 完了
+              </div>
+              <div className="mt-2.5 h-[5px] overflow-hidden rounded-full bg-[rgba(26,26,26,0.08)]">
+                <div className="h-full bg-[var(--color-accent)]" style={{ width: `${goalProgress}%` }} />
+              </div>
+              <div className="mt-3 flex items-center gap-[3px] text-[var(--solid-ink)]">
+                <span className="text-[13px] font-bold">復習を始める</span>
+                <span className="inline-flex text-[var(--color-accent)]">
+                  <Icon name="chevron_right" size={12} />
+                </span>
+              </div>
+            </SolidPanel>
+          </Link>
+        )}
 
         <SolidPanel className="!rounded-2xl" faceClassName="!p-3 min-h-[120px]">
           <div className="font-mono text-[10px] font-semibold uppercase tracking-[0.02em] text-[var(--color-muted)]">

--- a/src/app/quiz/[projectId]/page.tsx
+++ b/src/app/quiz/[projectId]/page.tsx
@@ -35,8 +35,8 @@ function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-const getQuizStorageKey = (projectId: string, reviewMode: boolean) =>
-  `quiz_state_${reviewMode ? 'review' : projectId}`;
+const getQuizStorageKey = (projectId: string, reviewMode: boolean, learnMode: boolean) =>
+  `quiz_state_${reviewMode ? 'review' : learnMode ? 'learn' : projectId}`;
 
 interface QuizPersistState {
   questions: QuizQuestion[];
@@ -145,6 +145,7 @@ export default function QuizPage() {
   const countFromUrl = searchParams.get('count');
   const returnPath = searchParams.get('from');
   const reviewMode = searchParams.get('review') === '1';
+  const learnMode = searchParams.get('learn') === '1';
   const collectionId = searchParams.get('collectionId');
   const [questionCount, setQuestionCount] = useState<number | null>(() => {
     if (!countFromUrl) return DEFAULT_QUESTION_COUNT;
@@ -185,7 +186,7 @@ export default function QuizPage() {
 
   const restoredFromStorage = useRef(false);
   const vocabularyMergeFromLocalAppliedRef = useRef(false);
-  const storageKey = getQuizStorageKey(projectId, reviewMode);
+  const storageKey = getQuizStorageKey(projectId, reviewMode, learnMode);
 
   const saveQuizState = useCallback(() => {
     if (questions.length === 0 || !questionCount) return;
@@ -205,9 +206,10 @@ export default function QuizPage() {
     restoredFromStorage.current = false;
     const fromQ = returnPath ? `&from=${encodeURIComponent(returnPath)}` : '';
     const cnt = Math.max(1, Math.min(questionCount ?? DEFAULT_QUESTION_COUNT, MAX_NORMAL_QUIZ_QUESTION_COUNT));
-    const url = `${pathname}?review=1&count=${cnt}${fromQ}&_rs=${Date.now()}`;
+    const modeParam = learnMode ? 'learn=1' : 'review=1';
+    const url = `${pathname}?${modeParam}&count=${cnt}${fromQ}&_rs=${Date.now()}`;
     window.location.assign(url);
-  }, [clearQuizState, returnPath, questionCount, pathname]);
+  }, [clearQuizState, returnPath, questionCount, pathname, learnMode]);
 
   useEffect(() => {
     if (questions.length > 0 && questionCount && !isComplete) saveQuizState();
@@ -379,7 +381,7 @@ export default function QuizPage() {
 
         let sourceWords: Word[] = [];
 
-        if (reviewMode) {
+        if (reviewMode || learnMode) {
           const userId = user ? user.id : getGuestUserId();
           let projects = await repository.getProjects(userId);
           let wordRepo = repository;
@@ -404,7 +406,10 @@ export default function QuizPage() {
             const arrays = await Promise.all(projectIds.map((id) => wordRepo.getWords(id)));
             wordsByProject = Object.fromEntries(projectIds.map((id, idx) => [id, arrays[idx] ?? []]));
           }
-          sourceWords = getWordsDueForReview(projectIds.flatMap((id) => wordsByProject[id] ?? []));
+          const allFlat = projectIds.flatMap((id) => wordsByProject[id] ?? []);
+          sourceWords = reviewMode
+            ? getWordsDueForReview(allFlat)
+            : allFlat.filter((w) => w.status !== 'mastered');
         } else if (collectionId) {
           sourceWords = await loadCollectionWords(collectionId);
         } else {
@@ -417,7 +422,7 @@ export default function QuizPage() {
           sourceWords = loadedWords;
         }
 
-        if (!reviewMode) {
+        if (!reviewMode && !learnMode) {
           const nonMastered = sourceWords.filter((w) => w.status !== 'mastered');
           if (nonMastered.length > 0) sourceWords = nonMastered;
         }
@@ -447,10 +452,10 @@ export default function QuizPage() {
     };
 
     loadWords();
-  }, [projectId, repository, router, generateQuestions, startQuizWithDistractors, authLoading, userPreferencesLoading, aiEnabled, questionCount, reviewMode, collectionId, backToProject, user, storageKey, needsDistractors, quizDirection]);
+  }, [projectId, repository, router, generateQuestions, startQuizWithDistractors, authLoading, userPreferencesLoading, aiEnabled, questionCount, reviewMode, learnMode, collectionId, backToProject, user, storageKey, needsDistractors, quizDirection]);
 
   useEffect(() => {
-    if (authLoading || !user || reviewMode || collectionId) return;
+    if (authLoading || !user || reviewMode || learnMode || collectionId) return;
     const syncRemote = async () => {
       try {
         const remoteWords = await remoteRepository.getWords(projectId);
@@ -459,11 +464,11 @@ export default function QuizPage() {
       } catch { /* silent */ }
     };
     syncRemote();
-  }, [authLoading, user, projectId, reviewMode, collectionId]);
+  }, [authLoading, user, projectId, reviewMode, learnMode, collectionId]);
 
   useEffect(() => {
     if (!restoredFromStorage.current) return;
-    if (reviewMode || collectionId) return;
+    if (reviewMode || learnMode || collectionId) return;
     if (questions.length === 0) return;
     if (vocabularyMergeFromLocalAppliedRef.current) return;
     vocabularyMergeFromLocalAppliedRef.current = true;
@@ -488,7 +493,7 @@ export default function QuizPage() {
       } catch { vocabularyMergeFromLocalAppliedRef.current = false; }
     })();
     return () => { cancelled = true; };
-  }, [questions.length, projectId, repository, reviewMode, collectionId]);
+  }, [questions.length, projectId, repository, reviewMode, learnMode, collectionId]);
 
   const currentQuestion = questions[currentIndex];
   const isActiveVocab = currentQuestion?.word.vocabularyType === 'active';
@@ -506,7 +511,7 @@ export default function QuizPage() {
       return next;
     });
     if (isCorrect) recordCorrectAnswer(false);
-    else recordWrongAnswer(word.id, word.english, word.japanese, reviewMode ? word.projectId : projectId, word.distractors);
+    else recordWrongAnswer(word.id, word.english, word.japanese, reviewMode || learnMode ? word.projectId : projectId, word.distractors);
     recordActivity();
     try {
       const newStatus = getStatusAfterAnswer(word.status, isCorrect);
@@ -532,7 +537,7 @@ export default function QuizPage() {
       return next;
     });
     if (isCorrect) recordCorrectAnswer(false);
-    else recordWrongAnswer(word.id, word.english, word.japanese, reviewMode ? word.projectId : projectId, word.distractors);
+    else recordWrongAnswer(word.id, word.english, word.japanese, reviewMode || learnMode ? word.projectId : projectId, word.distractors);
     recordActivity();
     try {
       const newStatus = getStatusAfterAnswer(word.status, isCorrect);
@@ -698,7 +703,7 @@ export default function QuizPage() {
               {percentage === 100 ? 'パーフェクト! 素晴らしい!' : percentage >= 80 ? 'よくできました!' : percentage >= 60 ? 'もう少し! 復習しましょう' : '繰り返し練習しましょう!'}
             </p>
             <div className="space-y-3">
-              {reviewMode ? (
+              {reviewMode || learnMode ? (
                 <>
                   <SolidButton variant="inverse" onClick={goToNextReviewQuiz} iconRight="arrow_forward" className="w-full justify-center">次へ進む</SolidButton>
                   <SolidButton onClick={handleRestart} iconLeft="refresh" className="w-full justify-center">もう一度</SolidButton>


### PR DESCRIPTION
## Summary

新規ユーザや SR の復習タイミングが未到来のとき、「今日の目標」ウィジットが `0 語 / 復習を始める` を表示してしまい、初回ユーザの導線として機能していなかった。状態に応じて CTA を切り替え、未習得の単語を「習得できてない順」(new → review) で学習させる新しいクイズモードに誘導する。

### ウィジットの 3 状態 (`src/app/page.tsx`)
- **`totalWords === 0`**: 「最初のスキャン」CTA。タップで既存の `ScanCaptureModal` (`vocabScanOpen`) を起動。
- **`dueCount === 0 && unmasteredCount > 0`**: 未習得語数を表示し、「学習を始める」で `/quiz/all?learn=1&from=/` に遷移。
- **`dueCount > 0`**: 既存の復習 CTA(挙動は変更なし)。

### `?learn=1` 学習モード (`src/app/quiz/[projectId]/page.tsx`)
- `reviewMode || learnMode` で全プロジェクトの単語をロードする既存パスを再利用。
- `reviewMode` は `getWordsDueForReview` でフィルタ、`learnMode` は `status !== 'mastered'` でフィルタ。
- どちらも最終的に `sortWordsByPriority` を通すので「未復習の new → 期日前 review」の順 = 「習得できてない順」になる。
- セッションストレージキー / 完了画面の「次へ進む」ボタン / 多プロジェクト跨ぎの recordWrongAnswer / 単一プロジェクト前提の syncRemote・vocabularyMerge も `learnMode` を考慮するよう更新。

## Test plan

- [ ] 単語ゼロのアカウントでホームを開き、ウィジットが「最初のスキャン」表示になり、タップでスキャンモーダルが開く
- [ ] スキャンして単語を作成し、復習がまだ来ていない状態でホームを開く → 「未習得 N 語 / 学習を始める」表示
- [ ] CTA をタップ → `/quiz/all?learn=1&from=/` で new ステータスの単語から順に出題される
- [ ] 完了画面の「次へ進む」で同モードの新セットに進める
- [ ] 復習期日が来た単語がある状態では従来の復習 CTA が出る (回帰なし)
- [ ] `npm run lint` / `npx tsc --noEmit` がパス (確認済)


---
_Generated by [Claude Code](https://claude.ai/code/session_01DhYhRCy2HTxAf3g1kjpafd)_