### PR TITLE
fix(dark-mode): white-on-white の解消と画面下バー周辺の霧（フォグ）除去

### DIFF
--- a/src/app/flashcard/[projectId]/page.tsx
+++ b/src/app/flashcard/[projectId]/page.tsx
@@ -573,7 +573,7 @@ export default function FlashcardPage() {
                   style={{
                     color: statusColor(currentWord?.status ?? 'new'),
                     border: `1px solid ${statusColor(currentWord?.status ?? 'new')}`,
-                    background: 'white',
+                    background: 'var(--color-surface)',
                   }}
                 >
                   {statusLabel(currentWord?.status ?? 'new')}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -253,6 +253,67 @@ body {
   background-color: #283039;
 }
 
+/* Translucent white utilities — bypass `.dark .bg-white` rule.
+   In dark mode they paint a near-white wash on top of dark surfaces,
+   leaving any `--solid-ink` / `--color-foreground` text invisible. */
+.dark .bg-white\/80 {
+  background-color: rgb(30 36 43 / 0.8);
+}
+
+.dark .bg-white\/70 {
+  background-color: rgb(30 36 43 / 0.7);
+}
+
+.dark .bg-white\/10 {
+  background-color: rgb(255 255 255 / 0.08);
+}
+
+.dark .hover\:bg-white:hover {
+  background-color: var(--color-surface);
+}
+
+.dark .hover\:bg-white\/80:hover {
+  background-color: rgb(30 36 43 / 0.85);
+}
+
+/* Inverted-fill surfaces — backgrounds whose color flips to near-white
+   in dark mode. Anything painted `text-white` on top of them disappears. */
+.dark .bg-\[var\(--solid-ink\)\].text-white,
+.dark .bg-\[var\(--solid-ink\)\] .text-white,
+.dark .bg-\[var\(--color-foreground\)\].text-white,
+.dark .bg-\[var\(--color-foreground\)\] .text-white,
+.dark .bg-\[var\(--color-primary\)\].text-white,
+.dark .bg-\[var\(--color-primary\)\] .text-white,
+.dark .bg-\[var\(--color-hero-btn\)\].text-white,
+.dark .bg-\[var\(--color-hero-btn\)\] .text-white {
+  color: var(--color-background);
+}
+
+/* Same flip for fractional-opacity text classes (text-white/90, /75 …)
+   used on inverted surfaces. */
+.dark .bg-\[var\(--solid-ink\)\] .text-white\/90,
+.dark .bg-\[var\(--solid-ink\)\] .text-white\/75,
+.dark .bg-\[var\(--solid-ink\)\] .text-white\/70,
+.dark .bg-\[var\(--solid-ink\)\] .text-white\/60,
+.dark .bg-\[var\(--solid-ink\)\] .text-white\/50,
+.dark .bg-\[var\(--color-foreground\)\] .text-white\/90,
+.dark .bg-\[var\(--color-foreground\)\] .text-white\/75,
+.dark .bg-\[var\(--color-foreground\)\] .text-white\/70,
+.dark .bg-\[var\(--color-foreground\)\] .text-white\/60,
+.dark .bg-\[var\(--color-foreground\)\] .text-white\/50 {
+  color: rgb(17 20 24 / 0.85);
+}
+
+/* Built-in Merken classes whose CSS hardcodes `color: white`. The bg
+   flips with `--color-foreground`/`--solid-ink`, so the text needs to
+   flip too in dark mode. */
+.dark .btn-primary,
+.dark .chip-pro,
+.dark .solid-link-primary,
+.dark .fab {
+  color: var(--color-background);
+}
+
 /* ===== Custom Shadows ===== */
 
 .shadow-soft {

--- a/src/app/project/[id]/page.tsx
+++ b/src/app/project/[id]/page.tsx
@@ -987,7 +987,7 @@ export default function ProjectPage() {
               style={{
                 maxWidth: 480,
                 maxHeight: '80dvh',
-                background: '#faf7f1',
+                background: 'var(--color-surface)',
                 border: '1.5px solid var(--solid-ink)',
                 borderRadius: 20,
                 boxShadow: '4px 5px 0 var(--solid-ink)',

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -171,7 +171,7 @@ export default function SignupPage() {
       {/* Bottom CTAs */}
       <div
         className="px-6 pb-7 pt-3"
-        style={{ background: 'linear-gradient(to top, #fafaf7 70%, rgba(250,250,247,0))' }}
+        style={{ background: 'linear-gradient(to top, var(--color-background) 70%, rgba(0,0,0,0))' }}
       >
         <div className="relative">
           <div

--- a/src/components/home/ScanCaptureModal.tsx
+++ b/src/components/home/ScanCaptureModal.tsx
@@ -196,7 +196,7 @@ export function ScanCaptureModal({ isOpen, onClose, defaultMode, targetProjectId
           className="w-full animate-fade-in-up"
           style={{
             maxWidth: 480,
-            background: '#faf7f1',
+            background: 'var(--color-surface)',
             border: '1.5px solid var(--solid-ink)',
             borderBottomWidth: 0,
             borderTopLeftRadius: 20,

--- a/src/components/project/ProjectDetailSheet.tsx
+++ b/src/components/project/ProjectDetailSheet.tsx
@@ -323,7 +323,7 @@ export function ProjectDetailSheet({ projectId, onClose }: { projectId: string; 
       <div
         className="relative w-full animate-fade-in-up"
         style={{
-          background: '#faf7f1',
+          background: 'var(--color-surface)',
           border: '1.5px solid var(--solid-ink)',
           borderBottomWidth: 0,
           borderTopLeftRadius: 20,

--- a/src/components/project/ProjectShareSheet.tsx
+++ b/src/components/project/ProjectShareSheet.tsx
@@ -64,7 +64,7 @@ export function ProjectShareSheet({
           className="w-full animate-fade-in-up"
           style={{
             maxWidth: 480,
-            background: '#faf7f1',
+            background: 'var(--color-surface)',
             border: '1.5px solid var(--solid-ink)',
             borderBottomWidth: 0,
             borderTopLeftRadius: 20,

--- a/src/components/project/WordListSheets.tsx
+++ b/src/components/project/WordListSheets.tsx
@@ -44,7 +44,7 @@ function BottomSheetShell({ open, onClose, title, children, footer }: BottomShee
       <div
         className="relative w-full animate-fade-in-up"
         style={{
-          background: '#faf7f1',
+          background: 'var(--color-surface)',
           border: '1.5px solid var(--solid-ink)',
           borderBottomWidth: 0,
           borderTopLeftRadius: 20,

--- a/src/components/ui/bottom-nav.tsx
+++ b/src/components/ui/bottom-nav.tsx
@@ -158,14 +158,15 @@ export function BottomNav() {
           bottom: 0,
           zIndex: 40,
           paddingBottom: 'max(20px, env(safe-area-inset-bottom))',
-          background: 'linear-gradient(to top, #faf7f1 70%, rgba(250,247,241,0))',
+          background:
+            'linear-gradient(to top, var(--color-background) 70%, rgba(0,0,0,0))',
           pointerEvents: 'none',
         }}
       >
         <div
           style={{
             margin: '0 14px',
-            background: '#fff',
+            background: 'var(--color-surface)',
             border: '1.25px solid var(--solid-ink)',
             borderRadius: 22,
             boxShadow: '3px 3px 0 var(--solid-ink)',
@@ -207,7 +208,7 @@ export function BottomNav() {
                       height: 42,
                       borderRadius: 21,
                       background: 'var(--solid-ink)',
-                      color: '#fff',
+                      color: 'var(--color-background)',
                       display: 'flex',
                       alignItems: 'center',
                       justifyContent: 'center',


### PR DESCRIPTION
## Summary
ダークモード時に「白い文字 × 白い背景」で読めなくなる箇所と、画面下部のボトムナビ周辺に明るい霧（フォグ）がかかる現象をまとめて修正。

### 何が起きていたか

1. **ボトムナビ周辺の「霧」**
   `src/components/ui/bottom-nav.tsx` のフェード用グラデーションが `linear-gradient(to top, #faf7f1 70%, ...)` のハードコード。ダークモードでも下から上に **クリーム色の霧** が湧き、コンテンツが薄く見える原因に。
   さらに内側のピル本体が `background: '#fff'`、テキスト色は `var(--solid-ink)`（ダークモードでは `#f1f3f5` ≒ ほぼ白）→ **白いピルに白文字** で完全に読めない状態。
2. **モーダル / ボトムシートの背景**
   `ProjectDetailSheet`, `ProjectShareSheet`, `ScanCaptureModal`, `WordListSheets`, `project/[id]` の単語詳細モーダル、`signup` の下部 CTA グラデーション、`flashcard` のステータスチップが、いずれも `#faf7f1` / `#fff` / `#fafaf7` をインラインスタイルで指定。CSS 変数を経由していないので、`.dark` クラス切り替えで色が変わらず、シート内の `text-[var(--solid-ink)]` が同色になり潰れる。
3. **`bg-[var(--solid-ink)] text-white` 系**
   `--solid-ink` はダークモードで near-white に反転するが、`text-white` は純白のまま → 反転塗りつぶしのボタンや `.btn-primary` / `.fab` / `.chip-pro` などが軒並み「白に白」。
4. **`bg-white/80`、`bg-white/70`、`hover:bg-white`**
   既存の `.dark .bg-white` 上書きはこの透明度バリアントには効かないため、ダークモードでも明るい白半透明の塗りが残り、内側のテキストが消える。

### 直したもの

- `src/components/ui/bottom-nav.tsx`
  - フォググラデーション → `var(--color-background)` ベースに
  - 内側ピルの `#fff` → `var(--color-surface)`
  - 真ん中のスキャン丸ボタン文字色 `#fff` → `var(--color-background)`（`--solid-ink` 反転に追従）
- `src/components/project/{ProjectDetailSheet,ProjectShareSheet,WordListSheets}.tsx`、`src/components/home/ScanCaptureModal.tsx`、`src/app/project/[id]/page.tsx` の単語詳細モーダル
  - シート背景 `#faf7f1` → `var(--color-surface)`
- `src/app/signup/page.tsx`
  - 下部 CTA フォググラデーションを `var(--color-background)` ベースに
- `src/app/flashcard/[projectId]/page.tsx`
  - ステータスチップの `background: 'white'` → `var(--color-surface)`
- `src/app/globals.css`
  - `bg-white/80`, `bg-white/70`, `bg-white/10`, `hover:bg-white`, `hover:bg-white/80` のダーク上書き
  - 反転塗りつぶし背景（`--solid-ink` / `--color-foreground` / `--color-primary` / `--color-hero-btn`）と組み合わさった `.text-white` を `var(--color-background)` に
  - `.btn-primary` / `.chip-pro` / `.solid-link-primary` / `.fab` の `color: white` をダークモードで `var(--color-background)` に反転（背景は `--color-foreground` で反転するため）

`accent`（フォレストグリーン）と `error`（赤）はダーク／ライトで色が変わらないため、その上の `text-white` はそのまま残しています。

## Test plan
- [ ] ライトモードで見た目に変化がないことを確認（特にボトムナビ、モーダル群、サインアップ下部 CTA）
- [ ] ダークモードに切り替え：
  - [ ] ホーム画面下部のフォグが消え、ボトムナビが背景色に溶け込む
  - [ ] ボトムナビのピルが暗色になり、アイコン・ラベルが読める
  - [ ] スキャン（中央＋ボタン）の `+` 記号が読める
  - [ ] プロジェクト詳細シート / 共有シート / スキャン撮影モーダル / 単語フィルタシート / 単語詳細モーダルが暗色背景になり、テキストが読める
  - [ ] サインアップ下部 CTA の上のグラデーションがクリーム色でなく背景色
  - [ ] フラッシュカードのステータスチップ背景が暗色
  - [ ] 反転塗りつぶしボタン群（`.btn-primary`、`.fab`、各種 `bg-[var(--solid-ink)] text-white` バッジ）の文字が読める
- [x] `npm run lint` 通過（既存 warning のみ、エラー 0）
- [x] `npm run build` 成功

https://claude.ai/code

---
_Generated by [Claude Code](https://claude.ai/code/session_01GamorWSu43Y9n47EB1v4kQ)_