### PR TITLE
[codex] Bootstrap empty remote sync from local data

### DIFF
--- a/src/lib/db/hybrid-repository.test.ts
+++ b/src/lib/db/hybrid-repository.test.ts
@@ -307,7 +307,7 @@ test('FULL_SYNC_INTERVAL_MS is fixed to 1 hour', () => {
   assert.equal(FULL_SYNC_INTERVAL_MS, 60 * 60 * 1000);
 });
 
-test('fullSync does not delete local data when remote is empty and local data exists', async (t) => {
+test('fullSync bootstraps empty remote from local data before marking synced', async (t) => {
   const { storage, restore } = installLocalStorage();
   t.after(restore);
 
@@ -318,18 +318,69 @@ test('fullSync does not delete local data when remote is empty and local data ex
   const syncQueue = makeSyncQueue([]);
   const repository = makeRepository({
     getDb: () => db,
-    remoteRepository: makeRemoteRepository({ getProjectsResponses: [[]], calls }),
+    remoteRepository: makeRemoteRepository({
+      getProjectsResponses: [[], [localProject]],
+      remoteWords: [localWord],
+      calls,
+    }),
     syncQueue,
   });
 
   await repository.fullSync(USER_ID);
 
-  assert.deepEqual(calls, ['getProjects:user_123']);
-  assert.deepEqual(projectsTable.deleteCalls, []);
-  assert.deepEqual(wordsTable.deleteCalls, []);
-  assert.deepEqual(projectsTable.getRows(), [localProject]);
-  assert.deepEqual(wordsTable.getRows(), [localWord]);
-  assert.equal(syncQueue.clearCalls, 0);
+  assert.deepEqual(calls, [
+    'getProjects:user_123',
+    'createProjectWithId:local_project',
+    'createWordsWithIds:local_word',
+    'getProjects:user_123',
+    'getAllWordsByProjectIds:local_project',
+  ]);
+  assert.deepEqual(projectsTable.deleteCalls, [{ field: 'userId', values: [USER_ID] }]);
+  assert.deepEqual(wordsTable.deleteCalls, [{ field: 'projectId', values: [localProject.id] }]);
+  assert.deepEqual(projectsTable.bulkPutCalls, [[localProject]]);
+  assert.deepEqual(wordsTable.bulkPutCalls, [[localWord]]);
+  assert.equal(syncQueue.clearCalls, 1);
+  assert.equal(storage.getItem('scanvocab_sync_user'), USER_ID);
+  assert.equal(storage.getItem('scanvocab_last_sync'), String(FIXED_NOW));
+});
+
+test('delta sync falls back to local bootstrap when remote is empty but local data exists', async (t) => {
+  const { storage, restore } = installLocalStorage({
+    scanvocab_last_sync: String(FIXED_NOW - 2 * 60 * 60 * 1000),
+    scanvocab_sync_user: USER_ID,
+  });
+  t.after(restore);
+
+  const localProject = makeProject('local_project');
+  const localWord = makeWord('local_word', localProject.id);
+  const { db, projectsTable, wordsTable } = makeDb([localProject], [localWord]);
+  const calls: string[] = [];
+  const syncQueue = makeSyncQueue([]);
+  const repository = makeRepository({
+    getDb: () => db,
+    remoteRepository: makeRemoteRepository({
+      getProjectsResponses: [[], [localProject]],
+      remoteWords: [localWord],
+      calls,
+    }),
+    syncQueue,
+  });
+
+  await repository.fullSync(USER_ID);
+
+  assert.deepEqual(calls, [
+    'getProjectIds:user_123',
+    'getProjectsUpdatedSince:user_123',
+    'getProjects:user_123',
+    'createProjectWithId:local_project',
+    'createWordsWithIds:local_word',
+    'getProjects:user_123',
+    'getAllWordsByProjectIds:local_project',
+  ]);
+  assert.deepEqual(projectsTable.bulkDeleteCalls, []);
+  assert.deepEqual(projectsTable.deleteCalls, [{ field: 'userId', values: [USER_ID] }]);
+  assert.deepEqual(wordsTable.deleteCalls, [{ field: 'projectId', values: [localProject.id] }]);
+  assert.equal(syncQueue.clearCalls, 1);
   assert.equal(storage.getItem('scanvocab_sync_user'), USER_ID);
   assert.equal(storage.getItem('scanvocab_last_sync'), String(FIXED_NOW));
 });

--- a/src/lib/db/hybrid-repository.ts
+++ b/src/lib/db/hybrid-repository.ts
@@ -65,6 +65,28 @@ const defaultDependencies: HybridRepositoryDependencies = {
 export class HybridWordRepository implements WordRepository {
   constructor(private readonly dependencies: HybridRepositoryDependencies = defaultDependencies) {}
 
+  private async pushLocalProjectToRemote(
+    db: ReturnType<HybridRepositoryDependencies['getDb']>,
+    project: Project,
+  ): Promise<void> {
+    await this.dependencies.remoteRepository.createProjectWithId(project);
+
+    try {
+      const localWords = await db.words.where('projectId').equals(project.id).toArray();
+      if (localWords.length > 0) {
+        await this.dependencies.remoteRepository.createWordsWithIds(localWords as Word[]);
+      }
+      console.log('[HybridRepo] Pushed local-only project to remote:', project.id);
+    } catch (error) {
+      try {
+        await this.dependencies.remoteRepository.deleteProject(project.id);
+      } catch (rollbackError) {
+        console.error('[HybridRepo] Failed to roll back remote project after word sync failure:', project.id, rollbackError);
+      }
+      throw error;
+    }
+  }
+
   // Get last sync timestamp
   getLastSync(): number | null {
     if (typeof localStorage === 'undefined') return null;
@@ -144,22 +166,21 @@ export class HybridWordRepository implements WordRepository {
           .map(item => item.entityId)
       );
 
-      const projectsToPush = localOnlyProjects.filter(p => pendingCreateProjectIds.has(p.id));
+      const shouldBootstrapRemoteFromLocal = remoteProjects.length === 0 && localProjects.length > 0;
+      const projectsToPush = shouldBootstrapRemoteFromLocal
+        ? localOnlyProjects
+        : localOnlyProjects.filter(p => pendingCreateProjectIds.has(p.id));
 
       for (const project of projectsToPush) {
         try {
-          await this.dependencies.remoteRepository.createProjectWithId(project as Project);
-          const localWords = await db.words.where('projectId').equals(project.id).toArray();
-          if (localWords.length > 0) {
-            await this.dependencies.remoteRepository.createWordsWithIds(localWords as Word[]);
-          }
-          console.log('[HybridRepo] Pushed local-only project to remote:', project.id);
+          await this.pushLocalProjectToRemote(db, project as Project);
         } catch (err) {
           console.error('[HybridRepo] Failed to push local-only project:', project.id, err);
+          if (shouldBootstrapRemoteFromLocal) throw err;
         }
       }
 
-      if (localOnlyProjects.length > projectsToPush.length) {
+      if (!shouldBootstrapRemoteFromLocal && localOnlyProjects.length > projectsToPush.length) {
         console.log('[HybridRepo] Skipped', localOnlyProjects.length - projectsToPush.length, 'local-only projects (deleted on another device)');
       }
 
@@ -171,8 +192,6 @@ export class HybridWordRepository implements WordRepository {
       // 5. Safety: skip local delete if remote is empty but local has data
       if (mergedProjects.length === 0 && localProjects.length > 0) {
         console.warn('[HybridRepo] Remote is empty but local has data — skipping destructive sync');
-        this.setLastSync(this.dependencies.now());
-        this.setSyncedUserId(userId);
         return;
       }
 
@@ -242,6 +261,14 @@ export class HybridWordRepository implements WordRepository {
       // 2. Detect deleted projects
       const remoteProjectIdSet = new Set(remoteProjectIds);
       const localProjects = await db.projects.where('userId').equals(userId).toArray();
+
+      if (remoteProjectIds.length === 0 && localProjects.length > 0) {
+        console.warn('[HybridRepo] Remote is empty during delta sync while local has data — falling back to full sync');
+        this.clearSyncData();
+        await this._fullSyncAll(userId);
+        return;
+      }
+
       const deletedProjectIds = localProjects
         .map(p => p.id)
         .filter(id => !remoteProjectIdSet.has(id));


### PR DESCRIPTION
## Summary

- Bootstrap an empty remote project set from existing local projects during hybrid full sync.
- Preserve local project and word IDs when pushing the initial local data to Supabase.
- Fall back from delta sync to full-sync bootstrap when the remote is empty but local data exists.
- Cover the bootstrap and delta fallback paths in `hybrid-repository` tests.

## Root Cause

The previous safety guard prevented a destructive local delete when remote data was empty, but it did not populate the remote. In some cases the sync state could still advance and later delta sync could treat local-only projects as remotely deleted.

## Validation

- `npx tsx --test src/lib/db/hybrid-repository.test.ts`
