### PR TITLE
Codex/normalized source modes

### DIFF
--- a/src/app/api/extract/route.contract.test.ts
+++ b/src/app/api/extract/route.contract.test.ts
@@ -109,6 +109,7 @@ function createDeps(
               english: 'book',
               japanese: '本',
               japaneseSource: 'scan',
+              sourceModes: ['idiom'],
               distractors: ['ペン', '机', '紙'],
               partOfSpeechTags: ['noun'],
             },
@@ -131,6 +132,7 @@ function createDeps(
       calls.push('extractEikenWords');
       return {
         success: true,
+        extractedText: 'mock ocr',
         data: {
           words: [],
           sourceLabels: ['ノート'],
@@ -157,7 +159,7 @@ function createDeps(
               english: 'look forward to',
               japanese: '楽しみに待つ',
               japaneseSource: 'scan',
-              sourceModes: ['idiom', 'all'],
+              sourceModes: ['idiom'],
               distractors: [],
               partOfSpeechTags: ['idiom'],
               exampleSentence: 'I look forward to hearing from you.',
@@ -355,7 +357,7 @@ test('/api/extract uses scan usage response to reject free users from Pro-only m
   assert.deepEqual(calls, []);
 });
 
-test('/api/extract runs one composite extraction for multiple scanModes', async () => {
+test('/api/extract runs one composite extraction and overwrites sourceModes from normalized scanModes', async () => {
   const client = new FakeExtractClient({
     scanData: allowedScanData({
       current_count: 2,
@@ -369,7 +371,8 @@ test('/api/extract runs one composite extraction for multiple scanModes', async 
     jsonRequest({
       image: 'data:image/png;base64,AAAA',
       mode: 'all',
-      scanModes: ['all', 'idiom'],
+      scanModes: ['all', 'idiom', 'eiken'],
+      eikenLevel: '2',
     }),
     createDeps(client, calls),
   );
@@ -384,7 +387,7 @@ test('/api/extract runs one composite extraction for multiple scanModes', async 
     },
   ]);
   assert.deepEqual(calls, [
-    'extractCompositeWords:all,idiom:',
+    'extractCompositeWords:all,idiom,eiken:2',
     'resolveImmediateWords',
   ]);
   assert.deepEqual(payload.words, [
@@ -392,7 +395,7 @@ test('/api/extract runs one composite extraction for multiple scanModes', async 
       english: 'look forward to',
       japanese: '楽しみに待つ',
       japaneseSource: 'scan',
-      sourceModes: ['idiom', 'all'],
+      sourceModes: ['all', 'idiom', 'eiken'],
       distractors: [],
       partOfSpeechTags: ['idiom'],
       exampleSentence: 'I look forward to hearing from you.',

--- a/src/app/api/extract/route.ts
+++ b/src/app/api/extract/route.ts
@@ -10,6 +10,7 @@ import {
 import { getAPIKeys } from '@/lib/ai/config';
 import {
   EXTRACT_MODES,
+  applySourceModesFromScanModes,
   getMissingProviderKey,
   getMissingProviderKeyForModes,
   getProvidersForMode,
@@ -90,19 +91,6 @@ function isMasterFirstResolutionEnabledForModes(modes: Iterable<ExtractMode>): b
     .filter(Boolean);
 
   return normalizeExtractModes(Array.from(modes)).every((mode) => !disabledModes.includes(mode));
-}
-
-function withFallbackSourceModes<T>(words: T[], modes: ExtractMode[]): T[] {
-  return words.map((word) => {
-    if (!word || typeof word !== 'object') {
-      return word;
-    }
-    const sourceModes = normalizeExtractModes((word as { sourceModes?: unknown }).sourceModes, []);
-    return {
-      ...(word as Record<string, unknown>),
-      sourceModes: sourceModes.length > 0 ? sourceModes : modes,
-    } as T;
-  });
 }
 
 // API Route: POST /api/extract
@@ -308,7 +296,7 @@ export async function handleExtractPost(request: NextRequest, deps?: ExtractRout
       ...result,
       data: {
         ...result.data,
-        words: withFallbackSourceModes(result.data.words, modes),
+        words: applySourceModesFromScanModes(result.data.words, modes),
       },
     };
 
@@ -322,7 +310,10 @@ export async function handleExtractPost(request: NextRequest, deps?: ExtractRout
     const rollbackResult = masterFirstEnabled
       ? null
       : await backfillWords(result.data.words);
-    const extractedWords = resolved?.words ?? rollbackResult?.words ?? result.data.words;
+    const extractedWords = applySourceModesFromScanModes(
+      resolved?.words ?? rollbackResult?.words ?? result.data.words,
+      modes,
+    );
     const aiJapaneseCount = extractedWords.filter((word) => word.japaneseSource === 'ai').length;
 
     console.log('[extract] Extraction done', {

--- a/src/app/api/scan-jobs/process/route.contract.test.ts
+++ b/src/app/api/scan-jobs/process/route.contract.test.ts
@@ -616,6 +616,7 @@ test('processJobById uses scanModesOverride when scan_modes is not available on 
     claimedJob: pendingServerCloudJob({
       scan_mode: 'all',
       scan_modes: null,
+      eiken_level: '2',
     }),
     userPreference: { ai_enabled: false },
   });
@@ -623,9 +624,9 @@ test('processJobById uses scanModesOverride when scan_modes is not available on 
   const response = await processJobById(
     JOB_ID,
     createServerCloudContractDeps(client, {
-      scanModesOverride: ['all', 'idiom'],
+      scanModesOverride: ['all', 'idiom', 'eiken'],
       extractImage: async (_base64Image, modes) => {
-        observedModes.push(modes);
+        observedModes.push(Array.isArray(modes) ? modes : [modes]);
         return {
           result: {
             success: true,
@@ -635,7 +636,7 @@ test('processJobById uses scanModesOverride when scan_modes is not available on 
                   english: 'look forward to',
                   japanese: '楽しみに待つ',
                   japaneseSource: 'scan',
-                  sourceModes: ['all', 'idiom'],
+                  sourceModes: ['idiom'],
                   distractors: [],
                   partOfSpeechTags: ['idiom'],
                 },
@@ -649,7 +650,65 @@ test('processJobById uses scanModesOverride when scan_modes is not available on 
   );
 
   assert.equal(response.status, 200);
-  assert.deepEqual(observedModes, [['all', 'idiom']]);
+  assert.deepEqual(observedModes, [['all', 'idiom', 'eiken']]);
+
+  const wordsInsert = findOperation(
+    client,
+    (operation) => operation.table === 'words' && operation.action === 'insert',
+    'missing words insert',
+  );
+  assert.ok(Array.isArray(wordsInsert.payload));
+  assert.deepEqual(wordsInsert.payload[0]?.source_modes, ['all', 'idiom', 'eiken']);
+});
+
+test('server_cloud writes source_modes from normalized scan_modes instead of AI sourceModes', async () => {
+  const observedModes: string[][] = [];
+  const client = new FakeScanProcessClient({
+    claimedJob: pendingServerCloudJob({
+      scan_mode: 'all',
+      scan_modes: ['all', 'idiom', 'eiken'],
+      eiken_level: '2',
+    }),
+    userPreference: { ai_enabled: false },
+  });
+
+  const response = await processJobById(
+    JOB_ID,
+    createServerCloudContractDeps(client, {
+      extractImage: async (_base64Image, modes) => {
+        observedModes.push(Array.isArray(modes) ? modes : [modes]);
+        return {
+          result: {
+            success: true,
+            data: {
+              words: [
+                {
+                  english: 'look forward to',
+                  japanese: '楽しみに待つ',
+                  japaneseSource: 'scan',
+                  sourceModes: ['idiom'],
+                  distractors: [],
+                  partOfSpeechTags: ['idiom'],
+                },
+              ],
+              sourceLabels: ['鉄壁'],
+            },
+          },
+        };
+      },
+    }),
+  );
+
+  assert.equal(response.status, 200);
+  assert.deepEqual(observedModes, [['all', 'idiom', 'eiken']]);
+
+  const wordsInsert = findOperation(
+    client,
+    (operation) => operation.table === 'words' && operation.action === 'insert',
+    'missing words insert',
+  );
+  assert.ok(Array.isArray(wordsInsert.payload));
+  assert.deepEqual(wordsInsert.payload[0]?.source_modes, ['all', 'idiom', 'eiken']);
 });
 
 test('server_cloud new project completion keeps project insert, words insert, and completed update contract', async () => {
@@ -737,7 +796,7 @@ test('server_cloud new project completion keeps project insert, words insert, an
       example_sentence_ja: '私はりんごを食べました。',
       pronunciation: null,
       part_of_speech_tags: ['noun'],
-      source_modes: undefined,
+      source_modes: ['all'],
     },
   ]);
 
@@ -807,7 +866,7 @@ test('server_cloud retries words insert without source_modes when the database s
   );
   assert.equal(wordsInserts.length, 2);
   assert.ok(Array.isArray(wordsInserts[0].payload));
-  assert.equal(wordsInserts[0].payload[0]?.source_modes, undefined);
+  assert.deepEqual(wordsInserts[0].payload[0]?.source_modes, ['all']);
   assert.ok(Array.isArray(wordsInserts[1].payload));
   assert.equal('source_modes' in wordsInserts[1].payload[0], false);
 

--- a/src/app/api/scan-jobs/process/route.extractor.test.ts
+++ b/src/app/api/scan-jobs/process/route.extractor.test.ts
@@ -95,7 +95,7 @@ test('extractFromImage uses one composite extraction call for multiple modes', a
               english: 'look forward to',
               japanese: '楽しみに待つ',
               japaneseSource: 'scan',
-              sourceModes: ['idiom', 'all'],
+              sourceModes: ['idiom'],
               distractors: [],
               partOfSpeechTags: ['idiom'],
             },
@@ -117,7 +117,7 @@ test('extractFromImage uses one composite extraction call for multiple modes', a
   assert.deepEqual(calls, ['extractCompositeWordsFromImage:all,idiom,eiken:2']);
   assert.equal(result.success, true);
   if (result.success) {
-    assert.deepEqual((result.data.words[0] as { sourceModes?: string[] }).sourceModes, ['idiom', 'all']);
+    assert.deepEqual((result.data.words[0] as { sourceModes?: string[] }).sourceModes, ['all', 'idiom', 'eiken']);
   }
 });
 
@@ -146,11 +146,11 @@ test('scan-jobs parser preserves japaneseSource and prefers scan during dedupe',
     },
   ]);
 
-  const deduped = __internal.dedupeExtractedWords(parsed);
+  const deduped = __internal.dedupeExtractedWords(parsed, ['all', 'idiom', 'eiken']);
 
   assert.equal(deduped.length, 1);
   assert.equal(deduped[0]?.japaneseSource, 'scan');
-  assert.deepEqual(deduped[0]?.sourceModes, ['all', 'circled']);
+  assert.deepEqual(deduped[0]?.sourceModes, ['all', 'idiom', 'eiken']);
 });
 
 test('scan-jobs marks partial example generation with warning and payload summary', () => {
@@ -169,7 +169,11 @@ test('scan-jobs marks partial example generation with warning and payload summar
   };
 
   const warningSet = new Set<string>();
-  const payloadBase = { saveMode: 'server_cloud' as const, wordCount: 5 };
+  const payloadBase: {
+    saveMode: 'server_cloud';
+    wordCount: number;
+    exampleGeneration?: ExampleGenerationSummary;
+  } = { saveMode: 'server_cloud', wordCount: 5 };
   const payload = __internal.applyExampleGenerationSummary(
     payloadBase,
     warningSet,

--- a/src/app/api/scan-jobs/process/route.ts
+++ b/src/app/api/scan-jobs/process/route.ts
@@ -13,6 +13,7 @@ import { sendScanJobApnsNotifications } from '@/lib/notifications/apns';
 import { generateQuizContentForWords, type QuizContentResult } from '@/lib/ai/generate-quiz-content';
 import { AI_CONFIG, getAPIKeys } from '@/lib/ai/config';
 import {
+  applySourceModesFromScanModes,
   getMissingProviderKey,
   getMissingProviderKeyForModes,
   getProvidersForMode,
@@ -530,7 +531,7 @@ function mergeExtractSourceModes(
   return normalizeSourceModes([...(first ?? []), ...(second ?? [])], []);
 }
 
-function withFallbackSourceModes(
+function applySourceModesToExtractionResult(
   result: ExtractionLikeResult,
   modes: ExtractMode[],
 ): ExtractionLikeResult {
@@ -540,19 +541,7 @@ function withFallbackSourceModes(
     ...result,
     data: {
       ...result.data,
-      words: result.data.words.map((word) => {
-        if (!word || typeof word !== 'object') {
-          return word;
-        }
-        const sourceModes = normalizeSourceModes(
-          (word as { sourceModes?: unknown }).sourceModes,
-          modes,
-        );
-        return {
-          ...(word as Record<string, unknown>),
-          ...(sourceModes ? { sourceModes } : {}),
-        };
-      }),
+      words: applySourceModesFromScanModes(result.data.words, modes),
     },
   };
 }
@@ -605,9 +594,15 @@ function parseExtractedWords(rawWords: unknown[]): ProcessedExtractedWord[] {
   return parsed;
 }
 
-function dedupeExtractedWords(words: ProcessedExtractedWord[]): ProcessedExtractedWord[] {
+function dedupeExtractedWords(
+  words: ProcessedExtractedWord[],
+  sourceModesOverride?: ExtractMode[],
+): ProcessedExtractedWord[] {
   if (words.length === 0) return [];
 
+  const normalizedSourceModesOverride = sourceModesOverride
+    ? normalizeExtractModes(sourceModesOverride)
+    : undefined;
   const deduped: ProcessedExtractedWord[] = [];
   const indexByKey = new Map<string, number>();
 
@@ -621,7 +616,9 @@ function dedupeExtractedWords(words: ProcessedExtractedWord[]): ProcessedExtract
         english: source.english,
         japanese: source.japanese,
         japaneseSource: source.japaneseSource,
-        sourceModes: source.sourceModes,
+        sourceModes: normalizedSourceModesOverride
+          ? [...normalizedSourceModesOverride]
+          : source.sourceModes,
         distractors: mergeDistractors([], source.distractors),
         partOfSpeechTags: normalizePartOfSpeechTags(source.partOfSpeechTags),
         pronunciation: firstNonEmpty(source.pronunciation),
@@ -636,7 +633,9 @@ function dedupeExtractedWords(words: ProcessedExtractedWord[]): ProcessedExtract
       english: existing.english,
       japanese: existing.japanese,
       japaneseSource: preferJapaneseSource(existing.japaneseSource, source.japaneseSource),
-      sourceModes: mergeExtractSourceModes(existing.sourceModes, source.sourceModes),
+      sourceModes: normalizedSourceModesOverride
+        ? [...normalizedSourceModesOverride]
+        : mergeExtractSourceModes(existing.sourceModes, source.sourceModes),
       distractors: mergeDistractors(existing.distractors, source.distractors),
       partOfSpeechTags: normalizePartOfSpeechTags([
         ...(existing.partOfSpeechTags ?? []),
@@ -705,14 +704,14 @@ async function extractFromImage(
       modes,
       eikenLevel: modes.includes('eiken') ? normalizeEikenLevel(eikenLevel) : null,
     }) as ExtractionLikeResult;
-    return { result: withFallbackSourceModes(result, modes) };
+    return { result: applySourceModesToExtractionResult(result, modes) };
   }
 
   const mode = modes[0] ?? 'all';
   switch (mode) {
     case 'circled': {
       const result = await handlers.extractCircledWordsFromImage(base64Image, apiKeys, {}) as ExtractionLikeResult;
-      return { result: withFallbackSourceModes(result, ['circled']) };
+      return { result: applySourceModesToExtractionResult(result, modes) };
     }
     case 'eiken': {
       const normalizedLevel = normalizeEikenLevel(eikenLevel);
@@ -724,25 +723,25 @@ async function extractFromImage(
           apiKeys,
           normalizedLevel
         ) as ExtractionLikeResult;
-      return { result: withFallbackSourceModes(result, ['eiken']) };
+      return { result: applySourceModesToExtractionResult(result, modes) };
     }
     case 'idiom': {
       const idiomResult = await handlers.extractIdiomsFromImage(base64Image, apiKeys);
       if (!idiomResult.success && idiomResult.reason === 'no_idiom_found') {
         console.warn('No idioms found in background scan. Falling back to all-word extraction.');
         return {
-          result: withFallbackSourceModes(
+          result: applySourceModesToExtractionResult(
             await handlers.extractWordsFromImage(base64Image, apiKeys, { includeExamples: false }) as ExtractionLikeResult,
-            ['all'],
+            modes,
           ),
           warningCode: 'grammar_not_found',
         };
       }
-      return { result: withFallbackSourceModes(idiomResult as ExtractionLikeResult, ['idiom']) };
+      return { result: applySourceModesToExtractionResult(idiomResult as ExtractionLikeResult, modes) };
     }
     default: {
       const result = await handlers.extractWordsFromImage(base64Image, apiKeys, { includeExamples: false }) as ExtractionLikeResult;
-      return { result: withFallbackSourceModes(result, ['all']) };
+      return { result: applySourceModesToExtractionResult(result, modes) };
     }
   }
 }
@@ -875,7 +874,7 @@ export async function processJobById(jobId: string, processDeps?: ProcessJobDeps
               .from('scan-images')
               .download(imagePath),
             extractImage,
-            parseWords: parseExtractedWords,
+            parseWords: (rawWords) => applySourceModesFromScanModes(parseExtractedWords(rawWords), modes),
             withTimingPhase: withCloudRunTimingPhase,
             withTimeout,
           },
@@ -939,7 +938,7 @@ export async function processJobById(jobId: string, processDeps?: ProcessJobDeps
       }
 
       const parseStart = Date.now();
-      const dedupedWords = dedupeExtractedWords(allExtractedWords);
+      const dedupedWords = dedupeExtractedWords(allExtractedWords, modes);
       const dedupedSourceLabels = ensureSourceLabels(allSourceLabels);
       timing.parseValidationMs = Date.now() - parseStart;
 
@@ -987,7 +986,10 @@ export async function processJobById(jobId: string, processDeps?: ProcessJobDeps
         ? null
         : await backfillWords(dedupedWords);
       timing.lexiconResolutionMs = Date.now() - lexiconResolutionStart;
-      const resolvedWords = resolvedResult?.words ?? rollbackResult?.words ?? dedupedWords;
+      const resolvedWords = applySourceModesFromScanModes(
+        resolvedResult?.words ?? rollbackResult?.words ?? dedupedWords,
+        modes,
+      );
       const aiJapaneseCount = resolvedWords.filter((word) => word.japaneseSource === 'ai').length;
 
       console.log('[scan-jobs/process] Extraction finished', {

--- a/src/lib/ai/extract-composite-words.test.ts
+++ b/src/lib/ai/extract-composite-words.test.ts
@@ -16,6 +16,8 @@ test('composite extraction prompt treats multiple selected modes as an intersect
   assert.match(systemPrompt, /丸囲みされた熟語・句動詞だけ/);
   assert.match(systemPrompt, /丸囲みでも単語なら除外/);
   assert.match(systemPrompt, /熟語でも丸囲みでなければ除外/);
+  assert.doesNotMatch(systemPrompt, /sourceModes/);
   assert.ok(systemPrompt.includes(JAPANESE_PARENTHESIS_RULES));
   assert.match(userPrompt, /選択条件（丸囲み、熟語・イディオム）をすべて満たす/);
+  assert.doesNotMatch(userPrompt, /sourceModes/);
 });

--- a/src/lib/ai/extract-composite-words.ts
+++ b/src/lib/ai/extract-composite-words.ts
@@ -1,5 +1,6 @@
 import { parseAIResponse, type ValidatedAIResponse } from '@/lib/schemas/ai-response';
 import {
+  applySourceModesFromScanModes,
   type ExtractMode,
   getPrimaryExtractMode,
   normalizeExtractModes,
@@ -56,7 +57,6 @@ function buildCompositeExtractionPrompts(options: CompositeExtractionOptions): {
 } {
   const modes = normalizeExtractModes(options.modes);
   const modeLabels = modes.map((mode) => MODE_LABELS[mode]).join('、');
-  const modeValues = modes.map((mode) => `"${mode}"`).join(', ');
 
   return {
     systemPrompt: `あなたは英語学習教材の画像解析者です。ユーザーが選択した複数の抽出条件を1回の画像理解で同時に満たし、JSON形式で返してください。
@@ -66,9 +66,7 @@ function buildCompositeExtractionPrompts(options: CompositeExtractionOptions): {
 重要方針:
 - 出力は選択条件の「積集合」です。選択された複数条件をすべて満たす語・フレーズだけを返してください。
 - 1つでも選択条件を満たさない候補は返してはいけません。
-- 同じ英語表現が複数箇所で見つかる場合は1件だけ返し、sourceModes には満たした選択モードをすべて入れてください。
-- 複数選択時に返す単語の sourceModes は、原則として選択された全モードを含みます。
-- sourceModes は必ず選択されたモードの中から選びます。使用可能な値: ${modeValues}
+- 同じ英語表現が複数箇所で見つかる場合は1件だけ返してください。
 - 例: circled と idiom が選択された場合、丸囲みされた熟語・句動詞だけを返してください。丸囲みでも単語なら除外し、熟語でも丸囲みでなければ除外してください。
 - 例: all と idiom が選択された場合、画像内の学習価値が高い熟語・句動詞だけを返してください。通常の単語は除外してください。
 - 例: eiken と circled が選択された場合、英検レベル条件に合う丸囲み単語だけを返してください。
@@ -91,7 +89,6 @@ ${SOURCE_LABEL_OUTPUT_SNIPPET}
       "english": "look forward to",
       "japanese": "〜を楽しみに待つ",
       "japaneseSource": "scan",
-      "sourceModes": ["idiom", "all"],
       "distractors": [],
       "partOfSpeechTags": ["idiom"]
     }
@@ -100,25 +97,10 @@ ${SOURCE_LABEL_OUTPUT_SNIPPET}
 
 注意:
 - JSONのみを返してください。
-- sourceModes が空の単語は返さないでください。
 - 見つからない場合は {"sourceLabels": [], "words": []} を返してください。
 ${SOURCE_LABEL_NOTES}`,
-    userPrompt: `この画像から、選択条件（${modeLabels}）をすべて満たす学習対象だけを抽出してください。各単語・フレーズに sourceModes を必ず付けてください。`,
+    userPrompt: `この画像から、選択条件（${modeLabels}）をすべて満たす学習対象だけを抽出してください。`,
   };
-}
-
-function fallbackSourceModes<T extends { sourceModes?: unknown }>(
-  words: T[],
-  modes: ExtractMode[],
-): T[] {
-  const normalizedModes = normalizeExtractModes(modes);
-  return words.map((word) => {
-    const sourceModes = normalizeExtractModes(word.sourceModes, []);
-    return {
-      ...word,
-      sourceModes: sourceModes.length > 0 ? sourceModes : normalizedModes,
-    };
-  });
 }
 
 export async function extractCompositeWordsFromImage(
@@ -200,7 +182,7 @@ export async function extractCompositeWordsFromImage(
       success: true,
       data: {
         ...validated.data!,
-        words: fallbackSourceModes(validated.data!.words, modes),
+        words: applySourceModesFromScanModes(validated.data!.words, modes),
       },
     };
   } catch (error) {
@@ -219,5 +201,5 @@ export async function extractCompositeWordsFromImage(
 
 export const __internal = {
   buildCompositeExtractionPrompts,
-  fallbackSourceModes,
+  applySourceModesFromScanModes,
 };

--- a/src/lib/scan/mode-provider.test.ts
+++ b/src/lib/scan/mode-provider.test.ts
@@ -2,6 +2,7 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 
 import {
+  applySourceModesFromScanModes,
   getMissingProviderKey,
   getMissingProviderKeyForModes,
   getProvidersForMode,
@@ -51,6 +52,21 @@ test('normalizeExtractModes accepts arrays, JSON strings, and comma strings', ()
   assert.deepEqual(normalizeExtractModes('["circled","eiken"]'), ['circled', 'eiken']);
   assert.deepEqual(normalizeExtractModes('all,idiom,unknown'), ['all', 'idiom']);
   assert.deepEqual(normalizeExtractModes('unknown', ['all']), ['all']);
+});
+
+test('applySourceModesFromScanModes overwrites AI-provided source modes', () => {
+  const words = applySourceModesFromScanModes(
+    [
+      { english: 'look forward to', sourceModes: ['idiom'] },
+      { english: 'apple' },
+    ],
+    ['all', 'idiom', 'eiken'],
+  );
+
+  assert.deepEqual(words.map((word) => word.sourceModes), [
+    ['all', 'idiom', 'eiken'],
+    ['all', 'idiom', 'eiken'],
+  ]);
 });
 
 test('multiple scan modes use the composite extraction provider and Pro gate', () => {

--- a/src/lib/scan/mode-provider.ts
+++ b/src/lib/scan/mode-provider.ts
@@ -58,6 +58,24 @@ export function normalizeExtractModes(
   return normalized.length > 0 ? normalized : fallback;
 }
 
+export function applySourceModesFromScanModes<T extends readonly unknown[]>(
+  words: T,
+  scanModes: unknown,
+): T {
+  const sourceModes = normalizeExtractModes(scanModes);
+
+  return words.map((word) => {
+    if (!word || typeof word !== 'object') {
+      return word;
+    }
+
+    return {
+      ...(word as Record<string, unknown>),
+      sourceModes: [...sourceModes],
+    };
+  }) as unknown as T;
+}
+
 export function getPrimaryExtractMode(modes: Iterable<ExtractMode>): ExtractMode {
   for (const mode of modes) {
     return mode;


### PR DESCRIPTION
## Summary
- `sourceModes` をAI返却値ではなく、サーバー側で正規化済みの scan modes から常に付与するよう変更
- `/api/extract` と `/api/scan-jobs/process` の両方で、最終レスポンスおよび `words.source_modes` insert payload にサーバー確定値が入るよう統一
- `extractCompositeWordsFromImage` の prompt から `sourceModes` 出力要求を削除し、AIが返してもサーバー側で上書きする形に変更

## Details
- `applySourceModesFromScanModes` を追加し、`normalizeExtractModes` 後の modes を各 word に適用
- 即時スキャンではAI抽出直後と lexicon/backfill 後の最終 words に再適用
- バックグラウンドスキャンでは抽出結果、parse後、dedupe後、lexicon/backfill 後に normalized modes を適用
- 重複除去時の `sourceModes` マージも、AI由来ではなく scan/job の modes を優先
- 複数モード例 `['all', 'idiom', 'eiken']` では、各 word の `sourceModes` が常に同じ配列になることをテストで固定

## Verification
- `npm exec -- tsx --test src/lib/scan/mode-provider.test.ts src/lib/ai/extract-composite-words.test.ts src/app/api/extract/route.contract.test.ts src/app/api/scan-jobs/process/route.extractor.test.ts src/app/api/scan-jobs/process/route.contract.test.ts`
- `npm run lint:web`

## Notes
- `npm exec -- tsc --noEmit` は実行したが、今回変更外の既存テスト型エラーで失敗
- Pro制限、scan mode validation、既存の `words.source_modes` 保存形式は変更なし