### PR TITLE
デスクトップ単語詳細をモバイル同等のレイアウトに統一＋カスタムセクション対応

### DIFF
--- a/src/app/project/[id]/page.tsx
+++ b/src/app/project/[id]/page.tsx
@@ -704,6 +704,10 @@ export default function ProjectPage() {
         onRename={handleOpenRename}
         onToggleFavorite={(word) => void handleToggleFavorite(word)}
         onCycleVocabularyType={(word) => void handleCycleVocabularyType(word)}
+        onWordUpdated={(updated) => {
+          setWords((prev) => prev.map((w) => (w.id === updated.id ? updated : w)));
+        }}
+        onDeleteWord={handleOpenDeleteWord}
       />
       <div className="relative flex min-h-screen flex-col bg-[var(--color-background)] font-[var(--font-body)] lg:hidden">
       <div className="flex items-center justify-between px-4 pt-3 lg:hidden">
@@ -1008,6 +1012,10 @@ export default function ProjectPage() {
         </div>
       )}
 
+      </div>
+
+      {/* Shared overlays: rendered outside the lg:hidden wrapper so the
+          desktop view's filter / sort / select buttons can use them too */}
       <SingleWordDeleteModal
         open={deleteWordTarget !== null}
         loading={deleteWordLoading}
@@ -1015,10 +1023,6 @@ export default function ProjectPage() {
         onCancel={() => { if (!deleteWordLoading) setDeleteWordTarget(null); }}
         onConfirm={() => void handleConfirmSingleWordDelete()}
       />
-      </div>
-
-      {/* Shared overlays: rendered outside the lg:hidden wrapper so the
-          desktop view's filter / sort / select buttons can use them too */}
       <WordFilterSheet
         open={wordShowFilterSheet}
         onClose={() => setWordShowFilterSheet(false)}

--- a/src/components/desktop/DesktopProjectDetail.tsx
+++ b/src/components/desktop/DesktopProjectDetail.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Fragment, type CSSProperties, useEffect, useMemo, useState } from 'react';
+import { type CSSProperties, useEffect, useMemo, useState } from 'react';
 import Link from 'next/link';
 import { Icon } from '@/components/ui/Icon';
 import {
@@ -16,6 +16,7 @@ import {
   desktopThumbColor,
 } from '@/components/desktop/desktop-data';
 import { DesktopVocabularyTypeBadge } from '@/components/desktop/DesktopVocabularyTypeBadge';
+import { WordDetailView } from '@/components/word/WordDetailView';
 import type { Project, Word, WordStatus } from '@/types';
 
 type SortKey = 'order' | 'en' | 'vocabularyType' | 'status';
@@ -55,6 +56,8 @@ export function DesktopProjectDetailView({
   onRename,
   onToggleFavorite,
   onCycleVocabularyType,
+  onWordUpdated,
+  onDeleteWord,
 }: {
   project: Project;
   projectId: string;
@@ -75,6 +78,8 @@ export function DesktopProjectDetailView({
   onRename: () => void;
   onToggleFavorite: (word: Word) => void;
   onCycleVocabularyType: (word: Word) => void;
+  onWordUpdated: (word: Word) => void;
+  onDeleteWord: (wordId: string) => void;
 }) {
   const [sortKey, setSortKey] = useState<SortKey>('order');
   const [sortDir, setSortDir] = useState(1);
@@ -321,7 +326,8 @@ export function DesktopProjectDetailView({
           word={selectedWord}
           words={modalWords}
           onClose={() => setSelectedWordId(null)}
-          onToggleFavorite={() => onToggleFavorite(selectedWord)}
+          onWordUpdated={onWordUpdated}
+          onDeleteWord={onDeleteWord}
           onNav={(dir) => {
             const ids = modalWords.map((row) => row.id);
             const currentIndex = ids.indexOf(selectedWord.id);
@@ -429,18 +435,20 @@ function DesktopWordDetailModal({
   word,
   words,
   onClose,
-  onToggleFavorite,
+  onWordUpdated,
+  onDeleteWord,
   onNav,
 }: {
   word: Word;
   words: Word[];
   onClose: () => void;
-  onToggleFavorite: () => void;
+  onWordUpdated: (word: Word) => void;
+  onDeleteWord: (wordId: string) => void;
   onNav: (dir: -1 | 1) => void;
 }) {
   return (
     <div className="ds-overlay">
-      <div className="ds-modal">
+      <div className="ds-modal" style={{ width: 520, background: 'var(--color-background)' }}>
         <div className="ds-modal-head">
           <div className="lab">単語の詳細</div>
           <div className="nav">
@@ -459,75 +467,19 @@ function DesktopWordDetailModal({
             </button>
           </div>
         </div>
-        <div className="ds-modal-body">
-          <div>
-            <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
-              <div className="word-en">{word.english}</div>
-              <button type="button" className="ds-btn ghost sm" onClick={onToggleFavorite} aria-label="お気に入り">
-                <Icon
-                  name={word.isFavorite ? 'star' : 'star_border'}
-                  filled={word.isFavorite}
-                  style={{ color: word.isFavorite ? 'var(--color-warning)' : 'var(--color-muted)' }}
-                />
-              </button>
-            </div>
-            <div className="ds-detail">
-              {(word.pronunciation || word.cefrLevel) && (
-                <div className="word-ph" style={{ display: 'flex', alignItems: 'center', gap: 10, flexWrap: 'wrap' }}>
-                  {word.pronunciation && <span>{word.pronunciation}</span>}
-                  {word.cefrLevel && <span className="ds-tag plain">{word.cefrLevel}</span>}
-                </div>
-              )}
-              <div style={{ display: 'flex', gap: 8, marginTop: 12 }}>
-                {(word.partOfSpeechTags?.length ? word.partOfSpeechTags : ['未分類']).map((tag) => (
-                  <span key={tag} className="ds-tag accent">{desktopPosLabel([tag])}</span>
-                ))}
-              </div>
-              <div className="word-ja">{word.japanese}</div>
-            </div>
-          </div>
-
-          {(word.exampleSentence || word.exampleSentenceJa) && (
-            <div style={{ paddingTop: 2 }}>
-              <div className="mono" style={{ fontSize: 10, letterSpacing: '0.08em', textTransform: 'uppercase', color: 'var(--color-accent-ink)', fontWeight: 700, display: 'flex', alignItems: 'center', gap: 6, marginBottom: 10 }}>
-                <Icon name="auto_awesome" style={{ fontSize: 14 }} />AI 例文
-              </div>
-              {word.exampleSentence && (
-                <div style={{ fontSize: 16, fontWeight: 600, lineHeight: 1.75 }}>
-                  {renderExample(word.exampleSentence, word.english)}
-                </div>
-              )}
-              {word.exampleSentenceJa && (
-                <div style={{ fontSize: 13.5, color: 'var(--color-secondary-text)', lineHeight: 1.75, marginTop: 4 }}>
-                  {word.exampleSentenceJa}
-                </div>
-              )}
-            </div>
-          )}
-
-          {word.relatedWords && word.relatedWords.length > 0 && (
-            <div>
-              <div className="muted" style={{ fontSize: 13, fontWeight: 600, marginBottom: 10 }}>関連語</div>
-              <div className="ds-rel">
-                {word.relatedWords.map((related) => (
-                  <div key={`${related.relation}-${related.term}`} className="item">
-                    <span className="rel">{related.relation}</span>
-                    <span className="tm">{related.term}</span>
-                  </div>
-                ))}
-              </div>
-            </div>
-          )}
-        </div>
+        {/* Shared word detail view (same layout as mobile), keyed per word so
+            prev/next navigation fully resets edit state and custom sections */}
+        <WordDetailView
+          key={word.id}
+          wordId={word.id}
+          variant="modal"
+          initialWord={word}
+          hideClose
+          onClose={onClose}
+          onWordUpdated={onWordUpdated}
+          onDelete={onDeleteWord}
+        />
       </div>
     </div>
-  );
-}
-
-function renderExample(sentence: string, word: string) {
-  const escaped = word.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-  const parts = sentence.split(new RegExp(`(${escaped})`, 'i'));
-  return parts.map((part, index) =>
-    part.toLowerCase() === word.toLowerCase() ? <b key={index}>{part}</b> : <Fragment key={index}>{part}</Fragment>,
   );
 }

--- a/src/components/word/WordDetailView.tsx
+++ b/src/components/word/WordDetailView.tsx
@@ -73,6 +73,12 @@ export interface WordDetailViewProps {
   /** Called when the user taps the delete button. */
   onDelete?: (wordId: string) => void;
   /**
+   * Hide the built-in close/back button. Used when the view is embedded in an
+   * outer chrome (e.g. the desktop modal) that already provides its own close
+   * control.
+   */
+  hideClose?: boolean;
+  /**
    * Optional pre-known word object. When opened from the project list we already
    * have the full word in the parent's state (including freshly manually added
    * words that are not yet reflected in the home-cache snapshot and may not
@@ -90,6 +96,7 @@ export function WordDetailView({
   variant = 'page',
   onWordUpdated,
   onDelete,
+  hideClose = false,
   initialWord: initialWordFromProps,
 }: WordDetailViewProps) {
   const isModal = variant === 'modal';
@@ -421,13 +428,17 @@ export function WordDetailView({
   return (
     <div className={isModal ? 'bg-[var(--color-background)] pb-6 font-[var(--font-body)]' : 'min-h-screen bg-[var(--color-background)] pb-24 font-[var(--font-body)]'}>
       <header className="mx-auto flex w-full max-w-xl items-center justify-between px-5 pb-3 pt-4 sm:px-7">
-        <button
-          onClick={onClose}
-          className="flex h-9 w-9 items-center justify-center rounded-full border-[1.25px] border-[var(--solid-ink)] bg-white text-[var(--solid-ink)] shadow-[2px_2px_0_var(--solid-ink)] transition-all duration-100 active:translate-x-px active:translate-y-px active:shadow-none"
-          aria-label={isModal ? '閉じる' : '戻る'}
-        >
-          <Icon name={isModal ? 'close' : 'chevron_left'} size={16} />
-        </button>
+        {hideClose ? (
+          <span aria-hidden />
+        ) : (
+          <button
+            onClick={onClose}
+            className="flex h-9 w-9 items-center justify-center rounded-full border-[1.25px] border-[var(--solid-ink)] bg-white text-[var(--solid-ink)] shadow-[2px_2px_0_var(--solid-ink)] transition-all duration-100 active:translate-x-px active:translate-y-px active:shadow-none"
+            aria-label={isModal ? '閉じる' : '戻る'}
+          >
+            <Icon name={isModal ? 'close' : 'chevron_left'} size={16} />
+          </button>
+        )}
         {isEditing ? (
           <button
             onClick={handleFinishEditing}


### PR DESCRIPTION
## 概要

デスクトップ版の単語詳細モーダルが簡易表示（枠なし・セクション区切りなし）で視認性が悪く、カスタムセクションも表示・追加できなかった問題を解消します。

## 変更内容

- **デスクトップの単語詳細モーダルを共有 `WordDetailView` に置き換え** (`src/components/desktop/DesktopProjectDetail.tsx`)
  - モバイルと同じ MEANING / EXAMPLE / RELATED / USAGE のセクション見出し＋枠付きカードレイアウトで表示
  - カスタムセクションの閲覧・追加・編集・ドラッグ並べ替え（プロジェクトのカスタム列も含む）がデスクトップでも可能に
  - 意味・例文の編集、発音再生、A/P 切替、ブックマーク、削除もモーダル内から操作可能に
  - 既存の前へ/次へナビゲーションは維持（`key={word.id}` で単語切替時に編集状態をリセット）
- **`WordDetailView` に `hideClose` プロップを追加** (`src/components/word/WordDetailView.tsx`)
  - 外側のモーダルクロームに閉じるボタンがある場合に内側の閉じるボタンを非表示にする
- **単語削除確認モーダルを `lg:hidden` ラッパーの外（共有オーバーレイ領域）へ移動** (`src/app/project/[id]/page.tsx`)
  - デスクトップからの削除操作でも確認ダイアログが表示されるように修正
  - デスクトップビューに `onWordUpdated` / `onDeleteWord` を配線し、編集内容が単語一覧テーブルへ即時反映

## 検証

- `npx tsc --noEmit`: 変更ファイルにエラーなし（既存エラー数に変化なし）
- `npm run lint`: エラー 0（既存警告のみ）
- `npm test`: 477 件全パス
- `npm run build`: 成功

https://claude.ai/code/session_01Ek3ZhmKqLMxTQRG8FycwJ8

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ek3ZhmKqLMxTQRG8FycwJ8)_