### PR TITLE
スキャンボタンの影を削除し、ナビバー内に収める

### DIFF
--- a/src/components/ui/Sidebar.tsx
+++ b/src/components/ui/Sidebar.tsx
@@ -109,7 +109,7 @@ export function Sidebar() {
       <div className="px-5 py-5 border-t border-dashed border-[var(--color-border)]">
         <Link
           href="/scan"
-          className="flex items-center justify-center gap-2 w-full py-3 rounded-xl bg-[var(--color-foreground)] text-white font-bold text-sm border-[1.5px] border-[var(--solid-ink)] shadow-[2px_3px_0_var(--solid-ink)] transition-all hover:opacity-90 active:translate-x-px active:translate-y-px active:shadow-[1px_1px_0_var(--solid-ink)]"
+          className="flex items-center justify-center gap-2 w-full py-3 rounded-xl bg-[var(--color-foreground)] text-white font-bold text-sm border-[1.5px] border-[var(--solid-ink)] transition-all hover:opacity-90 active:translate-x-px active:translate-y-px"
         >
           <Icon name="add" size={18} />
           新規スキャン

--- a/src/components/ui/bottom-nav.tsx
+++ b/src/components/ui/bottom-nav.tsx
@@ -203,17 +203,15 @@ export function BottomNav() {
                 >
                   <div
                     style={{
-                      width: 42,
-                      height: 42,
-                      borderRadius: 21,
+                      width: 36,
+                      height: 36,
+                      borderRadius: 18,
                       background: 'var(--solid-ink)',
                       color: '#fff',
                       display: 'flex',
                       alignItems: 'center',
                       justifyContent: 'center',
                       border: '1.25px solid var(--solid-ink)',
-                      boxShadow: '2px 2px 0 var(--solid-ink)',
-                      marginTop: -18,
                       marginBottom: 2,
                     }}
                   >


### PR DESCRIPTION
## 概要
スキャンボタンの見た目を調整しました。

- **モバイル下部ナビ (`bottom-nav.tsx`)**: スキャンボタンの `box-shadow` と `marginTop: -18` を削除し、バーの上にはみ出さないようにバー内に収めました。円のサイズを 42px → 36px に縮小し、他のタブと高さが揃うようにしています。
- **デスクトップサイドバー (`Sidebar.tsx`)**: 「新規スキャン」ボタンのオフセットシャドウ(`shadow-[2px_3px_0_...]`)を削除しました。

## 確認
- `npm run lint` エラーなし(既存warningのみ)

https://claude.ai/code/session_01DTfodEtt5v3osgpP1Z6WDb

---
_Generated by [Claude Code](https://claude.ai/code/session_01DTfodEtt5v3osgpP1Z6WDb)_