### PR TITLE
fix(fallback): skip retries when circuit breaker opens mid-retry

### DIFF
--- a/cloud-run-scan/src/fallback/classifier.test.ts
+++ b/cloud-run-scan/src/fallback/classifier.test.ts
@@ -52,3 +52,30 @@ test('classifyGeminiError treats empty-content as fallback eligible', () => {
   assert.equal(classified.retriable, true);
   assert.equal(classified.shouldFallback, true);
 });
+
+// Regression: production Vertex AI error format observed 2026-06-11
+// The @google/genai SDK embeds the JSON response body as the error message.
+test('classifyGeminiError handles Vertex AI nested JSON error (RESOURCE_EXHAUSTED/OVERLOADED)', () => {
+  const vertexError = new Error(
+    '{"error":{"code":429,"message":"Resource exhausted. Please try again later. Please refer to https://cloud.google.com/vertex-ai/generative-ai/docs/error-code-429 for more details.","status":"RESOURCE_EXHAUSTED"}}',
+  );
+  const classified = classifyGeminiError(vertexError);
+  assert.equal(classified.kind, '429');
+  assert.equal(classified.label, 'OVERLOADED');
+  assert.equal(classified.statusCode, 429);
+  assert.equal(classified.retriable, true);
+  assert.equal(classified.shouldFallback, true);
+  assert.equal(classified.eligibleForBreaker, true);
+});
+
+test('classifyGeminiError handles Vertex AI nested JSON quota error', () => {
+  const vertexError = new Error(
+    '{"error":{"code":429,"message":"Quota exceeded for quota metric generate_content_free_tier_requests","status":"RESOURCE_EXHAUSTED"}}',
+  );
+  const classified = classifyGeminiError(vertexError);
+  assert.equal(classified.kind, '429');
+  assert.equal(classified.label, 'QUOTA_EXHAUSTED');
+  assert.equal(classified.statusCode, 429);
+  assert.equal(classified.retriable, false);
+  assert.equal(classified.shouldFallback, true);
+});

--- a/cloud-run-scan/src/fallback/classifier.ts
+++ b/cloud-run-scan/src/fallback/classifier.ts
@@ -71,6 +71,28 @@ function extractStatusCode(error: unknown): number | undefined {
     return code;
   }
 
+  // Vertex AI REST errors arrive as JSON strings in the error message:
+  // {"error":{"code":429,"message":"Resource exhausted...","status":"RESOURCE_EXHAUSTED"}}
+  // Parse the message and extract the nested HTTP code when present.
+  const rawMsg = (error as { message?: unknown }).message;
+  const msgStr = typeof rawMsg === 'string' ? rawMsg : null;
+  if (msgStr) {
+    const jsonStart = msgStr.indexOf('{');
+    if (jsonStart !== -1) {
+      try {
+        const parsed: unknown = JSON.parse(msgStr.slice(jsonStart));
+        if (parsed && typeof parsed === 'object') {
+          const nested = (parsed as { error?: { code?: unknown } }).error?.code;
+          if (typeof nested === 'number') {
+            return nested;
+          }
+        }
+      } catch {
+        // Not JSON — keyword-based detection handles it
+      }
+    }
+  }
+
   return undefined;
 }
 

--- a/cloud-run-scan/src/fallback/runner.test.ts
+++ b/cloud-run-scan/src/fallback/runner.test.ts
@@ -192,6 +192,54 @@ test('OpenAI fallback failure does not recurse', async () => {
   assert.equal(openaiCalls, 1);
 });
 
+// Regression: production logs 2026-06-11 showed window_stats growing by 2 extra 429s
+// after BREAKER_OPEN because the retry loop kept calling Gemini after the breaker tripped.
+// Fix: bail immediately on transitionedToOpen instead of continuing retries.
+test('when breaker opens mid-retry, remaining retries are skipped', async () => {
+  // Use instant backoffs so the test accumulates 10 429s quickly.
+  // 3 requests × 3 Gemini calls (1 initial + 2 retries) = 9 429s → still CLOSED.
+  // 4th request: 1st Gemini call = 10th 429 → breaker opens → must fall back immediately
+  // (no retries 2 or 3 for that request).
+  const runner = createRunner({ retryBackoffsMs: [0, 0, 0] });
+
+  let geminiCalls = 0;
+  let openaiCalls = 0;
+
+  const makeRequest = () =>
+    runner.execute(
+      { ctx: { env: 'prod', feature: 'scan_extraction', requestId: `req-${geminiCalls}` } },
+      {
+        runGemini: async () => {
+          geminiCalls += 1;
+          throw { status: 429, message: 'Please try again later. Resource exhausted' };
+        },
+        runOpenAI: async () => {
+          openaiCalls += 1;
+          return { content: 'ok', modelUsed: 'gpt-4o' };
+        },
+      },
+    );
+
+  // Requests 1–3: breaker still CLOSED, each does 1 + 2 retries = 3 Gemini calls
+  await makeRequest();
+  await makeRequest();
+  await makeRequest();
+  assert.equal(geminiCalls, 9);
+  assert.equal(openaiCalls, 3);
+
+  // Request 4: 1st Gemini call is the 10th 429 → breaker opens → must stop here
+  await makeRequest();
+  assert.equal(geminiCalls, 10, 'only 1 Gemini call on the breaker-opening request, not 3');
+  assert.equal(openaiCalls, 4);
+
+  // Request 5: breaker is OPEN, Gemini must not be called at all
+  const result = await makeRequest();
+  assert.equal(geminiCalls, 10, 'no Gemini calls when breaker is already OPEN');
+  assert.equal(result.provider, 'openai');
+  assert.equal(result.fallbackReason, 'BREAKER_OPEN');
+  assert.equal(openaiCalls, 5);
+});
+
 test('empty-content errors retry and fallback to OpenAI', async () => {
   const runner = createRunner();
 

--- a/cloud-run-scan/src/fallback/runner.ts
+++ b/cloud-run-scan/src/fallback/runner.ts
@@ -61,25 +61,28 @@ async function sleep(ms: number): Promise<void> {
   await new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-function retryPlanFor(error: ClassifiedGeminiError): RetryPlan {
+function retryPlanFor(error: ClassifiedGeminiError, backoffsMs?: [number, number, number]): RetryPlan {
+  const defaultBackoffs = backoffsMs ?? [...DEFAULT_RETRY_BACKOFFS];
+  const timeoutBackoff = backoffsMs ? backoffsMs[0] : TIMEOUT_RETRY_BACKOFF;
+
   if (error.kind === '429') {
     return {
       maxRetries: error.label === 'QUOTA_EXHAUSTED' ? 0 : 2,
-      backoffsMs: [...DEFAULT_RETRY_BACKOFFS],
+      backoffsMs: defaultBackoffs,
     };
   }
 
   if (error.kind === 'UPSTREAM_5XX') {
     return {
       maxRetries: 2,
-      backoffsMs: [...DEFAULT_RETRY_BACKOFFS],
+      backoffsMs: defaultBackoffs,
     };
   }
 
   if (error.kind === 'TIMEOUT') {
     return {
       maxRetries: 1,
-      backoffsMs: [TIMEOUT_RETRY_BACKOFF],
+      backoffsMs: [timeoutBackoff],
     };
   }
 
@@ -161,6 +164,18 @@ export class GeminiFallbackRunner {
 
         if (observed.transitionedToOpen) {
           await this.notifyBreakerOpened(input.ctx, observed.openReason ?? classified.reasonForSlack);
+          // Breaker just tripped — skip remaining retries and fall back now rather than
+          // making more Gemini calls that will almost certainly fail the same way.
+          if (classified.shouldFallback) {
+            return this.fallbackOpenAIOrFail(
+              input.ctx,
+              deps,
+              classified.reasonForSlack,
+              classified.message,
+              input.modelOverride,
+            );
+          }
+          throw new Error(classified.message || 'Gemini call failed');
         }
 
         if (classified.kind === '429' && classified.label === 'QUOTA_EXHAUSTED') {
@@ -188,7 +203,7 @@ export class GeminiFallbackRunner {
         }
 
         if (!retryPlan) {
-          retryPlan = retryPlanFor(classified);
+          retryPlan = retryPlanFor(classified, this.config.retryBackoffsMs);
         }
 
         if (retryPlan.maxRetries > retriesDone) {

--- a/cloud-run-scan/src/fallback/types.ts
+++ b/cloud-run-scan/src/fallback/types.ts
@@ -92,6 +92,8 @@ export interface FallbackConfig {
   fallbackRateWarnThreshold: number;
   slackWebhookUrl?: string;
   appEnv: AppEnv;
+  /** Override retry backoff timings (ms). Useful in tests to keep suites fast. */
+  retryBackoffsMs?: [number, number, number];
 }
 
 export interface ProviderUsage {


### PR DESCRIPTION
## Summary

Production logs (2026-06-11) revealed that after the circuit breaker opened (`BREAKER_OPEN`, `reason=THRESHOLD_429`), the `window_stats` count kept growing by 2 more 429s on the same request — meaning Gemini was called twice more before the fallback happened.

Root cause: the runner's retry loop checked `transitionedToOpen` only to send a Slack notification, but did **not** bail out of the retry loop. So after the breaker tripped on the 10th 429, retries 2 and 3 still ran against an already-overloaded Gemini (~700 ms wasted latency, 2 unnecessary API calls).

## Changes

- **`runner.ts`** — after `recordFailure` returns `transitionedToOpen: true`, immediately call `fallbackOpenAIOrFail` instead of continuing the retry loop.
- **`runner.ts`** — add optional `retryBackoffsMs` to `FallbackConfig` so tests can override backoffs with `[0,0,0]` and run in milliseconds rather than seconds.
- **`classifier.ts`** — improve `extractStatusCode` to parse the Vertex AI nested JSON error format (`{"error":{"code":429,...}}`) that appears in the error `.message` string when the `@google/genai` SDK wraps a REST API response.

## Tests

- Regression: `when breaker opens mid-retry, remaining retries are skipped` — verifies exactly 10 Gemini calls across 4 requests (not 12), and that the 5th request goes direct-to-OpenAI with `fallbackReason=BREAKER_OPEN`.
- Regression: `classifyGeminiError handles Vertex AI nested JSON error` — pins the exact production error format against the correct `OVERLOADED` classification with `statusCode=429`.
- Regression: `classifyGeminiError handles Vertex AI nested JSON quota error` — verifies `QUOTA_EXHAUSTED` classification from nested JSON.

All 25 tests pass.

https://claude.ai/code/session_01U557TkunqNP8pCbjFWCLp7

---
_Generated by [Claude Code](https://claude.ai/code/session_01U557TkunqNP8pCbjFWCLp7)_