### PR TITLE
プロジェクトページの単語一覧をフラット+区切り線スタイルに変更

### DIFF
--- a/src/app/project/[id]/page.tsx
+++ b/src/app/project/[id]/page.tsx
@@ -893,7 +893,7 @@ export default function ProjectPage() {
         </button>
       </div>
 
-      <div className="flex flex-col gap-2 px-4 pb-[160px]">
+      <div className="flex flex-col divide-y divide-[var(--color-border)] px-4 pb-[160px]">
         {!wordsLoaded ? (
           <div className="flex items-center justify-center py-12 text-[var(--color-muted)]">
             <Icon name="progress_activity" size={20} className="animate-spin" />
@@ -1555,68 +1555,59 @@ function WordRow({
   onSelect: () => void;
 }) {
   const pos = word.partOfSpeechTags?.[0] ?? null;
-  const cardClasses = selectMode
-    ? `relative rounded-xl border-[1.25px] bg-white px-[13px] py-2 transition-colors ${
-        selected ? 'border-[var(--solid-ink)] bg-[rgba(19,127,236,0.06)]' : 'border-[var(--solid-ink)]'
-      }`
-    : 'relative rounded-xl border-[1.25px] border-[var(--solid-ink)] bg-white px-[13px] py-2';
 
   if (selectMode) {
     return (
-      <div className="relative">
-        <div className="absolute inset-0 rounded-xl bg-[var(--solid-ink)]" style={{ transform: 'translate(2px, 2px)' }} />
-        <button
-          type="button"
-          onClick={onToggleSelect}
-          aria-pressed={selected}
-          className={`${cardClasses} block w-full text-left transition-all duration-100 active:translate-x-px active:translate-y-px`}
-        >
-          <div className="flex items-center gap-2.5">
-            <SelectCheckbox checked={selected} />
-            <div className="min-w-0 flex-1">
-              <div className="truncate font-display text-[15px] font-bold text-[var(--solid-ink)]">{word.english}</div>
-              <div className="mt-px flex items-center gap-1 text-[11px] text-[var(--color-muted)]">
-                {pos && <span className="shrink-0 font-mono text-[9px]">{posShort(pos)}</span>}
-                <span className="truncate">{word.japanese}</span>
-              </div>
-            </div>
-            <VocabularyTypeBadge vocabularyType={word.vocabularyType} />
-            <BookmarkBadge active={word.isFavorite} />
-          </div>
-        </button>
-      </div>
-    );
-  }
-
-  return (
-    <div className="relative">
-      <div className="absolute inset-0 rounded-xl bg-[var(--solid-ink)]" style={{ transform: 'translate(2px, 2px)' }} />
-      <div className={cardClasses}>
+      <button
+        type="button"
+        onClick={onToggleSelect}
+        aria-pressed={selected}
+        className={`block w-full px-1 py-2.5 text-left transition-colors ${
+          selected ? 'bg-[rgba(19,127,236,0.06)]' : ''
+        }`}
+      >
         <div className="flex items-center gap-2.5">
-          <StatusSquares wordId={word.id} status={word.status} onStatusChange={onCycleStatus} />
-
-          <button type="button" onClick={onSelect} className="min-w-0 flex-1 text-left">
+          <SelectCheckbox checked={selected} />
+          <div className="min-w-0 flex-1">
             <div className="truncate font-display text-[15px] font-bold text-[var(--solid-ink)]">{word.english}</div>
             <div className="mt-px flex items-center gap-1 text-[11px] text-[var(--color-muted)]">
               {pos && <span className="shrink-0 font-mono text-[9px]">{posShort(pos)}</span>}
               <span className="truncate">{word.japanese}</span>
             </div>
-          </button>
-
-          <VocabularyTypeButton
-            vocabularyType={word.vocabularyType}
-            onClick={onCycleVocabularyType}
-            className="shrink-0"
-          />
-          <button
-            type="button"
-            onClick={onToggleFavorite}
-            className="inline-flex h-[26px] w-[26px] shrink-0 items-center justify-center text-[var(--color-accent)]"
-            aria-label="お気に入りを切り替え"
-          >
-            <Icon name="bookmark" size={22} filled={word.isFavorite} />
-          </button>
+          </div>
+          <VocabularyTypeBadge vocabularyType={word.vocabularyType} />
+          <BookmarkBadge active={word.isFavorite} />
         </div>
+      </button>
+    );
+  }
+
+  return (
+    <div className="px-1 py-2.5">
+      <div className="flex items-center gap-2.5">
+        <StatusSquares wordId={word.id} status={word.status} onStatusChange={onCycleStatus} />
+
+        <button type="button" onClick={onSelect} className="min-w-0 flex-1 text-left">
+          <div className="truncate font-display text-[15px] font-bold text-[var(--solid-ink)]">{word.english}</div>
+          <div className="mt-px flex items-center gap-1 text-[11px] text-[var(--color-muted)]">
+            {pos && <span className="shrink-0 font-mono text-[9px]">{posShort(pos)}</span>}
+            <span className="truncate">{word.japanese}</span>
+          </div>
+        </button>
+
+        <VocabularyTypeButton
+          vocabularyType={word.vocabularyType}
+          onClick={onCycleVocabularyType}
+          className="shrink-0"
+        />
+        <button
+          type="button"
+          onClick={onToggleFavorite}
+          className="inline-flex h-[26px] w-[26px] shrink-0 items-center justify-center text-[var(--color-accent)]"
+          aria-label="お気に入りを切り替え"
+        >
+          <Icon name="bookmark" size={22} filled={word.isFavorite} />
+        </button>
       </div>
     </div>
   );

--- a/src/components/home/WordList.tsx
+++ b/src/components/home/WordList.tsx
@@ -204,7 +204,7 @@ function WordItem({
 
   if (isEditing) {
     return (
-      <div className="card p-4 border-2 border-[var(--color-primary)]">
+      <div className="card p-4 my-2 border-2 border-[var(--color-primary)]">
         <div className="space-y-3">
           <input
             type="text"
@@ -236,7 +236,7 @@ function WordItem({
   }
 
   return (
-    <div className="card px-3 py-3 flex items-center gap-2">
+    <div className="px-1 py-3 flex items-center gap-2">
       {onStatusChange && (
         <NotionCheckbox wordId={word.id} status={word.status} onStatusChange={onStatusChange} />
       )}
@@ -431,7 +431,7 @@ export function WordList({
 
       {/* Word list */}
       <div
-        className={`space-y-2 ${
+        className={`divide-y divide-[var(--color-border)] ${
           listMaxHeightClassName
             ? `${listMaxHeightClassName} overflow-y-auto overscroll-contain pr-1`
             : ''


### PR DESCRIPTION
## 概要

`/project/*` ページの単語一覧で、単語ごとのカード枠(枠線+オフセット影)が視覚的ノイズとなり注意をそらす問題を解消します。枠を取り払い、単語間に細い区切り線(既存トークン `--color-border`)を引くフラットなリスト表示に変更しました。デスクトップのテーブル表示(既にフラット+行区切り)と統一感のある見た目になります。

## 変更内容

- **`/project/[id]`(モバイル表示)の `WordRow`**: ネオブルータリズム風のカード枠・オフセット影を削除し、リストコンテナを `divide-y divide-[var(--color-border)]` に変更。選択モードでは選択行の背景ハイライトを維持。
- **`/project/[id]/words` の `WordItem`(`WordList.tsx`)**: `.card` クラスを外しフラット行に変更、コンテナの `space-y-2` を `divide-y` に置き換え。
- 編集中の単語は従来どおりカード表示(フォーカス状態として維持)。

## 確認

- `npm run lint` … エラーなし(既存warningのみ)
- `npm run build` … 成功

https://claude.ai/code/session_01HpaZzJg8c93DGnUSV64RgR

---
_Generated by [Claude Code](https://claude.ai/code/session_01HpaZzJg8c93DGnUSV64RgR)_