### PR TITLE
Show word gaps in active idiom typing quiz

### DIFF
--- a/src/app/quiz/[projectId]/page.tsx
+++ b/src/app/quiz/[projectId]/page.tsx
@@ -970,9 +970,7 @@ export default function QuizPage() {
   const currentQuestion = questions[currentIndex];
   const currentIsWordOrder = isWordOrderQuestion(currentQuestion);
   const isActiveVocab = !currentIsWordOrder && currentQuestion?.word.vocabularyType === 'active';
-  const typeInExpectedAnswer = isActiveVocab
-    ? stripActiveQuizAnswerSpaces(currentQuestion?.word.english ?? '')
-    : currentQuestion?.word.english ?? '';
+  const typeInExpectedAnswer = currentQuestion?.word.english ?? '';
 
   const applyAnswerOutcome = async (word: Word, isCorrect: boolean) => {
     playAnswerFeedbackSound(isCorrect);
@@ -1359,6 +1357,7 @@ export default function QuizPage() {
           <div style={{ width: '100%', maxWidth: 520 }}>
             <TypeInQuizField
               answer={typeInExpectedAnswer}
+              spaceAsGap={isActiveVocab}
               value={typeInAnswer}
               onChange={setTypeInAnswer}
               normalizeInput={isActiveVocab ? stripActiveQuizAnswerSpaces : undefined}
@@ -1454,7 +1453,7 @@ export default function QuizPage() {
               </span>
               {typeInResult === 'wrong' && isMultipleChoiceQuestion(currentQuestion) && (
                 <span className="muted" style={{ fontSize: 13.5 }}>
-                  正解：<b style={{ color: 'var(--color-ink)' }}>{isActiveVocab ? typeInExpectedAnswer : currentQuestion.word.english}</b>
+                  正解：<b style={{ color: 'var(--color-ink)' }}>{currentQuestion.word.english}</b>
                 </span>
               )}
               <button type="button" className="ds-btn accent" onClick={moveToNext} disabled={isTransitioning}>
@@ -1591,6 +1590,7 @@ export default function QuizPage() {
           <div className="mt-[18px] w-full space-y-4">
             <TypeInQuizField
               answer={typeInExpectedAnswer}
+              spaceAsGap={isActiveVocab}
               value={typeInAnswer}
               onChange={setTypeInAnswer}
               normalizeInput={isActiveVocab ? stripActiveQuizAnswerSpaces : undefined}
@@ -1611,7 +1611,7 @@ export default function QuizPage() {
               >
                 <p className="text-sm font-bold text-white/85">正解</p>
                 <p className="mt-1 text-lg font-black text-white">
-                  {isActiveVocab ? typeInExpectedAnswer : currentQuestion.word.english}
+                  {currentQuestion.word.english}
                 </p>
               </div>
             )}

--- a/src/components/quiz/TypeInQuizField.tsx
+++ b/src/components/quiz/TypeInQuizField.tsx
@@ -5,9 +5,18 @@ import { Icon } from '@/components/ui/Icon';
 
 export type TypeInQuizFieldResult = 'correct' | 'wrong' | null;
 
+const SPACE_RE = /[\s　]/;
+
+type Slot = { kind: 'char'; index: number } | { kind: 'gap' };
+
 export interface TypeInQuizFieldProps {
   /** Expected answer (length drives slots / underscores). */
   answer: string;
+  /**
+   * Treat spaces in `answer` as visual gaps in the underscore line instead of
+   * typeable slots (idiom/active quizzes where input is space-stripped).
+   */
+  spaceAsGap?: boolean;
   value: string;
   onChange: (value: string) => void;
   normalizeInput?: (value: string) => string;
@@ -27,6 +36,7 @@ export interface TypeInQuizFieldProps {
  */
 export function TypeInQuizField({
   answer,
+  spaceAsGap = false,
   value,
   onChange,
   normalizeInput,
@@ -36,7 +46,18 @@ export function TypeInQuizField({
   variant = 'plain',
 }: TypeInQuizFieldProps) {
   const inputRef = useRef<HTMLInputElement>(null);
-  const target = [...answer];
+  const target: string[] = [];
+  const slots: Slot[] = [];
+  for (const ch of answer) {
+    if (spaceAsGap && SPACE_RE.test(ch)) {
+      if (slots.length > 0 && slots[slots.length - 1].kind !== 'gap') {
+        slots.push({ kind: 'gap' });
+      }
+    } else {
+      slots.push({ kind: 'char', index: target.length });
+      target.push(ch);
+    }
+  }
   const typed = [...value];
   const n = target.length;
   const visibleTyped = typed.slice(0, n);
@@ -74,43 +95,40 @@ export function TypeInQuizField({
   const hintClass = 'text-[var(--color-muted)]/70 font-medium text-xl';
   const caretClass = isSolid ? 'bg-[var(--color-accent)]' : 'bg-blue-600';
 
-  const renderUnderscores = (count: number, keyPrefix: string) =>
-    Array.from({ length: count }, (_, i) => (
-      <span key={`${keyPrefix}-${i}`} className={underscoreClass}>
-        _
-      </span>
-    ));
-
   const content = (
     <div className="flex items-center justify-center min-h-[3.5rem] px-5 py-4 gap-x-1 flex-wrap text-xl select-none">
-      {visibleTyped.map((ch, i) => (
-        <span key={`typed-${i}`} className={`font-black text-xl ${typedColorClass}`}>
-          {ch}
-        </span>
-      ))}
-
-      {n > 0 && t < n && (
-        <>
-          {!disabled && (
-            <span
-              className={`inline-block w-[2px] h-[1.2em] shrink-0 self-center rounded-sm ${caretClass}`}
-              aria-hidden
-            />
-          )}
-
-          {!disabled && t === 0 && target[0] != null && target[0] !== '' && (
-            <span className={hintClass} aria-hidden>
-              {target[0].toLowerCase()}
+      {slots.map((slot, slotIndex) => {
+        if (slot.kind === 'gap') {
+          return <span key={`gap-${slotIndex}`} className="inline-block w-[0.5em] shrink-0" aria-hidden />;
+        }
+        const i = slot.index;
+        if (i < t) {
+          return (
+            <span key={`typed-${i}`} className={`font-black text-xl ${typedColorClass}`}>
+              {visibleTyped[i]}
             </span>
-          )}
-
-          {disabled
-            ? renderUnderscores(n - t, 'u-dis')
-            : t === 0
-              ? renderUnderscores(Math.max(0, n - 1), 'u-act')
-              : renderUnderscores(Math.max(0, n - t), 'u-act')}
-        </>
-      )}
+          );
+        }
+        const showCaret = !disabled && i === t;
+        const showHint = !disabled && t === 0 && i === 0 && target[0] != null && target[0] !== '';
+        return (
+          <span key={`slot-${slotIndex}`} className="inline-flex items-center">
+            {showCaret && (
+              <span
+                className={`inline-block w-[2px] h-[1.2em] shrink-0 self-center rounded-sm ${caretClass}`}
+                aria-hidden
+              />
+            )}
+            {showHint ? (
+              <span className={hintClass} aria-hidden>
+                {target[0].toLowerCase()}
+              </span>
+            ) : (
+              <span className={underscoreClass}>_</span>
+            )}
+          </span>
+        );
+      })}
 
       {isSolid && result && (
         <Icon


### PR DESCRIPTION
## Summary

Active(タイプ入力)クイズでイディオムを出題する際、これまでは空白を除去した文字列(例: `takecareof`)をそのまま下線スロットとして表示していたため、単語の区切りが分からず不自然でした。

このPRでは、イディオムの空白位置で下線(点線)を途切れさせ、視覚的に単語の区切りが分かるようにします。

- `TypeInQuizField` に `spaceAsGap` プロパティを追加。`answer` に元の(空白あり)イディオムを渡すと、空白位置に視覚的なギャップを描画し、文字スロットは空白以外の文字のみで構成
- 入力自体は従来どおり空白を除去して扱うため、ユーザーは空白を打つ必要がなく、正誤判定ロジック(`normalizeActiveQuizAnswer`)も変更なし
- 不正解時に表示される正解は、空白除去版ではなく元のイディオム(`take care of`)を表示

## 表示イメージ

`take care of` の場合(従来は `_ _ _ _ _ _ _ _ _ _ _` の連続):

```
t _ _ _   _ _ _ _   _ _
```

## Test plan

- [x] `npm run lint`(エラーなし、警告は既存のもの)
- [x] `npm test`(498件すべてパス)
- [x] `npx tsc --noEmit`(変更ファイルにエラーなし。既存テストファイルのエラーは変更前から存在)
- [ ] 実機確認: activeに指定したイディオムでタイプ入力クイズを開き、空白位置で下線が途切れること、正誤判定が従来どおり空白なし入力で通ることを確認

https://claude.ai/code/session_01KB5QKLH3S8EWLVzFhAEZoa

---
_Generated by [Claude Code](https://claude.ai/code/session_01KB5QKLH3S8EWLVzFhAEZoa)_