### PR TITLE
単語一覧のチェックボックス拡大 & 単語詳細の影タップで閉じる対応

### DIFF
--- a/src/app/project/[id]/page.tsx
+++ b/src/app/project/[id]/page.tsx
@@ -992,9 +992,13 @@ export default function ProjectPage() {
             style={{ background: 'rgba(26,26,26,0.45)', backdropFilter: 'blur(3px)' }}
             onClick={() => setSelectedWord(null)}
           />
-          <div className="absolute inset-0 flex items-center justify-center px-4 py-10">
+          <div
+            className="absolute inset-0 flex items-center justify-center px-4 py-10"
+            onClick={() => setSelectedWord(null)}
+          >
             <div
               className="w-full overflow-y-auto overscroll-contain"
+              onClick={(e) => e.stopPropagation()}
               style={{
                 maxWidth: 480,
                 maxHeight: '80dvh',
@@ -1517,11 +1521,11 @@ function StatusSquares({
       aria-label={`ステータス: ${status === 'new' ? '未学習' : status === 'review' ? '学習中' : '習得済み'}`}
       className="shrink-0 rounded p-0.5 transition-colors active:bg-[rgba(26,26,26,0.06)]"
     >
-      <div className="flex flex-col gap-[1.5px]">
+      <div className="flex flex-col gap-[2px]">
         {[0, 1, 2].map((i) => (
           <div
             key={i}
-            className="h-[10px] w-[10px] rounded-[2px] border-[1.25px] border-[var(--solid-ink)]"
+            className="h-[13px] w-[13px] rounded-[2.5px] border-[1.25px] border-[var(--solid-ink)]"
             style={{ background: i < filledCount ? 'var(--solid-ink)' : 'transparent' }}
           />
         ))}

--- a/src/components/desktop/DesktopProjectDetail.tsx
+++ b/src/components/desktop/DesktopProjectDetail.tsx
@@ -439,8 +439,8 @@ function DesktopWordDetailModal({
   onNav: (dir: -1 | 1) => void;
 }) {
   return (
-    <div className="ds-overlay">
-      <div className="ds-modal">
+    <div className="ds-overlay" onClick={onClose}>
+      <div className="ds-modal" onClick={(e) => e.stopPropagation()}>
         <div className="ds-modal-head">
           <div className="lab">単語の詳細</div>
           <div className="nav">

--- a/src/components/home/WordList.tsx
+++ b/src/components/home/WordList.tsx
@@ -120,10 +120,10 @@ export function NotionCheckbox({
       <div
         className="relative overflow-hidden"
         style={{
-          width: 13,
-          height: 39,
+          width: 17,
+          height: 51,
           border: '1px solid var(--color-border)',
-          borderRadius: 3,
+          borderRadius: 4,
         }}
       >
         {[0, 1, 2].map((i) => (
@@ -131,10 +131,10 @@ export function NotionCheckbox({
             key={i}
             style={{
               position: 'absolute',
-              top: i * 13,
+              top: i * 17,
               left: 0,
               width: '100%',
-              height: 13,
+              height: 17,
               background: i < filledCount ? 'var(--color-foreground)' : 'transparent',
               borderTop: i > 0 ? '1px solid var(--color-border)' : 'none',
               transition: 'background 0.15s ease',


### PR DESCRIPTION
## 概要

`/project/*` ページの単語一覧まわりの UI を 2 点改善しました。

### 1. チェックボックス UI を 1.3 倍に拡大
ステータス変更用チェックボックスのタップ領域・視認性を向上。

- **`/project/[id]`**（`StatusSquares`）: 各マス `10px → 13px`、間隔 `1.5px → 2px`、角丸 `2px → 2.5px`
- **`/project/[id]/words`**（`NotionCheckbox`）: 幅 `13 → 17`、高さ `39 → 51`、各セグメント `13 → 17`、角丸 `3 → 4`

### 2. 単語詳細を「影（バックドロップ）部分のタップ」で閉じられるように
これまでモーダル中央のコンテンツ領域より外側（センタリング用の余白＝影が見えている部分）をタップしても閉じませんでした。センタリングラッパーに `onClick`（閉じる）を追加し、モーダル本体には `stopPropagation` を付与して、影部分のタップで閉じられるようにしました。

- モバイル: `src/app/project/[id]/page.tsx` の単語詳細モーダル
- デスクトップ: `src/components/desktop/DesktopProjectDetail.tsx` の `DesktopWordDetailModal`（`ds-overlay` タップで閉じる）

## 動作確認に関する注意
コンテナに依存関係（`node_modules`）が未インストールのため、ローカルでの `lint` / `build` は実行できていません。変更は JSX とスタイル値のみの最小変更です。

https://claude.ai/code/session_01FUNKLnf5yhQtAXJjpf9Mbj

---
_Generated by [Claude Code](https://claude.ai/code/session_01FUNKLnf5yhQtAXJjpf9Mbj)_