### PR TITLE
Remove shadows from /project/* page UI (except project icon)

### DIFF
--- a/src/app/project/[id]/page.tsx
+++ b/src/app/project/[id]/page.tsx
@@ -860,7 +860,7 @@ export default function ProjectPage() {
                 aria-label="メニューを閉じる"
                 onClick={() => setMenuOpen(false)}
               />
-              <div className="absolute right-0 top-11 z-30 w-[170px] overflow-hidden rounded-[14px] border-[1.25px] border-[var(--solid-ink)] bg-white shadow-[3px_4px_0_var(--solid-ink)]">
+              <div className="absolute right-0 top-11 z-30 w-[170px] overflow-hidden rounded-[14px] border-[1.25px] border-[var(--solid-ink)] bg-white">
                 <MenuButton icon="edit" label="名称変更" onClick={handleOpenRename} />
                 <MenuButton icon="image" label="画像設定" onClick={handleOpenImagePicker} />
                 <MenuButton
@@ -947,7 +947,7 @@ export default function ProjectPage() {
               />
               <div
                 role="menu"
-                className="absolute right-0 top-[52px] z-30 w-[180px] overflow-hidden rounded-[14px] border-[1.25px] border-[var(--solid-ink)] bg-white shadow-[3px_4px_0_var(--solid-ink)]"
+                className="absolute right-0 top-[52px] z-30 w-[180px] overflow-hidden rounded-[14px] border-[1.25px] border-[var(--solid-ink)] bg-white"
               >
                 <MenuButton
                   icon="photo_camera"
@@ -974,7 +974,7 @@ export default function ProjectPage() {
       <div className="flex items-center gap-2 px-5 pb-2">
         <label
           htmlFor="project-word-search"
-          className="flex min-w-0 flex-1 items-center gap-1.5 rounded-full border-[1.25px] border-[var(--solid-ink)] bg-white px-3 py-[7px] text-[var(--color-muted)] shadow-[2px_2px_0_var(--solid-ink)]"
+          className="flex min-w-0 flex-1 items-center gap-1.5 rounded-full border-[1.25px] border-[var(--solid-ink)] bg-white px-3 py-[7px] text-[var(--color-muted)]"
         >
           <Icon name="search" size={14} />
           <span className="sr-only">単語を検索</span>
@@ -996,7 +996,7 @@ export default function ProjectPage() {
           type="button"
           onClick={() => setWordShowFilterSheet(true)}
           aria-label="フィルタ"
-          className={`inline-flex h-[32px] w-[32px] shrink-0 items-center justify-center rounded-full border-[1.25px] border-[var(--solid-ink)] shadow-[2px_2px_0_var(--solid-ink)] transition-all duration-100 active:translate-x-px active:translate-y-px active:shadow-none ${
+          className={`inline-flex h-[32px] w-[32px] shrink-0 items-center justify-center rounded-full border-[1.25px] border-[var(--solid-ink)] transition-all duration-100 active:translate-x-px active:translate-y-px ${
             wordFilterActive
               ? 'bg-[var(--solid-ink)] text-white'
               : 'bg-white text-[var(--solid-ink)]'
@@ -1008,7 +1008,7 @@ export default function ProjectPage() {
           type="button"
           onClick={() => setWordShowSortSheet(true)}
           aria-label="並べ替え"
-          className={`inline-flex h-[32px] w-[32px] shrink-0 items-center justify-center rounded-full border-[1.25px] border-[var(--solid-ink)] shadow-[2px_2px_0_var(--solid-ink)] transition-all duration-100 active:translate-x-px active:translate-y-px active:shadow-none ${
+          className={`inline-flex h-[32px] w-[32px] shrink-0 items-center justify-center rounded-full border-[1.25px] border-[var(--solid-ink)] transition-all duration-100 active:translate-x-px active:translate-y-px ${
             wordSortOrder !== 'createdAsc'
               ? 'bg-[var(--solid-ink)] text-white'
               : 'bg-white text-[var(--solid-ink)]'
@@ -1020,7 +1020,7 @@ export default function ProjectPage() {
           type="button"
           onClick={() => { if (selectMode) { handleExitSelectMode(); } else { setSelectMode(true); setSelectedWordIds(new Set()); } }}
           aria-label="選択"
-          className={`inline-flex h-[32px] w-[32px] shrink-0 items-center justify-center rounded-full border-[1.25px] border-[var(--solid-ink)] shadow-[2px_2px_0_var(--solid-ink)] transition-all duration-100 active:translate-x-px active:translate-y-px active:shadow-none ${
+          className={`inline-flex h-[32px] w-[32px] shrink-0 items-center justify-center rounded-full border-[1.25px] border-[var(--solid-ink)] transition-all duration-100 active:translate-x-px active:translate-y-px ${
             selectMode
               ? 'bg-[var(--solid-ink)] text-white'
               : 'bg-white text-[var(--solid-ink)]'
@@ -1134,7 +1134,6 @@ export default function ProjectPage() {
                 background: '#faf7f1',
                 border: '1.5px solid var(--solid-ink)',
                 borderRadius: 20,
-                boxShadow: '4px 5px 0 var(--solid-ink)',
               }}
             >
               <WordDetailView
@@ -1224,7 +1223,7 @@ export default function ProjectPage() {
             style={{ background: 'rgba(26,26,26,0.45)', backdropFilter: 'blur(3px)' }}
           />
           <div className="absolute inset-0 flex items-center justify-center px-5">
-            <div className="w-full max-w-[360px] rounded-[16px] border-[1.25px] border-[var(--solid-ink)] bg-white p-5" style={{ boxShadow: '3px 4px 0 var(--solid-ink)' }}>
+            <div className="w-full max-w-[360px] rounded-[16px] border-[1.25px] border-[var(--solid-ink)] bg-white p-5">
               <div className="font-mono text-[10px] font-bold uppercase tracking-[0.06em] text-[var(--color-muted)]">RENAME</div>
               <h2 className="mt-1 font-display text-[18px] font-extrabold text-[var(--solid-ink)]">名称変更</h2>
               <input
@@ -1234,7 +1233,7 @@ export default function ProjectPage() {
                 onKeyDown={(e) => { if (e.key === 'Enter') void handleConfirmRename(); }}
                 autoFocus
                 maxLength={60}
-                className="mt-3 w-full rounded-[10px] border-[1.25px] border-[var(--solid-ink)] bg-white px-3 py-2.5 font-display text-[15px] font-bold text-[var(--solid-ink)] outline-none focus:shadow-[2px_2px_0_var(--color-accent)]"
+                className="mt-3 w-full rounded-[10px] border-[1.25px] border-[var(--solid-ink)] bg-white px-3 py-2.5 font-display text-[15px] font-bold text-[var(--solid-ink)] outline-none"
               />
               <div className="mt-4 flex gap-2">
                 <button
@@ -1288,7 +1287,6 @@ function DeleteProjectModal({
       <div className="absolute inset-0 flex items-center justify-center px-5">
         <div
           className="w-full max-w-[360px] rounded-[16px] border-[1.25px] border-[var(--solid-ink)] bg-white p-5"
-          style={{ boxShadow: '3px 4px 0 var(--solid-ink)' }}
         >
           <div className="font-mono text-[10px] font-bold uppercase tracking-[0.06em] text-[var(--color-muted)]">
             DELETE
@@ -1372,7 +1370,6 @@ function ManualWordModal({
       <div className="absolute inset-0 flex items-center justify-center px-5">
         <div
           className="w-full max-w-[400px] rounded-[16px] border-[1.25px] border-[var(--solid-ink)] bg-white p-5"
-          style={{ boxShadow: '3px 4px 0 var(--solid-ink)' }}
         >
           <div className="font-mono text-[10px] font-bold uppercase tracking-[0.06em] text-[var(--color-muted)]">
             ADD WORD
@@ -1398,7 +1395,7 @@ function ManualWordModal({
                 disabled={loading}
                 maxLength={50}
                 autoFocus
-                className="w-full rounded-[10px] border-[1.25px] border-[var(--solid-ink)] bg-white px-3 py-2.5 font-display text-[15px] font-bold text-[var(--solid-ink)] outline-none focus:shadow-[2px_2px_0_var(--color-accent)] disabled:opacity-60"
+                className="w-full rounded-[10px] border-[1.25px] border-[var(--solid-ink)] bg-white px-3 py-2.5 font-display text-[15px] font-bold text-[var(--solid-ink)] outline-none disabled:opacity-60"
               />
             </div>
             <div>
@@ -1413,7 +1410,7 @@ function ManualWordModal({
                 placeholder="例: 美しい"
                 disabled={loading}
                 maxLength={100}
-                className="w-full rounded-[10px] border-[1.25px] border-[var(--solid-ink)] bg-white px-3 py-2.5 font-display text-[15px] font-bold text-[var(--solid-ink)] outline-none focus:shadow-[2px_2px_0_var(--color-accent)] disabled:opacity-60"
+                className="w-full rounded-[10px] border-[1.25px] border-[var(--solid-ink)] bg-white px-3 py-2.5 font-display text-[15px] font-bold text-[var(--solid-ink)] outline-none disabled:opacity-60"
               />
             </div>
 
@@ -1497,7 +1494,7 @@ function HeaderBtn({
       type="button"
       onClick={onClick}
       aria-label={ariaLabel}
-      className="flex h-[38px] w-[38px] items-center justify-center rounded-[19px] border-[1.25px] border-[var(--solid-ink)] bg-white text-[var(--solid-ink)] shadow-[2px_2px_0_var(--solid-ink)] transition-all duration-100 active:translate-x-px active:translate-y-px"
+      className="flex h-[38px] w-[38px] items-center justify-center rounded-[19px] border-[1.25px] border-[var(--solid-ink)] bg-white text-[var(--solid-ink)] transition-all duration-100 active:translate-x-px active:translate-y-px"
     >
       {children}
     </button>
@@ -2050,7 +2047,7 @@ function BulkActionMenuButton({
       role="menuitem"
       onClick={onClick}
       disabled={disabled}
-      className="inline-flex h-[38px] w-full items-center justify-between rounded-[10px] border-[1.25px] border-[var(--solid-ink)] bg-white px-3 text-[12px] font-bold text-[var(--solid-ink)] shadow-[2px_2px_0_var(--solid-ink)] transition-all duration-100 active:translate-x-px active:translate-y-px active:shadow-none disabled:opacity-50"
+      className="inline-flex h-[38px] w-full items-center justify-between rounded-[10px] border-[1.25px] border-[var(--solid-ink)] bg-white px-3 text-[12px] font-bold text-[var(--solid-ink)] transition-all duration-100 active:translate-x-px active:translate-y-px disabled:opacity-50"
     >
       <span>{label}</span>
       {loading ? (
@@ -2093,7 +2090,6 @@ function BulkDeleteModal({
       <div className="absolute inset-0 flex items-center justify-center px-5">
         <div
           className="w-full max-w-[360px] rounded-[16px] border-[1.25px] border-[var(--solid-ink)] bg-white p-5"
-          style={{ boxShadow: '3px 4px 0 var(--solid-ink)' }}
         >
           <div className="font-mono text-[10px] font-bold uppercase tracking-[0.06em] text-[var(--color-muted)]">
             DELETE
@@ -2156,7 +2152,6 @@ function SingleWordDeleteModal({
       <div className="absolute inset-0 flex items-center justify-center px-5">
         <div
           className="w-full max-w-[360px] rounded-[16px] border-[1.25px] border-[var(--solid-ink)] bg-white p-5"
-          style={{ boxShadow: '3px 4px 0 var(--solid-ink)' }}
         >
           <div className="font-mono text-[10px] font-bold uppercase tracking-[0.06em] text-[var(--color-muted)]">
             DELETE

--- a/src/components/project/ProjectDetailSheet.tsx
+++ b/src/components/project/ProjectDetailSheet.tsx
@@ -369,7 +369,7 @@ export function ProjectDetailSheet({ projectId, onClose }: { projectId: string; 
             type="button"
             onClick={onClose}
             aria-label="閉じる"
-            className="mt-0.5 flex h-[38px] w-[38px] shrink-0 items-center justify-center rounded-[19px] border-[1.25px] border-[var(--solid-ink)] bg-white text-[var(--solid-ink)] shadow-[2px_2px_0_var(--solid-ink)] transition-all duration-100 active:translate-x-px active:translate-y-px active:shadow-none"
+            className="mt-0.5 flex h-[38px] w-[38px] shrink-0 items-center justify-center rounded-[19px] border-[1.25px] border-[var(--solid-ink)] bg-white text-[var(--solid-ink)] transition-all duration-100 active:translate-x-px active:translate-y-px"
           >
             <Icon name="close" size={16} />
           </button>

--- a/src/components/project/WordListSheets.tsx
+++ b/src/components/project/WordListSheets.tsx
@@ -46,7 +46,7 @@ function BottomSheetShell({ open, onClose, title, children, footer }: BottomShee
       />
       {/* Mobile: bottom sheet / Desktop (lg+): centered solid card */}
       <div
-        className="relative flex max-h-[80vh] w-full animate-fade-in-up flex-col rounded-t-[20px] border-[1.5px] border-b-0 border-[var(--solid-ink)] bg-[#faf7f1] shadow-[0_-8px_24px_rgba(26,26,26,0.18)] lg:max-w-[460px] lg:rounded-[20px] lg:border-b-[1.5px] lg:shadow-[4px_5px_0_var(--solid-ink)]"
+        className="relative flex max-h-[80vh] w-full animate-fade-in-up flex-col rounded-t-[20px] border-[1.5px] border-b-0 border-[var(--solid-ink)] bg-[#faf7f1] lg:max-w-[460px] lg:rounded-[20px] lg:border-b-[1.5px]"
         onClick={(e) => e.stopPropagation()}
       >
         {/* Drag handle */}

--- a/src/components/word/WordDetailView.tsx
+++ b/src/components/word/WordDetailView.tsx
@@ -411,7 +411,7 @@ export function WordDetailView({
     return (
       <div className={isModal ? 'flex flex-col items-center justify-center px-6 py-16 text-center' : 'flex min-h-screen flex-col items-center justify-center bg-[var(--color-background)] px-6 text-center'}>
         <h1 className="font-display text-xl font-black text-[var(--solid-ink)]">単語が見つかりません</h1>
-        <button onClick={onClose} className="mt-4 rounded-[10px] border-[1.25px] border-[var(--solid-ink)] bg-white px-6 py-2.5 text-sm font-bold text-[var(--solid-ink)] shadow-[2px_2px_0_var(--solid-ink)]">
+        <button onClick={onClose} className="mt-4 rounded-[10px] border-[1.25px] border-[var(--solid-ink)] bg-white px-6 py-2.5 text-sm font-bold text-[var(--solid-ink)]">
           戻る
         </button>
       </div>
@@ -423,7 +423,7 @@ export function WordDetailView({
       <header className="mx-auto flex w-full max-w-xl items-center justify-between px-5 pb-3 pt-4 sm:px-7">
         <button
           onClick={onClose}
-          className="flex h-9 w-9 items-center justify-center rounded-full border-[1.25px] border-[var(--solid-ink)] bg-white text-[var(--solid-ink)] shadow-[2px_2px_0_var(--solid-ink)] transition-all duration-100 active:translate-x-px active:translate-y-px active:shadow-none"
+          className="flex h-9 w-9 items-center justify-center rounded-full border-[1.25px] border-[var(--solid-ink)] bg-white text-[var(--solid-ink)] transition-all duration-100 active:translate-x-px active:translate-y-px"
           aria-label={isModal ? '閉じる' : '戻る'}
         >
           <Icon name={isModal ? 'close' : 'chevron_left'} size={16} />
@@ -432,7 +432,7 @@ export function WordDetailView({
           <button
             onClick={handleFinishEditing}
             disabled={saving}
-            className="rounded-full border-[1.25px] border-[var(--solid-ink)] bg-[var(--solid-ink)] px-4 py-2 text-sm font-bold text-white shadow-[2px_2px_0_rgba(26,26,26,0.22)] disabled:opacity-50"
+            className="rounded-full border-[1.25px] border-[var(--solid-ink)] bg-[var(--solid-ink)] px-4 py-2 text-sm font-bold text-white disabled:opacity-50"
           >
             {saving ? '保存中...' : '完了'}
           </button>
@@ -440,14 +440,14 @@ export function WordDetailView({
           <div className="flex items-center gap-2">
             <button
               onClick={handleStartEditing}
-              className="flex h-9 w-9 items-center justify-center rounded-full border-[1.25px] border-[var(--solid-ink)] bg-white text-[var(--solid-ink)] shadow-[2px_2px_0_var(--solid-ink)] transition-all duration-100 active:translate-x-px active:translate-y-px active:shadow-none"
+              className="flex h-9 w-9 items-center justify-center rounded-full border-[1.25px] border-[var(--solid-ink)] bg-white text-[var(--solid-ink)] transition-all duration-100 active:translate-x-px active:translate-y-px"
               aria-label="編集"
             >
               <Icon name="edit" size={16} />
             </button>
             <button
               onClick={onDelete ? () => onDelete(wordId) : undefined}
-              className="flex h-9 w-9 items-center justify-center rounded-full border-[1.25px] border-[var(--solid-ink)] bg-white shadow-[2px_2px_0_var(--solid-ink)] transition-all duration-100 active:translate-x-px active:translate-y-px active:shadow-none"
+              className="flex h-9 w-9 items-center justify-center rounded-full border-[1.25px] border-[var(--solid-ink)] bg-white transition-all duration-100 active:translate-x-px active:translate-y-px"
               style={{ color: onDelete ? 'var(--color-error, #cc4d59)' : 'var(--solid-ink)' }}
               aria-label={onDelete ? '削除' : 'メニュー'}
             >
@@ -556,7 +556,7 @@ export function WordDetailView({
               />
             </div>
           ) : word.exampleSentence ? (
-            <div className="rounded-[14px] border-[1.25px] border-[var(--solid-ink)] bg-white px-4 py-4 shadow-[3px_3px_0_var(--color-accent)]">
+            <div className="rounded-[14px] border-[1.25px] border-[var(--solid-ink)] bg-white px-4 py-4">
               <div className="flex items-start gap-3">
                 <p className="min-w-0 flex-1 text-[15px] font-medium leading-[1.6] text-[var(--solid-ink)]">
                   {highlightWord(word.exampleSentence, word.english)}


### PR DESCRIPTION
## Summary\n- プロジェクト詳細ページ (`/project/*`) 内のすべてのUI要素から影（box-shadow）を削除\n- プロジェクトアイコンの影（`boxShadow: '2.5px 2.5px 0 var(--solid-ink)'`）のみ維持\n- 対象: ボタン、ドロップダウンメニュー、検索バー、モーダル、シート、単語詳細ビュー\n\n## Changed files\n- `src/app/project/[id]/page.tsx` — shadow classes/inline styles removed from menus, search bar, filter/sort/select buttons, modals, HeaderBtn, SelectModeActionButton\n- `src/components/word/WordDetailView.tsx` — shadow removed from buttons and example sentence card\n- `src/components/project/WordListSheets.tsx` — shadow removed from sheet container\n- `src/components/project/ProjectDetailSheet.tsx` — shadow removed from close button\n\n## Test plan\n- [ ] /project/[id] ページを開き、プロジェクトアイコンに影が残っていることを確認\n- [ ] メニュー、検索バー、フィルタ/ソート/選択ボタンに影がないことを確認\n- [ ] 単語詳細モーダル、名称変更モーダル、削除モーダルに影がないことを確認\n- [ ] フィルタ/ソートのシートに影がないことを確認\n\nhttps://claude.ai/code/session_01YKzJFyXDwV3Lt5fYtFF142"

---
_Generated by [Claude Code](https://claude.ai/code/session_01YKzJFyXDwV3Lt5fYtFF142)_