### PR TITLE
ライブラリ画像選択時にプレビュートレイを表示する

### DIFF
--- a/src/components/home/ScanCapturePanel.tsx
+++ b/src/components/home/ScanCapturePanel.tsx
@@ -274,11 +274,10 @@ export function ScanCapturePanel({
   const handleLibraryInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const files = Array.from(event.currentTarget.files ?? []);
     event.currentTarget.value = '';
-    if (captureView) {
-      addHeldShots(files);
-    } else {
-      void handleFilesSelected(files);
+    if (!captureView) {
+      setCaptureView(true);
     }
+    addHeldShots(files);
   };
 
   const handleCaptureClose = () => {


### PR DESCRIPTION
## Summary\n- 「写真から選ぶ」で画像を選択した際、即座にアップロード処理が始まっていた問題を修正\n- カメラ撮影フローと同様に、MultiShotCaptureView（プレビュートレイ）に画像をホールドし、ユーザーが確認ボタンを押してから処理を開始するように変更\n- 追加画像の選択や不要な画像の削除もプレビュー画面上で可能\n\n## Test plan\n- [ ] 「写真から選ぶ」ボタンで画像を選択し、プレビュートレイが表示されることを確認\n- [ ] プレビュートレイ上で画像の追加・削除ができることを確認\n- [ ] 確認ボタンを押した後に処理が開始されることを確認\n- [ ] カメラ撮影フローが引き続き正常に動作することを確認\n\nhttps://claude.ai/code/session_01Qb8Dnzfidum3D2WKM1cab1

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qb8Dnzfidum3D2WKM1cab1)_