### PR TITLE
Remove onboarding UI display, keep state management

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -9,9 +9,6 @@ import { DesktopHomeView } from '@/components/desktop/DesktopHome';
 import { SolidEmpty, SolidPanel } from '@/components/redesign/SolidPage';
 import { ScanCaptureModal } from '@/components/home/ScanCaptureModal';
 import { LpDemoSection } from '@/components/home/LpDemoSection';
-import { WelcomeOverlay } from '@/components/onboarding/WelcomeOverlay';
-import { EmptyStateGuide } from '@/components/onboarding/EmptyStateGuide';
-import { HintBanner } from '@/components/onboarding/HintBanner';
 import { GeneratingProjectCard } from '@/components/project/GeneratingProjectCard';
 import { useOnboarding } from '@/hooks/use-onboarding';
 import { useAuth } from '@/hooks/use-auth';
@@ -229,7 +226,7 @@ const EMPTY_STATS: HomeStats = {
 export default function HomePage() {
   const router = useRouter();
   const { user, subscription, isPro, loading: authLoading } = useAuth();
-  const { step: onboardingStep, loading: onboardingLoading, setStep: setOnboardingStep } = useOnboarding();
+  useOnboarding();
   const [projects, setProjects] = useState<HomeProjectStats[]>([]);
   const [stats, setStats] = useState<HomeStats>(EMPTY_STATS);
   const [loading, setLoading] = useState(true);
@@ -237,7 +234,7 @@ export default function HomePage() {
   const [pendingScans, setPendingScans] = useState<HomePendingScan[]>([]);
   const [recentScanJobs, setRecentScanJobs] = useState<RecentScanJob[]>([]);
   const [pendingGeneratingWordbook, setPendingGeneratingWordbook] = useState<HomeGeneratingWordbookPayload | null>(null);
-  const [welcomeOpen, setWelcomeOpen] = useState(false);
+
   const [vocabScanOpen, setVocabScanOpen] = useState(false);
   const loadHomeRef = useRef<() => Promise<void>>(() => Promise.resolve());
 
@@ -344,23 +341,6 @@ export default function HomePage() {
     }
   }, [showHomeGeneratingWordbook]);
 
-  useEffect(() => {
-    if (authLoading || onboardingLoading) return;
-    if (!user) {
-      setWelcomeOpen(false);
-      return;
-    }
-    if (onboardingStep === 'signed_up') {
-      setWelcomeOpen(true);
-      return;
-    }
-    setWelcomeOpen(false);
-  }, [authLoading, onboardingLoading, onboardingStep, user]);
-
-  const handleWelcomeSkip = useCallback(() => {
-    setWelcomeOpen(false);
-    void setOnboardingStep('skipped');
-  }, [setOnboardingStep]);
 
   // Pro: バックグラウンドスキャンのポーリング
   useEffect(() => {
@@ -618,19 +598,6 @@ export default function HomePage() {
         </Link>
       </div>
 
-      {onboardingStep === 'first_scan_done' && visibleProjects.length > 0 && (
-        <div className="px-[18px] pb-3">
-          <HintBanner
-            icon="bolt"
-            title="次はクイズで覚えよう！"
-            description="作った単語帳を 4 択クイズで定着させましょう。"
-            href={`/quiz/${visibleProjects[0].id}`}
-            ctaLabel="クイズへ"
-            tone="amber"
-          />
-        </div>
-      )}
-
       <div className="flex flex-col gap-2.5 px-[18px] pb-4">
         {displayedPendingScans.map((job) => (
           <GeneratingProjectCard
@@ -645,21 +612,17 @@ export default function HomePage() {
             <span className="ml-2 text-sm">読み込み中...</span>
           </div>
         ) : visibleProjects.length === 0 ? (
-          onboardingStep === 'completed' || onboardingStep === 'first_scan_done' ? (
-            <EmptyStateGuide onStartScan={() => setVocabScanOpen(true)} />
-          ) : (
-            <SolidEmpty
-              icon="menu_book"
-              title="単語帳はまだありません"
-              description="スキャンまたは手入力で最初の単語帳を作成しましょう。"
-              action={
-                <Link href="/scan" className="solid-link-primary">
-                  <Icon name="add_a_photo" size={16} />
-                  新規スキャン
-                </Link>
-              }
-            />
-          )
+          <SolidEmpty
+            icon="menu_book"
+            title="単語帳はまだありません"
+            description="スキャンまたは手入力で最初の単語帳を作成しましょう。"
+            action={
+              <Link href="/scan" className="solid-link-primary">
+                <Icon name="add_a_photo" size={16} />
+                新規スキャン
+              </Link>
+            }
+          />
         ) : (
           visibleProjects.map((project) => <ProjectRow key={project.id} project={project} />)
         )}
@@ -673,12 +636,7 @@ export default function HomePage() {
         onBackgroundScanStarted={showHomeGeneratingWordbook}
       />
 
-      <WelcomeOverlay
-        open={welcomeOpen}
-        onClose={() => setWelcomeOpen(false)}
-        onSkip={handleWelcomeSkip}
-        onStartScan={() => setVocabScanOpen(true)}
-      />
+
     </>
   );
 }

--- a/src/app/quiz/[projectId]/page.tsx
+++ b/src/app/quiz/[projectId]/page.tsx
@@ -55,7 +55,6 @@ import { useAuth } from '@/hooks/use-auth';
 import { isBillingEnabled } from '@/lib/billing/feature';
 import { useUserPreferences } from '@/hooks/use-user-preferences';
 import { useOnboarding } from '@/hooks/use-onboarding';
-import { HintBanner } from '@/components/onboarding/HintBanner';
 import { PwaInstallPromptModal } from '@/components/onboarding/PwaInstallPromptModal';
 import type {
   MultipleChoiceQuizQuestion,
@@ -1148,16 +1147,6 @@ export default function QuizPage() {
           <div className="w-full max-w-sm">
             <h1 className="mb-2 text-center font-display text-2xl font-black text-[var(--solid-ink)]">問題数を入力</h1>
             <p className="mb-4 text-center text-[var(--color-muted)]">1〜{maxQ}問まで</p>
-            {(onboardingStep === 'signed_up' || onboardingStep === 'first_scan_done') && (
-              <div className="mb-6">
-                <HintBanner
-                  icon="quiz"
-                  title="4 択から正しい意味を選ぼう！"
-                  description="間違えても OK。スピード感が大事です。"
-                  tone="violet"
-                />
-              </div>
-            )}
             <div className="space-y-6">
               <div className="flex items-center justify-center gap-3">
                 <input

--- a/src/app/scan/confirm/page.tsx
+++ b/src/app/scan/confirm/page.tsx
@@ -9,7 +9,6 @@ import { useWordCount } from '@/hooks/use-word-count';
 import { useAuth } from '@/hooks/use-auth';
 import { useOnboarding } from '@/hooks/use-onboarding';
 import { useUserPreferences } from '@/hooks/use-user-preferences';
-import { HintBanner } from '@/components/onboarding/HintBanner';
 import { getRepository } from '@/lib/db';
 import { getDb } from '@/lib/db/dexie';
 import { FREE_WORD_LIMIT, getGuestUserId } from '@/lib/utils';
@@ -384,17 +383,6 @@ export default function ConfirmPage() {
         </div>
       )}
 
-      {/* Onboarding hint */}
-      {onboardingStep === 'signed_up' && (
-        <div className="px-[18px] pb-3">
-          <HintBanner
-            icon="check_circle"
-            title="あと少し！保存ボタンで単語帳を作成しよう"
-            description="不要な単語を削除・編集してから保存できます。"
-            tone="accent"
-          />
-        </div>
-      )}
 
       {/* Word count + add button */}
       <div className="flex items-center justify-between px-[18px] pb-2.5">


### PR DESCRIPTION
## Summary
- WelcomeOverlay、HintBanner、EmptyStateGuideの表示を全ページから削除
- `useOnboarding` フックの呼び出しとステップ遷移ロジック（signed_up → first_scan_done → completed）はそのまま維持
- 対象ファイル: `src/app/page.tsx`、`src/app/quiz/[projectId]/page.tsx`、`src/app/scan/confirm/page.tsx`

## Test plan
- [ ] ホームページでWelcomeOverlayが表示されないことを確認
- [ ] クイズページでHintBannerが表示されないことを確認
- [ ] スキャン確認ページでHintBannerが表示されないことを確認
- [ ] 新規登録→スキャン→クイズ完了でオンボーディングステップが正常に遷移することを確認（API経由）

https://claude.ai/code/session_01S6qdjqxtubJMtMcv9jzmB4

---
_Generated by [Claude Code](https://claude.ai/code/session_01S6qdjqxtubJMtMcv9jzmB4)_