### PR TITLE
Remove subtitle text from login screen

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -130,9 +130,6 @@ function LoginForm() {
         <div className="font-display text-2xl font-extrabold leading-[1.2] tracking-[-0.02em] text-[var(--solid-ink)]">
           ログイン
         </div>
-        <div className="mt-1 text-xs text-[var(--color-muted)]">
-          アカウントに接続して、続きから始める。
-        </div>
       </div>
 
       <form onSubmit={handleSubmit}>


### PR DESCRIPTION
## Summary
- ログイン画面の「アカウントに接続して、続きから始める。」というサブタイトルテキストを削除

---
_Generated by [Claude Code](https://claude.ai/code/session_018Ds7Czy1va8wL9vYAnfRhW)_