### PR TITLE
Remove tagline text from login and signup screens

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -121,9 +121,6 @@ function LoginForm() {
           MERKEN
           <span className="ml-[5px] inline-block h-[7px] w-[7px] -translate-y-3 bg-[var(--color-accent)]" />
         </div>
-        <div className="mt-1.5 font-mono text-[10px] tracking-[0.06em] text-[var(--color-muted)]">
-          単語を覚えるためのノート
-        </div>
       </div>
 
       <div className="px-6 pb-4 pt-6">

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -130,9 +130,6 @@ function LoginForm() {
         <div className="font-display text-2xl font-extrabold leading-[1.2] tracking-[-0.02em] text-[var(--solid-ink)]">
           ログイン
         </div>
-        <div className="mt-1 text-xs text-[var(--color-muted)]">
-          アカウントに接続して、続きから始める。
-        </div>
       </div>
 
       <form onSubmit={handleSubmit}>

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -511,9 +511,6 @@ function SignupShell({
           MERKEN
           <span className="ml-[5px] inline-block h-[7px] w-[7px] -translate-y-3 bg-[var(--color-accent)]" />
         </div>
-        <div className="mt-1.5 font-mono text-[10px] tracking-[0.06em] text-[var(--color-muted)]">
-          単語を覚えるためのノート
-        </div>
       </div>
 
       <div className="px-6 pb-4 pt-6">


### PR DESCRIPTION
## Summary
- ログイン画面とサインアップ画面から「単語を覚えるためのノート」のタグラインテキストを削除

---
_Generated by [Claude Code](https://claude.ai/code/session_018Ds7Czy1va8wL9vYAnfRhW)_