### PR TITLE
リマインダーが届かない問題を修正: アプリ起動時のWeb Push購読リフレッシュを復元

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@ import { Lexend, Noto_Sans_JP } from 'next/font/google';
 import { ThemeProvider } from '@/components/theme-provider';
 import { ToastProvider } from '@/components/ui/toast';
 import { ServiceWorkerRegistration } from '@/components/pwa/ServiceWorkerRegistration';
+import { WebPushSync } from '@/components/pwa/WebPushSync';
 import { OfflineSyncProvider } from '@/components/pwa/OfflineSyncProvider';
 import { StatsSync } from '@/components/StatsSync';
 import { HomeOpenLogger } from '@/components/analytics/HomeOpenLogger';
@@ -138,6 +139,7 @@ export default function RootLayout({
           <StatsSync />
           <HomeOpenLogger />
           <ServiceWorkerRegistration />
+          <WebPushSync />
         </ThemeProvider>
       </body>
     </html>

--- a/src/components/pwa/WebPushSync.tsx
+++ b/src/components/pwa/WebPushSync.tsx
@@ -1,0 +1,55 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import { useAuth } from '@/hooks/use-auth';
+import { ensureWebPushSubscription } from '@/lib/notifications/push-client';
+import { createBrowserClient } from '@/lib/supabase';
+
+/**
+ * Transparent component that re-registers the browser's web push subscription
+ * for the signed-in user on every app load.
+ *
+ * Push subscriptions expire or get rotated by the browser/push service over
+ * time. When that happens the stale endpoint is pruned (410/404) and the user
+ * silently stops receiving push notifications -- including study reminders --
+ * until they manually toggle them again. Refreshing here keeps the
+ * `web_push_subscriptions` row current so scheduled reminders keep arriving.
+ *
+ * Runs with `requestPermission: false` so it never prompts: it only refreshes
+ * when notifications were already enabled. Mount once in the root layout.
+ */
+export function WebPushSync() {
+  const { user, isAuthenticated, loading } = useAuth();
+  const syncedUserIdRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (loading) return;
+
+    if (!isAuthenticated || !user?.id) {
+      syncedUserIdRef.current = null;
+      return;
+    }
+
+    if (syncedUserIdRef.current === user.id) {
+      return;
+    }
+    syncedUserIdRef.current = user.id;
+
+    const syncPushSubscription = async () => {
+      const supabase = createBrowserClient();
+      const { data: { session } } = await supabase.auth.getSession();
+      if (!session?.access_token) return;
+
+      await ensureWebPushSubscription({
+        accessToken: session.access_token,
+        requestPermission: false,
+      });
+    };
+
+    syncPushSubscription().catch(() => {
+      // Push refresh is best-effort; ignore failures.
+    });
+  }, [isAuthenticated, loading, user?.id]);
+
+  return null;
+}


### PR DESCRIPTION
## 概要

学習リマインダー（および通知全般）が「以前は動いていたのに、ある時から届かなくなった」原因を特定し、コードで修正しました。

## 原因

レガシーのホームページ `src/app/page.legacy.tsx` には、**認証済みユーザーがアプリを開くたびにWeb Push購読をサイレントに再登録する** `useEffect` がありました（`ensureWebPushSubscription({ requestPermission: false })`）。

```ts
// page.legacy.tsx
const syncPushSubscription = async () => {
  const { data: { session } } = await supabase.auth.getSession();
  if (!session?.access_token) return;
  await ensureWebPushSubscription({ accessToken: session.access_token, requestPermission: false });
};
```

デスクトップ対応のページ刷新（#161）で新しい `src/app/page.tsx` がこのページを置き換えた際、**このリフレッシュ処理が引き継がれませんでした**。現在アクティブなページ（`page.tsx` / `scan/page.tsx` / `project/[id]/page.tsx`）はどれも購読を再登録していません（`ensureWebPushSubscription` の呼び出しはレガシーファイルと設定画面のトグルのみ）。

ブラウザ／プッシュサービスは購読を定期的に期限切れ・ローテーションさせます。それが起きると、無効な endpoint は 410/404 で `web_push_subscriptions` から削除され（`removeInvalidSubscription`）、ユーザーの購読が消失します。アプリ起動時の再登録が失われたため、一度購読が切れると二度と復活せず、`study-reminder-push-dispatch` cron が配信先を失い、**リマインダーが届かなくなります**。設定画面で手動でトグルし直すまで復旧しません。

## 修正

レガシーにあったキープアライブ処理を、ルートレイアウトに常駐する透過コンポーネント `WebPushSync` として復元しました。

- `src/components/pwa/WebPushSync.tsx`（新規）: 認証済みユーザーごとに一度、購読をサイレントにリフレッシュ
- `src/app/layout.tsx`: `ServiceWorkerRegistration` / `StatsSync` と同じ階層にマウント

レイアウトに置くことで、今後ページがリファクタされても処理が失われません。`requestPermission: false` のため通知許可を**プロンプトすることはなく**、すでに通知が有効なユーザーの購読を更新するだけです。

## 検証

- `npm run build` 成功
- `npx eslint`（変更ファイル）: エラー0
- アプリ本体の型チェックはクリーン（既存の型エラーはテストファイルのみで本変更とは無関係）

https://claude.ai/code/session_01DNTDn1TbAEodtu96AZRuo1

---
_Generated by [Claude Code](https://claude.ai/code/session_01DNTDn1TbAEodtu96AZRuo1)_