### PR TITLE
グループ機能をフロントエンドから非表示にする

### DIFF
--- a/src/app/project/[id]/page.tsx
+++ b/src/app/project/[id]/page.tsx
@@ -1103,11 +1103,6 @@ export default function ProjectPage() {
         onCopyShareLink={(shareUrl) => void handleCopyShareLink(shareUrl)}
         onShareLink={(shareUrl) => void handleShareLink(shareUrl)}
         shareLinkCopied={shareLinkCopied}
-        groups={shareGroups}
-        groupsLoading={shareGroupsLoading}
-        groupsError={shareGroupsError}
-        groupSharingUpdatingId={groupSharingUpdatingId}
-        onToggleGroupShare={(group) => void handleToggleGroupShare(group)}
       />
 
       <DeleteProjectModal

--- a/src/app/shared/SharedPageClient.tsx
+++ b/src/app/shared/SharedPageClient.tsx
@@ -2,13 +2,11 @@
 
 import { startTransition, useCallback, useEffect, useEffectEvent, useMemo, useRef, useState } from 'react';
 import Link from 'next/link';
-import { DesktopSharedView, type SharedLibraryTab } from '@/components/desktop/DesktopShared';
+import { DesktopSharedView } from '@/components/desktop/DesktopShared';
 import { Icon } from '@/components/ui';
 import type {
   SharedProjectCard,
   SharedProjectMetricsMap,
-  StudyGroupProjectListPayload,
-  StudyGroupSummary,
 } from '@/lib/shared-projects/types';
 import {
   collectMetricProjectIds,
@@ -30,22 +28,6 @@ type MetricsResponse = {
   metrics?: SharedProjectMetricsMap;
 };
 
-type StudyGroupsResponse = {
-  success?: boolean;
-  groups?: StudyGroupSummary[];
-  error?: string;
-};
-
-type StudyGroupMutationResponse = {
-  success?: boolean;
-  group?: StudyGroupSummary;
-  error?: string;
-};
-
-type StudyGroupProjectsResponse =
-  | ({ success: true } & StudyGroupProjectListPayload)
-  | { success?: false; error?: string };
-
 const THUMBS = ['#137FEC', '#664DB3', '#228B22', '#2E66BF', '#D97340', '#3373B3', '#CC4D59', '#3DA1B8'];
 
 function thumbColor(id: string) {
@@ -60,42 +42,16 @@ export default function SharedPageClient({
   initialPublicItems,
   initialPublicNextCursor,
 }: SharedPageClientProps) {
-  const [activeTab, setActiveTab] = useState<SharedLibraryTab>('public');
   const [publicProjects, setPublicProjects] = useState<SharedProjectCard[]>(initialPublicItems);
   const [publicNextCursor, setPublicNextCursor] = useState<string | null>(initialPublicNextCursor);
   const [loadingMorePublic, setLoadingMorePublic] = useState(false);
   const [publicSectionError, setPublicSectionError] = useState<string | null>(null);
   const [activeFilter, setActiveFilter] = useState<FilterKey>('all');
-  const [groups, setGroups] = useState<StudyGroupSummary[]>([]);
-  const [groupsLoaded, setGroupsLoaded] = useState(false);
-  const [groupsLoading, setGroupsLoading] = useState(false);
-  const [groupsError, setGroupsError] = useState<string | null>(null);
-  const [selectedGroupId, setSelectedGroupId] = useState<string | null>(null);
-  const [groupProjectsByGroupId, setGroupProjectsByGroupId] = useState<Record<string, SharedProjectCard[]>>({});
-  const [groupProjectsLoading, setGroupProjectsLoading] = useState(false);
-  const [groupProjectsError, setGroupProjectsError] = useState<string | null>(null);
-  const [createGroupName, setCreateGroupName] = useState('');
-  const [joinGroupCode, setJoinGroupCode] = useState('');
-  const [groupActionLoading, setGroupActionLoading] = useState<'create' | 'join' | null>(null);
-  const [groupPanelOpen, setGroupPanelOpen] = useState(false);
   const pendingMetricIdsRef = useRef(new Set<string>());
-
-  const selectedGroup = useMemo(
-    () => groups.find((group) => group.id === selectedGroupId) ?? null,
-    [groups, selectedGroupId],
-  );
-  const selectedGroupProjects = selectedGroupId ? (groupProjectsByGroupId[selectedGroupId] ?? []) : [];
 
   const applyMetrics = useEffectEvent((metrics: SharedProjectMetricsMap) => {
     startTransition(() => {
       setPublicProjects((current) => mergeMetricsIntoCards(current, metrics));
-      setGroupProjectsByGroupId((current) => {
-        const next: Record<string, SharedProjectCard[]> = {};
-        for (const [groupId, cards] of Object.entries(current)) {
-          next[groupId] = mergeMetricsIntoCards(cards, metrics);
-        }
-        return next;
-      });
     });
   });
 
@@ -121,92 +77,9 @@ export default function SharedPageClient({
   });
 
   useEffect(() => {
-    const groupProjects = Object.values(groupProjectsByGroupId).flat();
-    const projectIds = collectMetricProjectIds([], [], [...publicProjects, ...groupProjects]);
+    const projectIds = collectMetricProjectIds([], [], publicProjects);
     if (projectIds.length > 0) requestMetrics(projectIds);
-  }, [groupProjectsByGroupId, publicProjects]);
-
-  const loadGroups = useCallback(async () => {
-    setGroupsLoading(true);
-    setGroupsError(null);
-
-    try {
-      const response = await fetch('/api/shared-projects/groups', { cache: 'no-store' });
-      const payload = await response.json().catch(() => null) as StudyGroupsResponse | null;
-
-      if (response.status === 401) {
-        setGroups([]);
-        setGroupsLoaded(true);
-        setSelectedGroupId(null);
-        setGroupsError('ログインするとグループを使えます。');
-        return;
-      }
-      if (!response.ok || !payload?.success) {
-        throw new Error(payload?.error || 'study_groups_fetch_failed');
-      }
-
-      const nextGroups = payload.groups ?? [];
-      startTransition(() => {
-        setGroups(nextGroups);
-        setGroupsLoaded(true);
-        setSelectedGroupId((current) => {
-          if (current && nextGroups.some((group) => group.id === current)) return current;
-          return null;
-        });
-      });
-    } catch (error) {
-      console.warn('Failed to load study groups:', error);
-      setGroups([]);
-      setSelectedGroupId(null);
-      setGroupsLoaded(true);
-      setGroupsError('グループ一覧を読み込めませんでした。');
-    } finally {
-      setGroupsLoading(false);
-    }
-  }, []);
-
-  const loadGroupProjects = useCallback(async (groupId: string) => {
-    setGroupProjectsLoading(true);
-    setGroupProjectsError(null);
-
-    try {
-      const response = await fetch(`/api/shared-projects/groups/${encodeURIComponent(groupId)}/projects`, {
-        cache: 'no-store',
-      });
-      const payload = await response.json().catch(() => null) as StudyGroupProjectsResponse | null;
-
-      if (!response.ok || !payload || payload.success !== true) {
-        const message = payload && 'error' in payload ? payload.error : undefined;
-        throw new Error(message || 'study_group_projects_fetch_failed');
-      }
-
-      startTransition(() => {
-        setGroupProjectsByGroupId((current) => ({
-          ...current,
-          [groupId]: payload.projects ?? [],
-        }));
-        setGroups((current) => current.map((group) => (
-          group.id === payload.group.id ? { ...group, ...payload.group } : group
-        )));
-      });
-    } catch (error) {
-      console.warn('Failed to load group projects:', error);
-      setGroupProjectsError('グループ内の単語帳を読み込めませんでした。');
-    } finally {
-      setGroupProjectsLoading(false);
-    }
-  }, []);
-
-  useEffect(() => {
-    if (activeTab !== 'groups' || groupsLoaded || groupsLoading) return;
-    void loadGroups();
-  }, [activeTab, groupsLoaded, groupsLoading, loadGroups]);
-
-  useEffect(() => {
-    if (activeTab !== 'groups' || !selectedGroupId) return;
-    if (groupProjectsByGroupId[selectedGroupId]) return;
-    void loadGroupProjects(selectedGroupId);
-  }, [activeTab, groupProjectsByGroupId, loadGroupProjects, selectedGroupId]);
+  }, [publicProjects]);
 
   async function handleLoadMorePublic() {
     if (!publicNextCursor || loadingMorePublic) return;
@@ -235,118 +108,20 @@ export default function SharedPageClient({
     }
   }
 
-  async function handleCreateGroup() {
-    const name = createGroupName.trim();
-    if (!name || groupActionLoading) return;
-
-    setGroupActionLoading('create');
-    setGroupsError(null);
-
-    try {
-      const response = await fetch('/api/shared-projects/groups', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ name }),
-      });
-      const payload = await response.json().catch(() => null) as StudyGroupMutationResponse | null;
-      if (!response.ok || !payload?.success || !payload.group) {
-        throw new Error(payload?.error || 'study_group_create_failed');
-      }
-
-      startTransition(() => {
-        setGroups((current) => [payload.group!, ...current.filter((group) => group.id !== payload.group!.id)]);
-        setGroupProjectsByGroupId((current) => ({ ...current, [payload.group!.id]: [] }));
-        setSelectedGroupId(payload.group!.id);
-        setGroupsLoaded(true);
-        setActiveTab('groups');
-      });
-      setCreateGroupName('');
-    } catch (error) {
-      console.error('Failed to create group:', error);
-      setGroupsError(error instanceof Error ? error.message : 'グループの作成に失敗しました。');
-    } finally {
-      setGroupActionLoading(null);
-    }
-  }
-
-  async function handleJoinGroup() {
-    const inviteCode = joinGroupCode.trim();
-    if (!inviteCode || groupActionLoading) return;
-
-    setGroupActionLoading('join');
-    setGroupsError(null);
-
-    try {
-      const response = await fetch('/api/shared-projects/groups/join', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ inviteCode }),
-      });
-      const payload = await response.json().catch(() => null) as StudyGroupMutationResponse | null;
-      if (!response.ok || !payload?.success || !payload.group) {
-        throw new Error(payload?.error || 'グループへの参加に失敗しました。');
-      }
-
-      startTransition(() => {
-        setGroups((current) => [payload.group!, ...current.filter((group) => group.id !== payload.group!.id)]);
-        setSelectedGroupId(payload.group!.id);
-        setGroupsLoaded(true);
-        setActiveTab('groups');
-        setGroupProjectsByGroupId((current) => {
-          if (current[payload.group!.id]) return current;
-          return { ...current, [payload.group!.id]: [] };
-        });
-      });
-      setJoinGroupCode('');
-      void loadGroupProjects(payload.group.id);
-    } catch (error) {
-      console.error('Failed to join group:', error);
-      setGroupsError(error instanceof Error ? error.message : 'グループへの参加に失敗しました。');
-    } finally {
-      setGroupActionLoading(null);
-    }
-  }
-
-  async function handleCopyGroupInvite() {
-    if (!selectedGroup) return;
-    await copyToClipboard(formatInviteCode(selectedGroup.inviteCode));
-  }
-
   const popularCount = publicProjects.filter((project) => (project.likeCount ?? 0) > 0).length;
 
   const filteredPublicProjects = activeFilter === 'popular'
     ? [...publicProjects].filter((p) => (p.likeCount ?? 0) > 0).sort((a, b) => (b.likeCount ?? 0) - (a.likeCount ?? 0))
     : publicProjects;
 
-  const mobileProjects = activeTab === 'public' ? filteredPublicProjects : selectedGroupProjects;
-
   return (
     <>
       <DesktopSharedView
-        activeTab={activeTab}
-        onActiveTabChange={setActiveTab}
         publicProjects={publicProjects}
-        groupProjects={selectedGroupProjects}
-        groups={groups}
-        selectedGroup={selectedGroup}
-        selectedGroupId={selectedGroupId}
-        groupsLoading={groupsLoading}
-        groupProjectsLoading={groupProjectsLoading}
         publicNextCursor={publicNextCursor}
         publicLoadingMore={loadingMorePublic}
         publicError={publicSectionError}
-        groupsError={groupsError}
-        groupProjectsError={groupProjectsError}
-        createGroupName={createGroupName}
-        joinGroupCode={joinGroupCode}
-        groupActionLoading={groupActionLoading}
         onLoadMorePublic={() => void handleLoadMorePublic()}
-        onSelectGroup={setSelectedGroupId}
-        onCreateGroupNameChange={setCreateGroupName}
-        onJoinGroupCodeChange={setJoinGroupCode}
-        onCreateGroup={() => void handleCreateGroup()}
-        onJoinGroup={() => void handleJoinGroup()}
-        onCopyGroupInvite={() => void handleCopyGroupInvite()}
       />
       <div className="flex min-h-screen flex-col bg-[var(--color-background)] pb-[110px] pt-3 font-[var(--font-body)] lg:hidden">
       <div className="px-[18px] pb-2 pt-1">
@@ -357,238 +132,37 @@ export default function SharedPageClient({
           共有単語帳
         </div>
         <div className="mt-1 text-xs leading-[1.5] text-[var(--color-muted)]">
-          みんなの単語帳と所属グループの単語帳を閲覧できます。
+          みんなの公開単語帳を閲覧できます。
         </div>
       </div>
 
-      <div className="mx-[14px] mt-2 flex border-[1.25px] border-[var(--solid-ink)] bg-white p-[3px]">
-        <button
-          type="button"
-          onClick={() => setActiveTab('public')}
-          className="flex flex-1 items-center justify-center gap-1.5 rounded-[10px] py-2.5 text-[13px] font-bold transition-colors"
-          style={{
-            background: activeTab === 'public' ? 'var(--solid-ink)' : 'transparent',
-            color: activeTab === 'public' ? '#fff' : 'var(--solid-ink)',
-          }}
-        >
-          <Icon name="public" size={16} />
-          公開
-          <span className="font-mono text-[10px] tabular-nums opacity-60">{publicProjects.length}</span>
-        </button>
-        <button
-          type="button"
-          onClick={() => setActiveTab('groups')}
-          className="flex flex-1 items-center justify-center gap-1.5 rounded-[10px] py-2.5 text-[13px] font-bold transition-colors"
-          style={{
-            background: activeTab === 'groups' ? 'var(--solid-ink)' : 'transparent',
-            color: activeTab === 'groups' ? '#fff' : 'var(--solid-ink)',
-          }}
-        >
-          <Icon name="group" size={16} />
-          グループ
-          <span className="font-mono text-[10px] tabular-nums opacity-60">{groups.length}</span>
-        </button>
+      <div className="flex gap-1.5 overflow-x-auto px-[14px] py-3">
+        <FilterChip label="すべて" count={publicProjects.length} active={activeFilter === 'all'} onClick={() => setActiveFilter('all')} />
+        <FilterChip label="人気" count={popularCount} active={activeFilter === 'popular'} onClick={() => setActiveFilter('popular')} />
+        <FilterChip label="公開中" count={publicProjects.length} active={activeFilter === 'public'} onClick={() => setActiveFilter('public')} />
       </div>
-
-      {activeTab === 'public' && (
-        <div className="flex gap-1.5 overflow-x-auto px-[14px] py-3">
-          <FilterChip label="すべて" count={publicProjects.length} active={activeFilter === 'all'} onClick={() => setActiveFilter('all')} />
-          <FilterChip label="人気" count={popularCount} active={activeFilter === 'popular'} onClick={() => setActiveFilter('popular')} />
-          <FilterChip label="公開中" count={publicProjects.length} active={activeFilter === 'public'} onClick={() => setActiveFilter('public')} />
-        </div>
-      )}
-
-      {activeTab === 'groups' && !selectedGroupId && (
-        <div className="px-[14px] pt-3 pb-1">
-          <div className="mb-3 flex items-center justify-between">
-            <div className="font-mono text-[10px] font-bold uppercase tracking-[0.08em] text-[var(--color-muted)]">
-              {groups.length > 0 ? `${groups.length} グループ` : ''}
-            </div>
-            <button
-              type="button"
-              onClick={() => setGroupPanelOpen((v) => !v)}
-              className="inline-flex items-center gap-1 rounded-[10px] border-[1.25px] border-[var(--solid-ink)] bg-white px-2.5 py-1.5 text-[11px] font-bold text-[var(--solid-ink)] transition-all duration-100 active:translate-x-px active:translate-y-px"
-            >
-              <Icon name="settings" size={14} />
-              管理
-            </button>
-          </div>
-
-          {groupPanelOpen && (
-            <div className="relative mb-3">
-              <div className="absolute inset-0 translate-x-[2.5px] translate-y-[2.5px] rounded-xl bg-[var(--solid-ink)]" />
-              <div className="relative rounded-xl border-[1.25px] border-[var(--solid-ink)] bg-white p-3">
-                <div className="mb-2.5 font-mono text-[9px] font-bold uppercase tracking-[0.08em] text-[var(--color-muted)]">グループに参加・作成</div>
-                <div className="mb-2 flex gap-2">
-                  <input
-                    value={joinGroupCode}
-                    onChange={(event) => setJoinGroupCode(event.target.value)}
-                    placeholder="招待コードを入力"
-                    className="min-w-0 flex-1 rounded-[10px] border-[1.25px] border-[var(--solid-ink)] bg-white px-3 py-2 text-[13px] font-bold text-[var(--solid-ink)] outline-none"
-                  />
-                  <button
-                    type="button"
-                    onClick={() => void handleJoinGroup()}
-                    disabled={groupActionLoading === 'join' || !joinGroupCode.trim()}
-                    className="inline-flex shrink-0 items-center gap-1 rounded-[10px] border-[1.25px] border-[var(--solid-ink)] bg-[var(--solid-ink)] px-3 py-2 text-[12px] font-bold text-white disabled:opacity-40"
-                  >
-                    <Icon name={groupActionLoading === 'join' ? 'progress_activity' : 'login'} size={14} className={groupActionLoading === 'join' ? 'animate-spin' : undefined} />
-                    参加
-                  </button>
-                </div>
-                <div className="flex gap-2">
-                  <input
-                    value={createGroupName}
-                    onChange={(event) => setCreateGroupName(event.target.value)}
-                    placeholder="新しいグループ名"
-                    className="min-w-0 flex-1 rounded-[10px] border-[1.25px] border-[var(--solid-ink)] bg-white px-3 py-2 text-[13px] font-bold text-[var(--solid-ink)] outline-none"
-                  />
-                  <button
-                    type="button"
-                    onClick={() => void handleCreateGroup()}
-                    disabled={groupActionLoading === 'create' || !createGroupName.trim()}
-                    className="inline-flex shrink-0 items-center gap-1 rounded-[10px] border-[1.25px] border-[var(--solid-ink)] bg-white px-3 py-2 text-[12px] font-bold text-[var(--solid-ink)] disabled:opacity-40"
-                  >
-                    <Icon name={groupActionLoading === 'create' ? 'progress_activity' : 'add'} size={14} className={groupActionLoading === 'create' ? 'animate-spin' : undefined} />
-                    作成
-                  </button>
-                </div>
-              </div>
-            </div>
-          )}
-
-          {groups.length > 0 && (
-            <div className="flex flex-col gap-2">
-              {groups.map((group) => (
-                <button
-                  key={group.id}
-                  type="button"
-                  onClick={() => setSelectedGroupId(group.id)}
-                  className="relative block text-left"
-                >
-                  <div className="absolute inset-0 translate-x-[2.5px] translate-y-[2.5px] rounded-xl bg-[var(--solid-ink)]" />
-                  <div className="relative flex items-center gap-3 rounded-xl border-[1.25px] border-[var(--solid-ink)] bg-white px-3 py-2.5 transition-all duration-100 active:translate-x-px active:translate-y-px">
-                    <div
-                      className="flex h-9 w-9 shrink-0 items-center justify-center rounded-[10px] border-[1.25px] border-[var(--solid-ink)] font-display text-[15px] font-extrabold text-white"
-                      style={{ background: thumbColor(group.id) }}
-                    >
-                      {group.name.charAt(0)}
-                    </div>
-                    <div className="min-w-0 flex-1">
-                      <div className="truncate text-[13px] font-bold text-[var(--solid-ink)]">{group.name}</div>
-                      <div className="mt-0.5 text-[11px] text-[var(--color-muted)]">{group.memberCount}人 · {group.projectCount}冊</div>
-                    </div>
-                    <Icon name="chevron_right" size={20} className="shrink-0 text-[var(--color-muted)]" />
-                  </div>
-                </button>
-              ))}
-            </div>
-          )}
-
-          {groupsLoading && (
-            <div className="flex items-center gap-2 py-4 text-sm text-[var(--color-muted)]">
-              <Icon name="progress_activity" size={16} className="animate-spin" />
-              読み込み中...
-            </div>
-          )}
-
-          {groupsError && (
-            <div className="relative mt-2">
-              <div className="absolute inset-0 translate-x-[2px] translate-y-[2px] rounded-xl bg-red-800" />
-              <div className="relative rounded-xl border-[1.25px] border-red-700 bg-red-50 px-3 py-2.5 text-[12px] font-bold text-red-700">
-                {groupsError}
-              </div>
-            </div>
-          )}
-        </div>
-      )}
-
-      {activeTab === 'groups' && selectedGroupId && (
-        <div className="px-[14px] pt-3 pb-1">
-          <div className="mb-3 flex items-center gap-2">
-            <button
-              type="button"
-              onClick={() => setSelectedGroupId(null)}
-              className="inline-flex items-center gap-1 rounded-[10px] border-[1.25px] border-[var(--solid-ink)] bg-white px-2.5 py-1.5 text-[11px] font-bold text-[var(--solid-ink)] transition-all duration-100 active:translate-x-px active:translate-y-px"
-            >
-              <Icon name="arrow_back" size={14} />
-              戻る
-            </button>
-            <div className="min-w-0 flex-1">
-              <div className="truncate font-display text-[16px] font-extrabold text-[var(--solid-ink)]">
-                {selectedGroup?.name}
-              </div>
-            </div>
-            {selectedGroup && (
-              <span
-                className="shrink-0 rounded px-[7px] py-[3px] font-mono text-[9px] font-bold tracking-[0.04em]"
-                style={{ background: 'var(--solid-ink)', color: '#fff' }}
-              >
-                {selectedGroup.role === 'owner' ? 'オーナー' : 'メンバー'}
-              </span>
-            )}
-          </div>
-
-          {selectedGroup && (
-            <div className="mb-3 flex items-center gap-2 rounded-xl border-[1.25px] border-[var(--solid-ink)] bg-white px-3 py-2">
-              <span className="min-w-0 flex-1 truncate font-mono text-[10px] font-bold text-[var(--color-muted)]">
-                招待 {formatInviteCode(selectedGroup.inviteCode)}
-              </span>
-              <button type="button" onClick={() => void handleCopyGroupInvite()} className="inline-flex shrink-0 items-center gap-1 rounded-lg border-[1.25px] border-[var(--solid-ink)] px-2 py-1 text-[11px] font-bold text-[var(--solid-ink)]">
-                <Icon name="content_copy" size={12} />
-                コピー
-              </button>
-            </div>
-          )}
-        </div>
-      )}
 
       <div className="flex flex-col gap-2 px-[14px]">
-        {activeTab === 'groups' && !selectedGroupId ? null : (
-          <>
-            {activeTab === 'groups' && groupProjectsLoading && (
-              <div className="relative">
-                <div className="absolute inset-0 translate-x-[2.5px] translate-y-[2.5px] rounded-xl bg-[var(--solid-ink)]" />
-                <div className="relative rounded-xl border-[1.25px] border-[var(--solid-ink)] bg-white px-4 py-4 text-sm font-bold text-[var(--color-muted)]">
-                  <Icon name="progress_activity" size={16} className="mr-1 inline animate-spin" />
-                  読み込み中...
-                </div>
-              </div>
-            )}
-
-            {mobileProjects.length === 0 && !(activeTab === 'groups' && groupProjectsLoading) ? (
-              <div className="relative">
-                <div className="absolute inset-0 translate-x-[2.5px] translate-y-[2.5px] rounded-xl bg-[var(--solid-ink)]" />
-                <div className="relative rounded-xl border-[1.25px] border-[var(--solid-ink)] bg-white px-4 py-12 text-center text-sm font-bold text-[var(--color-muted)]">
-                  {activeTab === 'public'
-                    ? '公開中の単語帳はまだありません'
-                    : 'このグループの単語帳はまだありません'}
-                </div>
-              </div>
-            ) : (
-              mobileProjects.map((project) => (
-                <ProjectCard key={project.project.id} project={project} />
-              ))
-            )}
-
-            {groupProjectsError && activeTab === 'groups' && (
-              <div className="relative">
-                <div className="absolute inset-0 translate-x-[2px] translate-y-[2px] rounded-xl bg-red-800" />
-                <div className="relative rounded-xl border-[1.25px] border-red-700 bg-red-50 px-4 py-3 text-sm font-bold text-red-700">
-                  {groupProjectsError}
-                </div>
-              </div>
-            )}
-          </>
+        {filteredPublicProjects.length === 0 ? (
+          <div className="relative">
+            <div className="absolute inset-0 translate-x-[2.5px] translate-y-[2.5px] rounded-xl bg-[var(--solid-ink)]" />
+            <div className="relative rounded-xl border-[1.25px] border-[var(--solid-ink)] bg-white px-4 py-12 text-center text-sm font-bold text-[var(--color-muted)]">
+              公開中の単語帳はまだありません
+            </div>
+          </div>
+        ) : (
+          filteredPublicProjects.map((project) => (
+            <ProjectCard key={project.project.id} project={project} />
+          ))
         )}
 
-        {publicSectionError && activeTab === 'public' && (
+        {publicSectionError && (
           <div className="rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm font-bold text-red-700">
             {publicSectionError}
           </div>
         )}
 
-        {publicNextCursor && activeTab === 'public' && (
+        {publicNextCursor && (
           <button
             type="button"
             onClick={handleLoadMorePublic}
@@ -701,33 +275,4 @@ function ProjectCard({ project }: { project: SharedProjectCard }) {
       </div>
     </Link>
   );
-}
-
-async function copyToClipboard(text: string): Promise<boolean> {
-  try {
-    if (navigator.clipboard && window.isSecureContext) {
-      await navigator.clipboard.writeText(text);
-      return true;
-    }
-    const textarea = document.createElement('textarea');
-    textarea.value = text;
-    textarea.style.position = 'fixed';
-    textarea.style.opacity = '0';
-    document.body.appendChild(textarea);
-    textarea.select();
-    const ok = document.execCommand('copy');
-    document.body.removeChild(textarea);
-    return ok;
-  } catch {
-    return false;
-  }
-}
-
-function formatInviteCode(value: string): string {
-  const compact = value.replace(/-/g, '');
-  const parts: string[] = [];
-  for (let index = 0; index < compact.length; index += 4) {
-    parts.push(compact.slice(index, index + 4));
-  }
-  return parts.join('-');
 }

--- a/src/components/desktop/DesktopChrome.tsx
+++ b/src/components/desktop/DesktopChrome.tsx
@@ -13,7 +13,7 @@ type NavKey = 'home' | 'books' | 'stats' | 'shared' | 'fav' | 'scan' | 'settings
 const NAV_ITEMS: { key: NavKey; href: string; icon: string; label: string; count?: number }[] = [
   { key: 'home', href: '/', icon: 'home', label: 'ホーム' },
   { key: 'stats', href: '/stats', icon: 'bar_chart', label: '統計' },
-  { key: 'shared', href: '/shared', icon: 'group', label: '共有ライブラリ', count: 6 },
+  { key: 'shared', href: '/shared', icon: 'public', label: '共有ライブラリ', count: 6 },
   { key: 'fav', href: '/favorites', icon: 'star', label: 'お気に入り', count: 21 },
   { key: 'scan', href: '/scan', icon: 'photo_camera', label: 'スキャン' },
   { key: 'settings', href: '/settings', icon: 'settings', label: '設定' },

--- a/src/components/desktop/DesktopShared.tsx
+++ b/src/components/desktop/DesktopShared.tsx
@@ -5,373 +5,91 @@ import { useMemo, useState } from 'react';
 import { Icon } from '@/components/ui/Icon';
 import { DesktopSearchBox, DesktopTopbar } from '@/components/desktop/DesktopChrome';
 import { desktopThumbColor } from '@/components/desktop/desktop-data';
-import type { SharedProjectCard, StudyGroupSummary } from '@/lib/shared-projects/types';
+import type { SharedProjectCard } from '@/lib/shared-projects/types';
 
 export type SharedLibraryTab = 'public' | 'groups';
 
 export function DesktopSharedView({
-  activeTab,
-  onActiveTabChange,
   publicProjects,
-  groupProjects,
-  groups,
-  selectedGroup,
-  selectedGroupId,
-  groupsLoading,
-  groupProjectsLoading,
   publicNextCursor,
   publicLoadingMore,
   publicError,
-  groupsError,
-  groupProjectsError,
-  createGroupName,
-  joinGroupCode,
-  groupActionLoading,
   onLoadMorePublic,
-  onSelectGroup,
-  onCreateGroupNameChange,
-  onJoinGroupCodeChange,
-  onCreateGroup,
-  onJoinGroup,
-  onCopyGroupInvite,
 }: {
-  activeTab: SharedLibraryTab;
-  onActiveTabChange: (tab: SharedLibraryTab) => void;
+  activeTab?: SharedLibraryTab;
+  onActiveTabChange?: (tab: SharedLibraryTab) => void;
   publicProjects: SharedProjectCard[];
-  groupProjects: SharedProjectCard[];
-  groups: StudyGroupSummary[];
-  selectedGroup: StudyGroupSummary | null;
-  selectedGroupId: string | null;
-  groupsLoading: boolean;
-  groupProjectsLoading: boolean;
+  groupProjects?: SharedProjectCard[];
+  groups?: unknown[];
+  selectedGroup?: unknown;
+  selectedGroupId?: string | null;
+  groupsLoading?: boolean;
+  groupProjectsLoading?: boolean;
   publicNextCursor: string | null;
   publicLoadingMore: boolean;
   publicError: string | null;
-  groupsError: string | null;
-  groupProjectsError: string | null;
-  createGroupName: string;
-  joinGroupCode: string;
-  groupActionLoading: 'create' | 'join' | null;
+  groupsError?: string | null;
+  groupProjectsError?: string | null;
+  createGroupName?: string;
+  joinGroupCode?: string;
+  groupActionLoading?: 'create' | 'join' | null;
   onLoadMorePublic: () => void;
-  onSelectGroup: (groupId: string | null) => void;
-  onCreateGroupNameChange: (value: string) => void;
-  onJoinGroupCodeChange: (value: string) => void;
-  onCreateGroup: () => void;
-  onJoinGroup: () => void;
-  onCopyGroupInvite: () => void;
+  onSelectGroup?: (groupId: string | null) => void;
+  onCreateGroupNameChange?: (value: string) => void;
+  onJoinGroupCodeChange?: (value: string) => void;
+  onCreateGroup?: () => void;
+  onJoinGroup?: () => void;
+  onCopyGroupInvite?: () => void;
 }) {
   const [filter, setFilter] = useState<'all' | 'popular' | 'public'>('all');
   const [query, setQuery] = useState('');
-  const [groupPanelOpen, setGroupPanelOpen] = useState(false);
   const q = query.trim().toLowerCase();
-  const sourceProjects = activeTab === 'public' ? publicProjects : groupProjects;
-  const popularCount = sourceProjects.filter((project) => (project.likeCount ?? 0) > 0).length;
+  const popularCount = publicProjects.filter((project) => (project.likeCount ?? 0) > 0).length;
   const rows = useMemo(() => {
     const base = filter === 'popular'
-      ? [...sourceProjects].filter((project) => (project.likeCount ?? 0) > 0).sort((a, b) => (b.likeCount ?? 0) - (a.likeCount ?? 0))
-      : sourceProjects;
+      ? [...publicProjects].filter((project) => (project.likeCount ?? 0) > 0).sort((a, b) => (b.likeCount ?? 0) - (a.likeCount ?? 0))
+      : publicProjects;
     return base.filter((project) => !q || project.project.title.toLowerCase().includes(q));
-  }, [filter, q, sourceProjects]);
-
-  const emptyMessage = activeTab === 'public'
-    ? '公開中の単語帳はまだありません'
-    : selectedGroup
-      ? 'このグループの単語帳はまだありません'
-      : 'グループを選択してください';
+  }, [filter, q, publicProjects]);
 
   return (
     <div className="hidden h-full min-h-0 flex-col lg:flex">
       <DesktopTopbar
         title="共有ライブラリ"
-        crumb={activeTab === 'public' ? 'コレクション / みんなの単語帳' : 'コレクション / グループ'}
+        crumb="コレクション / みんなの単語帳"
       >
         <DesktopSearchBox
-          placeholder={activeTab === 'public' ? '公開単語帳を検索' : 'グループ内を検索'}
+          placeholder="公開単語帳を検索"
           value={query}
           onChange={(event) => setQuery(event.target.value)}
         />
       </DesktopTopbar>
       <div className="ds-scroll">
         <div style={{ display: 'flex', alignItems: 'center', gap: 12, marginBottom: 18 }}>
-          <div style={{ display: 'inline-flex', borderRadius: 0, border: '1.5px solid var(--solid-ink)', background: '#fff', padding: 3 }}>
-            <button
-              type="button"
-              onClick={() => onActiveTabChange('public')}
-              style={{
-                display: 'inline-flex', alignItems: 'center', gap: 6,
-                padding: '7px 16px', borderRadius: 8, fontSize: 13, fontWeight: 700, border: 'none', cursor: 'pointer',
-                background: activeTab === 'public' ? 'var(--solid-ink)' : 'transparent',
-                color: activeTab === 'public' ? '#fff' : 'var(--solid-ink)',
-                transition: 'all 0.15s',
-              }}
-            >
-              <Icon name="public" style={{ fontSize: 16 }} />
-              公開
-              <span className="tnum" style={{ opacity: 0.6, fontSize: 11 }}>{publicProjects.length}</span>
-            </button>
-            <button
-              type="button"
-              onClick={() => onActiveTabChange('groups')}
-              style={{
-                display: 'inline-flex', alignItems: 'center', gap: 6,
-                padding: '7px 16px', borderRadius: 8, fontSize: 13, fontWeight: 700, border: 'none', cursor: 'pointer',
-                background: activeTab === 'groups' ? 'var(--solid-ink)' : 'transparent',
-                color: activeTab === 'groups' ? '#fff' : 'var(--solid-ink)',
-                transition: 'all 0.15s',
-              }}
-            >
-              <Icon name="group" style={{ fontSize: 16 }} />
-              グループ
-              <span className="tnum" style={{ opacity: 0.6, fontSize: 11 }}>{groups.length}</span>
-            </button>
+          <div style={{ display: 'flex', gap: 6 }}>
+            <button type="button" className={'ds-chip' + (filter === 'all' ? ' active' : '')} onClick={() => setFilter('all')}>すべて <span className="tnum" style={{ opacity: 0.7 }}>{publicProjects.length}</span></button>
+            <button type="button" className={'ds-chip' + (filter === 'popular' ? ' active' : '')} onClick={() => setFilter('popular')}>人気 <span className="tnum" style={{ opacity: 0.7 }}>{popularCount}</span></button>
+            <button type="button" className={'ds-chip' + (filter === 'public' ? ' active' : '')} onClick={() => setFilter('public')}>公開中 <span className="tnum" style={{ opacity: 0.7 }}>{publicProjects.length}</span></button>
           </div>
-
-          {activeTab === 'public' && (
-            <div style={{ display: 'flex', gap: 6 }}>
-              <button type="button" className={'ds-chip' + (filter === 'all' ? ' active' : '')} onClick={() => setFilter('all')}>すべて <span className="tnum" style={{ opacity: 0.7 }}>{sourceProjects.length}</span></button>
-              <button type="button" className={'ds-chip' + (filter === 'popular' ? ' active' : '')} onClick={() => setFilter('popular')}>人気 <span className="tnum" style={{ opacity: 0.7 }}>{popularCount}</span></button>
-              <button type="button" className={'ds-chip' + (filter === 'public' ? ' active' : '')} onClick={() => setFilter('public')}>公開中 <span className="tnum" style={{ opacity: 0.7 }}>{publicProjects.length}</span></button>
-            </div>
-          )}
         </div>
 
-        {activeTab === 'groups' && !selectedGroupId && (
-          <div style={{ display: 'flex', gap: 18, marginBottom: 22 }}>
-            <div style={{ flex: 1, display: 'flex', flexDirection: 'column' }}>
-              <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 12 }}>
-                <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-                  <h2 style={{ fontSize: 14, fontWeight: 800, letterSpacing: '-0.01em' }}>所属グループ</h2>
-                  {groupsLoading && <Icon name="progress_activity" className="animate-spin" style={{ fontSize: 16 }} />}
-                  {groups.length > 0 && <span className="muted" style={{ fontSize: 11 }}>{groups.length} グループ</span>}
-                </div>
-                <button
-                  type="button"
-                  onClick={() => setGroupPanelOpen((v) => !v)}
-                  style={{
-                    display: 'inline-flex', alignItems: 'center', gap: 6,
-                    padding: '6px 12px', borderRadius: 10, fontSize: 12, fontWeight: 700,
-                    border: '1.25px solid var(--solid-ink)', background: '#fff', color: 'var(--solid-ink)',
-                    cursor: 'pointer', transition: 'transform 0.1s',
-                  }}
-                  className="active:translate-x-px active:translate-y-px"
-                >
-                  <Icon name="settings" style={{ fontSize: 14 }} />
-                  管理
-                </button>
-              </div>
-
-              {groupPanelOpen && (
-                <div style={{ position: 'relative', marginBottom: 14 }}>
-                  <div style={{ position: 'absolute', inset: 0, transform: 'translate(2.5px, 2.5px)', borderRadius: 12, background: 'var(--solid-ink)' }} />
-                  <div style={{ position: 'relative', borderRadius: 12, border: '1.25px solid var(--solid-ink)', background: '#fff', padding: 14 }}>
-                    {selectedGroup && (
-                      <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 14, paddingBottom: 12, borderBottom: '1px solid var(--color-border)' }}>
-                        <span style={{ fontSize: 10, fontWeight: 700, padding: '2px 7px', borderRadius: 4, background: 'var(--solid-ink)', color: '#fff' }}>{selectedGroup.role === 'owner' ? 'オーナー' : 'メンバー'}</span>
-                        <span className="mono muted" style={{ fontSize: 11, flex: 1, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{formatInviteCode(selectedGroup.inviteCode)}</span>
-                        <button
-                          type="button"
-                          onClick={onCopyGroupInvite}
-                          style={{
-                            display: 'inline-flex', alignItems: 'center', gap: 4,
-                            padding: '4px 10px', borderRadius: 8, fontSize: 11, fontWeight: 700,
-                            border: '1.25px solid var(--solid-ink)', background: '#fff', color: 'var(--solid-ink)',
-                            cursor: 'pointer',
-                          }}
-                        >
-                          <Icon name="content_copy" style={{ fontSize: 12 }} />コピー
-                        </button>
-                      </div>
-                    )}
-                    <div style={{ fontSize: 11, fontWeight: 700, letterSpacing: '0.04em', color: 'var(--color-muted)', marginBottom: 12 }}>グループに参加・作成</div>
-                    <div style={{ display: 'flex', gap: 8, marginBottom: 10 }}>
-                      <input
-                        className="ds-input"
-                        value={joinGroupCode}
-                        onChange={(event) => onJoinGroupCodeChange(event.target.value)}
-                        placeholder="招待コードを入力"
-                        style={{ flex: 1 }}
-                      />
-                      <button
-                        type="button"
-                        onClick={onJoinGroup}
-                        disabled={groupActionLoading === 'join' || !joinGroupCode.trim()}
-                        style={{
-                          display: 'inline-flex', alignItems: 'center', gap: 4,
-                          padding: '6px 12px', borderRadius: 10, fontSize: 12, fontWeight: 700,
-                          border: '1.25px solid var(--solid-ink)', background: 'var(--solid-ink)', color: '#fff',
-                          cursor: 'pointer', opacity: (groupActionLoading === 'join' || !joinGroupCode.trim()) ? 0.4 : 1,
-                        }}
-                      >
-                        {groupActionLoading === 'join' ? <Icon name="progress_activity" className="animate-spin" style={{ fontSize: 14 }} /> : <Icon name="login" style={{ fontSize: 14 }} />}
-                        参加
-                      </button>
-                    </div>
-                    <div style={{ display: 'flex', gap: 8 }}>
-                      <input
-                        className="ds-input"
-                        value={createGroupName}
-                        onChange={(event) => onCreateGroupNameChange(event.target.value)}
-                        placeholder="新しいグループ名"
-                        style={{ flex: 1 }}
-                      />
-                      <button
-                        type="button"
-                        onClick={onCreateGroup}
-                        disabled={groupActionLoading === 'create' || !createGroupName.trim()}
-                        style={{
-                          display: 'inline-flex', alignItems: 'center', gap: 4,
-                          padding: '6px 12px', borderRadius: 10, fontSize: 12, fontWeight: 700,
-                          border: '1.25px solid var(--solid-ink)', background: '#fff', color: 'var(--solid-ink)',
-                          cursor: 'pointer', opacity: (groupActionLoading === 'create' || !createGroupName.trim()) ? 0.4 : 1,
-                        }}
-                      >
-                        {groupActionLoading === 'create' ? <Icon name="progress_activity" className="animate-spin" style={{ fontSize: 14 }} /> : <Icon name="add" style={{ fontSize: 14 }} />}
-                        作成
-                      </button>
-                    </div>
-                  </div>
-                </div>
-              )}
-
-              <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: 14 }}>
-                {groups.map((group) => (
-                  <button
-                    key={group.id}
-                    type="button"
-                    onClick={() => onSelectGroup(group.id)}
-                    style={{ position: 'relative', display: 'block', textAlign: 'left', cursor: 'pointer', background: 'none', border: 'none', padding: 0 }}
-                    className="active:translate-x-px active:translate-y-px"
-                  >
-                    <div style={{ position: 'absolute', inset: 0, transform: 'translate(2.5px, 2.5px)', borderRadius: 12, background: 'var(--solid-ink)' }} />
-                    <div style={{
-                      position: 'relative', display: 'flex', alignItems: 'center', gap: 10,
-                      padding: '12px 14px', borderRadius: 12,
-                      border: '1.25px solid var(--solid-ink)', background: '#fff',
-                      transition: 'transform 0.1s',
-                    }}>
-                      <div style={{
-                        width: 36, height: 36, borderRadius: 10, display: 'flex', alignItems: 'center', justifyContent: 'center',
-                        background: desktopThumbColor(group.id), color: '#fff', fontWeight: 800, fontSize: 15, flexShrink: 0,
-                        border: '1.25px solid var(--solid-ink)',
-                      }}>
-                        {group.name.charAt(0)}
-                      </div>
-                      <div style={{ flex: 1, minWidth: 0 }}>
-                        <div style={{ fontSize: 13, fontWeight: 700, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>{group.name}</div>
-                        <div className="muted" style={{ fontSize: 11, marginTop: 2 }}>{group.memberCount}人 · {group.projectCount}冊</div>
-                      </div>
-                      <Icon name="chevron_right" style={{ fontSize: 20, flexShrink: 0, color: 'var(--color-muted)' }} />
-                    </div>
-                  </button>
-                ))}
-              </div>
-              {!groupsLoading && groups.length === 0 && (
-                <div style={{ position: 'relative', marginTop: 8 }}>
-                  <div style={{ position: 'absolute', inset: 0, transform: 'translate(2.5px, 2.5px)', borderRadius: 12, background: 'var(--solid-ink)' }} />
-                  <div style={{ position: 'relative', borderRadius: 12, border: '1.25px solid var(--solid-ink)', background: '#fff', padding: '28px 0', textAlign: 'center' }}>
-                    <Icon name="group_add" style={{ fontSize: 28, opacity: 0.3, display: 'block', margin: '0 auto 6px' }} />
-                    <div className="muted" style={{ fontSize: 12, lineHeight: 1.6 }}>グループに参加しましょう</div>
-                  </div>
-                </div>
-              )}
-
-              {groupsError && (
-                <div style={{ position: 'relative', marginTop: 10 }}>
-                  <div style={{ position: 'absolute', inset: 0, transform: 'translate(2px, 2px)', borderRadius: 12, background: '#991b1b' }} />
-                  <div style={{ position: 'relative', borderRadius: 12, border: '1.25px solid #b91c1c', background: '#fef2f2', padding: '10px 14px', fontSize: 12, fontWeight: 700, color: '#b91c1c' }}>
-                    {groupsError}
-                  </div>
-                </div>
-              )}
-            </div>
+        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3,1fr)', gap: 18 }}>
+          {rows.map((project) => (
+            <DesktopSharedCard key={project.project.id} project={project} />
+          ))}
+        </div>
+        {rows.length === 0 && (
+          <div className="ds-card" style={{ padding: 42, textAlign: 'center', color: 'var(--color-muted)' }}>
+            公開中の単語帳はまだありません
           </div>
         )}
 
-        {activeTab === 'groups' && selectedGroupId && (
-          <div style={{ marginBottom: 18 }}>
-            <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 14 }}>
-              <button
-                type="button"
-                onClick={() => onSelectGroup(null)}
-                style={{
-                  display: 'inline-flex', alignItems: 'center', gap: 4,
-                  padding: '6px 12px', borderRadius: 10, fontSize: 12, fontWeight: 700,
-                  border: '1.25px solid var(--solid-ink)', background: '#fff', color: 'var(--solid-ink)',
-                  cursor: 'pointer', transition: 'transform 0.1s',
-                }}
-                className="active:translate-x-px active:translate-y-px"
-              >
-                <Icon name="arrow_back" style={{ fontSize: 14 }} />
-                戻る
-              </button>
-              <h2 style={{ flex: 1, fontSize: 16, fontWeight: 800, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis', fontFamily: 'var(--font-display)' }}>
-                {selectedGroup?.name}
-              </h2>
-              {selectedGroup && (
-                <span style={{ flexShrink: 0, padding: '3px 7px', borderRadius: 4, fontSize: 10, fontWeight: 700, letterSpacing: '0.04em', fontFamily: 'var(--font-mono)', background: 'var(--solid-ink)', color: '#fff' }}>
-                  {selectedGroup.role === 'owner' ? 'オーナー' : 'メンバー'}
-                </span>
-              )}
-            </div>
-            {selectedGroup && (
-              <div style={{
-                display: 'flex', alignItems: 'center', gap: 10, marginBottom: 14,
-                padding: '10px 14px', borderRadius: 12, border: '1.25px solid var(--solid-ink)', background: '#fff',
-              }}>
-                <span className="mono muted" style={{ flex: 1, fontSize: 11, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
-                  招待 {formatInviteCode(selectedGroup.inviteCode)}
-                </span>
-                <button
-                  type="button"
-                  onClick={onCopyGroupInvite}
-                  style={{
-                    display: 'inline-flex', alignItems: 'center', gap: 4, flexShrink: 0,
-                    padding: '4px 10px', borderRadius: 8, fontSize: 11, fontWeight: 700,
-                    border: '1.25px solid var(--solid-ink)', background: '#fff', color: 'var(--solid-ink)',
-                    cursor: 'pointer',
-                  }}
-                >
-                  <Icon name="content_copy" style={{ fontSize: 12 }} />
-                  コピー
-                </button>
-              </div>
-            )}
-          </div>
-        )}
-
-        {!(activeTab === 'groups' && !selectedGroupId) && (
-          <>
-            {activeTab === 'groups' && groupProjectsLoading && (
-              <div className="ds-card" style={{ padding: 18, marginBottom: 16, color: 'var(--color-muted)', display: 'flex', gap: 8, alignItems: 'center' }}>
-                <Icon name="progress_activity" className="animate-spin" />
-                読み込み中...
-              </div>
-            )}
-
-            {groupProjectsError && (
-              <div className="ds-card" style={{ marginBottom: 16, padding: 14, color: 'var(--color-error)', borderColor: 'var(--color-error)' }}>
-                {groupProjectsError}
-              </div>
-            )}
-
-            <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3,1fr)', gap: 18 }}>
-              {rows.map((project) => (
-                <DesktopSharedCard key={project.project.id} project={project} />
-              ))}
-            </div>
-            {rows.length === 0 && !groupProjectsLoading && (
-              <div className="ds-card" style={{ padding: 42, textAlign: 'center', color: 'var(--color-muted)' }}>
-                {emptyMessage}
-              </div>
-            )}
-          </>
-        )}
-        {publicError && activeTab === 'public' && (
+        {publicError && (
           <div className="ds-card" style={{ marginTop: 16, padding: 14, color: 'var(--color-error)', borderColor: 'var(--color-error)' }}>
             {publicError}
           </div>
         )}
-        {publicNextCursor && activeTab === 'public' && (
+        {publicNextCursor && (
           <button type="button" onClick={onLoadMorePublic} disabled={publicLoadingMore} className="ds-btn" style={{ marginTop: 18 }}>
             <Icon name={publicLoadingMore ? 'progress_activity' : 'expand_more'} className={publicLoadingMore ? 'animate-spin' : undefined} />
             {publicLoadingMore ? '読み込み中...' : 'もっと見る'}
@@ -420,13 +138,4 @@ function DesktopSharedCard({ project }: { project: SharedProjectCard }) {
       <span className="ds-btn" style={{ width: '100%' }}><Icon name="add" />詳細を見る</span>
     </Link>
   );
-}
-
-function formatInviteCode(value: string): string {
-  const compact = value.replace(/-/g, '');
-  const parts: string[] = [];
-  for (let index = 0; index < compact.length; index += 4) {
-    parts.push(compact.slice(index, index + 4));
-  }
-  return parts.join('-');
 }

--- a/src/components/home/CreateWordbookSheet.tsx
+++ b/src/components/home/CreateWordbookSheet.tsx
@@ -22,7 +22,7 @@ interface MethodOption {
 
 const METHODS: MethodOption[] = [
   { k: 'scan', icon: 'photo_camera', title: '写真でスキャン', description: 'AIが英単語と意味を自動抽出', recommended: true },
-  { k: 'shared', icon: 'group', title: '共有ライブラリから', description: '公開単語帳をコピー' },
+  { k: 'shared', icon: 'public', title: '共有ライブラリから', description: '公開単語帳をコピー' },
   { k: 'blank', icon: 'edit_note', title: '空の単語帳を作成', description: 'あとから手動で追加' },
 ];
 

--- a/src/components/project/ProjectShareSheet.tsx
+++ b/src/components/project/ProjectShareSheet.tsx
@@ -180,60 +180,6 @@ export function ProjectShareSheet({
             )}
           </div>
 
-          <div className="mb-3">
-            <div className="mb-2 flex items-center gap-1.5 font-mono text-[9px] font-bold uppercase tracking-[0.08em] text-[var(--color-muted)]">
-              <Icon name="group" size={11} />
-              グループ
-            </div>
-            <div className="flex max-h-[150px] flex-col gap-2 overflow-y-auto pr-1">
-              {groupsLoading ? (
-                <div className="flex h-10 items-center gap-2 rounded-[10px] border border-[var(--color-border)] bg-white px-3 text-[12px] text-[var(--color-muted)]">
-                  <Icon name="progress_activity" size={14} className="animate-spin" />
-                  読み込み中...
-                </div>
-              ) : groups.length === 0 ? (
-                <div className="rounded-[10px] border border-[var(--color-border)] bg-white px-3 py-3 text-[12px] text-[var(--color-muted)]">
-                  所属グループはまだありません
-                </div>
-              ) : (
-                groups.map((group) => {
-                  const updating = groupSharingUpdatingId === group.id;
-                  const shared = Boolean(group.projectShared);
-                  return (
-                    <button
-                      key={group.id}
-                      type="button"
-                      disabled={preparing || updating || !onToggleGroupShare}
-                      onClick={() => onToggleGroupShare?.(group)}
-                      className="flex items-center gap-2 rounded-[10px] border-[1.25px] border-[var(--solid-ink)] bg-white px-3 py-2 text-left disabled:opacity-50"
-                    >
-                      <div
-                        className="flex h-8 w-8 shrink-0 items-center justify-center rounded-[8px] border border-[var(--solid-ink)]"
-                        style={{ background: shared ? 'var(--solid-ink)' : '#fff', color: shared ? '#fff' : 'var(--solid-ink)' }}
-                      >
-                        <Icon name={updating ? 'progress_activity' : shared ? 'check' : 'group'} size={15} className={updating ? 'animate-spin' : undefined} />
-                      </div>
-                      <div className="min-w-0 flex-1">
-                        <div className="truncate text-[13px] font-bold text-[var(--solid-ink)]">{group.name}</div>
-                        <div className="mt-0.5 font-mono text-[9px] text-[var(--color-muted)]">
-                          {group.memberCount}人 · {group.projectCount}冊
-                        </div>
-                      </div>
-                      <span className="shrink-0 rounded-full border border-[var(--solid-ink)] px-2 py-0.5 text-[10px] font-bold text-[var(--solid-ink)]">
-                        {shared ? '掲載中' : '掲載'}
-                      </span>
-                    </button>
-                  );
-                })
-              )}
-            </div>
-            {groupsError && (
-              <div className="mt-2 rounded-[8px] border border-red-200 bg-red-50 px-3 py-2 text-[11px] font-bold text-red-700">
-                {groupsError}
-              </div>
-            )}
-          </div>
-
           <div className="mb-3 rounded-[10px] border border-dashed border-[var(--solid-ink)] bg-[rgba(26,26,26,0.04)] p-[11px]">
             <div className="mb-2 flex items-center justify-between">
               <span className="font-mono text-[9px] font-bold uppercase tracking-[0.08em] text-[var(--color-muted)]">

--- a/src/components/ui/Sidebar.tsx
+++ b/src/components/ui/Sidebar.tsx
@@ -31,7 +31,7 @@ const navGroups: NavGroup[] = [
   {
     label: 'その他',
     items: [
-      { href: '/shared', icon: 'group', label: '共有', matchPaths: ['/shared', '/share'], count: '3' },
+      { href: '/shared', icon: 'public', label: '共有', matchPaths: ['/shared', '/share'], count: '3' },
       { href: '/search', icon: 'search', label: '検索', matchPaths: ['/search'] },
       { href: '/settings', icon: 'settings', label: 'アカウント', matchPaths: ['/settings', '/subscription'] },
     ],


### PR DESCRIPTION
## Summary

- 共有ライブラリページからグループタブを削除し、公開単語帳のみ表示するように変更
- ProjectShareSheet からグループ共有セクションを削除
- サイドバー・デスクトップナビのアイコンを `group` → `public` に変更
- バックエンドのAPIルートやロジックはそのまま保持

## Changes

- `SharedPageClient.tsx` — グループ関連のstate、fetch、UIをすべて削除
- `DesktopShared.tsx` — グループタブ・グループパネルを削除、公開タブのみ表示
- `ProjectShareSheet.tsx` — グループ共有セクションを削除
- `Sidebar.tsx` / `DesktopChrome.tsx` — 共有ナビアイコンを `public` に変更
- `CreateWordbookSheet.tsx` — 共有ライブラリオプションのアイコンを `public` に変更
- `project/[id]/page.tsx` — グループ関連propsの受け渡しを削除

## Test plan

- [ ] `/shared` ページで公開単語帳のみ表示されることを確認
- [ ] グループタブが表示されないことを確認
- [ ] プロジェクト詳細の共有シートにグループセクションが表示されないことを確認
- [ ] サイドバーの共有リンクが正常に動作することを確認
- [ ] `npm run build` がエラーなく完了することを確認 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016w61nB8PxMKcjJpM44CxfR

---
_Generated by [Claude Code](https://claude.ai/code/session_016w61nB8PxMKcjJpM44CxfR)_