### PR TITLE
デスクトップ単語一覧のボタンからテキストを除去しアイコンのみに

### DIFF
--- a/src/components/desktop/DesktopProjectDetail.tsx
+++ b/src/components/desktop/DesktopProjectDetail.tsx
@@ -196,7 +196,7 @@ export function DesktopProjectDetailView({
                 onClick={onOpenFilterSheet}
                 aria-pressed={filterActive}
               >
-                <Icon name="filter_list" />フィルタ
+                <Icon name="filter_list" />
               </button>
               <button
                 type="button"
@@ -204,7 +204,7 @@ export function DesktopProjectDetailView({
                 onClick={onOpenSortSheet}
                 aria-pressed={sortActive}
               >
-                <Icon name="swap_vert" />並べ替え
+                <Icon name="swap_vert" />
               </button>
               <button
                 type="button"
@@ -212,7 +212,7 @@ export function DesktopProjectDetailView({
                 onClick={onToggleSelectMode}
                 aria-pressed={selectMode}
               >
-                <Icon name="check_box" />選択
+                <Icon name="check_box" />
               </button>
             </div>
             {(filterActive || query.trim()) && (


### PR DESCRIPTION
## Summary\n- デスクトップ版プロジェクト詳細ページの単語一覧上部にある3つのボタン（フィルタ・並べ替え・選択）から日本語テキストを除去\n- アイコンのみのボタンに変更\n\n## Test plan\n- [ ] デスクトップ幅でプロジェクト詳細ページを開き、3つのボタンがアイコンのみで表示されることを確認\n- [ ] 各ボタン（フィルタ・並べ替え・選択）が正常に動作することを確認\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)\n\nhttps://claude.ai/code/session_01Frbz8XDoRpXofeMc47LPuh

---
_Generated by [Claude Code](https://claude.ai/code/session_01Frbz8XDoRpXofeMc47LPuh)_