### PR TITLE
デスクトップサイドバーに折りたたみ機能を追加

### DIFF
--- a/src/app/desktop.css
+++ b/src/app/desktop.css
@@ -82,6 +82,30 @@
 .ds-user .nm { font-size: 13px; font-weight: 600; }
 .ds-user .pl { font-size: 11px; color: var(--color-accent); font-weight: 600; }
 
+/* ── Sidebar collapse toggle ─────────────────────────────── */
+.ds-sidebar-toggle {
+  display: flex; align-items: center; justify-content: center;
+  width: 100%; height: 38px; border-radius: 10px;
+  border: 1.5px solid var(--color-border); background: #fff;
+  cursor: pointer; color: var(--color-secondary-text);
+  transition: border-color var(--dur-fast), color var(--dur-fast), background var(--dur-fast);
+}
+.ds-sidebar-toggle:hover { border-color: var(--solid-ink); color: var(--color-ink); background: rgba(26,26,26,0.03); }
+.ds-sidebar-toggle .material-symbols-outlined { font-size: 20px; }
+
+/* ── Sidebar collapsed state ─────────────────────────────── */
+.ds-side--collapsed {
+  padding: 26px 10px 20px;
+  align-items: center;
+}
+.ds-side--collapsed .ds-brand { align-items: center; padding: 0; }
+.ds-side--collapsed .ds-brand-row { justify-content: center; }
+.ds-side--collapsed .ds-wordmark { font-size: 20px; }
+.ds-side--collapsed .ds-nav-item {
+  justify-content: center; padding: 11px;
+}
+.ds-side--collapsed .ds-side-foot { align-items: center; }
+
 /* ── Main / topbar ───────────────────────────────────────── */
 .ds-main { display: flex; flex-direction: column; min-width: 0; overflow: hidden; }
 .ds-top {
@@ -793,5 +817,17 @@ button.ds-tile { appearance: none; }
 
   .ds-live-main > * {
     min-height: 0;
+  }
+
+  .ds-live-shell, .ds-live-shell > .ds-side {
+    transition: grid-template-columns var(--dur-slower) var(--ease-out),
+                width var(--dur-slower) var(--ease-out);
+  }
+
+  .ds-live-shell--collapsed {
+    grid-template-columns: 68px minmax(0, 1fr);
+  }
+  .ds-live-shell--collapsed > .ds-side {
+    width: 68px;
   }
 }

--- a/src/app/desktop.css
+++ b/src/app/desktop.css
@@ -82,22 +82,26 @@
 .ds-user .nm { font-size: 13px; font-weight: 600; }
 .ds-user .pl { font-size: 11px; color: var(--color-accent); font-weight: 600; }
 
-/* ── Sidebar collapse toggle ─────────────────────────────── */
+/* ── Sidebar header (brand + toggle) ─────────────────────── */
+.ds-side-head {
+  display: flex; align-items: flex-start; justify-content: space-between;
+}
 .ds-sidebar-toggle {
   display: flex; align-items: center; justify-content: center;
-  width: 100%; height: 38px; border-radius: 10px;
+  width: 34px; height: 34px; border-radius: 9px; flex-shrink: 0;
   border: 1.5px solid var(--color-border); background: #fff;
   cursor: pointer; color: var(--color-secondary-text);
   transition: border-color var(--dur-fast), color var(--dur-fast), background var(--dur-fast);
 }
 .ds-sidebar-toggle:hover { border-color: var(--solid-ink); color: var(--color-ink); background: rgba(26,26,26,0.03); }
-.ds-sidebar-toggle .material-symbols-outlined { font-size: 20px; }
+.ds-sidebar-toggle .material-symbols-outlined { font-size: 18px; }
 
 /* ── Sidebar collapsed state ─────────────────────────────── */
 .ds-side--collapsed {
   padding: 26px 10px 20px;
   align-items: center;
 }
+.ds-side--collapsed .ds-side-head { flex-direction: column; align-items: center; gap: 12px; }
 .ds-side--collapsed .ds-brand { align-items: center; padding: 0; }
 .ds-side--collapsed .ds-brand-row { justify-content: center; }
 .ds-side--collapsed .ds-wordmark { font-size: 20px; }

--- a/src/app/desktop.css
+++ b/src/app/desktop.css
@@ -823,15 +823,24 @@ button.ds-tile { appearance: none; }
     min-height: 0;
   }
 
-  .ds-live-shell, .ds-live-shell > .ds-side {
-    transition: grid-template-columns var(--dur-slower) var(--ease-out),
-                width var(--dur-slower) var(--ease-out);
+  .ds-live-shell {
+    --sidebar-width: 264px;
+    transition: grid-template-columns var(--dur-slower) var(--ease-out);
+  }
+
+  .ds-live-shell > .ds-side {
+    transition: width var(--dur-slower) var(--ease-out);
   }
 
   .ds-live-shell--collapsed {
+    --sidebar-width: 68px;
     grid-template-columns: 68px minmax(0, 1fr);
   }
   .ds-live-shell--collapsed > .ds-side {
     width: 68px;
+  }
+
+  .ds-fixed-main {
+    left: var(--sidebar-width, 264px);
   }
 }

--- a/src/app/flashcard/[projectId]/page.tsx
+++ b/src/app/flashcard/[projectId]/page.tsx
@@ -555,7 +555,7 @@ export default function FlashcardPage() {
 
   return (
     <>
-    <div className="fixed inset-0 z-30 hidden flex-col overflow-hidden bg-[var(--color-background)] font-[var(--font-body)] lg:left-[264px] lg:flex">
+    <div className="ds-fixed-main fixed inset-0 z-30 hidden flex-col overflow-hidden bg-[var(--color-background)] font-[var(--font-body)] lg:flex">
       <div className="ds-fc-wrap">
         <div className="ds-quiz-head" style={{ maxWidth: 720 }}>
           <button type="button" className="x" onClick={backToProject} aria-label="閉じる">

--- a/src/app/quiz/[projectId]/page.tsx
+++ b/src/app/quiz/[projectId]/page.tsx
@@ -1184,7 +1184,7 @@ export default function QuizPage() {
     return (
       <>
       <PwaInstallPromptModal open={pwaPromptOpen} onClose={() => setPwaPromptOpen(false)} />
-      <div className="fixed inset-0 z-30 hidden flex-col items-center justify-center bg-[var(--color-background)] font-[var(--font-body)] lg:left-[264px] lg:flex">
+      <div className="ds-fixed-main fixed inset-0 z-30 hidden flex-col items-center justify-center bg-[var(--color-background)] font-[var(--font-body)] lg:flex">
         <div className="ds-card" style={{ padding: '44px 56px', textAlign: 'center', maxWidth: 520, display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 8 }}>
           <div style={{ width: 72, height: 72, borderRadius: 18, background: 'var(--color-warning-light)', display: 'flex', alignItems: 'center', justifyContent: 'center', marginBottom: 8 }}>
             <Icon name="trophy" filled style={{ fontSize: 38, color: '#d97706' }} />
@@ -1299,7 +1299,7 @@ export default function QuizPage() {
 
   return (
     <>
-    <div className="fixed inset-0 z-30 hidden flex-col overflow-hidden bg-[var(--color-background)] font-[var(--font-body)] lg:left-[264px] lg:flex">
+    <div className="ds-fixed-main fixed inset-0 z-30 hidden flex-col overflow-hidden bg-[var(--color-background)] font-[var(--font-body)] lg:flex">
       <div className="ds-quiz-wrap">
         <div className="ds-quiz-head">
           <button type="button" className="x" onClick={backToProject} aria-label="閉じる">

--- a/src/components/desktop/DesktopChrome.tsx
+++ b/src/components/desktop/DesktopChrome.tsx
@@ -51,12 +51,25 @@ export function DesktopSidebar({
 
   return (
     <aside className={cn('ds-side', collapsed && 'ds-side--collapsed')} aria-label="デスクトップナビゲーション">
-      <div className="ds-brand">
-        <div className="ds-brand-row">
-          <span className="ds-wordmark">{collapsed ? 'M' : 'MERKEN'}</span>
-          <span className="ds-brand-dot" />
+      <div className="ds-side-head">
+        <div className="ds-brand">
+          <div className="ds-brand-row">
+            <span className="ds-wordmark">{collapsed ? 'M' : 'MERKEN'}</span>
+            <span className="ds-brand-dot" />
+          </div>
+          {!collapsed && <span className="ds-brand-sub">単語帳 · Desktop</span>}
         </div>
-        {!collapsed && <span className="ds-brand-sub">単語帳 · Desktop</span>}
+        {onToggle && (
+          <button
+            type="button"
+            className="ds-sidebar-toggle"
+            onClick={onToggle}
+            title={collapsed ? 'サイドバーを展開' : 'サイドバーを折りたたむ'}
+            aria-label={collapsed ? 'サイドバーを展開' : 'サイドバーを折りたたむ'}
+          >
+            <Icon name={collapsed ? 'chevron_right' : 'chevron_left'} />
+          </button>
+        )}
       </div>
 
       <nav className="ds-nav">
@@ -98,17 +111,6 @@ export function DesktopSidebar({
               <div className="pl">{isPro ? 'Pro メンバー' : 'Free メンバー'}</div>
             </div>
           </div>
-        )}
-        {onToggle && (
-          <button
-            type="button"
-            className="ds-sidebar-toggle"
-            onClick={onToggle}
-            title={collapsed ? 'サイドバーを展開' : 'サイドバーを折りたたむ'}
-            aria-label={collapsed ? 'サイドバーを展開' : 'サイドバーを折りたたむ'}
-          >
-            <Icon name={collapsed ? 'chevron_right' : 'chevron_left'} />
-          </button>
         )}
       </div>
     </aside>

--- a/src/components/desktop/DesktopChrome.tsx
+++ b/src/components/desktop/DesktopChrome.tsx
@@ -30,7 +30,13 @@ function activeKeyForPath(pathname: string): NavKey {
   return 'home';
 }
 
-export function DesktopSidebar() {
+export function DesktopSidebar({
+  collapsed = false,
+  onToggle,
+}: {
+  collapsed?: boolean;
+  onToggle?: () => void;
+}) {
   const pathname = usePathname();
   const { user, isPro } = useAuth();
   const [streak, setStreak] = useState(0);
@@ -44,46 +50,66 @@ export function DesktopSidebar() {
   }, [isLoggedIn]);
 
   return (
-    <aside className="ds-side" aria-label="デスクトップナビゲーション">
+    <aside className={cn('ds-side', collapsed && 'ds-side--collapsed')} aria-label="デスクトップナビゲーション">
       <div className="ds-brand">
         <div className="ds-brand-row">
-          <span className="ds-wordmark">MERKEN</span>
+          <span className="ds-wordmark">{collapsed ? 'M' : 'MERKEN'}</span>
           <span className="ds-brand-dot" />
         </div>
-        <span className="ds-brand-sub">単語帳 · Desktop</span>
+        {!collapsed && <span className="ds-brand-sub">単語帳 · Desktop</span>}
       </div>
 
       <nav className="ds-nav">
         {NAV_ITEMS.map((item) => {
           const isActive = active === item.key;
           return (
-            <Link key={item.key} href={item.href} className={cn('ds-nav-item', isActive && 'active')}>
+            <Link
+              key={item.key}
+              href={item.href}
+              className={cn('ds-nav-item', isActive && 'active')}
+              title={collapsed ? item.label : undefined}
+            >
               <Icon name={item.icon} filled={isActive} />
-              <span className="ds-nav-text">{item.label}</span>
-              {item.count != null && <span className="ds-nav-count">{item.count}</span>}
+              {!collapsed && <span className="ds-nav-text">{item.label}</span>}
+              {!collapsed && item.count != null && <span className="ds-nav-count">{item.count}</span>}
             </Link>
           );
         })}
       </nav>
 
       <div className="ds-side-foot">
-        <div className="ds-streak">
-          <Icon name="local_fire_department" style={{ color: '#f97316', fontSize: 22 }} />
-          <div>
-            <div className="n">
-              {streak}
-              <span style={{ fontSize: 11, fontWeight: 600 }}> 日連続</span>
+        {!collapsed && (
+          <div className="ds-streak">
+            <Icon name="local_fire_department" style={{ color: '#f97316', fontSize: 22 }} />
+            <div>
+              <div className="n">
+                {streak}
+                <span style={{ fontSize: 11, fontWeight: 600 }}> 日連続</span>
+              </div>
+              <div className="l">今日も学習を継続中</div>
             </div>
-            <div className="l">今日も学習を継続中</div>
           </div>
-        </div>
-        <div className="ds-user">
-          <div className="ds-avatar">{userInitial}</div>
-          <div>
-            <div className="nm">{user?.email?.split('@')[0] ?? 'ゲスト'}</div>
-            <div className="pl">{isPro ? 'Pro メンバー' : 'Free メンバー'}</div>
+        )}
+        {!collapsed && (
+          <div className="ds-user">
+            <div className="ds-avatar">{userInitial}</div>
+            <div>
+              <div className="nm">{user?.email?.split('@')[0] ?? 'ゲスト'}</div>
+              <div className="pl">{isPro ? 'Pro メンバー' : 'Free メンバー'}</div>
+            </div>
           </div>
-        </div>
+        )}
+        {onToggle && (
+          <button
+            type="button"
+            className="ds-sidebar-toggle"
+            onClick={onToggle}
+            title={collapsed ? 'サイドバーを展開' : 'サイドバーを折りたたむ'}
+            aria-label={collapsed ? 'サイドバーを展開' : 'サイドバーを折りたたむ'}
+          >
+            <Icon name={collapsed ? 'chevron_right' : 'chevron_left'} />
+          </button>
+        )}
       </div>
     </aside>
   );

--- a/src/components/ui/PersistentAppShell.tsx
+++ b/src/components/ui/PersistentAppShell.tsx
@@ -1,10 +1,12 @@
 'use client';
 
-import { ReactNode, useEffect, useState } from 'react';
+import { ReactNode, useCallback, useEffect, useState } from 'react';
 import { usePathname } from 'next/navigation';
 import { DesktopSidebar } from '@/components/desktop/DesktopChrome';
 import { useAuth } from '@/hooks/use-auth';
 import { BottomNav } from './bottom-nav';
+
+const SIDEBAR_STORAGE_KEY = 'merken-sidebar-collapsed';
 
 const NO_SHELL_PATHS = [
   '/lp', '/login', '/signup', '/reset-password', '/auth',
@@ -31,6 +33,22 @@ export function PersistentAppShell({ children }: { children: ReactNode }) {
   const pathname = usePathname();
   const { user } = useAuth();
   const [scrollEnding, setScrollEnding] = useState(false);
+  const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
+
+  useEffect(() => {
+    try {
+      const stored = localStorage.getItem(SIDEBAR_STORAGE_KEY);
+      if (stored === 'true') setSidebarCollapsed(true);
+    } catch {}
+  }, []);
+
+  const toggleSidebar = useCallback(() => {
+    setSidebarCollapsed((prev) => {
+      const next = !prev;
+      try { localStorage.setItem(SIDEBAR_STORAGE_KEY, String(next)); } catch {}
+      return next;
+    });
+  }, []);
 
   useEffect(() => {
     let touchStartY = 0;
@@ -71,8 +89,8 @@ export function PersistentAppShell({ children }: { children: ReactNode }) {
   const hideNav = shouldHideBottomNav(pathname);
 
   return (
-    <div className="ds-live-shell relative">
-      <DesktopSidebar />
+    <div className={`ds-live-shell relative${sidebarCollapsed ? ' ds-live-shell--collapsed' : ''}`}>
+      <DesktopSidebar collapsed={sidebarCollapsed} onToggle={toggleSidebar} />
       <div className="ds-live-main relative">
         {children}
       </div>


### PR DESCRIPTION
## Summary
- デスクトップサイドバー下部にトグルボタンを追加し、折りたたみ/展開を切り替え可能にした
- 折りたたみ時はアイコンのみ表示（68px幅）、展開時は従来通り264px幅
- 折りたたみ状態は `localStorage` に永続化され、リロード後も維持される
- 既存の `ds-iconbtn` スタイルに合わせたボタンデザイン（ボーダー、ホバーエフェクト）

## 変更ファイル
- `src/components/desktop/DesktopChrome.tsx` — `DesktopSidebar` に `collapsed`/`onToggle` props を追加
- `src/components/ui/PersistentAppShell.tsx` — 折りたたみ状態の管理と localStorage 永続化
- `src/app/desktop.css` — 折りたたみ時のレイアウト・スタイル定義

## Test plan
- [ ] デスクトップ（1024px以上）でサイドバー下部のトグルボタンをクリックして折りたたみを確認
- [ ] 折りたたみ時にアイコンのみ表示され、ナビゲーションアイテムにホバーでラベルが表示されることを確認
- [ ] ページリロード後も折りたたみ状態が維持されることを確認
- [ ] 展開ボタンで元に戻ることを確認
- [ ] モバイル表示に影響がないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GLKDuWByBk5Cz7PXQCjBaU

---
_Generated by [Claude Code](https://claude.ai/code/session_01GLKDuWByBk5Cz7PXQCjBaU)_