### PR TITLE
デスクトップビューに単語削除導線を追加

### DIFF
--- a/src/app/project/[id]/page.tsx
+++ b/src/app/project/[id]/page.tsx
@@ -839,6 +839,8 @@ export default function ProjectPage() {
         onRename={handleOpenRename}
         onToggleFavorite={(word) => void handleToggleFavorite(word)}
         onCycleVocabularyType={(word) => void handleCycleVocabularyType(word)}
+        onDeleteWord={handleOpenDeleteWord}
+        onBulkDelete={() => setBulkDeleteModalOpen(true)}
       />
       <div className="relative flex min-h-screen flex-col bg-[var(--color-background)] font-[var(--font-body)] lg:hidden">
       <div className="flex items-center justify-between px-4 pt-3 lg:hidden">
@@ -1153,6 +1155,10 @@ export default function ProjectPage() {
         </div>
       )}
 
+      </div>
+
+      {/* Shared overlays: rendered outside the lg:hidden wrapper so the
+          desktop view's filter / sort / select buttons can use them too */}
       <SingleWordDeleteModal
         open={deleteWordTarget !== null}
         loading={deleteWordLoading}
@@ -1160,10 +1166,6 @@ export default function ProjectPage() {
         onCancel={() => { if (!deleteWordLoading) setDeleteWordTarget(null); }}
         onConfirm={() => void handleConfirmSingleWordDelete()}
       />
-      </div>
-
-      {/* Shared overlays: rendered outside the lg:hidden wrapper so the
-          desktop view's filter / sort / select buttons can use them too */}
       <WordFilterSheet
         open={wordShowFilterSheet}
         onClose={() => setWordShowFilterSheet(false)}

--- a/src/components/desktop/DesktopProjectDetail.tsx
+++ b/src/components/desktop/DesktopProjectDetail.tsx
@@ -55,6 +55,8 @@ export function DesktopProjectDetailView({
   onRename,
   onToggleFavorite,
   onCycleVocabularyType,
+  onDeleteWord,
+  onBulkDelete,
 }: {
   project: Project;
   projectId: string;
@@ -75,6 +77,8 @@ export function DesktopProjectDetailView({
   onRename: () => void;
   onToggleFavorite: (word: Word) => void;
   onCycleVocabularyType: (word: Word) => void;
+  onDeleteWord: (wordId: string) => void;
+  onBulkDelete: () => void;
 }) {
   const [sortKey, setSortKey] = useState<SortKey>('order');
   const [sortDir, setSortDir] = useState(1);
@@ -214,6 +218,16 @@ export function DesktopProjectDetailView({
               >
                 <Icon name="check_box" />選択
               </button>
+              {selectMode && selectedWordIds.size > 0 && (
+                <button
+                  type="button"
+                  className="ds-btn sm"
+                  onClick={onBulkDelete}
+                  style={{ color: 'var(--color-error, #cc4d59)' }}
+                >
+                  <Icon name="delete" />{selectedWordIds.size}語を削除
+                </button>
+              )}
             </div>
             {(filterActive || query.trim()) && (
               <span className="mono muted tnum" style={{ fontSize: 12 }}>
@@ -322,6 +336,7 @@ export function DesktopProjectDetailView({
           words={modalWords}
           onClose={() => setSelectedWordId(null)}
           onToggleFavorite={() => onToggleFavorite(selectedWord)}
+          onDelete={() => onDeleteWord(selectedWord.id)}
           onNav={(dir) => {
             const ids = modalWords.map((row) => row.id);
             const currentIndex = ids.indexOf(selectedWord.id);
@@ -430,12 +445,14 @@ function DesktopWordDetailModal({
   words,
   onClose,
   onToggleFavorite,
+  onDelete,
   onNav,
 }: {
   word: Word;
   words: Word[];
   onClose: () => void;
   onToggleFavorite: () => void;
+  onDelete: () => void;
   onNav: (dir: -1 | 1) => void;
 }) {
   return (
@@ -454,6 +471,9 @@ function DesktopWordDetailModal({
                 </button>
               </>
             )}
+            <button type="button" className="ds-iconbtn" onClick={onDelete} aria-label="削除" style={{ color: 'var(--color-error, #cc4d59)' }}>
+              <Icon name="delete" />
+            </button>
             <button type="button" className="ds-iconbtn" onClick={onClose} aria-label="閉じる">
               <Icon name="close" />
             </button>


### PR DESCRIPTION
## Summary
- デスクトップの単語詳細モーダルにゴミ箱アイコンボタンを追加（単語個別削除）
- 選択モード時、デスクトップのツールバーに「N語を削除」ボタンを追加（一括削除）
- `SingleWordDeleteModal` を `lg:hidden` ラッパー外へ移動し、デスクトップでも確認ダイアログが表示されるように修正

## Test plan
- [ ] デスクトップで単語詳細モーダルを開き、ゴミ箱ボタンから削除確認ダイアログが出ることを確認
- [ ] 削除確認後、単語が削除されモーダルが閉じることを確認
- [ ] 選択モードで複数単語を選択し、ツールバーの削除ボタンから一括削除できることを確認
- [ ] モバイルビューの既存削除フローが壊れていないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WJQN4aKTakJKmkcMf3LQj1

---
_Generated by [Claude Code](https://claude.ai/code/session_01WJQN4aKTakJKmkcMf3LQj1)_