### PR TITLE
デスクトップ単語一覧の英単語・日本語カラムに非表示トグル機能を追加

### DIFF
--- a/src/components/desktop/DesktopProjectDetail.tsx
+++ b/src/components/desktop/DesktopProjectDetail.tsx
@@ -91,6 +91,7 @@ export function DesktopProjectDetailView({
   const [sortKey, setSortKey] = useState<SortKey>('order');
   const [sortDir, setSortDir] = useState(1);
   const [selectedWordId, setSelectedWordId] = useState<string | null>(null);
+  const [hiddenCols, setHiddenCols] = useState<Set<'en' | 'ja'>>(new Set());
   const [wrongAnswers, setWrongAnswers] = useState<WrongAnswer[]>([]);
   const [nowMs, setNowMs] = useState(0);
   const bg = desktopThumbColor(project.id);
@@ -181,6 +182,15 @@ export function DesktopProjectDetailView({
     }
   };
 
+  const toggleCol = (col: 'en' | 'ja') => {
+    setHiddenCols((prev) => {
+      const next = new Set(prev);
+      if (next.has(col)) next.delete(col);
+      else next.add(col);
+      return next;
+    });
+  };
+
   const sortHead = (key: SortKey, label: string, extra?: CSSProperties) => (
     <th onClick={() => toggleSort(key)} style={extra}>
       {label} {sortKey === key && <Icon name={sortDir === 1 ? 'arrow_downward' : 'arrow_upward'} />}
@@ -267,6 +277,20 @@ export function DesktopProjectDetailView({
                 </button>
               )}
             </div>
+            {hiddenCols.size > 0 && (
+              <div style={{ display: 'flex', gap: 6, alignItems: 'center' }}>
+                {hiddenCols.has('en') && (
+                  <button type="button" className="ds-btn sm" onClick={() => toggleCol('en')} style={{ fontSize: 11, gap: 4 }}>
+                    <Icon name="visibility" style={{ fontSize: 14 }} />英単語
+                  </button>
+                )}
+                {hiddenCols.has('ja') && (
+                  <button type="button" className="ds-btn sm" onClick={() => toggleCol('ja')} style={{ fontSize: 11, gap: 4 }}>
+                    <Icon name="visibility" style={{ fontSize: 14 }} />日本語
+                  </button>
+                )}
+              </div>
+            )}
             {(filterActive || query.trim()) && (
               <span className="mono muted tnum" style={{ fontSize: 12 }}>
                 {rows.length} / {counts.total}
@@ -286,9 +310,27 @@ export function DesktopProjectDetailView({
               <thead>
                 <tr>
                   <th style={{ width: 42 }} />
-                  {sortHead('en', '英単語', { minWidth: 150 })}
+                  {hiddenCols.has('en') ? null : (
+                    <th onClick={() => toggleSort('en')} style={{ minWidth: 150 }}>
+                      英単語 {sortKey === 'en' && <Icon name={sortDir === 1 ? 'arrow_downward' : 'arrow_upward'} />}
+                      <Icon
+                        name="visibility_off"
+                        style={{ fontSize: 14, marginLeft: 4, opacity: 0.35, verticalAlign: 'middle' }}
+                        onClick={(e: React.MouseEvent) => { e.stopPropagation(); toggleCol('en'); }}
+                      />
+                    </th>
+                  )}
                   <th style={{ width: 70 }}>品詞</th>
-                  <th>日本語</th>
+                  {hiddenCols.has('ja') ? null : (
+                    <th>
+                      日本語
+                      <Icon
+                        name="visibility_off"
+                        style={{ fontSize: 14, marginLeft: 4, opacity: 0.35, verticalAlign: 'middle', cursor: 'pointer' }}
+                        onClick={() => toggleCol('ja')}
+                      />
+                    </th>
+                  )}
                   {sortHead('vocabularyType', 'A/P', { width: 64, textAlign: 'center' })}
                   {sortHead('status', 'ステータス', { width: 130 })}
                 </tr>
@@ -325,14 +367,18 @@ export function DesktopProjectDetailView({
                         />
                       )}
                     </td>
-                    <td className="en">
-                      {word.english}
-                      <div className="mono" style={{ fontSize: 10, color: 'var(--color-muted)', fontWeight: 400 }}>
-                        {word.pronunciation || '-'}
-                      </div>
-                    </td>
+                    {hiddenCols.has('en') ? null : (
+                      <td className="en">
+                        {word.english}
+                        <div className="mono" style={{ fontSize: 10, color: 'var(--color-muted)', fontWeight: 400 }}>
+                          {word.pronunciation || '-'}
+                        </div>
+                      </td>
+                    )}
                     <td className="pos">{desktopPosLabel(word.partOfSpeechTags)}</td>
-                    <td className="ja">{word.japanese}</td>
+                    {hiddenCols.has('ja') ? null : (
+                      <td className="ja">{word.japanese}</td>
+                    )}
                     <td style={{ textAlign: 'center' }}>
                       <DesktopVocabularyTypeBadge
                         vocabularyType={word.vocabularyType}


### PR DESCRIPTION
## Summary\n- デスクトップの単語一覧テーブルで「英単語」「日本語」カラムのヘッダーにある目アイコン（visibility_off）をクリックすると、そのカラム全体が非表示になる\n- 非表示にしたカラムはツールバーに復元ボタン（visibility + カラム名）として表示され、クリックで再表示できる\n- ソート機能との共存：英単語ヘッダーのクリックは従来通りソート、目アイコンのクリックのみで非表示（stopPropagation）\n\n## Test plan\n- [ ] デスクトップで単語一覧を開き、「英単語」ヘッダーの目アイコンをクリック → 英単語カラムが非表示になる\n- [ ] 「日本語」ヘッダーの目アイコンをクリック → 日本語カラムが非表示になる\n- [ ] 両方非表示にした場合、ツールバーに2つの復元ボタンが表示される\n- [ ] 復元ボタンをクリック → カラムが再表示される\n- [ ] 英単語ヘッダーのテキスト部分をクリック → ソートが動作する（非表示にならない）\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)\n\nhttps://claude.ai/code/session_0191nPhARwzetbkhiDyGZED6

---
_Generated by [Claude Code](https://claude.ai/code/session_0191nPhARwzetbkhiDyGZED6)_