### PR TITLE
デスクトップのスキャンオプションを単一選択に変更

### DIFF
--- a/src/components/desktop/DesktopScan.tsx
+++ b/src/components/desktop/DesktopScan.tsx
@@ -103,11 +103,7 @@ export function DesktopScanView({
   const eikenLevel = scanModes.includes('eiken') ? '3' : null;
 
   const toggleOption = (key: ScanOptionKey) => {
-    setSelectedOptions((current) => {
-      if (!current.includes(key)) return [...current, key];
-      if (current.length === 1) return current;
-      return current.filter((item) => item !== key);
-    });
+    setSelectedOptions([key]);
   };
 
   const createBackgroundScanJob = async (files: readonly File[]) => {
@@ -407,7 +403,7 @@ export function DesktopScanView({
           <div>
             <div className="ds-sec-head" style={{ marginBottom: 14 }}>
               <h2 style={{ fontSize: 18 }}>抽出オプション</h2>
-              <span className="mono muted" style={{ fontSize: 12 }}>複数選択可</span>
+              <span className="mono muted" style={{ fontSize: 12 }}>1つ選択</span>
             </div>
             <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(220px, 1fr))', gap: 14 }}>
               {SCAN_OPTIONS.map((option) => {


### PR DESCRIPTION
## Summary
- デスクトップのスキャン画面（`DesktopScan.tsx`）で抽出オプションの複数選択を廃止し、モバイルと同じ単一選択に変更
- `toggleOption` 関数を単一選択ロジックに置き換え
- ラベルを「複数選択可」から「1つ選択」に更新

## Test plan
- [ ] デスクトップでスキャン画面を開き、抽出オプションが1つだけ選択できることを確認
- [ ] オプションを切り替えると、前の選択が解除されることを確認
- [ ] モバイルの動作と一致していることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K7zZ2QKjg8TwcTLAfudS64

---
_Generated by [Claude Code](https://claude.ai/code/session_01K7zZ2QKjg8TwcTLAfudS64)_