### PR TITLE
共有単語帳でログイン済み非Proユーザーに課金誘導を表示

### DIFF
--- a/src/app/share/[shareId]/page.tsx
+++ b/src/app/share/[shareId]/page.tsx
@@ -365,6 +365,7 @@ export default function SharedDetailPage() {
         importing={importBusy}
         importedProjectId={importedProjectId}
         isPreviewLocked={isPreviewLocked}
+        isLoggedIn={!!user}
         totalWordCount={totalWordCount}
         previewClearWordCount={SHARE_PREVIEW_CLEAR_WORD_COUNT}
         lockedCtaHref={loginRedirectHref}
@@ -476,7 +477,9 @@ export default function SharedDetailPage() {
         })}
         {isPreviewLocked && lockedPreviewWordCount > 0 && (
           <div className="px-2 py-3 text-center font-mono text-[10px] font-semibold text-[var(--color-muted)]">
-            残り {lockedPreviewWordCount.toLocaleString()} 語はログインすると表示できます
+            {user
+              ? `残り ${lockedPreviewWordCount.toLocaleString()} 語はProプランで表示できます`
+              : `残り ${lockedPreviewWordCount.toLocaleString()} 語はログインすると表示できます`}
           </div>
         )}
       </div>
@@ -486,9 +489,15 @@ export default function SharedDetailPage() {
         style={{ background: 'linear-gradient(to top, var(--color-background) 70%, transparent)', paddingBottom: 'max(1.625rem, env(safe-area-inset-bottom))' }}
       >
         {isPreviewLocked ? (
-          <SolidButton href={loginRedirectHref} variant="inverse" size="lg" iconLeft="login" className="w-full" faceClassName="!w-full !justify-center">
-            ログインして単語を見る
-          </SolidButton>
+          user ? (
+            <SolidButton href="/subscription" variant="inverse" size="lg" iconLeft="auto_awesome" className="w-full" faceClassName="!w-full !justify-center">
+              Proにアップグレードして全単語を見る
+            </SolidButton>
+          ) : (
+            <SolidButton href={loginRedirectHref} variant="inverse" size="lg" iconLeft="login" className="w-full" faceClassName="!w-full !justify-center">
+              ログインして単語を見る
+            </SolidButton>
+          )
         ) : importedProjectId ? (
           <SolidButton href={`/project/${importedProjectId}`} variant="inverse" size="lg" iconLeft="check_circle" className="w-full" faceClassName="!w-full !justify-center">
             追加済み — 単語帳を開く
@@ -507,7 +516,7 @@ export default function SharedDetailPage() {
           </SolidButton>
         )}
         <p className="mt-2 text-center font-mono text-[10px] font-semibold text-[var(--color-muted)]">
-          {isPreviewLocked ? '一部だけプレビューしています' : 'オリジナルは変更されません'}
+          {isPreviewLocked ? (user ? 'Proプランで全単語を閲覧・インポートできます' : '一部だけプレビューしています') : 'オリジナルは変更されません'}
         </p>
       </div>
       </div>

--- a/src/components/desktop/DesktopSharedDetail.tsx
+++ b/src/components/desktop/DesktopSharedDetail.tsx
@@ -17,6 +17,7 @@ export function DesktopSharedDetailView({
   importing,
   importedProjectId,
   isPreviewLocked = false,
+  isLoggedIn = false,
   totalWordCount = words.length,
   previewClearWordCount = 5,
   lockedCtaHref = '/login',
@@ -36,6 +37,7 @@ export function DesktopSharedDetailView({
   importing: boolean;
   importedProjectId: string | null;
   isPreviewLocked?: boolean;
+  isLoggedIn?: boolean;
   totalWordCount?: number;
   previewClearWordCount?: number;
   lockedCtaHref?: string;
@@ -73,9 +75,15 @@ export function DesktopSharedDetailView({
           {liked ? 'いいね済み' : 'いいね'} {likeCount > 0 ? likeCount : ''}
         </DesktopButton>
         {isPreviewLocked ? (
-          <DesktopButton href={lockedCtaHref} variant="dark" icon="login">
-            ログインして単語を見る
-          </DesktopButton>
+          isLoggedIn ? (
+            <DesktopButton href="/subscription" variant="dark" icon="auto_awesome">
+              Proにアップグレード
+            </DesktopButton>
+          ) : (
+            <DesktopButton href={lockedCtaHref} variant="dark" icon="login">
+              ログインして単語を見る
+            </DesktopButton>
+          )
         ) : (
           <DesktopButton variant={selectMode ? 'dark' : undefined} icon="checklist" onClick={onToggleSelectMode}>
             {selectMode ? '選択を終了' : '選択して追加'}
@@ -110,6 +118,7 @@ export function DesktopSharedDetailView({
             {isPreviewLocked && (
               <div className="muted" style={{ fontSize: 12.5, marginTop: 7 }}>
                 最初の {Math.min(previewClearWordCount, words.length)} 語は表示し、以降はぼかしています。
+                {isLoggedIn && ' Proプランで全単語を閲覧・インポートできます。'}
               </div>
             )}
           </div>
@@ -185,15 +194,27 @@ export function DesktopSharedDetailView({
 
         <div className="ds-actionbar">
           {isPreviewLocked ? (
-            <>
-              <span className="muted" style={{ fontSize: 13 }}>
-                {hiddenWordCount > 0 ? `残り ${hiddenWordCount} 語はログインすると表示できます` : 'ログインすると単語を表示できます'}
-              </span>
-              <div className="grow" />
-              <DesktopButton href={lockedCtaHref} variant="accent" icon="login">
-                ログインして単語を見る
-              </DesktopButton>
-            </>
+            isLoggedIn ? (
+              <>
+                <span className="muted" style={{ fontSize: 13 }}>
+                  {hiddenWordCount > 0 ? `残り ${hiddenWordCount} 語はProプランで表示できます` : 'Proプランにアップグレードすると全単語を表示できます'}
+                </span>
+                <div className="grow" />
+                <DesktopButton href="/subscription" variant="accent" icon="auto_awesome">
+                  Proにアップグレード
+                </DesktopButton>
+              </>
+            ) : (
+              <>
+                <span className="muted" style={{ fontSize: 13 }}>
+                  {hiddenWordCount > 0 ? `残り ${hiddenWordCount} 語はログインすると表示できます` : 'ログインすると単語を表示できます'}
+                </span>
+                <div className="grow" />
+                <DesktopButton href={lockedCtaHref} variant="accent" icon="login">
+                  ログインして単語を見る
+                </DesktopButton>
+              </>
+            )
           ) : selectMode ? (
             <>
               <span className="muted" style={{ fontSize: 13 }}>{selectedCount} 語を選択中</span>


### PR DESCRIPTION
## Summary

- ログイン済みかつProでないユーザーが共有単語帳の詳細ページ (`/share/[shareId]`) を開いた際、「ログインして単語を見る」ではなく「Proにアップグレード」ボタンを表示するように変更
- モバイル・デスクトップ両方のビューで、ボタンテキスト・説明テキスト・アクションバーすべてを分岐
- 未ログインユーザーには従来通り「ログインして単語を見る」を表示

## Test plan

- [ ] 未ログイン状態で `/share/[shareId]` を開き、「ログインして単語を見る」ボタンが表示されることを確認
- [ ] ログイン済み・Freeプランで `/share/[shareId]` を開き、「Proにアップグレードして全単語を見る」ボタンが表示されることを確認
- [ ] 上記ボタンをタップすると `/subscription` に遷移することを確認
- [ ] ログイン済み・Proプランで `/share/[shareId]` を開き、全単語が表示されインポートできることを確認
- [ ] デスクトップ表示でも同様の分岐が正しく動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F7pngJ8BhbLdFkCDzDS4FG

---
_Generated by [Claude Code](https://claude.ai/code/session_01F7pngJ8BhbLdFkCDzDS4FG)_