### PR TITLE
英単語カラムヘッダーからソート矢印を削除

### DIFF
--- a/src/components/desktop/DesktopProjectDetail.tsx
+++ b/src/components/desktop/DesktopProjectDetail.tsx
@@ -319,8 +319,8 @@ export function DesktopProjectDetailView({
                 <tr>
                   <th style={{ width: 42 }} />
                   {hiddenCols.has('en') ? null : (
-                    <th onClick={() => toggleSort('en')} style={{ minWidth: 150 }}>
-                      英単語 {sortKey === 'en' && <Icon name={sortDir === 1 ? 'arrow_downward' : 'arrow_upward'} />}
+                    <th style={{ minWidth: 150 }}>
+                      英単語
                       <span
                         role="button"
                         style={{ cursor: 'pointer', verticalAlign: 'middle', marginLeft: 4, opacity: 0.35 }}


### PR DESCRIPTION
## Summary\n- 英単語カラムヘッダーのソート矢印アイコンとソートクリック機能を削除\n- 非表示トグル（目アイコン）はそのまま維持\n\n## Test plan\n- [ ] 英単語ヘッダーにソート矢印が表示されないこと\n- [ ] 非表示トグルは正常に動作すること\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)\n\nhttps://claude.ai/code/session_0191nPhARwzetbkhiDyGZED6

---
_Generated by [Claude Code](https://claude.ai/code/session_0191nPhARwzetbkhiDyGZED6)_