### PR TITLE
英単語カラム非表示時に日本語訳カラムが左に詰まらないよう修正

### DIFF
--- a/src/components/desktop/DesktopProjectDetail.tsx
+++ b/src/components/desktop/DesktopProjectDetail.tsx
@@ -318,18 +318,20 @@ export function DesktopProjectDetailView({
               <thead>
                 <tr>
                   <th style={{ width: 42 }} />
-                  {hiddenCols.has('en') ? null : (
-                    <th style={{ minWidth: 150 }}>
-                      英単語
-                      <span
-                        role="button"
-                        style={{ cursor: 'pointer', verticalAlign: 'middle', marginLeft: 4, opacity: 0.35 }}
-                        onClick={(e) => { e.stopPropagation(); toggleCol('en'); }}
-                      >
-                        <Icon name="visibility_off" style={{ fontSize: 14 }} />
-                      </span>
-                    </th>
-                  )}
+                  <th style={{ minWidth: 150 }}>
+                    {hiddenCols.has('en') ? null : (
+                      <>
+                        英単語
+                        <span
+                          role="button"
+                          style={{ cursor: 'pointer', verticalAlign: 'middle', marginLeft: 4, opacity: 0.35 }}
+                          onClick={(e) => { e.stopPropagation(); toggleCol('en'); }}
+                        >
+                          <Icon name="visibility_off" style={{ fontSize: 14 }} />
+                        </span>
+                      </>
+                    )}
+                  </th>
                   <th style={{ width: 70 }}>品詞</th>
                   {hiddenCols.has('ja') ? null : (
                     <th>
@@ -379,14 +381,16 @@ export function DesktopProjectDetailView({
                         />
                       )}
                     </td>
-                    {hiddenCols.has('en') ? null : (
-                      <td className="en">
-                        {word.english}
-                        <div className="mono" style={{ fontSize: 10, color: 'var(--color-muted)', fontWeight: 400 }}>
-                          {word.pronunciation || '-'}
-                        </div>
-                      </td>
-                    )}
+                    <td className="en">
+                      {hiddenCols.has('en') ? null : (
+                        <>
+                          {word.english}
+                          <div className="mono" style={{ fontSize: 10, color: 'var(--color-muted)', fontWeight: 400 }}>
+                            {word.pronunciation || '-'}
+                          </div>
+                        </>
+                      )}
+                    </td>
                     <td className="pos">{desktopPosLabel(word.partOfSpeechTags)}</td>
                     {hiddenCols.has('ja') ? null : (
                       <td className="ja">{word.japanese}</td>


### PR DESCRIPTION
## Summary\n- デスクトップの単語一覧テーブルで英単語カラムを非表示にした際、`<th>`/`<td>`要素ごと削除していたため日本語訳カラムが左にシフトしていた\n- セル要素は残して中身のみ非表示にすることで、カラム幅を維持し日本語訳の位置が変わらないよう修正\n\n## Test plan\n- [ ] `/project/[id]` ページをデスクトップ表示で開く\n- [ ] 英単語カラムの目のアイコンをクリックして非表示にする\n- [ ] 日本語訳カラムが左に詰まらず元の位置に留まることを確認\n- [ ] 「英単語」ボタンで再表示し、元通りに表示されることを確認\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)\n\nhttps://claude.ai/code/session_016ccToCLaHq4ELGbFN7sMNv

---
_Generated by [Claude Code](https://claude.ai/code/session_016ccToCLaHq4ELGbFN7sMNv)_