### PR TITLE
Fix desktop review button to match mobile quiz path

### DIFF
--- a/src/components/desktop/DesktopHome.tsx
+++ b/src/components/desktop/DesktopHome.tsx
@@ -187,7 +187,7 @@ export function DesktopHomeView({
           )}
         </div>
 
-        <DesktopStudySidebar stats={stats} reviewHref={firstProject ? `/quiz/${firstProject.id}` : '/projects'} />
+        <DesktopStudySidebar stats={stats} reviewHref={stats.totalWords > 0 ? '/quiz/all?review=1&from=/' : '/projects'} />
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- デスクトップ版ホーム画面の「復習を始める」ボタンのリンク先がモバイル版と異なっていたのを修正
- **Before (desktop):** `/quiz/{firstProjectId}` → 最初のプロジェクトの単語のみ、復習モードなし
- **After (desktop):** `/quiz/all?review=1&from=/` → 全プロジェクトの復習対象単語（モバイル版と同じ）

## Test plan
- [ ] デスクトップ表示でホーム画面の「復習を始める」をクリックし、復習モードで全プロジェクトの復習対象単語が出題されることを確認
- [ ] モバイル表示で同じ操作を行い、同じ単語セットが出題されることを確認
- [ ] 単語がない状態では `/projects` にリダイレクトされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011mCkohRHwwWE6PwrGmyhCS

---
_Generated by [Claude Code](https://claude.ai/code/session_011mCkohRHwwWE6PwrGmyhCS)_