### PR TITLE
feat: デスクトップ設定画面にユーザー名変更UIを追加

### DIFF
--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -185,6 +185,9 @@ export default function SettingsPage() {
         username={username}
         isPro={isPro}
         onSignOut={() => void handleSignOut()}
+        onUsernameChange={setUsername}
+        usernameSaving={profileSaving}
+        usernameError={profileError}
       />
       <div className="relative min-h-screen bg-[var(--color-background)] pb-[110px] pt-3 font-[var(--font-body)] lg:hidden">
       {/* Header */}

--- a/src/components/desktop/DesktopAccount.tsx
+++ b/src/components/desktop/DesktopAccount.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useState } from 'react';
 import Link from 'next/link';
 import { Icon } from '@/components/ui/Icon';
 import { DesktopButton, DesktopTopbar } from '@/components/desktop/DesktopChrome';
@@ -12,13 +13,37 @@ export function DesktopSettingsView({
   username,
   isPro,
   onSignOut,
+  onUsernameChange,
+  usernameSaving,
+  usernameError,
 }: {
   email?: string | null;
   username?: string | null;
   isPro: boolean;
   onSignOut: () => void;
+  onUsernameChange?: (newUsername: string) => Promise<boolean>;
+  usernameSaving?: boolean;
+  usernameError?: string | null;
 }) {
   const billingEnabled = isBillingEnabled();
+  const [isEditing, setIsEditing] = useState(false);
+  const [editInput, setEditInput] = useState('');
+
+  const startEditing = () => {
+    setEditInput(username ?? '');
+    setIsEditing(true);
+  };
+
+  const cancelEditing = () => {
+    setEditInput('');
+    setIsEditing(false);
+  };
+
+  const handleSave = async () => {
+    if (usernameSaving || !editInput.trim() || !onUsernameChange) return;
+    const success = await onUsernameChange(editInput);
+    if (success) setIsEditing(false);
+  };
 
   return (
     <div className="hidden h-full min-h-0 flex-col lg:flex">
@@ -45,7 +70,66 @@ export function DesktopSettingsView({
                 <Icon name={isPro ? 'bolt' : 'person'} filled style={{ fontSize: 13 }} />
                 {isPro ? 'PRO' : 'FREE'}
               </span>
+              {email && !isEditing && onUsernameChange && (
+                <button
+                  type="button"
+                  onClick={startEditing}
+                  className="ds-set-row-action"
+                  style={{ marginLeft: 8, background: 'none', border: '1px solid var(--color-border)', borderRadius: 8, padding: '4px 12px', cursor: 'pointer', display: 'inline-flex', alignItems: 'center', gap: 4, fontSize: 13, fontWeight: 600, color: 'var(--color-secondary-text)' }}
+                >
+                  <Icon name="edit" style={{ fontSize: 15 }} />
+                  変更
+                </button>
+              )}
             </div>
+            {isEditing && (
+              <div className="ds-set-row" style={{ flexDirection: 'column', alignItems: 'stretch', gap: 10, padding: '14px 16px' }}>
+                <label htmlFor="desktop-username" style={{ fontSize: 11, fontWeight: 700, color: 'var(--color-muted)', letterSpacing: '0.05em' }}>
+                  ユーザー名
+                </label>
+                <input
+                  id="desktop-username"
+                  type="text"
+                  value={editInput}
+                  onChange={(e) => setEditInput(e.target.value)}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter') { e.preventDefault(); void handleSave(); }
+                    if (e.key === 'Escape') cancelEditing();
+                  }}
+                  maxLength={20}
+                  autoFocus
+                  placeholder="ユーザー名を入力"
+                  style={{ width: '100%', padding: '8px 12px', border: '1px solid var(--color-border)', borderRadius: 8, fontSize: 14, outline: 'none' }}
+                />
+                <div style={{ display: 'flex', justifyContent: 'space-between', fontSize: 11, color: 'var(--color-muted)' }}>
+                  <span>1〜20文字</span>
+                  <span>{editInput.length}/20</span>
+                </div>
+                {usernameError && (
+                  <p style={{ margin: 0, padding: '6px 10px', borderRadius: 6, border: '1px solid var(--color-error)', background: 'rgba(239,68,68,0.08)', fontSize: 12, fontWeight: 600, color: 'var(--color-error)' }}>
+                    {usernameError}
+                  </p>
+                )}
+                <div style={{ display: 'flex', gap: 8 }}>
+                  <button
+                    type="button"
+                    onClick={() => void handleSave()}
+                    disabled={usernameSaving || !editInput.trim()}
+                    style={{ flex: 1, padding: '8px 0', border: 'none', borderRadius: 8, background: 'var(--color-foreground, #111)', color: '#fff', fontSize: 13, fontWeight: 700, cursor: 'pointer', opacity: (usernameSaving || !editInput.trim()) ? 0.5 : 1 }}
+                  >
+                    {usernameSaving ? '保存中...' : '保存'}
+                  </button>
+                  <button
+                    type="button"
+                    onClick={cancelEditing}
+                    disabled={usernameSaving}
+                    style={{ flex: 1, padding: '8px 0', border: '1px solid var(--color-border)', borderRadius: 8, background: '#fff', fontSize: 13, fontWeight: 600, cursor: 'pointer' }}
+                  >
+                    キャンセル
+                  </button>
+                </div>
+              </div>
+            )}
             {email && (
               <button type="button" className="ds-set-row" style={{ width: '100%', cursor: 'pointer', background: '#fff', borderLeft: 0, borderRight: 0, borderBottom: 0, textAlign: 'left' }} onClick={onSignOut}>
                 <div className="ic" style={{ background: 'var(--color-error-light)' }}><Icon name="logout" style={{ color: 'var(--color-error)' }} /></div>


### PR DESCRIPTION
## Summary
- デスクトップの設定画面（`DesktopSettingsView`）にユーザー名変更の「変更」ボタンとインライン編集フォームを追加
- モバイル側と同じ `useProfile` フックの `setUsername` を利用し、Enter/Escapeキー操作・バリデーション・エラー表示に対応
- 既存の `DesktopSettingsView` のpropsを拡張し、親の `settings/page.tsx` から編集コールバックを渡す設計

## Test plan
- [ ] デスクトップ幅でログイン後、設定画面のアカウント行に「変更」ボタンが表示される
- [ ] 「変更」をクリックするとインライン編集フォームが展開される
- [ ] ユーザー名を入力して「保存」で変更が反映される
- [ ] Enterキーで保存、Escapeキーでキャンセルが動作する
- [ ] 空文字では保存ボタンが無効化される
- [ ] 未ログイン時は「変更」ボタンが表示されない
- [ ] モバイル側の既存ユーザー名変更機能に影響がない

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SqbcyqK9QZ89i8rKSpQYm3

---
_Generated by [Claude Code](https://claude.ai/code/session_01SqbcyqK9QZ89i8rKSpQYm3)_