### PR TITLE
デスクトップ版プロジェクト詳細UIの改善

### DIFF
--- a/src/app/desktop.css
+++ b/src/app/desktop.css
@@ -149,6 +149,7 @@
 .ds-btn.ghost { box-shadow: none; background: transparent; border-color: transparent; }
 .ds-btn.ghost:hover { background: rgba(26,26,26,0.05); transform: none; }
 .ds-btn.sm { padding: 7px 12px; font-size: 13px; }
+.ds-btn.ds-btn--icon { padding: 10px; }
 
 /* ── Solid card (face + plate via box-shadow, hard) ──────── */
 .ds-card {
@@ -329,7 +330,7 @@
 .ds-table td { padding: 12px 14px; font-size: 13.5px; vertical-align: middle; }
 .ds-table td.en { font-family: var(--font-display); font-weight: 700; font-size: 15px; }
 .ds-table td.ja { color: var(--color-secondary-text); }
-.ds-table td.pos { font-family: var(--font-mono); font-size: 12px; color: var(--color-muted); }
+.ds-table td.pos { font-family: var(--font-mono); font-size: 12px; color: var(--color-muted); width: 70px; max-width: 70px; }
 .ds-table td.cefr { font-family: var(--font-mono); font-size: 11px; }
 .ds-table td.star .material-symbols-outlined { font-size: 18px; color: var(--color-muted); cursor: pointer; }
 .ds-table td.star .material-symbols-outlined.on { color: var(--color-warning); font-variation-settings: 'FILL' 1; }

--- a/src/app/project/[id]/page.tsx
+++ b/src/app/project/[id]/page.tsx
@@ -900,6 +900,8 @@ export default function ProjectPage() {
         onCycleVocabularyType={(word) => void handleCycleVocabularyType(word)}
         onDeleteWord={handleOpenDeleteWord}
         onBulkDelete={() => setBulkDeleteModalOpen(true)}
+        onScan={() => setShowScanCaptureModal(true)}
+        onManualAdd={() => setShowManualWordModal(true)}
       />
       <div className="relative flex min-h-screen flex-col bg-[var(--color-background)] font-[var(--font-body)] lg:hidden">
       <div className="sticky top-0 z-10 flex items-center justify-between bg-[var(--color-background)] px-4 pb-2 pt-3 lg:hidden">
@@ -1722,11 +1724,11 @@ function StatusSquares({
       aria-label={`ステータス: ${status === 'new' ? '未学習' : status === 'review' ? '学習中' : '習得済み'}`}
       className="shrink-0 rounded p-0.5 transition-colors active:bg-[rgba(26,26,26,0.06)]"
     >
-      <div className="flex flex-col gap-[1.5px]">
+      <div className="flex flex-col gap-[2px]">
         {[0, 1, 2].map((i) => (
           <div
             key={i}
-            className="h-[10px] w-[10px] rounded-[2px] border-2 border-[var(--solid-ink)]"
+            className="h-[13px] w-[13px] rounded-[2.5px] border-2 border-[var(--solid-ink)]"
             style={{ background: i < filledCount ? 'var(--solid-ink)' : 'transparent' }}
           />
         ))}

--- a/src/components/desktop/DesktopChrome.tsx
+++ b/src/components/desktop/DesktopChrome.tsx
@@ -167,13 +167,14 @@ export function DesktopButton({
   onClick?: () => void;
   title?: string;
 }) {
+  const iconOnly = children === '' || children === null || children === undefined;
   const content = (
     <>
       {icon && <Icon name={icon} />}
-      {children}
+      {!iconOnly && children}
     </>
   );
-  const classes = cn('ds-btn', variant, className);
+  const classes = cn('ds-btn', variant, iconOnly && 'ds-btn--icon', className);
   if (href) {
     return (
       <Link href={href} className={classes} title={title}>

--- a/src/components/desktop/DesktopProjectDetail.tsx
+++ b/src/components/desktop/DesktopProjectDetail.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Fragment, type CSSProperties, useEffect, useMemo, useState } from 'react';
+import { Fragment, type CSSProperties, useEffect, useMemo, useRef, useState } from 'react';
 import Link from 'next/link';
 import { Icon } from '@/components/ui/Icon';
 import {
@@ -66,6 +66,8 @@ export function DesktopProjectDetailView({
   onCycleVocabularyType,
   onDeleteWord,
   onBulkDelete,
+  onScan,
+  onManualAdd,
 }: {
   project: Project;
   projectId: string;
@@ -88,7 +90,11 @@ export function DesktopProjectDetailView({
   onCycleVocabularyType: (word: Word) => void;
   onDeleteWord: (wordId: string) => void;
   onBulkDelete: () => void;
+  onScan: () => void;
+  onManualAdd: () => void;
 }) {
+  const [addMenuOpen, setAddMenuOpen] = useState(false);
+  const addMenuRef = useRef<HTMLDivElement>(null);
   const [sortKey, setSortKey] = useState<SortKey>('order');
   const [sortDir, setSortDir] = useState(1);
   const [selectedWordId, setSelectedWordId] = useState<string | null>(null);
@@ -210,10 +216,43 @@ export function DesktopProjectDetailView({
   return (
     <div className="hidden h-full min-h-0 flex-col lg:flex">
       <DesktopTopbar title={project.title} crumb="単語帳 / 一覧">
-        <DesktopButton href={`/quiz/${projectId}`} variant="accent" icon="school">クイズ</DesktopButton>
-        <DesktopButton href={`/flashcard/${projectId}`} icon="style">カード</DesktopButton>
-        <DesktopButton onClick={onRename} icon="edit" title="単語帳名を変更">名称変更</DesktopButton>
-        <DesktopButton href={`/scan?projectId=${encodeURIComponent(projectId)}`} icon="photo_camera">追加</DesktopButton>
+        <DesktopButton href={`/quiz/${projectId}`} variant="accent" icon="school" title="クイズ">{''}</DesktopButton>
+        <DesktopButton href={`/flashcard/${projectId}`} icon="style" title="カード">{''}</DesktopButton>
+        <DesktopButton onClick={onRename} icon="edit" title="名称変更">{''}</DesktopButton>
+        <div ref={addMenuRef} style={{ position: 'relative' }}>
+          <DesktopButton onClick={() => setAddMenuOpen((v) => !v)} icon="add" title="単語を追加">{''}</DesktopButton>
+          {addMenuOpen && (
+            <>
+              <button
+                type="button"
+                className="fixed inset-0 z-40 cursor-default bg-transparent"
+                aria-label="メニューを閉じる"
+                onClick={() => setAddMenuOpen(false)}
+              />
+              <div
+                className="absolute right-0 top-[calc(100%+6px)] z-50 w-[180px] overflow-hidden rounded-[12px] border-2 border-[var(--solid-ink)] bg-white"
+                style={{ boxShadow: '2px 3px 0 var(--solid-ink)' }}
+              >
+                <button
+                  type="button"
+                  className="flex w-full items-center gap-2 px-4 py-3 text-left text-[13px] font-bold transition-colors hover:bg-[var(--color-surface-secondary)]"
+                  onClick={() => { setAddMenuOpen(false); onScan(); }}
+                >
+                  <Icon name="photo_camera" style={{ fontSize: 18 }} />
+                  スキャンで追加
+                </button>
+                <button
+                  type="button"
+                  className="flex w-full items-center gap-2 px-4 py-3 text-left text-[13px] font-bold transition-colors hover:bg-[var(--color-surface-secondary)]"
+                  onClick={() => { setAddMenuOpen(false); onManualAdd(); }}
+                >
+                  <Icon name="edit" style={{ fontSize: 18 }} />
+                  手動で追加
+                </button>
+              </div>
+            </>
+          )}
+        </div>
       </DesktopTopbar>
 
       <div className={`ds-scroll ds-project-detail-grid${railCollapsed ? ' ds-project-detail-grid--rail-collapsed' : ''}`}>

--- a/src/components/project/ProjectDetailSheet.tsx
+++ b/src/components/project/ProjectDetailSheet.tsx
@@ -120,9 +120,9 @@ function StatusSquares({ wordId, status, onStatusChange }: {
       aria-label={`ステータス: ${status === 'new' ? '未学習' : status === 'review' ? '学習中' : '習得済み'}`}
       className="shrink-0 rounded p-0.5 transition-colors active:bg-[rgba(26,26,26,0.06)]"
     >
-      <div className="flex flex-col gap-[1.5px]">
+      <div className="flex flex-col gap-[2px]">
         {[0, 1, 2].map((i) => (
-          <div key={i} className="h-[10px] w-[10px] rounded-[2px] border-2 border-[var(--solid-ink)]"
+          <div key={i} className="h-[13px] w-[13px] rounded-[2.5px] border-2 border-[var(--solid-ink)]"
             style={{ background: i < filledCount ? 'var(--solid-ink)' : 'transparent' }} />
         ))}
       </div>


### PR DESCRIPTION
## Summary
- 品詞(POS)列に固定幅(`width: 70px; max-width: 70px`)を設定し、2行折り返し時でも英単語列の位置がずれないよう修正
- ヘッダーの4つのボタン（クイズ・カード・名称変更・追加）からテキストを削除し、アイコンのみのUIに変更
- 「追加」ボタンをドロップダウンメニューに変更（「スキャンで追加」「手動で追加」の2択）。手動追加はモバイルと同じ`ManualWordModal`と`/api/words/enrich-manual` APIを使用
- StatusSquares（3つのステータスチェックボックス）のサイズを10px→13pxに拡大し、行の高さに対して視覚的なバランスを改善

## Test plan
- [ ] デスクトップ版のプロジェクト詳細ページを開き、品詞が2行になる単語で英単語列がずれないことを確認
- [ ] ヘッダーのボタンがアイコンのみで表示され、hover時にtitleが表示されることを確認
- [ ] 「+」ボタンをクリックしてドロップダウンが表示され、スキャン・手動追加が動作することを確認
- [ ] 手動追加で単語を追加し、AI enrichmentが正常に動作することを確認
- [ ] ステータスの3つの四角が以前より大きく表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A6JAd5u1hY2K88aPWUpX9p

---
_Generated by [Claude Code](https://claude.ai/code/session_01A6JAd5u1hY2K88aPWUpX9p)_