### PR TITLE
プロジェクト単語一覧のデフォルト並び順を暗記率昇順に変更

### DIFF
--- a/src/app/project/[id]/page.tsx
+++ b/src/app/project/[id]/page.tsx
@@ -77,7 +77,7 @@ export default function ProjectPage() {
   const [loading, setLoading] = useState(true);
   const [wordsLoaded, setWordsLoaded] = useState(false);
   const [query, setQuery] = useState('');
-  const [wordSortOrder, setWordSortOrder] = useState<ProjectWordSortOrder>('createdAsc');
+  const [wordSortOrder, setWordSortOrder] = useState<ProjectWordSortOrder>('statusAsc');
   const [wordShowSortSheet, setWordShowSortSheet] = useState(false);
   const [wordShowFilterSheet, setWordShowFilterSheet] = useState(false);
   const [wordFilterBookmark, setWordFilterBookmark] = useState(false);


### PR DESCRIPTION
## Summary
- プロジェクト詳細ページ (`/project/[id]`) の単語一覧のデフォルト並び順を「追加順 (createdAsc)」から「暗記率昇順 (statusAsc)」に変更
- 未習得 (new) → 学習中 (review) → 習得済 (mastered) の順で表示されるようになります

## Test plan
- [ ] プロジェクト詳細ページを開き、単語が暗記率昇順（未習得が先）で表示されることを確認
- [ ] 並べ替えシートから他のソート順に切り替えられることを確認
- [ ] デスクトップビューでも同様にデフォルト順が反映されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CrFSqg3p8Qfh5Qdc3pwu76

---
_Generated by [Claude Code](https://claude.ai/code/session_01CrFSqg3p8Qfh5Qdc3pwu76)_