### PR TITLE
単語詳細モーダルの外側タップで閉じる＆フラッシュカードにひっくり返しボタン追加

### DIFF
--- a/src/app/favorites/page.tsx
+++ b/src/app/favorites/page.tsx
@@ -351,9 +351,10 @@ function FavoritesPageContent() {
             style={{ background: 'rgba(26,26,26,0.45)', backdropFilter: 'blur(3px)' }}
             onClick={() => setSelectedWord(null)}
           />
-          <div className="absolute inset-0 flex items-center justify-center px-4 py-10">
+          <div className="absolute inset-0 flex items-center justify-center px-4 py-10" onClick={() => setSelectedWord(null)}>
             <div
               className="w-full overflow-y-auto"
+              onClick={(e) => e.stopPropagation()}
               style={{
                 maxWidth: 480,
                 maxHeight: '80dvh',

--- a/src/app/flashcard/[projectId]/page.tsx
+++ b/src/app/flashcard/[projectId]/page.tsx
@@ -848,6 +848,9 @@ export default function FlashcardPage() {
         <NavBtn onClick={() => handlePrev(true)} aria-label="前のカード">
           <Icon name="chevron_left" size={18} />
         </NavBtn>
+        <NavBtn onClick={handleFlip} aria-label="カードを回転">
+          <Icon name="cached" size={18} />
+        </NavBtn>
         <NavBtn onClick={() => handleNext(true)} aria-label="次のカード">
           <Icon name="chevron_right" size={18} />
         </NavBtn>

--- a/src/app/project/[id]/page.tsx
+++ b/src/app/project/[id]/page.tsx
@@ -1187,9 +1187,10 @@ export default function ProjectPage() {
             style={{ background: 'rgba(26,26,26,0.45)', backdropFilter: 'blur(3px)' }}
             onClick={() => setSelectedWord(null)}
           />
-          <div className="absolute inset-0 flex items-center justify-center px-4 py-10">
+          <div className="absolute inset-0 flex items-center justify-center px-4 py-10" onClick={() => setSelectedWord(null)}>
             <div
               className="w-full overflow-y-auto overscroll-contain"
+              onClick={(e) => e.stopPropagation()}
               style={{
                 maxWidth: 480,
                 maxHeight: '80dvh',


### PR DESCRIPTION
## Summary\n- 単語詳細モーダル表示時、カードの外側（背景部分）をタップ/クリックすると閉じるように修正（プロジェクトページ・お気に入りページ両方）\n- フラッシュカードのモバイルビューで、左右矢印ボタンの間にひっくり返し（回転）ボタンを追加\n\n## Test plan\n- [ ] プロジェクトページで単語をタップ → 詳細モーダル表示 → カード外側をタップ → 閉じることを確認\n- [ ] お気に入りページで同様の動作を確認\n- [ ] モーダル内のコンテンツをタップしても閉じないことを確認\n- [ ] フラッシュカード（モバイル）で左右矢印の間に回転ボタンが表示されることを確認\n- [ ] 回転ボタンをタップするとカードがフリップすることを確認\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)\n\nhttps://claude.ai/code/session_01XFP9ddXQ4dwNVPoFP8SDC6

---
_Generated by [Claude Code](https://claude.ai/code/session_01XFP9ddXQ4dwNVPoFP8SDC6)_