### PR TITLE
fix: keep project word loading resilient

### DIFF
--- a/src/lib/projects/load-helpers.test.ts
+++ b/src/lib/projects/load-helpers.test.ts
@@ -87,6 +87,57 @@ test('getWordsByProjectMap uses getAllWordsByProject for local repository', asyn
   assert.equal(result.p2.length, 1);
 });
 
+test('getWordsByProjectMap falls back from remote bulk to local bulk when available', async () => {
+  const calls: string[] = [];
+  const repo = {
+    getWords: async (projectId: string) => {
+      calls.push(`single:${projectId}`);
+      return [];
+    },
+    getAllWordsByProjectIds: async (projectIds: string[]) => {
+      calls.push(`bulk-remote:${projectIds.join(',')}`);
+      throw new Error('remote relation failed');
+    },
+    getAllWordsByProject: async (projectIds: string[]) => {
+      calls.push(`bulk-local:${projectIds.join(',')}`);
+      return {
+        p1: [createWord('p1', 'mastered')],
+      };
+    },
+  };
+
+  const result = await getWordsByProjectMap(repo, ['p1', 'p2']);
+
+  assert.deepEqual(calls, ['bulk-remote:p1,p2', 'bulk-local:p1,p2']);
+  assert.equal(result.p1.length, 1);
+  assert.deepEqual(result.p2, []);
+});
+
+test('getWordsByProjectMap keeps project keys when all bulk and one project load fail', async () => {
+  const calls: string[] = [];
+  const repo = {
+    getWords: async (projectId: string) => {
+      calls.push(`single:${projectId}`);
+      if (projectId === 'p2') throw new Error('single project failed');
+      return [createWord(projectId, 'new')];
+    },
+    getAllWordsByProjectIds: async (projectIds: string[]) => {
+      calls.push(`bulk-remote:${projectIds.join(',')}`);
+      throw new Error('remote bulk failed');
+    },
+    getAllWordsByProject: async (projectIds: string[]) => {
+      calls.push(`bulk-local:${projectIds.join(',')}`);
+      throw new Error('local bulk failed');
+    },
+  };
+
+  const result = await getWordsByProjectMap(repo, ['p1', 'p2']);
+
+  assert.deepEqual(calls, ['bulk-remote:p1,p2', 'bulk-local:p1,p2', 'single:p1', 'single:p2']);
+  assert.equal(result.p1.length, 1);
+  assert.deepEqual(result.p2, []);
+});
+
 test('buildProjectStats calculates totals/mastered/progress correctly', () => {
   const projects = [createProject('p1'), createProject('p2')];
   const wordsByProject: Record<string, Word[]> = {

--- a/src/lib/projects/load-helpers.ts
+++ b/src/lib/projects/load-helpers.ts
@@ -33,19 +33,40 @@ export async function getWordsByProjectMap(
   if (uniqueProjectIds.length === 0) return {};
 
   if (repository.getAllWordsByProjectIds) {
-    const wordsByProject = await repository.getAllWordsByProjectIds(uniqueProjectIds);
-    return withAllProjectKeys(uniqueProjectIds, wordsByProject);
+    try {
+      const wordsByProject = await repository.getAllWordsByProjectIds(uniqueProjectIds);
+      return withAllProjectKeys(uniqueProjectIds, wordsByProject);
+    } catch (error) {
+      console.warn('[load-helpers] getAllWordsByProjectIds failed; falling back to local bulk/per-project word loads', error);
+    }
   }
 
   if (repository.getAllWordsByProject) {
-    const wordsByProject = await repository.getAllWordsByProject(uniqueProjectIds);
-    return withAllProjectKeys(uniqueProjectIds, wordsByProject);
+    try {
+      const wordsByProject = await repository.getAllWordsByProject(uniqueProjectIds);
+      return withAllProjectKeys(uniqueProjectIds, wordsByProject);
+    } catch (error) {
+      console.warn('[load-helpers] getAllWordsByProject failed; falling back to per-project word loads', error);
+    }
   }
 
-  const wordsArrays = await Promise.all(uniqueProjectIds.map((projectId) => repository.getWords(projectId)));
-  const wordsByProject = Object.fromEntries(
-    uniqueProjectIds.map((projectId, index) => [projectId, wordsArrays[index] ?? []])
+  const wordsArrays = await Promise.allSettled(
+    uniqueProjectIds.map((projectId) => repository.getWords(projectId))
   );
+  const wordsByProject: Record<string, Word[]> = {};
+  uniqueProjectIds.forEach((projectId, index) => {
+    const result = wordsArrays[index];
+    if (result?.status === 'fulfilled') {
+      wordsByProject[projectId] = result.value ?? [];
+      return;
+    }
+
+    console.warn('[load-helpers] getWords failed; using an empty word list for project', {
+      projectId,
+      error: result?.reason,
+    });
+    wordsByProject[projectId] = [];
+  });
 
   return withAllProjectKeys(uniqueProjectIds, wordsByProject);
 }


### PR DESCRIPTION
## Summary
- Make project word loading tolerate bulk fetch failures instead of failing the whole home/projects view
- Fall back from remote bulk to local bulk or per-project loads, keeping failed projects as empty word lists
- Add tests for the fallback paths

## Verification
- npm test
- npm run lint:web (0 errors, existing warnings)
- npm run build