### PR TITLE
fix: use relation-free word select fallback

### DIFF
--- a/src/lib/db/remote-repository.test.ts
+++ b/src/lib/db/remote-repository.test.ts
@@ -2,6 +2,12 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import fs from 'node:fs';
 import { WORDS_SELECT_COLUMNS } from './remote-repository';
+import {
+  RESOLVED_WORD_MINIMAL_SELECT_COLUMNS,
+  RESOLVED_WORD_SELECT_COLUMNS_BASIC,
+  SHARE_VIEW_WORD_SELECT_COLUMNS_BASIC,
+  SHARE_VIEW_WORD_SELECT_COLUMNS_MINIMAL,
+} from '@/lib/words/resolved';
 
 test('WORDS_SELECT_COLUMNS excludes embedding and includes required columns', () => {
   assert.equal(WORDS_SELECT_COLUMNS.includes('embedding'), false);
@@ -59,6 +65,7 @@ test('word read methods query through compatibility fallback helpers', () => {
   assert.match(source, /primary: WORDS_SELECT_COLUMNS/);
   assert.match(source, /withoutSenses: WORDS_SELECT_COLUMNS_WITHOUT_SENSES/);
   assert.match(source, /basic: WORDS_SELECT_COLUMNS_BASIC/);
+  assert.match(source, /minimal: WORDS_SELECT_COLUMNS_MINIMAL/);
 
   assert.match(
     source,
@@ -78,12 +85,30 @@ test('word read methods query through compatibility fallback helpers', () => {
   );
 });
 
+test('basic word compatibility selects avoid all relation embeds', () => {
+  for (const columns of [
+    RESOLVED_WORD_SELECT_COLUMNS_BASIC,
+    SHARE_VIEW_WORD_SELECT_COLUMNS_BASIC,
+    RESOLVED_WORD_MINIMAL_SELECT_COLUMNS,
+    SHARE_VIEW_WORD_SELECT_COLUMNS_MINIMAL,
+  ]) {
+    assert.equal(columns.includes('word_translations('), false);
+    assert.equal(columns.includes('lexicon_entries('), false);
+    assert.equal(columns.includes('lexicon_senses('), false);
+  }
+
+  assert.equal(RESOLVED_WORD_MINIMAL_SELECT_COLUMNS, SHARE_VIEW_WORD_SELECT_COLUMNS_MINIMAL);
+  assert.equal(RESOLVED_WORD_MINIMAL_SELECT_COLUMNS.includes('lexicon_entry_id'), false);
+  assert.equal(RESOLVED_WORD_MINIMAL_SELECT_COLUMNS.includes('lexicon_sense_id'), false);
+});
+
 test('shared preview fetches only a limited page with an exact count through fallback helper', () => {
   const source = fs.readFileSync(new URL('./remote-repository.ts', import.meta.url), 'utf8');
 
   assert.match(source, /primary: SHARE_VIEW_WORD_SELECT_COLUMNS/);
   assert.match(source, /withoutSenses: SHARE_VIEW_WORD_SELECT_COLUMNS_WITHOUT_SENSES/);
   assert.match(source, /basic: SHARE_VIEW_WORD_SELECT_COLUMNS_BASIC/);
+  assert.match(source, /minimal: SHARE_VIEW_WORD_SELECT_COLUMNS_MINIMAL/);
   assert.match(
     source,
     /async getWordsForSharePreview\(projectId: string, limit = 5\): Promise<SharedWordsPreview> \{[\s\S]*?this\.selectShareWordsWithFallback\([\s\S]*?\.select\(columns, \{ count: 'exact' \}\)[\s\S]*?\.limit\(limit\)/

--- a/src/lib/db/remote-repository.test.ts
+++ b/src/lib/db/remote-repository.test.ts
@@ -66,6 +66,8 @@ test('word read methods query through compatibility fallback helpers', () => {
   assert.match(source, /withoutSenses: WORDS_SELECT_COLUMNS_WITHOUT_SENSES/);
   assert.match(source, /basic: WORDS_SELECT_COLUMNS_BASIC/);
   assert.match(source, /minimal: WORDS_SELECT_COLUMNS_MINIMAL/);
+  assert.match(source, /error\.code === '42703'/);
+  assert.match(source, /column \.\* does not exist/);
 
   assert.match(
     source,

--- a/src/lib/db/remote-repository.ts
+++ b/src/lib/db/remote-repository.ts
@@ -28,9 +28,11 @@ import {
 import {
   RESOLVED_WORD_SELECT_COLUMNS,
   RESOLVED_WORD_SELECT_COLUMNS_BASIC,
+  RESOLVED_WORD_MINIMAL_SELECT_COLUMNS,
   RESOLVED_WORD_SELECT_COLUMNS_WITHOUT_SENSES,
   SHARE_VIEW_WORD_SELECT_COLUMNS,
   SHARE_VIEW_WORD_SELECT_COLUMNS_BASIC,
+  SHARE_VIEW_WORD_SELECT_COLUMNS_MINIMAL,
   SHARE_VIEW_WORD_SELECT_COLUMNS_WITHOUT_SENSES,
 } from '@/lib/words/resolved';
 
@@ -40,6 +42,7 @@ import {
 export const WORDS_SELECT_COLUMNS = RESOLVED_WORD_SELECT_COLUMNS;
 const WORDS_SELECT_COLUMNS_WITHOUT_SENSES = RESOLVED_WORD_SELECT_COLUMNS_WITHOUT_SENSES;
 const WORDS_SELECT_COLUMNS_BASIC = RESOLVED_WORD_SELECT_COLUMNS_BASIC;
+const WORDS_SELECT_COLUMNS_MINIMAL = RESOLVED_WORD_MINIMAL_SELECT_COLUMNS;
 
 type SupabaseSelectError = {
   code?: string;
@@ -99,6 +102,7 @@ export class RemoteWordRepository implements WordRepository {
       primary: string;
       withoutSenses: string;
       basic: string;
+      minimal: string;
       label: string;
     },
   ): Promise<T> {
@@ -116,11 +120,20 @@ export class RemoteWordRepository implements WordRepository {
       return withoutSenses;
     }
 
-    console.warn(`[RemoteRepo] ${columns.label} compatibility fallback without translation relations`, {
+    console.warn(`[RemoteRepo] ${columns.label} compatibility fallback without relation embeds`, {
       code: withoutSenses.error?.code,
       message: withoutSenses.error?.message,
     });
-    return buildQuery(columns.basic);
+    const basic = await buildQuery(columns.basic);
+    if (!shouldRetryWordSelectWithoutRelations(basic.error)) {
+      return basic;
+    }
+
+    console.warn(`[RemoteRepo] ${columns.label} compatibility fallback with minimal word columns`, {
+      code: basic.error?.code,
+      message: basic.error?.message,
+    });
+    return buildQuery(columns.minimal);
   }
 
   private async selectFullWordsWithFallback<T extends SupabaseSelectResult>(
@@ -131,6 +144,7 @@ export class RemoteWordRepository implements WordRepository {
       primary: WORDS_SELECT_COLUMNS,
       withoutSenses: WORDS_SELECT_COLUMNS_WITHOUT_SENSES,
       basic: WORDS_SELECT_COLUMNS_BASIC,
+      minimal: WORDS_SELECT_COLUMNS_MINIMAL,
       label,
     });
   }
@@ -143,6 +157,7 @@ export class RemoteWordRepository implements WordRepository {
       primary: SHARE_VIEW_WORD_SELECT_COLUMNS,
       withoutSenses: SHARE_VIEW_WORD_SELECT_COLUMNS_WITHOUT_SENSES,
       basic: SHARE_VIEW_WORD_SELECT_COLUMNS_BASIC,
+      minimal: SHARE_VIEW_WORD_SELECT_COLUMNS_MINIMAL,
       label,
     });
   }

--- a/src/lib/db/remote-repository.ts
+++ b/src/lib/db/remote-repository.ts
@@ -63,7 +63,11 @@ function shouldRetryWordSelectWithoutRelations(error: SupabaseSelectError | null
   return (
     error.code === 'PGRST200'
     || error.code === 'PGRST204'
+    || error.code === '42703'
     || /schema cache/i.test(text)
+    || /column .* does not exist/i.test(text)
+    || /could not find .* column/i.test(text)
+    || /undefined column/i.test(text)
     || /relationship/i.test(text)
     || /word_translations|lexicon_senses/i.test(text)
   );

--- a/src/lib/projects/load-helpers.ts
+++ b/src/lib/projects/load-helpers.ts
@@ -25,6 +25,28 @@ function withAllProjectKeys(
   return normalized;
 }
 
+function summarizeLoadError(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+  if (error && typeof error === 'object') {
+    const record = error as Record<string, unknown>;
+    const parts = [
+      typeof record.code === 'string' ? record.code : undefined,
+      typeof record.message === 'string' ? record.message : undefined,
+      typeof record.details === 'string' ? record.details : undefined,
+      typeof record.hint === 'string' ? record.hint : undefined,
+    ].filter(Boolean);
+    if (parts.length > 0) return parts.join(' | ');
+  }
+
+  try {
+    return JSON.stringify(error);
+  } catch {
+    return String(error);
+  }
+}
+
 export async function getWordsByProjectMap(
   repository: WordReadRepository,
   projectIds: string[]
@@ -61,8 +83,10 @@ export async function getWordsByProjectMap(
       return;
     }
 
-    console.warn('[load-helpers] getWords failed; using an empty word list for project', {
+    const summary = summarizeLoadError(result?.reason);
+    console.warn(`[load-helpers] getWords failed for project ${projectId}: ${summary}; using an empty word list`, {
       projectId,
+      summary,
       error: result?.reason,
     });
     wordsByProject[projectId] = [];

--- a/src/lib/words/resolved.ts
+++ b/src/lib/words/resolved.ts
@@ -18,6 +18,9 @@ export const RESOLVED_WORD_TEXT_BASE_SELECT_COLUMNS =
 export const SHARE_VIEW_WORD_BASE_SELECT_COLUMNS =
   'id, project_id, english, japanese, japanese_source, vocabulary_type, lexicon_entry_id, lexicon_sense_id, distractors, example_sentence, example_sentence_ja, pronunciation, part_of_speech_tags, word_order_quiz, created_at' as const;
 
+export const RESOLVED_WORD_MINIMAL_SELECT_COLUMNS =
+  'id, project_id, english, japanese, distractors, status, created_at' as const;
+
 export const RESOLVED_WORD_SELECT_COLUMNS =
   `${RESOLVED_WORD_BASE_SELECT_COLUMNS}, word_translations(${WORD_TRANSLATION_SELECT_COLUMNS}), lexicon_entries(${LEXICON_ENTRY_SELECT_COLUMNS}), lexicon_senses(${LEXICON_SENSE_SELECT_COLUMNS})` as const;
 
@@ -25,7 +28,7 @@ export const RESOLVED_WORD_SELECT_COLUMNS_WITHOUT_SENSES =
   `${RESOLVED_WORD_BASE_SELECT_COLUMNS}, word_translations(${WORD_TRANSLATION_SELECT_COLUMNS}), lexicon_entries(${LEXICON_ENTRY_SELECT_COLUMNS})` as const;
 
 export const RESOLVED_WORD_SELECT_COLUMNS_BASIC =
-  `${RESOLVED_WORD_BASE_SELECT_COLUMNS}, lexicon_entries(${LEXICON_ENTRY_SELECT_COLUMNS})` as const;
+  RESOLVED_WORD_BASE_SELECT_COLUMNS;
 
 export const RESOLVED_WORD_TEXT_SELECT_COLUMNS =
   `${RESOLVED_WORD_TEXT_BASE_SELECT_COLUMNS}, word_translations(${WORD_TRANSLATION_SELECT_COLUMNS}), lexicon_entries(${LEXICON_ENTRY_SELECT_COLUMNS}), lexicon_senses(${LEXICON_SENSE_SELECT_COLUMNS})` as const;
@@ -34,7 +37,10 @@ export const RESOLVED_WORD_TEXT_SELECT_COLUMNS_WITHOUT_SENSES =
   `${RESOLVED_WORD_TEXT_BASE_SELECT_COLUMNS}, word_translations(${WORD_TRANSLATION_SELECT_COLUMNS}), lexicon_entries(${LEXICON_ENTRY_SELECT_COLUMNS})` as const;
 
 export const RESOLVED_WORD_TEXT_SELECT_COLUMNS_BASIC =
-  `${RESOLVED_WORD_TEXT_BASE_SELECT_COLUMNS}, lexicon_entries(${LEXICON_ENTRY_SELECT_COLUMNS})` as const;
+  RESOLVED_WORD_TEXT_BASE_SELECT_COLUMNS;
+
+export const RESOLVED_WORD_TEXT_SELECT_COLUMNS_MINIMAL =
+  RESOLVED_WORD_MINIMAL_SELECT_COLUMNS;
 
 export const SHARE_VIEW_WORD_SELECT_COLUMNS =
   `${SHARE_VIEW_WORD_BASE_SELECT_COLUMNS}, word_translations(${WORD_TRANSLATION_SELECT_COLUMNS}), lexicon_entries(${LEXICON_ENTRY_SELECT_COLUMNS}), lexicon_senses(${LEXICON_SENSE_SELECT_COLUMNS})` as const;
@@ -43,7 +49,10 @@ export const SHARE_VIEW_WORD_SELECT_COLUMNS_WITHOUT_SENSES =
   `${SHARE_VIEW_WORD_BASE_SELECT_COLUMNS}, word_translations(${WORD_TRANSLATION_SELECT_COLUMNS}), lexicon_entries(${LEXICON_ENTRY_SELECT_COLUMNS})` as const;
 
 export const SHARE_VIEW_WORD_SELECT_COLUMNS_BASIC =
-  `${SHARE_VIEW_WORD_BASE_SELECT_COLUMNS}, lexicon_entries(${LEXICON_ENTRY_SELECT_COLUMNS})` as const;
+  SHARE_VIEW_WORD_BASE_SELECT_COLUMNS;
+
+export const SHARE_VIEW_WORD_SELECT_COLUMNS_MINIMAL =
+  RESOLVED_WORD_MINIMAL_SELECT_COLUMNS;
 
 export const RESOLVED_WORD_WITH_EMBEDDING_SELECT_COLUMNS =
   `${RESOLVED_WORD_TEXT_SELECT_COLUMNS}, embedding` as const;


### PR DESCRIPTION
## Summary
- Make the final remote word select fallback use only words table columns, with no embedded relations
- Add a minimal words-column fallback for schema-cache, missing-column, and Postgres 42703 compatibility
- Print the actual per-project word-load error summary in the browser console instead of an opaque Object
- Cover the fallback constants and retry guard in tests

## Verification
- npm test
- npm run lint:web (0 errors, existing warnings)
- npm run build