### PR TITLE
fix: preserve examples in word select fallback

### DIFF
--- a/src/lib/db/remote-repository.test.ts
+++ b/src/lib/db/remote-repository.test.ts
@@ -3,9 +3,13 @@ import assert from 'node:assert/strict';
 import fs from 'node:fs';
 import { WORDS_SELECT_COLUMNS } from './remote-repository';
 import {
+  RESOLVED_WORD_DISPLAY_SELECT_COLUMNS,
+  RESOLVED_WORD_EXAMPLE_SELECT_COLUMNS,
   RESOLVED_WORD_MINIMAL_SELECT_COLUMNS,
   RESOLVED_WORD_SELECT_COLUMNS_BASIC,
   SHARE_VIEW_WORD_SELECT_COLUMNS_BASIC,
+  SHARE_VIEW_WORD_SELECT_COLUMNS_DISPLAY,
+  SHARE_VIEW_WORD_SELECT_COLUMNS_EXAMPLE,
   SHARE_VIEW_WORD_SELECT_COLUMNS_MINIMAL,
 } from '@/lib/words/resolved';
 
@@ -65,6 +69,8 @@ test('word read methods query through compatibility fallback helpers', () => {
   assert.match(source, /primary: WORDS_SELECT_COLUMNS/);
   assert.match(source, /withoutSenses: WORDS_SELECT_COLUMNS_WITHOUT_SENSES/);
   assert.match(source, /basic: WORDS_SELECT_COLUMNS_BASIC/);
+  assert.match(source, /display: WORDS_SELECT_COLUMNS_DISPLAY/);
+  assert.match(source, /example: WORDS_SELECT_COLUMNS_EXAMPLE/);
   assert.match(source, /minimal: WORDS_SELECT_COLUMNS_MINIMAL/);
   assert.match(source, /error\.code === '42703'/);
   assert.match(source, /column \.\* does not exist/);
@@ -91,6 +97,10 @@ test('basic word compatibility selects avoid all relation embeds', () => {
   for (const columns of [
     RESOLVED_WORD_SELECT_COLUMNS_BASIC,
     SHARE_VIEW_WORD_SELECT_COLUMNS_BASIC,
+    RESOLVED_WORD_DISPLAY_SELECT_COLUMNS,
+    SHARE_VIEW_WORD_SELECT_COLUMNS_DISPLAY,
+    RESOLVED_WORD_EXAMPLE_SELECT_COLUMNS,
+    SHARE_VIEW_WORD_SELECT_COLUMNS_EXAMPLE,
     RESOLVED_WORD_MINIMAL_SELECT_COLUMNS,
     SHARE_VIEW_WORD_SELECT_COLUMNS_MINIMAL,
   ]) {
@@ -104,12 +114,28 @@ test('basic word compatibility selects avoid all relation embeds', () => {
   assert.equal(RESOLVED_WORD_MINIMAL_SELECT_COLUMNS.includes('lexicon_sense_id'), false);
 });
 
+test('display word compatibility selects keep examples and part of speech before minimal fallback', () => {
+  assert.equal(RESOLVED_WORD_DISPLAY_SELECT_COLUMNS, SHARE_VIEW_WORD_SELECT_COLUMNS_DISPLAY);
+  assert.equal(RESOLVED_WORD_DISPLAY_SELECT_COLUMNS.includes('example_sentence'), true);
+  assert.equal(RESOLVED_WORD_DISPLAY_SELECT_COLUMNS.includes('example_sentence_ja'), true);
+  assert.equal(RESOLVED_WORD_DISPLAY_SELECT_COLUMNS.includes('part_of_speech_tags'), true);
+  assert.equal(RESOLVED_WORD_DISPLAY_SELECT_COLUMNS.includes('custom_sections'), false);
+  assert.equal(RESOLVED_WORD_DISPLAY_SELECT_COLUMNS.includes('lexicon_sense_id'), false);
+
+  assert.equal(RESOLVED_WORD_EXAMPLE_SELECT_COLUMNS, SHARE_VIEW_WORD_SELECT_COLUMNS_EXAMPLE);
+  assert.equal(RESOLVED_WORD_EXAMPLE_SELECT_COLUMNS.includes('example_sentence'), true);
+  assert.equal(RESOLVED_WORD_EXAMPLE_SELECT_COLUMNS.includes('example_sentence_ja'), true);
+  assert.equal(RESOLVED_WORD_EXAMPLE_SELECT_COLUMNS.includes('part_of_speech_tags'), false);
+});
+
 test('shared preview fetches only a limited page with an exact count through fallback helper', () => {
   const source = fs.readFileSync(new URL('./remote-repository.ts', import.meta.url), 'utf8');
 
   assert.match(source, /primary: SHARE_VIEW_WORD_SELECT_COLUMNS/);
   assert.match(source, /withoutSenses: SHARE_VIEW_WORD_SELECT_COLUMNS_WITHOUT_SENSES/);
   assert.match(source, /basic: SHARE_VIEW_WORD_SELECT_COLUMNS_BASIC/);
+  assert.match(source, /display: SHARE_VIEW_WORD_SELECT_COLUMNS_DISPLAY/);
+  assert.match(source, /example: SHARE_VIEW_WORD_SELECT_COLUMNS_EXAMPLE/);
   assert.match(source, /minimal: SHARE_VIEW_WORD_SELECT_COLUMNS_MINIMAL/);
   assert.match(
     source,

--- a/src/lib/db/remote-repository.ts
+++ b/src/lib/db/remote-repository.ts
@@ -26,12 +26,16 @@ import {
   type CollectionProjectRow,
 } from '../../../shared/db';
 import {
+  RESOLVED_WORD_DISPLAY_SELECT_COLUMNS,
+  RESOLVED_WORD_EXAMPLE_SELECT_COLUMNS,
   RESOLVED_WORD_SELECT_COLUMNS,
   RESOLVED_WORD_SELECT_COLUMNS_BASIC,
   RESOLVED_WORD_MINIMAL_SELECT_COLUMNS,
   RESOLVED_WORD_SELECT_COLUMNS_WITHOUT_SENSES,
   SHARE_VIEW_WORD_SELECT_COLUMNS,
   SHARE_VIEW_WORD_SELECT_COLUMNS_BASIC,
+  SHARE_VIEW_WORD_SELECT_COLUMNS_DISPLAY,
+  SHARE_VIEW_WORD_SELECT_COLUMNS_EXAMPLE,
   SHARE_VIEW_WORD_SELECT_COLUMNS_MINIMAL,
   SHARE_VIEW_WORD_SELECT_COLUMNS_WITHOUT_SENSES,
 } from '@/lib/words/resolved';
@@ -42,6 +46,8 @@ import {
 export const WORDS_SELECT_COLUMNS = RESOLVED_WORD_SELECT_COLUMNS;
 const WORDS_SELECT_COLUMNS_WITHOUT_SENSES = RESOLVED_WORD_SELECT_COLUMNS_WITHOUT_SENSES;
 const WORDS_SELECT_COLUMNS_BASIC = RESOLVED_WORD_SELECT_COLUMNS_BASIC;
+const WORDS_SELECT_COLUMNS_DISPLAY = RESOLVED_WORD_DISPLAY_SELECT_COLUMNS;
+const WORDS_SELECT_COLUMNS_EXAMPLE = RESOLVED_WORD_EXAMPLE_SELECT_COLUMNS;
 const WORDS_SELECT_COLUMNS_MINIMAL = RESOLVED_WORD_MINIMAL_SELECT_COLUMNS;
 
 type SupabaseSelectError = {
@@ -106,6 +112,8 @@ export class RemoteWordRepository implements WordRepository {
       primary: string;
       withoutSenses: string;
       basic: string;
+      display: string;
+      example: string;
       minimal: string;
       label: string;
     },
@@ -133,9 +141,27 @@ export class RemoteWordRepository implements WordRepository {
       return basic;
     }
 
-    console.warn(`[RemoteRepo] ${columns.label} compatibility fallback with minimal word columns`, {
+    console.warn(`[RemoteRepo] ${columns.label} compatibility fallback with display word columns`, {
       code: basic.error?.code,
       message: basic.error?.message,
+    });
+    const display = await buildQuery(columns.display);
+    if (!shouldRetryWordSelectWithoutRelations(display.error)) {
+      return display;
+    }
+
+    console.warn(`[RemoteRepo] ${columns.label} compatibility fallback with example word columns`, {
+      code: display.error?.code,
+      message: display.error?.message,
+    });
+    const example = await buildQuery(columns.example);
+    if (!shouldRetryWordSelectWithoutRelations(example.error)) {
+      return example;
+    }
+
+    console.warn(`[RemoteRepo] ${columns.label} compatibility fallback with minimal word columns`, {
+      code: example.error?.code,
+      message: example.error?.message,
     });
     return buildQuery(columns.minimal);
   }
@@ -148,6 +174,8 @@ export class RemoteWordRepository implements WordRepository {
       primary: WORDS_SELECT_COLUMNS,
       withoutSenses: WORDS_SELECT_COLUMNS_WITHOUT_SENSES,
       basic: WORDS_SELECT_COLUMNS_BASIC,
+      display: WORDS_SELECT_COLUMNS_DISPLAY,
+      example: WORDS_SELECT_COLUMNS_EXAMPLE,
       minimal: WORDS_SELECT_COLUMNS_MINIMAL,
       label,
     });
@@ -161,6 +189,8 @@ export class RemoteWordRepository implements WordRepository {
       primary: SHARE_VIEW_WORD_SELECT_COLUMNS,
       withoutSenses: SHARE_VIEW_WORD_SELECT_COLUMNS_WITHOUT_SENSES,
       basic: SHARE_VIEW_WORD_SELECT_COLUMNS_BASIC,
+      display: SHARE_VIEW_WORD_SELECT_COLUMNS_DISPLAY,
+      example: SHARE_VIEW_WORD_SELECT_COLUMNS_EXAMPLE,
       minimal: SHARE_VIEW_WORD_SELECT_COLUMNS_MINIMAL,
       label,
     });

--- a/src/lib/words/resolved.ts
+++ b/src/lib/words/resolved.ts
@@ -18,6 +18,12 @@ export const RESOLVED_WORD_TEXT_BASE_SELECT_COLUMNS =
 export const SHARE_VIEW_WORD_BASE_SELECT_COLUMNS =
   'id, project_id, english, japanese, japanese_source, vocabulary_type, lexicon_entry_id, lexicon_sense_id, distractors, example_sentence, example_sentence_ja, pronunciation, part_of_speech_tags, word_order_quiz, created_at' as const;
 
+export const RESOLVED_WORD_DISPLAY_SELECT_COLUMNS =
+  'id, project_id, english, japanese, distractors, example_sentence, example_sentence_ja, part_of_speech_tags, status, created_at, last_reviewed_at, next_review_at, ease_factor, interval_days, repetition, is_favorite' as const;
+
+export const RESOLVED_WORD_EXAMPLE_SELECT_COLUMNS =
+  'id, project_id, english, japanese, distractors, example_sentence, example_sentence_ja, status, created_at, last_reviewed_at, next_review_at, ease_factor, interval_days, repetition, is_favorite' as const;
+
 export const RESOLVED_WORD_MINIMAL_SELECT_COLUMNS =
   'id, project_id, english, japanese, distractors, status, created_at' as const;
 
@@ -50,6 +56,12 @@ export const SHARE_VIEW_WORD_SELECT_COLUMNS_WITHOUT_SENSES =
 
 export const SHARE_VIEW_WORD_SELECT_COLUMNS_BASIC =
   SHARE_VIEW_WORD_BASE_SELECT_COLUMNS;
+
+export const SHARE_VIEW_WORD_SELECT_COLUMNS_DISPLAY =
+  RESOLVED_WORD_DISPLAY_SELECT_COLUMNS;
+
+export const SHARE_VIEW_WORD_SELECT_COLUMNS_EXAMPLE =
+  RESOLVED_WORD_EXAMPLE_SELECT_COLUMNS;
 
 export const SHARE_VIEW_WORD_SELECT_COLUMNS_MINIMAL =
   RESOLVED_WORD_MINIMAL_SELECT_COLUMNS;


### PR DESCRIPTION
## Summary
- Add an intermediate display-column fallback before the minimal word select
- Preserve example_sentence, example_sentence_ja, and part_of_speech_tags when newer word columns are missing or schema cache is stale
- Keep the minimal fallback only as the final last-resort path
- Add tests covering the display/example fallback constants and fallback chain

## Verification
- npm test
- npm run lint:web (0 errors, existing warnings)
- npm run build