### PR TITLE
fix: preserve pronunciation in word select fallback

### DIFF
--- a/src/lib/db/remote-repository.test.ts
+++ b/src/lib/db/remote-repository.test.ts
@@ -3,11 +3,13 @@ import assert from 'node:assert/strict';
 import fs from 'node:fs';
 import { WORDS_SELECT_COLUMNS } from './remote-repository';
 import {
+  RESOLVED_WORD_DISPLAY_WITH_PRONUNCIATION_SELECT_COLUMNS,
   RESOLVED_WORD_DISPLAY_SELECT_COLUMNS,
   RESOLVED_WORD_EXAMPLE_SELECT_COLUMNS,
   RESOLVED_WORD_MINIMAL_SELECT_COLUMNS,
   RESOLVED_WORD_SELECT_COLUMNS_BASIC,
   SHARE_VIEW_WORD_SELECT_COLUMNS_BASIC,
+  SHARE_VIEW_WORD_SELECT_COLUMNS_DISPLAY_WITH_PRONUNCIATION,
   SHARE_VIEW_WORD_SELECT_COLUMNS_DISPLAY,
   SHARE_VIEW_WORD_SELECT_COLUMNS_EXAMPLE,
   SHARE_VIEW_WORD_SELECT_COLUMNS_MINIMAL,
@@ -69,6 +71,7 @@ test('word read methods query through compatibility fallback helpers', () => {
   assert.match(source, /primary: WORDS_SELECT_COLUMNS/);
   assert.match(source, /withoutSenses: WORDS_SELECT_COLUMNS_WITHOUT_SENSES/);
   assert.match(source, /basic: WORDS_SELECT_COLUMNS_BASIC/);
+  assert.match(source, /displayWithPronunciation: WORDS_SELECT_COLUMNS_DISPLAY_WITH_PRONUNCIATION/);
   assert.match(source, /display: WORDS_SELECT_COLUMNS_DISPLAY/);
   assert.match(source, /example: WORDS_SELECT_COLUMNS_EXAMPLE/);
   assert.match(source, /minimal: WORDS_SELECT_COLUMNS_MINIMAL/);
@@ -97,6 +100,8 @@ test('basic word compatibility selects avoid all relation embeds', () => {
   for (const columns of [
     RESOLVED_WORD_SELECT_COLUMNS_BASIC,
     SHARE_VIEW_WORD_SELECT_COLUMNS_BASIC,
+    RESOLVED_WORD_DISPLAY_WITH_PRONUNCIATION_SELECT_COLUMNS,
+    SHARE_VIEW_WORD_SELECT_COLUMNS_DISPLAY_WITH_PRONUNCIATION,
     RESOLVED_WORD_DISPLAY_SELECT_COLUMNS,
     SHARE_VIEW_WORD_SELECT_COLUMNS_DISPLAY,
     RESOLVED_WORD_EXAMPLE_SELECT_COLUMNS,
@@ -115,10 +120,22 @@ test('basic word compatibility selects avoid all relation embeds', () => {
 });
 
 test('display word compatibility selects keep examples and part of speech before minimal fallback', () => {
+  assert.equal(
+    RESOLVED_WORD_DISPLAY_WITH_PRONUNCIATION_SELECT_COLUMNS,
+    SHARE_VIEW_WORD_SELECT_COLUMNS_DISPLAY_WITH_PRONUNCIATION,
+  );
+  assert.equal(RESOLVED_WORD_DISPLAY_WITH_PRONUNCIATION_SELECT_COLUMNS.includes('example_sentence'), true);
+  assert.equal(RESOLVED_WORD_DISPLAY_WITH_PRONUNCIATION_SELECT_COLUMNS.includes('example_sentence_ja'), true);
+  assert.equal(RESOLVED_WORD_DISPLAY_WITH_PRONUNCIATION_SELECT_COLUMNS.includes('part_of_speech_tags'), true);
+  assert.equal(RESOLVED_WORD_DISPLAY_WITH_PRONUNCIATION_SELECT_COLUMNS.includes('pronunciation'), true);
+  assert.equal(RESOLVED_WORD_DISPLAY_WITH_PRONUNCIATION_SELECT_COLUMNS.includes('custom_sections'), false);
+  assert.equal(RESOLVED_WORD_DISPLAY_WITH_PRONUNCIATION_SELECT_COLUMNS.includes('lexicon_sense_id'), false);
+
   assert.equal(RESOLVED_WORD_DISPLAY_SELECT_COLUMNS, SHARE_VIEW_WORD_SELECT_COLUMNS_DISPLAY);
   assert.equal(RESOLVED_WORD_DISPLAY_SELECT_COLUMNS.includes('example_sentence'), true);
   assert.equal(RESOLVED_WORD_DISPLAY_SELECT_COLUMNS.includes('example_sentence_ja'), true);
   assert.equal(RESOLVED_WORD_DISPLAY_SELECT_COLUMNS.includes('part_of_speech_tags'), true);
+  assert.equal(RESOLVED_WORD_DISPLAY_SELECT_COLUMNS.includes('pronunciation'), false);
   assert.equal(RESOLVED_WORD_DISPLAY_SELECT_COLUMNS.includes('custom_sections'), false);
   assert.equal(RESOLVED_WORD_DISPLAY_SELECT_COLUMNS.includes('lexicon_sense_id'), false);
 
@@ -134,6 +151,7 @@ test('shared preview fetches only a limited page with an exact count through fal
   assert.match(source, /primary: SHARE_VIEW_WORD_SELECT_COLUMNS/);
   assert.match(source, /withoutSenses: SHARE_VIEW_WORD_SELECT_COLUMNS_WITHOUT_SENSES/);
   assert.match(source, /basic: SHARE_VIEW_WORD_SELECT_COLUMNS_BASIC/);
+  assert.match(source, /displayWithPronunciation: SHARE_VIEW_WORD_SELECT_COLUMNS_DISPLAY_WITH_PRONUNCIATION/);
   assert.match(source, /display: SHARE_VIEW_WORD_SELECT_COLUMNS_DISPLAY/);
   assert.match(source, /example: SHARE_VIEW_WORD_SELECT_COLUMNS_EXAMPLE/);
   assert.match(source, /minimal: SHARE_VIEW_WORD_SELECT_COLUMNS_MINIMAL/);

--- a/src/lib/db/remote-repository.ts
+++ b/src/lib/db/remote-repository.ts
@@ -26,6 +26,7 @@ import {
   type CollectionProjectRow,
 } from '../../../shared/db';
 import {
+  RESOLVED_WORD_DISPLAY_WITH_PRONUNCIATION_SELECT_COLUMNS,
   RESOLVED_WORD_DISPLAY_SELECT_COLUMNS,
   RESOLVED_WORD_EXAMPLE_SELECT_COLUMNS,
   RESOLVED_WORD_SELECT_COLUMNS,
@@ -34,6 +35,7 @@ import {
   RESOLVED_WORD_SELECT_COLUMNS_WITHOUT_SENSES,
   SHARE_VIEW_WORD_SELECT_COLUMNS,
   SHARE_VIEW_WORD_SELECT_COLUMNS_BASIC,
+  SHARE_VIEW_WORD_SELECT_COLUMNS_DISPLAY_WITH_PRONUNCIATION,
   SHARE_VIEW_WORD_SELECT_COLUMNS_DISPLAY,
   SHARE_VIEW_WORD_SELECT_COLUMNS_EXAMPLE,
   SHARE_VIEW_WORD_SELECT_COLUMNS_MINIMAL,
@@ -46,6 +48,7 @@ import {
 export const WORDS_SELECT_COLUMNS = RESOLVED_WORD_SELECT_COLUMNS;
 const WORDS_SELECT_COLUMNS_WITHOUT_SENSES = RESOLVED_WORD_SELECT_COLUMNS_WITHOUT_SENSES;
 const WORDS_SELECT_COLUMNS_BASIC = RESOLVED_WORD_SELECT_COLUMNS_BASIC;
+const WORDS_SELECT_COLUMNS_DISPLAY_WITH_PRONUNCIATION = RESOLVED_WORD_DISPLAY_WITH_PRONUNCIATION_SELECT_COLUMNS;
 const WORDS_SELECT_COLUMNS_DISPLAY = RESOLVED_WORD_DISPLAY_SELECT_COLUMNS;
 const WORDS_SELECT_COLUMNS_EXAMPLE = RESOLVED_WORD_EXAMPLE_SELECT_COLUMNS;
 const WORDS_SELECT_COLUMNS_MINIMAL = RESOLVED_WORD_MINIMAL_SELECT_COLUMNS;
@@ -112,6 +115,7 @@ export class RemoteWordRepository implements WordRepository {
       primary: string;
       withoutSenses: string;
       basic: string;
+      displayWithPronunciation: string;
       display: string;
       example: string;
       minimal: string;
@@ -141,9 +145,18 @@ export class RemoteWordRepository implements WordRepository {
       return basic;
     }
 
-    console.warn(`[RemoteRepo] ${columns.label} compatibility fallback with display word columns`, {
+    console.warn(`[RemoteRepo] ${columns.label} compatibility fallback with display word columns including pronunciation`, {
       code: basic.error?.code,
       message: basic.error?.message,
+    });
+    const displayWithPronunciation = await buildQuery(columns.displayWithPronunciation);
+    if (!shouldRetryWordSelectWithoutRelations(displayWithPronunciation.error)) {
+      return displayWithPronunciation;
+    }
+
+    console.warn(`[RemoteRepo] ${columns.label} compatibility fallback with display word columns`, {
+      code: displayWithPronunciation.error?.code,
+      message: displayWithPronunciation.error?.message,
     });
     const display = await buildQuery(columns.display);
     if (!shouldRetryWordSelectWithoutRelations(display.error)) {
@@ -174,6 +187,7 @@ export class RemoteWordRepository implements WordRepository {
       primary: WORDS_SELECT_COLUMNS,
       withoutSenses: WORDS_SELECT_COLUMNS_WITHOUT_SENSES,
       basic: WORDS_SELECT_COLUMNS_BASIC,
+      displayWithPronunciation: WORDS_SELECT_COLUMNS_DISPLAY_WITH_PRONUNCIATION,
       display: WORDS_SELECT_COLUMNS_DISPLAY,
       example: WORDS_SELECT_COLUMNS_EXAMPLE,
       minimal: WORDS_SELECT_COLUMNS_MINIMAL,
@@ -189,6 +203,7 @@ export class RemoteWordRepository implements WordRepository {
       primary: SHARE_VIEW_WORD_SELECT_COLUMNS,
       withoutSenses: SHARE_VIEW_WORD_SELECT_COLUMNS_WITHOUT_SENSES,
       basic: SHARE_VIEW_WORD_SELECT_COLUMNS_BASIC,
+      displayWithPronunciation: SHARE_VIEW_WORD_SELECT_COLUMNS_DISPLAY_WITH_PRONUNCIATION,
       display: SHARE_VIEW_WORD_SELECT_COLUMNS_DISPLAY,
       example: SHARE_VIEW_WORD_SELECT_COLUMNS_EXAMPLE,
       minimal: SHARE_VIEW_WORD_SELECT_COLUMNS_MINIMAL,

--- a/src/lib/words/resolved.ts
+++ b/src/lib/words/resolved.ts
@@ -18,6 +18,9 @@ export const RESOLVED_WORD_TEXT_BASE_SELECT_COLUMNS =
 export const SHARE_VIEW_WORD_BASE_SELECT_COLUMNS =
   'id, project_id, english, japanese, japanese_source, vocabulary_type, lexicon_entry_id, lexicon_sense_id, distractors, example_sentence, example_sentence_ja, pronunciation, part_of_speech_tags, word_order_quiz, created_at' as const;
 
+export const RESOLVED_WORD_DISPLAY_WITH_PRONUNCIATION_SELECT_COLUMNS =
+  'id, project_id, english, japanese, distractors, example_sentence, example_sentence_ja, pronunciation, part_of_speech_tags, status, created_at, last_reviewed_at, next_review_at, ease_factor, interval_days, repetition, is_favorite' as const;
+
 export const RESOLVED_WORD_DISPLAY_SELECT_COLUMNS =
   'id, project_id, english, japanese, distractors, example_sentence, example_sentence_ja, part_of_speech_tags, status, created_at, last_reviewed_at, next_review_at, ease_factor, interval_days, repetition, is_favorite' as const;
 
@@ -56,6 +59,9 @@ export const SHARE_VIEW_WORD_SELECT_COLUMNS_WITHOUT_SENSES =
 
 export const SHARE_VIEW_WORD_SELECT_COLUMNS_BASIC =
   SHARE_VIEW_WORD_BASE_SELECT_COLUMNS;
+
+export const SHARE_VIEW_WORD_SELECT_COLUMNS_DISPLAY_WITH_PRONUNCIATION =
+  RESOLVED_WORD_DISPLAY_WITH_PRONUNCIATION_SELECT_COLUMNS;
 
 export const SHARE_VIEW_WORD_SELECT_COLUMNS_DISPLAY =
   RESOLVED_WORD_DISPLAY_SELECT_COLUMNS;


### PR DESCRIPTION
## Summary
- Add a pronunciation-preserving display fallback before the lower-fidelity word select fallbacks.
- Keep examples, Japanese examples, part-of-speech tags, and pronunciation together when relation-free selects are needed.
- Cover the new fallback constants and fallback chain in repository tests.

## Root Cause
The previous compatibility fallback restored examples and part-of-speech tags, but the first successful relation-free display select omitted `pronunciation`. That allowed word loading to recover while hiding pronunciation symbols.

## Verification
- `npx tsx --test src/lib/db/remote-repository.test.ts src/lib/projects/load-helpers.test.ts`
- `npm test`
- `npm run lint:web` (0 errors, existing warnings)
- `npm run build`