### PR TITLE
fix: unify quiz answer colors and fix exit bug

### DIFF
--- a/src/app/quiz/[projectId]/page.tsx
+++ b/src/app/quiz/[projectId]/page.tsx
@@ -212,17 +212,21 @@ function DSQuizOption({
   let icon: ReactNode = null;
 
   if (isCorrectAnswer) {
-    faceBg = 'rgba(61,122,78,0.08)';
-    shadowColor = 'var(--color-success)';
-    badgeBg = 'var(--color-success)';
+    faceBg = 'var(--color-accent)';
+    borderColor = 'var(--color-accent-ink)';
+    shadowColor = 'var(--color-accent-ink)';
+    textColor = '#fff';
+    badgeBg = 'rgba(255,255,255,0.22)';
     badgeColor = '#fff';
-    icon = <Icon name="check" size={18} className="text-[var(--color-success)]" />;
+    icon = <Icon name="check" size={18} className="text-white" />;
   } else if (isWrongAnswer) {
-    faceBg = 'rgba(184,72,72,0.08)';
-    shadowColor = 'var(--color-error)';
-    badgeBg = 'var(--color-error)';
+    faceBg = 'var(--color-error)';
+    borderColor = '#b91c1c';
+    shadowColor = '#b91c1c';
+    textColor = '#fff';
+    badgeBg = 'rgba(255,255,255,0.22)';
     badgeColor = '#fff';
-    icon = <Icon name="close" size={18} className="text-[var(--color-error)]" />;
+    icon = <Icon name="close" size={18} className="text-white" />;
   } else if (isInactive) {
     borderColor = 'var(--color-border)';
     shadowColor = 'var(--color-border)';
@@ -457,16 +461,16 @@ function DSWordOrderPanel({
 
       {isRevealed && (
         <div
-          className="rounded-xl border p-3 text-center"
+          className="rounded-xl border-2 p-3 text-center"
           style={{
-            borderColor: result === 'correct' ? 'var(--color-success)' : 'var(--color-error)',
-            background: result === 'correct' ? 'rgba(61,122,78,0.08)' : 'rgba(184,72,72,0.08)',
+            borderColor: result === 'correct' ? 'var(--color-accent-ink)' : '#b91c1c',
+            background: result === 'correct' ? 'var(--color-accent)' : 'var(--color-error)',
           }}
         >
-          <p className="text-sm font-bold text-[var(--solid-ink)]">
+          <p className="text-sm font-bold text-white/85">
             {result === 'correct' ? '正解' : '不正解'}
           </p>
-          <p className="mt-1 text-lg font-black text-[var(--solid-ink)]">{question.word.english}</p>
+          <p className="mt-1 text-lg font-black text-white">{question.word.english}</p>
         </div>
       )}
 
@@ -511,16 +515,6 @@ export default function QuizPage() {
     const parsed = Number.parseInt(countFromUrl, 10);
     return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_QUESTION_COUNT;
   });
-
-  const backToProject = useCallback(() => {
-    // Reminder quizzes open in a fresh window from a push notification, so
-    // there is no history to go back to.
-    if (reminderMode) {
-      router.push('/');
-      return;
-    }
-    router.back();
-  }, [router, reminderMode]);
 
   const [allWords, setAllWords] = useState<Word[]>([]);
   const [questions, setQuestions] = useState<QuizQuestion[]>([]);
@@ -592,6 +586,15 @@ export default function QuizPage() {
   const clearQuizState = useCallback(() => {
     try { sessionStorage.removeItem(storageKey); } catch { /* ignore */ }
   }, [storageKey]);
+
+  const backToProject = useCallback(() => {
+    clearQuizState();
+    if (reminderMode) {
+      router.push('/');
+      return;
+    }
+    router.back();
+  }, [clearQuizState, router, reminderMode]);
 
   const goToNextReviewQuiz = useCallback(() => {
     clearQuizState();
@@ -1721,11 +1724,11 @@ export default function QuizPage() {
             )}
             {isRevealed && typeInResult === 'wrong' && currentQuestion && (
               <div
-                className="rounded-xl border p-3 text-center"
-                style={{ borderColor: 'var(--color-success)', background: 'rgba(61,122,78,0.08)' }}
+                className="rounded-xl border-2 p-3 text-center"
+                style={{ borderColor: 'var(--color-accent-ink)', background: 'var(--color-accent)' }}
               >
-                <p className="text-sm font-bold text-[var(--solid-ink)]">正解</p>
-                <p className="mt-1 text-lg font-black text-[var(--solid-ink)]">
+                <p className="text-sm font-bold text-white/85">正解</p>
+                <p className="mt-1 text-lg font-black text-white">
                   {currentQuestion.word.english}
                 </p>
               </div>

--- a/src/app/quiz/[projectId]/page.tsx
+++ b/src/app/quiz/[projectId]/page.tsx
@@ -212,21 +212,17 @@ function DSQuizOption({
   let icon: ReactNode = null;
 
   if (isCorrectAnswer) {
-    faceBg = 'var(--color-accent)';
-    borderColor = 'var(--color-accent-ink)';
-    shadowColor = 'var(--color-accent-ink)';
-    textColor = '#fff';
-    badgeBg = 'rgba(255,255,255,0.22)';
+    faceBg = 'rgba(61,122,78,0.08)';
+    shadowColor = 'var(--color-success)';
+    badgeBg = 'var(--color-success)';
     badgeColor = '#fff';
-    icon = <Icon name="check" size={18} className="text-white" />;
+    icon = <Icon name="check" size={18} className="text-[var(--color-success)]" />;
   } else if (isWrongAnswer) {
-    faceBg = 'var(--color-error)';
-    borderColor = '#b91c1c';
-    shadowColor = '#b91c1c';
-    textColor = '#fff';
-    badgeBg = 'rgba(255,255,255,0.22)';
+    faceBg = 'rgba(184,72,72,0.08)';
+    shadowColor = 'var(--color-error)';
+    badgeBg = 'var(--color-error)';
     badgeColor = '#fff';
-    icon = <Icon name="close" size={18} className="text-white" />;
+    icon = <Icon name="close" size={18} className="text-[var(--color-error)]" />;
   } else if (isInactive) {
     borderColor = 'var(--color-border)';
     shadowColor = 'var(--color-border)';
@@ -461,16 +457,16 @@ function DSWordOrderPanel({
 
       {isRevealed && (
         <div
-          className="rounded-xl border-2 p-3 text-center"
+          className="rounded-xl border p-3 text-center"
           style={{
-            borderColor: result === 'correct' ? 'var(--color-accent-ink)' : '#b91c1c',
-            background: result === 'correct' ? 'var(--color-accent)' : 'var(--color-error)',
+            borderColor: result === 'correct' ? 'var(--color-success)' : 'var(--color-error)',
+            background: result === 'correct' ? 'rgba(61,122,78,0.08)' : 'rgba(184,72,72,0.08)',
           }}
         >
-          <p className="text-sm font-bold text-white/85">
+          <p className="text-sm font-bold text-[var(--solid-ink)]">
             {result === 'correct' ? '正解' : '不正解'}
           </p>
-          <p className="mt-1 text-lg font-black text-white">{question.word.english}</p>
+          <p className="mt-1 text-lg font-black text-[var(--solid-ink)]">{question.word.english}</p>
         </div>
       )}
 

--- a/src/app/quiz/[projectId]/page.tsx
+++ b/src/app/quiz/[projectId]/page.tsx
@@ -212,17 +212,21 @@ function DSQuizOption({
   let icon: ReactNode = null;
 
   if (isCorrectAnswer) {
-    faceBg = 'rgba(61,122,78,0.08)';
-    shadowColor = 'var(--color-success)';
-    badgeBg = 'var(--color-success)';
+    faceBg = 'var(--color-accent)';
+    borderColor = 'var(--color-accent-ink)';
+    shadowColor = 'var(--color-accent-ink)';
+    textColor = '#fff';
+    badgeBg = 'rgba(255,255,255,0.22)';
     badgeColor = '#fff';
-    icon = <Icon name="check" size={18} className="text-[var(--color-success)]" />;
+    icon = <Icon name="check" size={18} className="text-white" />;
   } else if (isWrongAnswer) {
-    faceBg = 'rgba(184,72,72,0.08)';
-    shadowColor = 'var(--color-error)';
-    badgeBg = 'var(--color-error)';
+    faceBg = 'var(--color-error)';
+    borderColor = '#b91c1c';
+    shadowColor = '#b91c1c';
+    textColor = '#fff';
+    badgeBg = 'rgba(255,255,255,0.22)';
     badgeColor = '#fff';
-    icon = <Icon name="close" size={18} className="text-[var(--color-error)]" />;
+    icon = <Icon name="close" size={18} className="text-white" />;
   } else if (isInactive) {
     borderColor = 'var(--color-border)';
     shadowColor = 'var(--color-border)';
@@ -457,16 +461,16 @@ function DSWordOrderPanel({
 
       {isRevealed && (
         <div
-          className="rounded-xl border p-3 text-center"
+          className="rounded-xl border-2 p-3 text-center"
           style={{
-            borderColor: result === 'correct' ? 'var(--color-success)' : 'var(--color-error)',
-            background: result === 'correct' ? 'rgba(61,122,78,0.08)' : 'rgba(184,72,72,0.08)',
+            borderColor: result === 'correct' ? 'var(--color-accent-ink)' : '#b91c1c',
+            background: result === 'correct' ? 'var(--color-accent)' : 'var(--color-error)',
           }}
         >
-          <p className="text-sm font-bold text-[var(--solid-ink)]">
+          <p className="text-sm font-bold text-white/85">
             {result === 'correct' ? '正解' : '不正解'}
           </p>
-          <p className="mt-1 text-lg font-black text-[var(--solid-ink)]">{question.word.english}</p>
+          <p className="mt-1 text-lg font-black text-white">{question.word.english}</p>
         </div>
       )}
 

--- a/src/components/quiz/TypeInQuizField.tsx
+++ b/src/components/quiz/TypeInQuizField.tsx
@@ -79,18 +79,14 @@ export function TypeInQuizField({
         ? 'border-[#b91c1c] bg-[var(--color-error)]'
         : 'border-[var(--color-border)] bg-[var(--color-surface)] focus-within:border-[var(--color-foreground)]';
 
-  const typedColorClass = isSolid
-    ? result === 'correct'
-      ? 'text-[var(--color-success)]'
-      : result === 'wrong'
-        ? 'text-[var(--color-error)]'
-        : 'text-[var(--solid-ink)]'
-    : result
-      ? 'text-white'
+  const typedColorClass = result
+    ? 'text-white'
+    : isSolid
+      ? 'text-[var(--solid-ink)]'
       : 'text-[var(--color-foreground)]';
 
   const underscoreClass = `${
-    !isSolid && result ? 'text-white/60' : 'text-[var(--color-muted)]/50'
+    result ? 'text-white/60' : 'text-[var(--color-muted)]/50'
   } font-medium text-xl min-w-[0.55em] text-center`;
   const hintClass = 'text-[var(--color-muted)]/70 font-medium text-xl';
   const caretClass = isSolid ? 'bg-[var(--color-accent)]' : 'bg-blue-600';
@@ -134,10 +130,7 @@ export function TypeInQuizField({
         <Icon
           name={result === 'correct' ? 'check' : 'close'}
           size={20}
-          className={`ml-1.5 shrink-0 ${isSolid
-            ? result === 'correct' ? 'text-[var(--color-success)]' : 'text-[var(--color-error)]'
-            : 'text-white'
-          }`}
+          className="ml-1.5 shrink-0 text-white"
         />
       )}
     </div>
@@ -188,15 +181,17 @@ export function TypeInQuizField({
   }
 
   let faceBg = 'var(--color-surface)';
-  const borderColor = 'var(--solid-ink)';
+  let borderColor = 'var(--solid-ink)';
   let shadowColor = 'var(--solid-ink)';
 
   if (result === 'correct') {
-    faceBg = 'rgba(61,122,78,0.08)';
-    shadowColor = 'var(--color-success)';
+    faceBg = 'var(--color-accent)';
+    borderColor = 'var(--color-accent-ink)';
+    shadowColor = 'var(--color-accent-ink)';
   } else if (result === 'wrong') {
-    faceBg = 'rgba(184,72,72,0.08)';
-    shadowColor = 'var(--color-error)';
+    faceBg = 'var(--color-error)';
+    borderColor = '#b91c1c';
+    shadowColor = '#b91c1c';
   }
 
   return (


### PR DESCRIPTION
## Summary
- All quiz types (four-choice, word-order, active/type-in) now use the same solid color scheme on both mobile and desktop: solid `var(--color-accent)` background with white text for correct answers, solid `var(--color-error)` background with white text for wrong answers
- Fixed quiz not ending when pressing the close (X) button by calling `clearQuizState()` in `backToProject`, so sessionStorage state is properly cleared on exit

## Test plan
- [ ] Start a four-choice quiz on mobile — correct/wrong answers show solid green/red backgrounds with white text
- [ ] Start a word-order quiz on mobile — result box shows solid green/red with white text
- [ ] Start an active (type-in) quiz on mobile — correct/wrong shows solid green/red with white text
- [ ] Verify same solid colors on desktop for all three quiz types
- [ ] Start a quiz, answer a few questions, press the X close button, re-enter the quiz — should start fresh (not resume from where you left off)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RsA5TZqK4zGyfia8t1fTSV

---
_Generated by [Claude Code](https://claude.ai/code/session_01RsA5TZqK4zGyfia8t1fTSV)_