### PR TITLE
fix: repair scan japanese source schema

### DIFF
--- a/src/app/api/scan-jobs/process/route.contract.test.ts
+++ b/src/app/api/scan-jobs/process/route.contract.test.ts
@@ -911,6 +911,48 @@ test('server_cloud retries words insert without source_modes when the database s
   ), false);
 });
 
+test('server_cloud retries words insert without japanese_source when the database schema is older', async () => {
+  const client = new FakeScanProcessClient({
+    claimedJob: pendingServerCloudJob(),
+    userPreference: { ai_enabled: false },
+    wordsInsertResults: [
+      {
+        data: null,
+        error: {
+          code: 'PGRST204',
+          message: "Could not find the 'japanese_source' column of 'words' in the schema cache",
+        },
+      },
+    ],
+  });
+
+  const response = await processJobById(JOB_ID, createServerCloudContractDeps(client));
+
+  assert.equal(response.status, 200);
+  assert.deepEqual(await response.json(), {
+    success: true,
+    saveMode: 'server_cloud',
+    projectId: NEW_PROJECT_ID,
+    wordCount: 1,
+  });
+
+  const wordsInserts = client.operations.filter((operation) =>
+    operation.table === 'words' &&
+    operation.action === 'insert'
+  );
+  assert.equal(wordsInserts.length, 2);
+  assert.ok(Array.isArray(wordsInserts[0].payload));
+  assert.equal('japanese_source' in wordsInserts[0].payload[0], true);
+  assert.equal(wordsInserts[0].columns?.includes('japanese_source'), true);
+  assert.ok(Array.isArray(wordsInserts[1].payload));
+  assert.equal('japanese_source' in wordsInserts[1].payload[0], false);
+  assert.equal(wordsInserts[1].columns?.includes('japanese_source'), false);
+
+  const completedUpdate = findScanJobUpdate(client, 'completed');
+  assert.ok(isRecord(completedUpdate.payload));
+  assert.equal(completedUpdate.payload.status, 'completed');
+});
+
 test('server_cloud retries words insert without lexicon_sense_id when the schema cache is older', async () => {
   const client = new FakeScanProcessClient({
     claimedJob: pendingServerCloudJob(),

--- a/src/app/api/scan-jobs/process/route.ts
+++ b/src/app/api/scan-jobs/process/route.ts
@@ -1247,18 +1247,23 @@ export async function processJobById(jobId: string, processDeps?: ProcessJobDeps
       const dbInsertStart = Date.now();
       let insertedWords: InsertedServerCloudWord[] | null = null;
       let wordsError: unknown = null;
+      let omitJapaneseSource = false;
       let omitSourceModes = false;
       let omitLexiconSenseId = false;
 
-      for (let attempt = 0; attempt < 3; attempt += 1) {
+      for (let attempt = 0; attempt < 4; attempt += 1) {
         const insertPayload =
-          omitSourceModes || omitLexiconSenseId
+          omitJapaneseSource || omitSourceModes || omitLexiconSenseId
             ? stripServerCloudWordsInsertPayloadForCompat(wordsToInsert, {
+                omitJapaneseSource,
                 omitSourceModes,
                 omitLexiconSenseId,
               })
             : wordsToInsert;
-        const selectColumns = getServerCloudWordsInsertSelectColumns({ omitLexiconSenseId });
+        const selectColumns = getServerCloudWordsInsertSelectColumns({
+          omitJapaneseSource,
+          omitLexiconSenseId,
+        });
         const result = await supabaseAdmin
           .from('words')
           .insert(insertPayload)
@@ -1269,6 +1274,14 @@ export async function processJobById(jobId: string, processDeps?: ProcessJobDeps
         if (!wordsError) break;
 
         const missingColumn = getMissingWordsCompatColumn(wordsError);
+        if (missingColumn === 'japanese_source' && !omitJapaneseSource) {
+          omitJapaneseSource = true;
+          console.warn('[scan-jobs/process] words.japanese_source compatibility fallback used', {
+            jobId,
+            message: result.error?.message,
+          });
+          continue;
+        }
         if (missingColumn === 'source_modes' && !omitSourceModes) {
           omitSourceModes = true;
           console.warn('[scan-jobs/process] words.source_modes compatibility fallback used', {

--- a/src/lib/scan/server-cloud-persistence.contract.test.ts
+++ b/src/lib/scan/server-cloud-persistence.contract.test.ts
@@ -179,10 +179,29 @@ test('word insert compatibility detects missing lexicon_sense_id schema errors',
   assert.equal(isMissingWordsSourceModesColumn(error), false);
 });
 
+test('word insert compatibility detects missing japanese_source schema errors', () => {
+  const error = {
+    code: 'PGRST204',
+    message: "Could not find the 'japanese_source' column of 'words' in the schema cache",
+  };
+
+  assert.equal(getMissingWordsCompatColumn(error), 'japanese_source');
+  assert.equal(isMissingWordsLexiconSenseIdColumn(error), false);
+  assert.equal(isMissingWordsSourceModesColumn(error), false);
+});
+
 test('getServerCloudWordsInsertSelectColumns can omit lexicon_sense_id', () => {
   assert.equal(getServerCloudWordsInsertSelectColumns().includes('lexicon_sense_id'), true);
   assert.equal(
     getServerCloudWordsInsertSelectColumns({ omitLexiconSenseId: true }).includes('lexicon_sense_id'),
+    false,
+  );
+});
+
+test('getServerCloudWordsInsertSelectColumns can omit japanese_source', () => {
+  assert.equal(getServerCloudWordsInsertSelectColumns().includes('japanese_source'), true);
+  assert.equal(
+    getServerCloudWordsInsertSelectColumns({ omitJapaneseSource: true }).includes('japanese_source'),
     false,
   );
 });
@@ -218,12 +237,13 @@ test('stripSourceModesFromServerCloudWordsInsertPayload removes only source_mode
   ]);
 });
 
-test('stripServerCloudWordsInsertPayloadForCompat can omit source_modes and lexicon_sense_id', () => {
+test('stripServerCloudWordsInsertPayloadForCompat can omit compatibility columns', () => {
   const payload = buildServerCloudWordsInsertPayload(
     [
       {
         english: 'elaborate',
         japanese: '詳しく説明する',
+        japaneseSource: 'scan',
         lexiconSenseId: 'sense-1',
         distractors: ['短くする', '無視する', '隠す'],
         sourceModes: ['all'],
@@ -233,10 +253,12 @@ test('stripServerCloudWordsInsertPayloadForCompat can omit source_modes and lexi
   );
 
   const stripped = stripServerCloudWordsInsertPayloadForCompat(payload, {
+    omitJapaneseSource: true,
     omitSourceModes: true,
     omitLexiconSenseId: true,
   });
 
+  assert.equal('japanese_source' in stripped[0], false);
   assert.equal('source_modes' in stripped[0], false);
   assert.equal('lexicon_sense_id' in stripped[0], false);
   assert.equal(stripped[0]?.japanese, '詳しく説明する');

--- a/src/lib/scan/server-cloud-persistence.ts
+++ b/src/lib/scan/server-cloud-persistence.ts
@@ -55,9 +55,10 @@ type MaybePostgrestColumnError = {
   hint?: unknown;
 };
 
-export type MissingWordsCompatColumn = 'source_modes' | 'lexicon_sense_id';
+export type MissingWordsCompatColumn = 'japanese_source' | 'source_modes' | 'lexicon_sense_id';
 
 export type ServerCloudWordsInsertCompatOptions = {
+  omitJapaneseSource?: boolean;
   omitSourceModes?: boolean;
   omitLexiconSenseId?: boolean;
 };
@@ -128,6 +129,14 @@ export function getMissingWordsCompatColumn(error: unknown): MissingWordsCompatC
 
   const message = `${candidate.message ?? ''} ${candidate.details ?? ''} ${candidate.hint ?? ''}`.toLowerCase();
   if (
+    message.includes('words.japanese_source')
+    || message.includes("'japanese_source' column of 'words'")
+    || message.includes('japanese_source')
+  ) {
+    return 'japanese_source';
+  }
+
+  if (
     message.includes('words.source_modes')
     || message.includes("'source_modes' column of 'words'")
     || message.includes('source_modes')
@@ -158,6 +167,7 @@ export function getServerCloudWordsInsertSelectColumns(
   options: ServerCloudWordsInsertCompatOptions = {},
 ): string {
   return SERVER_CLOUD_WORD_INSERT_SELECT_BASE_COLUMNS
+    .filter((column) => !(options.omitJapaneseSource && column === 'japanese_source'))
     .filter((column) => !(options.omitLexiconSenseId && column === 'lexicon_sense_id'))
     .join(', ');
 }
@@ -171,7 +181,6 @@ export function stripServerCloudWordsInsertPayloadForCompat(
       project_id: word.project_id,
       english: word.english,
       japanese: word.japanese,
-      japanese_source: word.japanese_source,
       lexicon_entry_id: word.lexicon_entry_id,
       distractors: word.distractors,
       example_sentence: word.example_sentence,
@@ -183,6 +192,9 @@ export function stripServerCloudWordsInsertPayloadForCompat(
 
     if (!options.omitLexiconSenseId) {
       row.lexicon_sense_id = word.lexicon_sense_id;
+    }
+    if (!options.omitJapaneseSource) {
+      row.japanese_source = word.japanese_source;
     }
     if (!options.omitSourceModes) {
       row.source_modes = word.source_modes;

--- a/supabase/migrations/20260624153000_add_words_japanese_source.sql
+++ b/supabase/migrations/20260624153000_add_words_japanese_source.sql
@@ -1,0 +1,26 @@
+-- Store whether a word's Japanese translation came from the scan image or AI.
+-- Older migrations referenced this column but did not create it in every
+-- production database, which breaks scan word inserts.
+
+DO $$
+BEGIN
+  IF to_regclass('public.words') IS NOT NULL THEN
+    ALTER TABLE public.words
+      ADD COLUMN IF NOT EXISTS japanese_source text;
+
+    UPDATE public.words
+    SET japanese_source = NULL
+    WHERE japanese_source IS NOT NULL
+      AND japanese_source NOT IN ('scan', 'ai');
+
+    ALTER TABLE public.words
+      DROP CONSTRAINT IF EXISTS words_japanese_source_check;
+
+    ALTER TABLE public.words
+      ADD CONSTRAINT words_japanese_source_check
+      CHECK (japanese_source IS NULL OR japanese_source IN ('scan', 'ai'));
+  END IF;
+END
+$$;
+
+NOTIFY pgrst, 'reload schema';


### PR DESCRIPTION
## Summary
- add a repair migration for missing `words.japanese_source` and reload PostgREST schema cache
- extend server-cloud scan word insert compatibility fallback to omit `japanese_source` when older DB/schema cache rejects it
- add contract coverage for missing `japanese_source` retry behavior

## Production DB
- Applied `20260624153000_add_words_japanese_source.sql` to the linked production Supabase DB.
- Verified `words.japanese_source` and `words_japanese_source_check` exist.
- Verified a rollback-only scan payload insert with `japanese_source = scan` now succeeds.

## Verification
- `npm test -- src/lib/scan/server-cloud-persistence.contract.test.ts`
- `npm test -- src/app/api/scan-jobs/process/route.contract.test.ts`
- `npm run lint:web`
- `npm run build`
- `npm run security:all`
- `supabase db lint --linked --schema public --fail-on error`
- `git diff --check`