### PR TITLE
fix: expand split translations into quiz words

### DIFF
--- a/src/app/api/scan-jobs/process/route.contract.test.ts
+++ b/src/app/api/scan-jobs/process/route.contract.test.ts
@@ -720,6 +720,89 @@ test('server_cloud writes source_modes from normalized scan_modes instead of AI 
   assert.deepEqual(wordsInsert.payload[0]?.source_modes, ['all', 'idiom', 'eiken']);
 });
 
+test('server_cloud expands split translations before inserting quiz words', async () => {
+  const client = new FakeScanProcessClient({
+    claimedJob: pendingServerCloudJob(),
+    userPreference: { ai_enabled: false },
+  });
+
+  const response = await processJobById(
+    JOB_ID,
+    createServerCloudContractDeps(client, {
+      extractImage: async () => ({
+        result: {
+          success: true,
+          data: {
+            words: [
+              {
+                english: 'sense',
+                japanese: '感覚;分別',
+                japaneseSource: 'scan',
+                translations: [
+                  { japanese: '感覚;分別', source: 'scan', meaningRank: 1 },
+                ],
+                distractors: [],
+                partOfSpeechTags: ['noun'],
+              },
+            ],
+            sourceLabels: ['鉄壁'],
+          },
+        },
+      }),
+      resolveImmediateWords: async (words) => ({
+        words: words.map((word) => ({
+          ...word,
+          lexiconEntryId: 'lexicon-sense',
+          exampleSentence: 'The word has several senses.',
+          exampleSentenceJa: 'その単語には複数の意味があります。',
+          partOfSpeechTags: ['noun'],
+        })) as never,
+        lexiconEntries: [],
+        metrics: {
+          lookupKeyCount: 1,
+          masterHitCount: 1,
+          masterTranslationHitCount: 1,
+          aiMissCount: 0,
+          lookupElapsedMs: 0,
+          translationElapsedMs: 0,
+          totalElapsedMs: 0,
+        },
+      }),
+    }),
+  );
+
+  assert.equal(response.status, 200);
+  assert.deepEqual(await response.json(), {
+    success: true,
+    saveMode: 'server_cloud',
+    projectId: NEW_PROJECT_ID,
+    wordCount: 2,
+  });
+
+  const wordsInsert = findOperation(
+    client,
+    (operation) => operation.table === 'words' && operation.action === 'insert',
+    'missing words insert',
+  );
+  assert.ok(Array.isArray(wordsInsert.payload));
+  assert.deepEqual(wordsInsert.payload.map((row) => row.japanese), ['感覚', '分別']);
+
+  const translationsUpsert = findOperation(
+    client,
+    (operation) => operation.table === 'word_translations' && operation.action === 'upsert',
+    'missing word_translations upsert',
+  );
+  assert.deepEqual(translationsUpsert.payload.map((row) => ({
+    word_id: row.word_id,
+    translation_ja: row.translation_ja,
+    is_primary: row.is_primary,
+    position: row.position,
+  })), [
+    { word_id: 'word-1', translation_ja: '感覚', is_primary: true, position: 0 },
+    { word_id: 'word-2', translation_ja: '分別', is_primary: true, position: 0 },
+  ]);
+});
+
 test('server_cloud new project completion keeps project insert, words insert, and completed update contract', async () => {
   const trace: string[] = [];
   const client = new FakeScanProcessClient({

--- a/src/app/api/scan-jobs/process/route.ts
+++ b/src/app/api/scan-jobs/process/route.ts
@@ -85,6 +85,7 @@ import { resolveImmediateWordsWithMasterFirst } from '@/lib/lexicon/master-first
 import { backfillMissingJapaneseTranslationsWithMetadata } from '@/lib/words/backfill-japanese';
 import {
   buildWordTranslationInsertRows,
+  expandWordsByTranslationsForPersistence,
   isWordTranslationsSchemaError,
   normalizeWordForTranslationPersistence,
 } from '@/lib/words/translation-persistence';
@@ -1043,10 +1044,12 @@ export async function processJobById(jobId: string, processDeps?: ProcessJobDeps
         ? null
         : await backfillWords(dedupedWords);
       timing.lexiconResolutionMs = Date.now() - lexiconResolutionStart;
-      const resolvedWords = applySourceModesFromScanModes(
-        resolvedResult?.words ?? rollbackResult?.words ?? dedupedWords,
-        modes,
-      ).map((word) => normalizeWordForTranslationPersistence(word));
+      const resolvedWords = expandWordsByTranslationsForPersistence(
+        applySourceModesFromScanModes(
+          resolvedResult?.words ?? rollbackResult?.words ?? dedupedWords,
+          modes,
+        ).map((word) => normalizeWordForTranslationPersistence(word)),
+      );
       const aiJapaneseCount = resolvedWords.filter((word) => word.japaneseSource === 'ai').length;
 
       console.log('[scan-jobs/process] Extraction finished', {

--- a/src/app/api/words/create/route.test.ts
+++ b/src/app/api/words/create/route.test.ts
@@ -492,10 +492,11 @@ test('words/create uses master-first resolution before legacy backfill', async (
   );
 });
 
-test('words/create persists split translations with sequential meaning ranks', async () => {
+test('words/create expands split translations into separate persisted words', async () => {
   const projectId = '11111111-1111-4111-8111-111111111111';
   const createdAt = new Date('2026-03-15T00:00:00.000Z').toISOString();
   const wordId = '88888888-8888-4888-8888-888888888888';
+  const secondWordId = '99999999-9999-4999-8999-999999999999';
 
   const fakeClient = new FakeWordsCreateClient(
     'user-1',
@@ -506,6 +507,22 @@ test('words/create persists split translations with sequential meaning ranks', a
         project_id: projectId,
         english: 'sense',
         japanese: '感覚',
+        lexicon_entry_id: null,
+        distractors: [],
+        part_of_speech_tags: ['noun'],
+        created_at: createdAt,
+        status: 'new',
+        ease_factor: 2.5,
+        interval_days: 0,
+        repetition: 0,
+        is_favorite: false,
+        lexicon_entries: null,
+      },
+      {
+        id: secondWordId,
+        project_id: projectId,
+        english: 'sense',
+        japanese: '分別',
         lexicon_entry_id: null,
         distractors: [],
         part_of_speech_tags: ['noun'],
@@ -555,16 +572,18 @@ test('words/create persists split translations with sequential meaning ranks', a
 
   assert.equal(response.status, 200);
   assert.equal(fakeClient.insertedRows[0]?.['japanese'], '感覚');
+  assert.equal(fakeClient.insertedRows[1]?.['japanese'], '分別');
   assert.deepEqual(
     fakeClient.translationRows.map((row) => ({
+      word_id: row.word_id,
       translation_ja: row.translation_ja,
       meaning_rank: row.meaning_rank,
       is_primary: row.is_primary,
       position: row.position,
     })),
     [
-      { translation_ja: '感覚', meaning_rank: 1, is_primary: true, position: 0 },
-      { translation_ja: '分別', meaning_rank: 2, is_primary: false, position: 1 },
+      { word_id: wordId, translation_ja: '感覚', meaning_rank: 1, is_primary: true, position: 0 },
+      { word_id: secondWordId, translation_ja: '分別', meaning_rank: 1, is_primary: true, position: 0 },
     ],
   );
 });

--- a/src/app/api/words/create/route.ts
+++ b/src/app/api/words/create/route.ts
@@ -15,6 +15,7 @@ import { getSupabaseAdmin } from '@/lib/supabase/admin';
 import { prefillWordOrderQuizzesForWords } from '@/lib/scan/word-order-prefill';
 import {
   buildWordTranslationInsertRows,
+  expandWordsByTranslationsForPersistence,
   normalizeWordForTranslationPersistence,
 } from '@/lib/words/translation-persistence';
 import { z } from 'zod';
@@ -174,7 +175,13 @@ export async function handleWordsCreatePost(request: NextRequest, deps?: WordsCr
     const { words: translatedWordsRaw, aiBackfilledIndexes } = wordsNeedingBackfill.length > 0
       ? await backfillWords(immediateResolution.words)
       : { words: immediateResolution.words, aiBackfilledIndexes: [] };
-    const translatedWords = translatedWordsRaw.map((word) => normalizeWordForTranslationPersistence(word));
+    const aiBackfilledIndexSet = new Set(aiBackfilledIndexes);
+    const translatedWords = expandWordsByTranslationsForPersistence(
+      translatedWordsRaw.map((word, index) => normalizeWordForTranslationPersistence({
+        ...word,
+        ...(aiBackfilledIndexSet.has(index) ? { japaneseSource: 'ai' as const } : {}),
+      })),
+    );
 
     console.log('[words/create] Immediate resolution finished', {
       requestedWordCount: words.length,
@@ -250,14 +257,8 @@ export async function handleWordsCreatePost(request: NextRequest, deps?: WordsCr
       }
     }
 
-    const aiTranslatedIndexes = new Set<number>([
-      ...aiBackfilledIndexes,
-      ...translatedWords
-        .map((word, index) => (word.japaneseSource === 'ai' ? index : -1))
-        .filter((index) => index >= 0),
-    ]);
-    const aiTranslatedWordIds = Array.from(aiTranslatedIndexes)
-      .map((index) => ((data ?? []) as WordRow[])[index]?.id)
+    const aiTranslatedWordIds = translatedWords
+      .map((word, index) => (word.japaneseSource === 'ai' ? ((data ?? []) as WordRow[])[index]?.id : null))
       .filter((value): value is string => typeof value === 'string' && value.length > 0);
     const createdWordRowsWithTranslations = translationRows.length > 0
       ? await supabase

--- a/src/lib/words/memory.test.ts
+++ b/src/lib/words/memory.test.ts
@@ -63,7 +63,7 @@ test('groupWordsByMemory leaves non-distinct same-English translations as separa
   assert.equal(groups[1]?.isDistinctGroup, false);
 });
 
-test('selectPrimaryMeaningWords excludes explicit distinct non-primary senses', () => {
+test('selectPrimaryMeaningWords excludes linked non-primary senses', () => {
   const words = [
     word({
       id: 'free-primary',
@@ -79,10 +79,39 @@ test('selectPrimaryMeaningWords excludes explicit distinct non-primary senses', 
       japanese: '無料の',
       lexiconEntryId: 'lex-free',
       lexiconSenseId: 'sense-cost',
-      lexiconDistinctKey: 'cost',
+      lexiconSenseIsPrimary: false,
     }),
     word({ id: 'plain', english: 'plain', japanese: '明白な' }),
   ];
 
   assert.deepEqual(selectPrimaryMeaningWords(words).map((item) => item.id), ['free-primary', 'plain']);
+});
+
+test('groupWordsByMemory treats linked non-primary senses as one memory-rate word', () => {
+  const words = [
+    word({
+      id: 'sense-primary',
+      english: 'sense',
+      japanese: '感覚',
+      status: 'mastered',
+      lexiconEntryId: 'lex-sense',
+      lexiconSenseId: 'sense-primary',
+      lexiconSenseIsPrimary: true,
+    }),
+    word({
+      id: 'sense-discernment',
+      english: 'sense',
+      japanese: '分別',
+      status: 'new',
+      lexiconEntryId: 'lex-sense',
+      lexiconSenseId: 'sense-discernment',
+      lexiconSenseIsPrimary: false,
+    }),
+  ];
+
+  const [group] = groupWordsByMemory(words);
+
+  assert.equal(group?.isDistinctGroup, true);
+  assert.equal(group?.memoryRate, 50);
+  assert.deepEqual(selectPrimaryMeaningWords(words).map((item) => item.id), ['sense-primary']);
 });

--- a/src/lib/words/memory.ts
+++ b/src/lib/words/memory.ts
@@ -79,7 +79,9 @@ export function getWordMemorySenseKey(word: WordMemoryInput): string {
 }
 
 export function isPrimaryMeaningWord(word: WordMemoryInput): boolean {
-  return !normalizeKeyPart(word.lexiconDistinctKey) || word.lexiconSenseIsPrimary === true;
+  if (word.lexiconSenseIsPrimary === true) return true;
+  if (word.lexiconSenseIsPrimary === false) return false;
+  return !normalizeKeyPart(word.lexiconDistinctKey);
 }
 
 export function selectPrimaryMeaningWords<T extends WordMemoryInput>(words: readonly T[]): T[] {
@@ -111,7 +113,11 @@ export function groupWordsByMemory<T extends WordMemoryInput>(words: readonly T[
   });
 
   for (const [key, bucketWords] of buckets.entries()) {
-    const hasExplicitDistinct = bucketWords.some((word) => normalizeKeyPart(word.lexiconDistinctKey).length > 0);
+    const hasExplicitDistinct = bucketWords.some((word) =>
+      normalizeKeyPart(word.lexiconDistinctKey).length > 0 ||
+      Boolean(word.lexiconSenseId) ||
+      typeof word.lexiconSenseIsPrimary === 'boolean'
+    );
     const uniqueSenseKeys = new Set(bucketWords.map(getWordMemorySenseKey));
     const isDistinctGroup = hasExplicitDistinct && uniqueSenseKeys.size > 1;
 

--- a/src/lib/words/translation-persistence.test.ts
+++ b/src/lib/words/translation-persistence.test.ts
@@ -1,0 +1,43 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { expandWordsByTranslationsForPersistence } from './translation-persistence';
+
+test('expandWordsByTranslationsForPersistence creates one persisted word per translation', () => {
+  const words = expandWordsByTranslationsForPersistence([
+    {
+      english: 'sense',
+      japanese: '感覚;分別',
+      japaneseSource: 'scan' as const,
+      distractors: [],
+      translations: [
+        { japanese: '感覚;分別', source: 'scan', meaningRank: 1 },
+      ],
+      partOfSpeechTags: ['noun'],
+    },
+  ]);
+
+  assert.equal(words.length, 2);
+  assert.deepEqual(words.map((word) => word.japanese), ['感覚', '分別']);
+  assert.deepEqual(words.map((word) => word.translations?.[0]?.translationJa), ['感覚', '分別']);
+  assert.deepEqual(words.map((word) => word.translations?.[0]?.isPrimary), [true, true]);
+  assert.deepEqual(words.map((word) => word.translations?.[0]?.position), [0, 0]);
+});
+
+test('expandWordsByTranslationsForPersistence keeps explicit id words as one row for sync upserts', () => {
+  const [word] = expandWordsByTranslationsForPersistence([
+    {
+      id: 'word-1',
+      english: 'sense',
+      japanese: '感覚;分別',
+      japaneseSource: 'scan' as const,
+      translations: [
+        { japanese: '感覚;分別', source: 'scan', meaningRank: 1 },
+      ],
+    },
+  ]);
+
+  assert.equal(word?.id, 'word-1');
+  assert.equal(word?.japanese, '感覚');
+  assert.deepEqual(word?.translations?.map((translation) => translation.translationJa), ['感覚', '分別']);
+});

--- a/src/lib/words/translation-persistence.ts
+++ b/src/lib/words/translation-persistence.ts
@@ -2,6 +2,7 @@ import type { CustomSection, WordTranslation } from '@/types';
 import { normalizeWordTranslationPayload } from '../../../shared/word-translations';
 
 type WordTranslationInput = {
+  id?: string;
   japanese?: string;
   rawJapanese?: string;
   japaneseSource?: 'scan' | 'ai';
@@ -70,6 +71,53 @@ export function normalizeWordForTranslationPersistence<T extends WordTranslation
       ? { lexiconSenseId: primaryTranslation?.lexiconSenseId ?? word.lexiconSenseId }
       : {}),
   };
+}
+
+function getTranslationJapaneseSource(
+  translation: WordTranslation,
+  fallback?: 'scan' | 'ai',
+): 'scan' | 'ai' | undefined {
+  return translation.source === 'scan' || translation.source === 'ai'
+    ? translation.source
+    : fallback;
+}
+
+export function expandWordsByTranslationsForPersistence<T extends WordTranslationInput>(
+  words: readonly T[],
+): Array<ReturnType<typeof normalizeWordForTranslationPersistence<T>>> {
+  const expanded: Array<ReturnType<typeof normalizeWordForTranslationPersistence<T>>> = [];
+
+  for (const word of words) {
+    const normalizedWord = normalizeWordForTranslationPersistence(word);
+    const translations = normalizedWord.translations ?? [];
+
+    if (word.id || translations.length <= 1) {
+      expanded.push(normalizedWord);
+      continue;
+    }
+
+    const seen = new Set<string>();
+    for (const translation of translations) {
+      const normalizedTranslation = (translation.normalizedTranslationJa || translation.translationJa).trim().toLowerCase();
+      if (!normalizedTranslation || seen.has(normalizedTranslation)) continue;
+      seen.add(normalizedTranslation);
+
+      expanded.push({
+        ...normalizedWord,
+        japanese: translation.translationJa,
+        japaneseSource: getTranslationJapaneseSource(translation, normalizedWord.japaneseSource),
+        lexiconSenseId: translation.lexiconSenseId ?? (translation.isPrimary ? normalizedWord.lexiconSenseId : undefined),
+        translations: [{
+          ...translation,
+          meaningRank: 1,
+          position: 0,
+          isPrimary: true,
+        }],
+      });
+    }
+  }
+
+  return expanded;
 }
 
 export function buildWordTranslationInsertRows(


### PR DESCRIPTION
## Summary
- Expand split `word_translations` into separate persisted word rows before scan / words-create inserts so each translation can become its own quiz target.
- Keep explicit-id upserts as a single row to avoid breaking sync.
- Treat linked non-primary lexicon senses as non-primary in Free filtering and memory-rate grouping.

## Verification
- `npm test -- src/lib/words/translation-persistence.test.ts src/lib/words/memory.test.ts src/lib/quiz/quiz-state.test.ts src/app/api/words/create/route.test.ts src/app/api/scan-jobs/process/route.contract.test.ts`
- `npm run lint:web`
- `npm run build`

## Notes
- No iOS/native code touched.
- This changes newly saved scans/word creates; existing rows are not backfilled by this PR.