### PR TITLE
新規登録オンボーディングステップ追加 + 認証画面のLP配色統一

### DIFF
--- a/shared/types/index.ts
+++ b/shared/types/index.ts
@@ -342,9 +342,14 @@ export interface UserState {
 
 // ============ Profile Types ============
 
+export type EikenLevel = '5' | '4' | '3' | 'pre2' | '2' | 'pre1' | '1' | null;
+
 export interface Profile {
   userId: string;
   username: string | null;
+  displayName: string | null;
+  userHandle: string | null;
+  eikenLevel: EikenLevel;
 }
 
 // ============ Auth Types ============

--- a/src/app/api/auth/check-handle/route.ts
+++ b/src/app/api/auth/check-handle/route.ts
@@ -1,0 +1,28 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { getSupabaseAdmin } from '@/lib/supabase/admin';
+
+const querySchema = z.object({
+  handle: z.string().regex(/^[a-z0-9_]{3,20}$/),
+});
+
+export async function GET(request: NextRequest) {
+  const handle = request.nextUrl.searchParams.get('handle') ?? '';
+  const parsed = querySchema.safeParse({ handle });
+  if (!parsed.success) {
+    return NextResponse.json({ available: false, error: '不正なID形式です' }, { status: 400 });
+  }
+
+  const admin = getSupabaseAdmin();
+  const { data, error } = await admin
+    .from('profiles')
+    .select('user_id')
+    .eq('user_handle', parsed.data.handle)
+    .maybeSingle();
+
+  if (error) {
+    return NextResponse.json({ available: false, error: '確認に失敗しました' }, { status: 500 });
+  }
+
+  return NextResponse.json({ available: data === null });
+}

--- a/src/app/api/auth/signup-verify/route.ts
+++ b/src/app/api/auth/signup-verify/route.ts
@@ -45,7 +45,10 @@ const requestSchema = z.object({
   email: z.string().trim().email().max(254),
   code: z.string().trim().regex(/^\d{6}$/),
   password: z.string().min(8).max(128),
-}).strict();
+  display_name: z.string().trim().min(1).max(30).optional(),
+  user_handle: z.string().regex(/^[a-z0-9_]{3,20}$/).optional(),
+  eiken_level: z.enum(['5', '4', '3', 'pre2', '2', 'pre1', '1']).nullable().optional(),
+});
 
 export type SignupVerifyRouteDeps = {
   getAdminClient?: typeof getAdminClient;
@@ -67,7 +70,7 @@ export async function handleSignupVerifyPost(
     if (!parsed.ok) {
       return parsed.response;
     }
-    const { email, code, password } = parsed.data;
+    const { email, code, password, display_name, user_handle, eiken_level } = parsed.data;
 
     const adminClient = (deps.getAdminClient ?? getAdminClient)();
     const normalizedEmail = normalizeOtpEmail(email);
@@ -201,6 +204,20 @@ export async function handleSignupVerifyPost(
       );
     }
 
+    // Save onboarding profile fields if provided
+    const userId = sessionData.user?.id;
+    if (userId && (display_name || user_handle || eiken_level !== undefined)) {
+      const profileUpdate: Record<string, unknown> = {};
+      if (display_name) profileUpdate.display_name = display_name;
+      if (user_handle) profileUpdate.user_handle = user_handle;
+      if (eiken_level !== undefined) profileUpdate.eiken_level = eiken_level;
+
+      await adminClient
+        .from('profiles')
+        .update(profileUpdate)
+        .eq('user_id', userId);
+    }
+
     // 使用済みOTPを削除
     await adminClient
       .from('otp_requests')
@@ -210,7 +227,7 @@ export async function handleSignupVerifyPost(
     return NextResponse.json({
       success: true,
       user: {
-        id: sessionData.user?.id,
+        id: userId,
         email: sessionData.user?.email,
       },
     });

--- a/src/app/desktop.css
+++ b/src/app/desktop.css
@@ -665,16 +665,18 @@
 /* ── Auth (login / signup) ───────────────────────────────── */
 .ds-auth { display: grid; grid-template-columns: 1fr 1fr; width: 100%; height: 100%; background: #fff; font-family: var(--font-body); overflow: hidden; }
 .ds-auth-brand {
-  background: var(--color-ink); color: #fff; padding: 56px 56px; position: relative; overflow: hidden;
+  background: #f3f0e9; color: #1a1a1a; padding: 56px 56px; position: relative; overflow: hidden;
   display: flex; flex-direction: column; justify-content: space-between;
+  background-image: radial-gradient(rgba(26,26,26,0.045) 1px, transparent 1px);
+  background-size: 22px 22px;
 }
 .ds-auth-brand .wm { display: flex; align-items: center; gap: 9px; }
-.ds-auth-brand .wm .t { font-family: var(--font-display); font-weight: 800; font-size: 26px; letter-spacing: -0.02em; }
+.ds-auth-brand .wm .t { font-family: var(--font-display); font-weight: 800; font-size: 26px; letter-spacing: 0.1em; }
 .ds-auth-brand .wm .dot { width: 11px; height: 11px; border-radius: 3px; background: var(--color-accent); }
-.ds-auth-brand h2 { font-family: var(--font-display); font-weight: 800; font-size: 38px; letter-spacing: -0.02em; line-height: 1.2; margin: 0 0 14px; }
-.ds-auth-brand p { font-size: 15px; line-height: 1.7; color: rgba(255,255,255,0.7); margin: 0; max-width: 380px; }
+.ds-auth-brand h2 { font-family: var(--font-display); font-weight: 800; font-size: 38px; letter-spacing: normal; line-height: 1.06; margin: 0 0 14px; }
+.ds-auth-brand p { font-size: 15px; line-height: 1.7; color: #555; margin: 0; max-width: 380px; }
 .ds-auth-books { display: flex; gap: 16px; }
-.ds-auth-books .bk { width: 92px; aspect-ratio: 3/4; border-radius: 10px; border: 1.5px solid rgba(255,255,255,0.25); padding: 12px; color: #fff; font-family: var(--font-display); font-weight: 700; font-size: 13px; display: flex; align-items: flex-end; }
+.ds-auth-books .bk { width: 92px; aspect-ratio: 3/4; border-radius: 10px; border: 2px solid #1a1a1a; padding: 12px; color: #fff; font-family: var(--font-display); font-weight: 700; font-size: 13px; display: flex; align-items: flex-end; box-shadow: 3px 4px 0 #1a1a1a; }
 .ds-auth-form { display: flex; flex-direction: column; justify-content: center; padding: 56px 72px; max-width: 560px; }
 .ds-auth-form h1 { font-size: 28px; margin: 0 0 6px; }
 .ds-auth-form .sub { color: var(--color-secondary-text); font-size: 14px; margin-bottom: 28px; }

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -105,7 +105,7 @@ function LoginForm() {
         </div>
       </DesktopAuthShell>
 
-      <div className="relative mx-auto flex min-h-screen w-full max-w-[480px] flex-col bg-[var(--color-background)] pt-3 font-[var(--font-body)] lg:hidden">
+      <div className="relative mx-auto flex min-h-screen w-full max-w-[480px] flex-col bg-[#f3f0e9] pt-3 font-[var(--font-body)] [background-image:radial-gradient(rgba(26,26,26,0.045)_1px,transparent_1px)] [background-size:22px_22px] lg:hidden">
       <div className="px-[14px] pt-1">
         <Link
           href="/"
@@ -180,7 +180,7 @@ function LoginForm() {
             disabled={loading || email.trim().length === 0 || password.length === 0}
             className="group w-full disabled:pointer-events-none disabled:opacity-60"
           >
-            <div className="flex items-center justify-center gap-2 rounded-xl border-2 border-[var(--solid-ink)] bg-[var(--solid-ink)] py-3.5 text-center text-sm font-bold text-white">
+            <div className="flex items-center justify-center gap-2 rounded-[14px] border-2 border-[var(--solid-ink)] bg-[var(--solid-ink)] py-3.5 text-center text-sm font-bold text-white shadow-[3px_4px_0_#000] transition-all active:translate-x-0.5 active:translate-y-0.5 active:shadow-[1px_1px_0_#000]">
               {loading && <Icon name="progress_activity" size={16} className="animate-spin" />}
               {loading ? 'ログイン中...' : 'ログイン'}
             </div>
@@ -195,15 +195,15 @@ function LoginForm() {
       />
 
       <div className="flex items-center gap-2.5 px-6 pb-3.5 pt-1.5">
-        <div className="h-px flex-1 bg-[var(--color-border)]" />
-        <span className="font-mono text-[10px] text-[var(--color-muted)]">または</span>
-        <div className="h-px flex-1 bg-[var(--color-border)]" />
+        <div className="h-px flex-1 bg-[rgba(26,26,26,0.15)]" />
+        <span className="font-mono text-[10px] text-[#8a857a]">または</span>
+        <div className="h-px flex-1 bg-[rgba(26,26,26,0.15)]" />
       </div>
 
       <div className="flex flex-col gap-2 px-6 pb-3">
         <Link
           href={`/signup?redirect=${encodeURIComponent(redirect)}`}
-          className="flex items-center justify-center gap-2 rounded-xl border-2 border-[var(--solid-ink)] bg-white px-3 py-3 text-[13px] font-bold text-[var(--solid-ink)]"
+          className="flex items-center justify-center gap-2 rounded-[14px] border-2 border-[var(--solid-ink)] bg-white px-3 py-3 text-[13px] font-bold text-[var(--solid-ink)] shadow-[3px_4px_0_var(--solid-ink)] transition-all active:translate-x-0.5 active:translate-y-0.5 active:shadow-[1px_1px_0_var(--solid-ink)]"
         >
           <Icon name="person_add" size={16} />
           新規登録する
@@ -218,7 +218,7 @@ function LoginForm() {
 
 function LoginFallback() {
   return (
-    <div className="relative mx-auto flex min-h-screen w-full max-w-[480px] flex-col items-center justify-center bg-[var(--color-background)] font-[var(--font-body)]">
+    <div className="relative mx-auto flex min-h-screen w-full max-w-[480px] flex-col items-center justify-center bg-[#f3f0e9] font-[var(--font-body)] [background-image:radial-gradient(rgba(26,26,26,0.045)_1px,transparent_1px)] [background-size:22px_22px]">
       <Icon name="progress_activity" size={28} className="animate-spin text-[var(--solid-ink)]" />
     </div>
   );
@@ -253,7 +253,7 @@ function FormField({
 }) {
   return (
     <label className="block">
-      <div className="mb-[5px] pl-0.5 font-mono text-[9px] font-bold tracking-[0.06em] text-[var(--color-muted)]">
+      <div className="mb-[5px] pl-0.5 font-mono text-[9px] font-bold tracking-[0.06em] text-[#8a857a]">
         {label}
       </div>
       <div className="flex items-center gap-2 rounded-[10px] border-2 border-[var(--solid-ink)] bg-white px-3 py-[11px]">

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Suspense, useEffect, useState, type FormEvent, type ReactNode } from 'react';
+import { Suspense, useCallback, useEffect, useRef, useState, type FormEvent, type ReactNode } from 'react';
 import Link from 'next/link';
 import { useSearchParams } from 'next/navigation';
 import { OAuthProviderButtons } from '@/components/auth/OAuthProviderButtons';
@@ -21,9 +21,22 @@ import {
   buildSignupVerifyRequestBody,
   isSignupOtpComplete,
   resolveSignupRouteError,
+  validateOnboardingData,
   validateSignupCredentials,
+  type EikenLevelOption,
+  type OnboardingData,
   type SignupStep,
 } from '@/lib/auth/signup-flow';
+
+const EIKEN_LEVELS: { value: EikenLevelOption; label: string }[] = [
+  { value: '5', label: '5級' },
+  { value: '4', label: '4級' },
+  { value: '3', label: '3級' },
+  { value: 'pre2', label: '準2級' },
+  { value: '2', label: '2級' },
+  { value: 'pre1', label: '準1級' },
+  { value: '1', label: '1級' },
+];
 
 async function readJson(response: Response): Promise<unknown> {
   try {
@@ -37,7 +50,16 @@ function SignupForm() {
   const searchParams = useSearchParams();
   const redirect = searchParams.get('redirect') || '/';
 
-  const [step, setStep] = useState<SignupStep>('form');
+  const [step, setStep] = useState<SignupStep>('onboarding');
+
+  // Onboarding state
+  const [displayName, setDisplayName] = useState('');
+  const [userHandle, setUserHandle] = useState('');
+  const [eikenLevel, setEikenLevel] = useState<EikenLevelOption>(null);
+  const [handleAvailable, setHandleAvailable] = useState<boolean | null>(null);
+  const [handleChecking, setHandleChecking] = useState(false);
+
+  // Auth state
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [confirmPassword, setConfirmPassword] = useState('');
@@ -47,6 +69,8 @@ function SignupForm() {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
+  const checkTimerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+
   useEffect(() => {
     if (resendCooldown <= 0) return;
     const timer = window.setTimeout(() => {
@@ -55,7 +79,49 @@ function SignupForm() {
     return () => window.clearTimeout(timer);
   }, [resendCooldown]);
 
-  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+  const checkHandleAvailability = useCallback((handle: string) => {
+    if (checkTimerRef.current) clearTimeout(checkTimerRef.current);
+    if (!/^[a-z0-9_]{3,20}$/.test(handle)) {
+      setHandleAvailable(null);
+      return;
+    }
+    setHandleChecking(true);
+    checkTimerRef.current = setTimeout(async () => {
+      try {
+        const res = await fetch(`/api/auth/check-handle?handle=${encodeURIComponent(handle)}`);
+        const data = await res.json() as { available?: boolean };
+        setHandleAvailable(data.available ?? false);
+      } catch {
+        setHandleAvailable(null);
+      } finally {
+        setHandleChecking(false);
+      }
+    }, 400);
+  }, []);
+
+  const handleUserHandleChange = (value: string) => {
+    const normalized = value.toLowerCase().replace(/[^a-z0-9_]/g, '');
+    setUserHandle(normalized);
+    setHandleAvailable(null);
+    checkHandleAvailability(normalized);
+  };
+
+  const handleOnboardingSubmit = () => {
+    setError(null);
+    const onboarding: OnboardingData = { displayName, userHandle, eikenLevel };
+    const validation = validateOnboardingData(onboarding);
+    if (!validation.ok) {
+      setError(validation.error);
+      return;
+    }
+    if (handleAvailable === false) {
+      setError('このIDは既に使われています');
+      return;
+    }
+    setStep('form');
+  };
+
+  const handleFormSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     if (loading) return;
 
@@ -96,6 +162,7 @@ function SignupForm() {
     setError(null);
     setLoading(true);
     try {
+      const onboarding: OnboardingData = { displayName, userHandle, eikenLevel };
       const response = await fetch('/api/auth/signup-verify', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -103,6 +170,7 @@ function SignupForm() {
           email,
           code: otpCode,
           password,
+          onboarding,
         })),
       });
       const data = await readJson(response);
@@ -147,6 +215,10 @@ function SignupForm() {
     }
   };
 
+  const stepIndex = step === 'onboarding' ? 1 : step === 'form' ? 2 : 3;
+  const totalSteps = 3;
+
+  // ── OTP Step ─────────────────────────────────────────────
   if (step === 'otp') {
     return (
       <>
@@ -205,7 +277,8 @@ function SignupForm() {
 
         <div className="lg:hidden">
           <SignupShell
-            stepLabel="2/2"
+            stepIndex={stepIndex}
+            totalSteps={totalSteps}
             title="メールを確認"
             description="届いた6桁の認証コードを入力してください。"
             onBack={() => {
@@ -274,77 +347,262 @@ function SignupForm() {
     );
   }
 
+  // ── Form Step (email + password) ─────────────────────────
+  if (step === 'form') {
+    return (
+      <>
+        <DesktopAuthShell
+          title="アカウントを作成"
+          description="無料で始められます。クレジットカード不要。"
+        >
+          <form onSubmit={handleFormSubmit}>
+            {error && <DesktopAuthError>{error}</DesktopAuthError>}
+            <DesktopAuthField
+              label="メールアドレス"
+              placeholder="you@example.com"
+              type="email"
+              value={email}
+              onChange={setEmail}
+              autoComplete="email"
+              disabled={loading}
+            />
+            <DesktopAuthField
+              label="パスワード"
+              placeholder="8文字以上"
+              type={showPassword ? 'text' : 'password'}
+              value={password}
+              onChange={setPassword}
+              autoComplete="new-password"
+              disabled={loading}
+              trailing={
+                <button
+                  type="button"
+                  onClick={() => setShowPassword((value) => !value)}
+                  style={{ fontFamily: 'var(--font-mono)', fontSize: 10, fontWeight: 800, color: 'var(--color-muted)' }}
+                  aria-label={showPassword ? 'パスワードを隠す' : 'パスワードを表示'}
+                >
+                  {showPassword ? '非表示' : '表示'}
+                </button>
+              }
+            />
+            <DesktopAuthField
+              label="パスワード（確認）"
+              placeholder="もう一度入力"
+              type={showPassword ? 'text' : 'password'}
+              value={confirmPassword}
+              onChange={setConfirmPassword}
+              autoComplete="new-password"
+              disabled={loading}
+            />
+            <DesktopAuthPrimaryButton
+              variant="accent"
+              disabled={
+                loading ||
+                email.trim().length === 0 ||
+                password.length === 0 ||
+                confirmPassword.length === 0
+              }
+            >
+              {loading ? '送信中...' : '認証コードを送信'}
+            </DesktopAuthPrimaryButton>
+          </form>
+
+          <DesktopAuthOAuth
+            redirectPath={redirect}
+            disabled={loading}
+            onError={(message) => setError(message || null)}
+          />
+
+          <div className="muted" style={{ fontSize: 12, textAlign: 'center', marginTop: 18, lineHeight: 1.6 }}>
+            登録すると
+            <Link href="/terms" style={{ color: 'var(--color-accent)', textDecoration: 'none' }}>利用規約</Link>
+            と
+            <Link href="/privacy" style={{ color: 'var(--color-accent)', textDecoration: 'none' }}>プライバシーポリシー</Link>
+            に同意したものとみなされます。
+          </div>
+          <div className="muted" style={{ fontSize: 13.5, textAlign: 'center', marginTop: 16 }}>
+            すでにアカウントをお持ちの方は{' '}
+            <Link
+              href={`/login?redirect=${encodeURIComponent(redirect)}`}
+              style={{ color: 'var(--color-accent)', fontWeight: 700, textDecoration: 'none' }}
+            >
+              ログイン
+            </Link>
+          </div>
+        </DesktopAuthShell>
+
+        <div className="lg:hidden">
+          <SignupShell
+            stepIndex={stepIndex}
+            totalSteps={totalSteps}
+            title="アカウント情報"
+            description="メールアドレスとパスワードを入力してください。"
+            onBack={() => {
+              setStep('onboarding');
+              setError(null);
+            }}
+          >
+            <form onSubmit={handleFormSubmit}>
+              <div className="flex flex-col gap-2.5 px-6 pb-3">
+                {error && <ErrorMessage>{error}</ErrorMessage>}
+
+                <FormField
+                  label="メールアドレス"
+                  placeholder="kenta@example.com"
+                  type="email"
+                  value={email}
+                  onChange={setEmail}
+                  autoComplete="email"
+                  disabled={loading}
+                />
+
+                <FormField
+                  label="パスワード"
+                  placeholder="8文字以上"
+                  type={showPassword ? 'text' : 'password'}
+                  value={password}
+                  onChange={setPassword}
+                  autoComplete="new-password"
+                  disabled={loading}
+                  trailing={
+                    <button
+                      type="button"
+                      onClick={() => setShowPassword((value) => !value)}
+                      className="font-mono text-[10px] font-bold text-[var(--color-muted)]"
+                      aria-label={showPassword ? 'パスワードを隠す' : 'パスワードを表示'}
+                    >
+                      {showPassword ? '非表示' : '表示'}
+                    </button>
+                  }
+                />
+
+                <FormField
+                  label="パスワード（確認）"
+                  placeholder="もう一度入力"
+                  type={showPassword ? 'text' : 'password'}
+                  value={confirmPassword}
+                  onChange={setConfirmPassword}
+                  autoComplete="new-password"
+                  disabled={loading}
+                />
+              </div>
+
+              <div className="px-6 pb-4">
+                <PrimaryAction
+                  type="submit"
+                  disabled={
+                    loading ||
+                    email.trim().length === 0 ||
+                    password.length === 0 ||
+                    confirmPassword.length === 0
+                  }
+                >
+                  {loading ? '送信中...' : '認証コードを送信'}
+                </PrimaryAction>
+              </div>
+            </form>
+
+            <OAuthProviderButtons
+              redirectPath={redirect}
+              disabled={loading}
+              onError={(message) => setError(message || null)}
+            />
+
+            <div className="flex items-center gap-2.5 px-6 pb-3.5 pt-1.5">
+              <div className="h-px flex-1 bg-[var(--color-border)]" />
+              <span className="font-mono text-[10px] text-[var(--color-muted)]">または</span>
+              <div className="h-px flex-1 bg-[var(--color-border)]" />
+            </div>
+
+            <div className="flex flex-col gap-2 px-6 pb-3">
+              <Link
+                href={`/login?redirect=${encodeURIComponent(redirect)}`}
+                className="flex items-center justify-center gap-2 rounded-xl border-2 border-[var(--solid-ink)] bg-white px-3 py-3 text-[13px] font-bold text-[var(--solid-ink)]"
+              >
+                <Icon name="login" size={16} />
+                ログインする
+              </Link>
+            </div>
+          </SignupShell>
+        </div>
+      </>
+    );
+  }
+
+  // ── Onboarding Step ──────────────────────────────────────
+  const onboardingValid =
+    displayName.trim().length >= 1 &&
+    /^[a-z0-9_]{3,20}$/.test(userHandle) &&
+    handleAvailable !== false;
+
   return (
     <>
+      {/* Desktop */}
       <DesktopAuthShell
-        title="アカウントを作成"
-        description="無料で始められます。クレジットカード不要。"
+        title="プロフィール設定"
+        description="まずは、あなたのことを教えてください。"
       >
-        <form onSubmit={handleSubmit}>
-          {error && <DesktopAuthError>{error}</DesktopAuthError>}
-          <DesktopAuthField
-            label="メールアドレス"
-            placeholder="you@example.com"
-            type="email"
-            value={email}
-            onChange={setEmail}
-            autoComplete="email"
-            disabled={loading}
-          />
-          <DesktopAuthField
-            label="パスワード"
-            placeholder="8文字以上"
-            type={showPassword ? 'text' : 'password'}
-            value={password}
-            onChange={setPassword}
-            autoComplete="new-password"
-            disabled={loading}
-            trailing={
-              <button
-                type="button"
-                onClick={() => setShowPassword((value) => !value)}
-                style={{ fontFamily: 'var(--font-mono)', fontSize: 10, fontWeight: 800, color: 'var(--color-muted)' }}
-                aria-label={showPassword ? 'パスワードを隠す' : 'パスワードを表示'}
-              >
-                {showPassword ? '非表示' : '表示'}
-              </button>
-            }
-          />
-          <DesktopAuthField
-            label="パスワード（確認）"
-            placeholder="もう一度入力"
-            type={showPassword ? 'text' : 'password'}
-            value={confirmPassword}
-            onChange={setConfirmPassword}
-            autoComplete="new-password"
-            disabled={loading}
-          />
-          <DesktopAuthPrimaryButton
-            variant="accent"
-            disabled={
-              loading ||
-              email.trim().length === 0 ||
-              password.length === 0 ||
-              confirmPassword.length === 0
-            }
-          >
-            {loading ? '送信中...' : '無料で始める'}
-          </DesktopAuthPrimaryButton>
-        </form>
-
-        <DesktopAuthOAuth
-          redirectPath={redirect}
+        {error && <DesktopAuthError>{error}</DesktopAuthError>}
+        <DesktopAuthField
+          label="ユーザー名"
+          placeholder="けんた"
+          type="text"
+          value={displayName}
+          onChange={setDisplayName}
+          autoComplete="name"
           disabled={loading}
-          onError={(message) => setError(message || null)}
         />
-
-        <div className="muted" style={{ fontSize: 12, textAlign: 'center', marginTop: 18, lineHeight: 1.6 }}>
-          登録すると
-          <Link href="/terms" style={{ color: 'var(--color-accent)', textDecoration: 'none' }}>利用規約</Link>
-          と
-          <Link href="/privacy" style={{ color: 'var(--color-accent)', textDecoration: 'none' }}>プライバシーポリシー</Link>
-          に同意したものとみなされます。
+        <div className="ds-field">
+          <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 12, marginBottom: 7 }}>
+            <label style={{ marginBottom: 0 }}>ユーザーID</label>
+            {userHandle.length >= 3 && (
+              <span style={{ fontSize: 11, fontWeight: 700, color: handleChecking ? 'var(--color-muted)' : handleAvailable ? 'var(--color-accent)' : handleAvailable === false ? 'var(--color-error)' : 'var(--color-muted)' }}>
+                {handleChecking ? '確認中...' : handleAvailable ? '利用可能' : handleAvailable === false ? '使用済み' : ''}
+              </span>
+            )}
+          </div>
+          <div style={{ position: 'relative' }}>
+            <input
+              className="ds-input"
+              type="text"
+              value={userHandle}
+              onChange={(e) => handleUserHandleChange(e.target.value)}
+              placeholder="kenta_123"
+              autoComplete="username"
+              style={{ paddingLeft: 30 }}
+            />
+            <span style={{ position: 'absolute', left: 12, top: '50%', transform: 'translateY(-50%)', fontSize: 14, fontWeight: 700, color: 'var(--color-muted)' }}>@</span>
+          </div>
+          <div style={{ fontSize: 11, color: 'var(--color-muted)', marginTop: 5 }}>
+            半角英小文字・数字・アンダースコア（3〜20文字）
+          </div>
         </div>
+        <div className="ds-field">
+          <label>英検レベル（任意）</label>
+          <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8, marginTop: 4 }}>
+            {EIKEN_LEVELS.map((level) => (
+              <button
+                key={level.value}
+                type="button"
+                onClick={() => setEikenLevel(eikenLevel === level.value ? null : level.value)}
+                className={`ds-chip ${eikenLevel === level.value ? 'active' : ''}`}
+              >
+                {level.label}
+              </button>
+            ))}
+          </div>
+          <div style={{ fontSize: 11, color: 'var(--color-muted)', marginTop: 8 }}>
+            英検の級に合わせて学習レベルを調整します。あとから変更できます。
+          </div>
+        </div>
+        <DesktopAuthPrimaryButton
+          type="button"
+          variant="accent"
+          disabled={!onboardingValid}
+          onClick={handleOnboardingSubmit}
+        >
+          次へ進む
+        </DesktopAuthPrimaryButton>
         <div className="muted" style={{ fontSize: 13.5, textAlign: 'center', marginTop: 16 }}>
           すでにアカウントをお持ちの方は{' '}
           <Link
@@ -356,78 +614,89 @@ function SignupForm() {
         </div>
       </DesktopAuthShell>
 
+      {/* Mobile */}
       <div className="lg:hidden">
         <SignupShell
-          stepLabel="1/2"
-          title="新規登録"
-          description="メールアドレスとパスワードでアカウントを作成します。"
+          stepIndex={stepIndex}
+          totalSteps={totalSteps}
+          title="プロフィール設定"
+          description="まずは、あなたのことを教えてください。"
           backHref="/"
         >
-          <form onSubmit={handleSubmit}>
-            <div className="flex flex-col gap-2.5 px-6 pb-3">
-              {error && <ErrorMessage>{error}</ErrorMessage>}
+          <div className="flex flex-col gap-3 px-6 pb-3">
+            {error && <ErrorMessage>{error}</ErrorMessage>}
 
-              <FormField
-                label="メールアドレス"
-                placeholder="kenta@example.com"
-                type="email"
-                value={email}
-                onChange={setEmail}
-                autoComplete="email"
-                disabled={loading}
-              />
+            <FormField
+              label="ユーザー名"
+              placeholder="けんた"
+              type="text"
+              value={displayName}
+              onChange={setDisplayName}
+              autoComplete="name"
+            />
 
-              <FormField
-                label="パスワード"
-                placeholder="8文字以上"
-                type={showPassword ? 'text' : 'password'}
-                value={password}
-                onChange={setPassword}
-                autoComplete="new-password"
-                disabled={loading}
-                trailing={
+            <div>
+              <div className="mb-[5px] flex items-center justify-between pl-0.5">
+                <span className="font-mono text-[9px] font-bold tracking-[0.06em] text-[var(--color-muted)]">
+                  ユーザーID
+                </span>
+                {userHandle.length >= 3 && (
+                  <span className={`text-[10px] font-bold ${handleChecking ? 'text-[var(--color-muted)]' : handleAvailable ? 'text-[var(--color-accent)]' : handleAvailable === false ? 'text-[var(--color-error)]' : 'text-[var(--color-muted)]'}`}>
+                    {handleChecking ? '確認中...' : handleAvailable ? '利用可能' : handleAvailable === false ? '使用済み' : ''}
+                  </span>
+                )}
+              </div>
+              <div className="flex items-center gap-0 rounded-[10px] border-2 border-[var(--solid-ink)] bg-white px-3 py-[11px]">
+                <span className="mr-1 text-sm font-bold text-[var(--color-muted)]">@</span>
+                <input
+                  type="text"
+                  value={userHandle}
+                  onChange={(e) => handleUserHandleChange(e.target.value)}
+                  placeholder="kenta_123"
+                  autoComplete="username"
+                  className="flex-1 border-none bg-transparent text-[13px] text-[var(--solid-ink)] outline-none placeholder:text-[var(--color-muted)]"
+                />
+              </div>
+              <div className="mt-1 pl-0.5 text-[10px] text-[var(--color-muted)]">
+                半角英小文字・数字・_（3〜20文字）
+              </div>
+            </div>
+
+            <div>
+              <div className="mb-[5px] pl-0.5 font-mono text-[9px] font-bold tracking-[0.06em] text-[var(--color-muted)]">
+                英検レベル（任意）
+              </div>
+              <div className="flex flex-wrap gap-[7px]">
+                {EIKEN_LEVELS.map((level) => (
                   <button
+                    key={level.value}
                     type="button"
-                    onClick={() => setShowPassword((value) => !value)}
-                    className="font-mono text-[10px] font-bold text-[var(--color-muted)]"
-                    aria-label={showPassword ? 'パスワードを隠す' : 'パスワードを表示'}
+                    onClick={() => setEikenLevel(eikenLevel === level.value ? null : level.value)}
+                    className={`rounded-[10px] border-2 px-3.5 py-2 text-[12px] font-bold transition-all ${
+                      eikenLevel === level.value
+                        ? 'border-[var(--solid-ink)] bg-[var(--solid-ink)] text-white shadow-[2px_3px_0_var(--solid-ink)]'
+                        : 'border-[var(--solid-ink)] bg-white text-[var(--solid-ink)]'
+                    }`}
                   >
-                    {showPassword ? '非表示' : '表示'}
+                    {level.label}
                   </button>
-                }
-              />
-
-              <FormField
-                label="パスワード（確認）"
-                placeholder="もう一度入力"
-                type={showPassword ? 'text' : 'password'}
-                value={confirmPassword}
-                onChange={setConfirmPassword}
-                autoComplete="new-password"
-                disabled={loading}
-              />
+                ))}
+              </div>
+              <div className="mt-2 pl-0.5 text-[10px] leading-relaxed text-[var(--color-muted)]">
+                英検の級に合わせて学習レベルを調整します。あとから変更できます。
+              </div>
             </div>
+          </div>
 
-            <div className="px-6 pb-4">
-              <PrimaryAction
-                type="submit"
-                disabled={
-                  loading ||
-                  email.trim().length === 0 ||
-                  password.length === 0 ||
-                  confirmPassword.length === 0
-                }
-              >
-                {loading ? '送信中...' : '認証コードを送信'}
-              </PrimaryAction>
-            </div>
-          </form>
-
-          <OAuthProviderButtons
-            redirectPath={redirect}
-            disabled={loading}
-            onError={(message) => setError(message || null)}
-          />
+          <div className="px-6 pb-4 pt-2">
+            <PrimaryAction
+              type="button"
+              disabled={!onboardingValid}
+              onClick={handleOnboardingSubmit}
+            >
+              次へ進む
+            </PrimaryAction>
+          </div>
 
           <div className="flex items-center gap-2.5 px-6 pb-3.5 pt-1.5">
             <div className="h-px flex-1 bg-[var(--color-border)]" />
@@ -451,14 +720,16 @@ function SignupForm() {
 }
 
 function SignupShell({
-  stepLabel,
+  stepIndex,
+  totalSteps,
   title,
   description,
   backHref,
   onBack,
   children,
 }: {
-  stepLabel: string;
+  stepIndex: number;
+  totalSteps: number;
   title: string;
   description: string;
   backHref?: string;
@@ -468,7 +739,7 @@ function SignupShell({
   const backClassName = 'flex h-[38px] w-[38px] items-center justify-center rounded-[19px] border-2 border-[var(--solid-ink)] bg-white text-[var(--solid-ink)] transition-all duration-100 active:translate-x-px active:translate-y-px';
 
   return (
-    <div className="relative mx-auto flex min-h-screen w-full max-w-[480px] flex-col bg-[var(--color-background)] pt-3 font-[var(--font-body)]">
+    <div className="relative mx-auto flex min-h-screen w-full max-w-[480px] flex-col bg-[#f3f0e9] pt-3 font-[var(--font-body)] [background-image:radial-gradient(rgba(26,26,26,0.045)_1px,transparent_1px)] [background-size:22px_22px]">
       <div className="flex items-center gap-2 px-[14px] pt-1">
         {backHref ? (
           <Link href={backHref} className={backClassName} aria-label="戻る">
@@ -486,17 +757,17 @@ function SignupShell({
         )}
         <div className="flex-1" />
         <div className="mr-1.5 flex items-center gap-1">
-          <span className="font-mono text-[10px] font-bold tabular-nums text-[var(--color-muted)]">
-            {stepLabel}
+          <span className="font-mono text-[10px] font-bold tabular-nums text-[#8a857a]">
+            {stepIndex}/{totalSteps}
           </span>
           <div className="flex gap-[3px]">
-            {[1, 2].map((item) => (
+            {Array.from({ length: totalSteps }, (_, i) => (
               <div
-                key={item}
+                key={i}
                 className="h-1 w-[18px] rounded-sm"
                 style={{
                   background:
-                    Number(stepLabel[0]) >= item
+                    stepIndex > i
                       ? 'var(--solid-ink)'
                       : 'rgba(26,26,26,0.15)',
                 }}
@@ -517,7 +788,7 @@ function SignupShell({
         <div className="font-display text-2xl font-extrabold leading-[1.2] tracking-[-0.02em] text-[var(--solid-ink)]">
           {title}
         </div>
-        <div className="mt-1 text-xs text-[var(--color-muted)]">{description}</div>
+        <div className="mt-1 text-xs text-[#8a857a]">{description}</div>
       </div>
 
       {children}
@@ -556,7 +827,7 @@ function PrimaryAction({
       onClick={onClick}
       className="group w-full disabled:pointer-events-none disabled:opacity-60"
     >
-      <div className="flex items-center justify-center gap-2 rounded-xl border-2 border-[var(--solid-ink)] bg-[var(--solid-ink)] py-3.5 text-center text-sm font-bold text-white">
+      <div className="flex items-center justify-center gap-2 rounded-[14px] border-2 border-[var(--solid-ink)] bg-[var(--solid-ink)] py-3.5 text-center text-sm font-bold text-white shadow-[3px_4px_0_#000] transition-all active:translate-x-0.5 active:translate-y-0.5 active:shadow-[1px_1px_0_#000]">
         {children}
       </div>
     </button>
@@ -565,7 +836,7 @@ function PrimaryAction({
 
 function SignupFallback() {
   return (
-    <div className="relative mx-auto flex min-h-screen w-full max-w-[480px] flex-col items-center justify-center bg-[var(--color-background)] font-[var(--font-body)]">
+    <div className="relative mx-auto flex min-h-screen w-full max-w-[480px] flex-col items-center justify-center bg-[#f3f0e9] font-[var(--font-body)] [background-image:radial-gradient(rgba(26,26,26,0.045)_1px,transparent_1px)] [background-size:22px_22px]">
       <Icon name="progress_activity" size={28} className="animate-spin text-[var(--solid-ink)]" />
     </div>
   );
@@ -600,7 +871,7 @@ function FormField({
 }) {
   return (
     <label className="block">
-      <div className="mb-[5px] pl-0.5 font-mono text-[9px] font-bold tracking-[0.06em] text-[var(--color-muted)]">
+      <div className="mb-[5px] pl-0.5 font-mono text-[9px] font-bold tracking-[0.06em] text-[#8a857a]">
         {label}
       </div>
       <div className="flex items-center gap-2 rounded-[10px] border-2 border-[var(--solid-ink)] bg-white px-3 py-[11px]">

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -540,12 +540,12 @@ function SignupForm() {
       {/* Desktop */}
       <DesktopAuthShell
         title="プロフィール設定"
-        description="まずは、あなたのことを教えてください。"
+        description=""
       >
         {error && <DesktopAuthError>{error}</DesktopAuthError>}
         <DesktopAuthField
           label="ユーザー名"
-          placeholder="けんた"
+          placeholder="山田太郎"
           type="text"
           value={displayName}
           onChange={setDisplayName}
@@ -620,7 +620,7 @@ function SignupForm() {
           stepIndex={stepIndex}
           totalSteps={totalSteps}
           title="プロフィール設定"
-          description="まずは、あなたのことを教えてください。"
+          description=""
           backHref="/"
         >
           <div className="flex flex-col gap-3 px-6 pb-3">
@@ -628,7 +628,7 @@ function SignupForm() {
 
             <FormField
               label="ユーザー名"
-              placeholder="けんた"
+              placeholder="山田太郎"
               type="text"
               value={displayName}
               onChange={setDisplayName}

--- a/src/lib/auth/signup-flow.test.ts
+++ b/src/lib/auth/signup-flow.test.ts
@@ -10,10 +10,11 @@ import {
   isSignupOtpComplete,
   resolveSignupRouteError,
   validateSignupCredentials,
+  validateOnboardingData,
 } from './signup-flow';
 
-test('signup flow is fixed to form then otp without onboarding steps', () => {
-  assert.deepEqual(SIGNUP_STEPS, ['form', 'otp']);
+test('signup flow includes onboarding, form, then otp steps', () => {
+  assert.deepEqual(SIGNUP_STEPS, ['onboarding', 'form', 'otp']);
   assert.equal(SIGNUP_OTP_LENGTH, 6);
   assert.equal(SIGNUP_RESEND_COOLDOWN_SECONDS, 60);
 });
@@ -66,6 +67,49 @@ test('signup request bodies use the existing OTP API contracts', () => {
       code: '123456',
       password: 'password123',
     },
+  );
+
+  assert.deepEqual(
+    buildSignupVerifyRequestBody({
+      email: 'User@Example.COM',
+      code: '123456',
+      password: 'password123',
+      onboarding: {
+        displayName: ' けんた ',
+        userHandle: 'kenta_123',
+        eikenLevel: '3',
+      },
+    }),
+    {
+      email: 'User@Example.COM',
+      code: '123456',
+      password: 'password123',
+      display_name: 'けんた',
+      user_handle: 'kenta_123',
+      eiken_level: '3',
+    },
+  );
+});
+
+test('validateOnboardingData validates name and handle', () => {
+  assert.deepEqual(
+    validateOnboardingData({ displayName: '', userHandle: 'abc', eikenLevel: null }),
+    { ok: false, error: 'ユーザー名は1〜30文字で入力してください' },
+  );
+
+  assert.deepEqual(
+    validateOnboardingData({ displayName: 'けんた', userHandle: 'ab', eikenLevel: null }),
+    { ok: false, error: 'IDは半角英小文字・数字・アンダースコアで3〜20文字です' },
+  );
+
+  assert.deepEqual(
+    validateOnboardingData({ displayName: 'けんた', userHandle: 'AB_UPPER', eikenLevel: null }),
+    { ok: false, error: 'IDは半角英小文字・数字・アンダースコアで3〜20文字です' },
+  );
+
+  assert.deepEqual(
+    validateOnboardingData({ displayName: 'けんた', userHandle: 'kenta_123', eikenLevel: '3' }),
+    { ok: true },
   );
 });
 

--- a/src/lib/auth/signup-flow.test.ts
+++ b/src/lib/auth/signup-flow.test.ts
@@ -75,7 +75,7 @@ test('signup request bodies use the existing OTP API contracts', () => {
       code: '123456',
       password: 'password123',
       onboarding: {
-        displayName: ' けんた ',
+        displayName: ' 山田太郎 ',
         userHandle: 'kenta_123',
         eikenLevel: '3',
       },
@@ -84,7 +84,7 @@ test('signup request bodies use the existing OTP API contracts', () => {
       email: 'User@Example.COM',
       code: '123456',
       password: 'password123',
-      display_name: 'けんた',
+      display_name: '山田太郎',
       user_handle: 'kenta_123',
       eiken_level: '3',
     },
@@ -98,17 +98,17 @@ test('validateOnboardingData validates name and handle', () => {
   );
 
   assert.deepEqual(
-    validateOnboardingData({ displayName: 'けんた', userHandle: 'ab', eikenLevel: null }),
+    validateOnboardingData({ displayName: '山田太郎', userHandle: 'ab', eikenLevel: null }),
     { ok: false, error: 'IDは半角英小文字・数字・アンダースコアで3〜20文字です' },
   );
 
   assert.deepEqual(
-    validateOnboardingData({ displayName: 'けんた', userHandle: 'AB_UPPER', eikenLevel: null }),
+    validateOnboardingData({ displayName: '山田太郎', userHandle: 'AB_UPPER', eikenLevel: null }),
     { ok: false, error: 'IDは半角英小文字・数字・アンダースコアで3〜20文字です' },
   );
 
   assert.deepEqual(
-    validateOnboardingData({ displayName: 'けんた', userHandle: 'kenta_123', eikenLevel: '3' }),
+    validateOnboardingData({ displayName: '山田太郎', userHandle: 'kenta_123', eikenLevel: '3' }),
     { ok: true },
   );
 });

--- a/src/lib/auth/signup-flow.ts
+++ b/src/lib/auth/signup-flow.ts
@@ -1,8 +1,16 @@
-export const SIGNUP_STEPS = ['form', 'otp'] as const;
+export const SIGNUP_STEPS = ['onboarding', 'form', 'otp'] as const;
 export type SignupStep = typeof SIGNUP_STEPS[number];
 
 export const SIGNUP_OTP_LENGTH = 6;
 export const SIGNUP_RESEND_COOLDOWN_SECONDS = 60;
+
+export type EikenLevelOption = '5' | '4' | '3' | 'pre2' | '2' | 'pre1' | '1' | null;
+
+export interface OnboardingData {
+  displayName: string;
+  userHandle: string;
+  eikenLevel: EikenLevelOption;
+}
 
 export type SignupCredentialsValidation =
   | { ok: true }
@@ -29,6 +37,19 @@ export function validateSignupCredentials(params: {
   return { ok: true };
 }
 
+export function validateOnboardingData(data: OnboardingData): SignupCredentialsValidation {
+  const trimmedName = data.displayName.trim();
+  if (trimmedName.length < 1 || trimmedName.length > 30) {
+    return { ok: false, error: 'ユーザー名は1〜30文字で入力してください' };
+  }
+
+  if (!/^[a-z0-9_]{3,20}$/.test(data.userHandle)) {
+    return { ok: false, error: 'IDは半角英小文字・数字・アンダースコアで3〜20文字です' };
+  }
+
+  return { ok: true };
+}
+
 export function isSignupOtpComplete(code: string): boolean {
   return code.length === SIGNUP_OTP_LENGTH;
 }
@@ -41,11 +62,17 @@ export function buildSignupVerifyRequestBody(params: {
   email: string;
   code: string;
   password: string;
+  onboarding?: OnboardingData;
 }) {
   return {
     email: params.email,
     code: params.code,
     password: params.password,
+    ...(params.onboarding ? {
+      display_name: params.onboarding.displayName.trim(),
+      user_handle: params.onboarding.userHandle,
+      eiken_level: params.onboarding.eikenLevel,
+    } : {}),
   };
 }
 

--- a/supabase/migrations/20260625130000_add_onboarding_profile_fields.sql
+++ b/supabase/migrations/20260625130000_add_onboarding_profile_fields.sql
@@ -1,0 +1,56 @@
+-- Add onboarding profile fields: display_name, user_handle, eiken_level.
+-- These are collected during signup BEFORE email authentication.
+
+ALTER TABLE public.profiles
+  ADD COLUMN IF NOT EXISTS display_name TEXT,
+  ADD COLUMN IF NOT EXISTS user_handle TEXT,
+  ADD COLUMN IF NOT EXISTS eiken_level TEXT;
+
+-- user_handle must be unique and follow a slug-like pattern (lowercase alphanum + underscore)
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'profiles_user_handle_unique'
+      AND conrelid = 'public.profiles'::regclass
+  ) THEN
+    ALTER TABLE public.profiles
+      ADD CONSTRAINT profiles_user_handle_unique UNIQUE (user_handle);
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'profiles_user_handle_format'
+      AND conrelid = 'public.profiles'::regclass
+  ) THEN
+    ALTER TABLE public.profiles
+      ADD CONSTRAINT profiles_user_handle_format
+      CHECK (user_handle IS NULL OR user_handle ~ '^[a-z0-9_]{3,20}$');
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'profiles_display_name_length'
+      AND conrelid = 'public.profiles'::regclass
+  ) THEN
+    ALTER TABLE public.profiles
+      ADD CONSTRAINT profiles_display_name_length
+      CHECK (display_name IS NULL OR (char_length(trim(display_name)) >= 1 AND char_length(trim(display_name)) <= 30));
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'profiles_eiken_level_check'
+      AND conrelid = 'public.profiles'::regclass
+  ) THEN
+    ALTER TABLE public.profiles
+      ADD CONSTRAINT profiles_eiken_level_check
+      CHECK (eiken_level IS NULL OR eiken_level IN ('5', '4', '3', 'pre2', '2', 'pre1', '1'));
+  END IF;
+END;
+$$;
+
+-- Index for handle lookups (uniqueness check during signup)
+CREATE INDEX IF NOT EXISTS idx_profiles_user_handle
+  ON public.profiles (user_handle)
+  WHERE user_handle IS NOT NULL;


### PR DESCRIPTION
## Summary

- 新規ユーザー登録フローにメアド認証前のオンボーディングステップを追加（ユーザー名、ユーザーID、英検レベル選択）
- ログイン/サインアップ画面のモバイル版をLPページの配色（クリーム背景 `#f3f0e9` + ドットグリッド + ウォームグレーラベル + ソリッドシャドウ）に統一
- デスクトップ版の認証ブランドパネルもLP風に変更
- `profiles` テーブルに `display_name`, `user_handle`, `eiken_level` カラムを追加するマイグレーションSQL
- `/api/auth/check-handle` エンドポイントでハンドル重複チェック（リアルタイム）
- `signup-verify` API でオンボーディングデータをユーザー作成後に保存

## Test plan

- [x] `npm run build` パス
- [x] `npm test` 全578テストパス
- [x] `npm run lint` 新規エラーなし
- [ ] サインアップフロー: オンボーディング → メアド/パスワード → OTP の3ステップ確認
- [ ] ユーザーID重複チェックがリアルタイムで動作すること
- [ ] 英検レベル選択がトグル動作すること
- [ ] マイグレーション適用後、profiles テーブルに新カラムが追加されること
- [ ] ログイン/サインアップ画面の配色がLPと統一されていること

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016vJp7tLKiPL8D6EG1nmdGc

---
_Generated by [Claude Code](https://claude.ai/code/session_016vJp7tLKiPL8D6EG1nmdGc)_