### PR TITLE
Fix distinct translation quiz targets

### DIFF
--- a/shared/db/mappers.ts
+++ b/shared/db/mappers.ts
@@ -182,12 +182,19 @@ export interface WordTranslationRow {
   id?: string | null;
   word_id?: string | null;
   lexicon_sense_id?: string | null;
+  lexicon_senses?: LexiconSenseRow | LexiconSenseRow[] | null;
   translation_ja?: string | null;
   normalized_translation_ja?: string | null;
   source?: string | null;
   meaning_rank?: number | null;
   position?: number | null;
   is_primary?: boolean | null;
+  status?: string | null;
+  last_reviewed_at?: string | null;
+  next_review_at?: string | null;
+  ease_factor?: number | null;
+  interval_days?: number | null;
+  repetition?: number | null;
   created_at?: string | null;
   updated_at?: string | null;
 }
@@ -239,6 +246,12 @@ function normalizeDistractors(value: unknown): string[] {
   return value.filter((item): item is string => typeof item === 'string');
 }
 
+function normalizeWordStatus(value: unknown): Word['status'] | undefined {
+  return value === 'new' || value === 'review' || value === 'mastered'
+    ? value
+    : undefined;
+}
+
 function resolveLexiconRow(
   value: WordRow['lexicon_entries'],
 ): LexiconEntryRow | null {
@@ -287,6 +300,7 @@ function normalizeWordTranslationRows(value: unknown): WordTranslation[] {
   for (const item of value) {
     if (!item || typeof item !== 'object') continue;
     const row = item as WordTranslationRow;
+    const sense = resolveLexiconSenseRow(row.lexicon_senses);
     const translationJa = normalizeTranslationText(row.translation_ja);
     if (!translationJa) continue;
     const normalizedTranslationJa = normalizeTranslationText(row.normalized_translation_ja) || translationJa;
@@ -296,13 +310,21 @@ function normalizeWordTranslationRows(value: unknown): WordTranslation[] {
     translations.push({
       id: row.id ?? undefined,
       wordId: row.word_id ?? undefined,
-      lexiconSenseId: row.lexicon_sense_id ?? undefined,
+      lexiconSenseId: row.lexicon_sense_id ?? sense?.id ?? undefined,
+      distinctKey: toNonEmptyString(sense?.distinct_key) ?? undefined,
+      lexiconSenseIsPrimary: sense?.is_primary ?? undefined,
       translationJa,
       normalizedTranslationJa,
       source: row.source === 'scan' || row.source === 'ai' || row.source === 'user' ? row.source : undefined,
       meaningRank: typeof row.meaning_rank === 'number' && row.meaning_rank > 0 ? row.meaning_rank : translations.length + 1,
       position: typeof row.position === 'number' ? row.position : translations.length,
       isPrimary: row.is_primary ?? false,
+      status: normalizeWordStatus(row.status),
+      lastReviewedAt: row.last_reviewed_at ?? undefined,
+      nextReviewAt: row.next_review_at ?? undefined,
+      easeFactor: row.ease_factor ?? undefined,
+      intervalDays: row.interval_days ?? undefined,
+      repetition: row.repetition ?? undefined,
       createdAt: row.created_at ?? undefined,
       updatedAt: row.updated_at ?? undefined,
     });
@@ -328,12 +350,18 @@ function resolveWordTranslations(row: WordRow): WordTranslation[] {
 
   const lexicon = resolveLexiconRow(row.lexicon_entries);
   const sense = resolveLexiconSenseRow(row.lexicon_senses);
-  return normalizeWordTranslationPayload({
+  const fallback = normalizeWordTranslationPayload({
     japanese: normalizeLexiconTranslation(sense?.translation_ja)
       ?? normalizeLexiconTranslation(lexicon?.translation_ja)
       ?? row.japanese,
     lexiconSenseId: row.lexicon_sense_id ?? sense?.id,
   }).translations;
+
+  return fallback.map((translation) => ({
+    ...translation,
+    distinctKey: toNonEmptyString(sense?.distinct_key) ?? undefined,
+    lexiconSenseIsPrimary: sense?.is_primary ?? undefined,
+  }));
 }
 
 function resolveWordCefrLevel(row: WordRow): string | undefined {

--- a/shared/types/index.ts
+++ b/shared/types/index.ts
@@ -53,12 +53,20 @@ export interface WordTranslation {
   id?: string;
   wordId?: string;
   lexiconSenseId?: string;
+  distinctKey?: string;
+  lexiconSenseIsPrimary?: boolean;
   translationJa: string;
   normalizedTranslationJa: string;
   source?: WordTranslationSource;
   meaningRank: number;
   position: number;
   isPrimary: boolean;
+  status?: WordStatus;
+  lastReviewedAt?: string;
+  nextReviewAt?: string;
+  easeFactor?: number;
+  intervalDays?: number;
+  repetition?: number;
   createdAt?: string;
   updatedAt?: string;
 }
@@ -180,6 +188,14 @@ export interface Word {
   wordOrderQuiz?: WordOrderQuizCache;
   // User-created custom sections
   customSections?: CustomSection[];
+  quizTarget?: {
+    kind: 'word' | 'translation';
+    key: string;
+    wordId: string;
+    translationId?: string;
+    lexiconSenseId?: string;
+    distinctKey?: string;
+  };
 }
 
 export interface Project {

--- a/src/app/api/scan-jobs/process/route.contract.test.ts
+++ b/src/app/api/scan-jobs/process/route.contract.test.ts
@@ -720,7 +720,7 @@ test('server_cloud writes source_modes from normalized scan_modes instead of AI 
   assert.deepEqual(wordsInsert.payload[0]?.source_modes, ['all', 'idiom', 'eiken']);
 });
 
-test('server_cloud expands split translations before inserting quiz words', async () => {
+test('server_cloud keeps split translations on one inserted word', async () => {
   const client = new FakeScanProcessClient({
     claimedJob: pendingServerCloudJob(),
     userPreference: { ai_enabled: false },
@@ -776,7 +776,7 @@ test('server_cloud expands split translations before inserting quiz words', asyn
     success: true,
     saveMode: 'server_cloud',
     projectId: NEW_PROJECT_ID,
-    wordCount: 2,
+    wordCount: 1,
   });
 
   const wordsInsert = findOperation(
@@ -785,7 +785,7 @@ test('server_cloud expands split translations before inserting quiz words', asyn
     'missing words insert',
   );
   assert.ok(Array.isArray(wordsInsert.payload));
-  assert.deepEqual(wordsInsert.payload.map((row) => row.japanese), ['感覚', '分別']);
+  assert.deepEqual(wordsInsert.payload.map((row) => row.japanese), ['感覚']);
 
   const translationsUpsert = findOperation(
     client,
@@ -799,7 +799,7 @@ test('server_cloud expands split translations before inserting quiz words', asyn
     position: row.position,
   })), [
     { word_id: 'word-1', translation_ja: '感覚', is_primary: true, position: 0 },
-    { word_id: 'word-2', translation_ja: '分別', is_primary: true, position: 0 },
+    { word_id: 'word-1', translation_ja: '分別', is_primary: false, position: 1 },
   ]);
 });
 

--- a/src/app/api/scan-jobs/process/route.ts
+++ b/src/app/api/scan-jobs/process/route.ts
@@ -85,7 +85,6 @@ import { resolveImmediateWordsWithMasterFirst } from '@/lib/lexicon/master-first
 import { backfillMissingJapaneseTranslationsWithMetadata } from '@/lib/words/backfill-japanese';
 import {
   buildWordTranslationInsertRows,
-  expandWordsByTranslationsForPersistence,
   isWordTranslationsSchemaError,
   normalizeWordForTranslationPersistence,
 } from '@/lib/words/translation-persistence';
@@ -1044,12 +1043,10 @@ export async function processJobById(jobId: string, processDeps?: ProcessJobDeps
         ? null
         : await backfillWords(dedupedWords);
       timing.lexiconResolutionMs = Date.now() - lexiconResolutionStart;
-      const resolvedWords = expandWordsByTranslationsForPersistence(
-        applySourceModesFromScanModes(
-          resolvedResult?.words ?? rollbackResult?.words ?? dedupedWords,
-          modes,
-        ).map((word) => normalizeWordForTranslationPersistence(word)),
-      );
+      const resolvedWords = applySourceModesFromScanModes(
+        resolvedResult?.words ?? rollbackResult?.words ?? dedupedWords,
+        modes,
+      ).map((word) => normalizeWordForTranslationPersistence(word));
       const aiJapaneseCount = resolvedWords.filter((word) => word.japaneseSource === 'ai').length;
 
       console.log('[scan-jobs/process] Extraction finished', {

--- a/src/app/api/words/create/route.test.ts
+++ b/src/app/api/words/create/route.test.ts
@@ -492,11 +492,10 @@ test('words/create uses master-first resolution before legacy backfill', async (
   );
 });
 
-test('words/create expands split translations into separate persisted words', async () => {
+test('words/create keeps split translations on one persisted word', async () => {
   const projectId = '11111111-1111-4111-8111-111111111111';
   const createdAt = new Date('2026-03-15T00:00:00.000Z').toISOString();
   const wordId = '88888888-8888-4888-8888-888888888888';
-  const secondWordId = '99999999-9999-4999-8999-999999999999';
 
   const fakeClient = new FakeWordsCreateClient(
     'user-1',
@@ -507,22 +506,6 @@ test('words/create expands split translations into separate persisted words', as
         project_id: projectId,
         english: 'sense',
         japanese: '感覚',
-        lexicon_entry_id: null,
-        distractors: [],
-        part_of_speech_tags: ['noun'],
-        created_at: createdAt,
-        status: 'new',
-        ease_factor: 2.5,
-        interval_days: 0,
-        repetition: 0,
-        is_favorite: false,
-        lexicon_entries: null,
-      },
-      {
-        id: secondWordId,
-        project_id: projectId,
-        english: 'sense',
-        japanese: '分別',
         lexicon_entry_id: null,
         distractors: [],
         part_of_speech_tags: ['noun'],
@@ -571,8 +554,8 @@ test('words/create expands split translations into separate persisted words', as
   await afterPromise;
 
   assert.equal(response.status, 200);
+  assert.equal(fakeClient.insertedRows.length, 1);
   assert.equal(fakeClient.insertedRows[0]?.['japanese'], '感覚');
-  assert.equal(fakeClient.insertedRows[1]?.['japanese'], '分別');
   assert.deepEqual(
     fakeClient.translationRows.map((row) => ({
       word_id: row.word_id,
@@ -583,7 +566,7 @@ test('words/create expands split translations into separate persisted words', as
     })),
     [
       { word_id: wordId, translation_ja: '感覚', meaning_rank: 1, is_primary: true, position: 0 },
-      { word_id: secondWordId, translation_ja: '分別', meaning_rank: 1, is_primary: true, position: 0 },
+      { word_id: wordId, translation_ja: '分別', meaning_rank: 2, is_primary: false, position: 1 },
     ],
   );
 });

--- a/src/app/api/words/create/route.ts
+++ b/src/app/api/words/create/route.ts
@@ -15,7 +15,6 @@ import { getSupabaseAdmin } from '@/lib/supabase/admin';
 import { prefillWordOrderQuizzesForWords } from '@/lib/scan/word-order-prefill';
 import {
   buildWordTranslationInsertRows,
-  expandWordsByTranslationsForPersistence,
   normalizeWordForTranslationPersistence,
 } from '@/lib/words/translation-persistence';
 import { z } from 'zod';
@@ -176,12 +175,10 @@ export async function handleWordsCreatePost(request: NextRequest, deps?: WordsCr
       ? await backfillWords(immediateResolution.words)
       : { words: immediateResolution.words, aiBackfilledIndexes: [] };
     const aiBackfilledIndexSet = new Set(aiBackfilledIndexes);
-    const translatedWords = expandWordsByTranslationsForPersistence(
-      translatedWordsRaw.map((word, index) => normalizeWordForTranslationPersistence({
-        ...word,
-        ...(aiBackfilledIndexSet.has(index) ? { japaneseSource: 'ai' as const } : {}),
-      })),
-    );
+    const translatedWords = translatedWordsRaw.map((word, index) => normalizeWordForTranslationPersistence({
+      ...word,
+      ...(aiBackfilledIndexSet.has(index) ? { japaneseSource: 'ai' as const } : {}),
+    }));
 
     console.log('[words/create] Immediate resolution finished', {
       requestedWordCount: words.length,

--- a/src/app/quiz/[projectId]/page.tsx
+++ b/src/app/quiz/[projectId]/page.tsx
@@ -8,6 +8,7 @@ import { TypeInQuizField } from '@/components/quiz';
 import { TranslationDisplay } from '@/components/word/TranslationDisplay';
 import { getRepository } from '@/lib/db';
 import { remoteRepository } from '@/lib/db/remote-repository';
+import { createBrowserClient } from '@/lib/supabase';
 import {
   recordCorrectAnswer,
   recordWrongAnswer,
@@ -16,7 +17,7 @@ import {
   getWrongAnswers,
   type WrongAnswer,
 } from '@/lib/utils';
-import { getWordsDueForReview, sortWordsByPriority } from '@/lib/spaced-repetition';
+import { sortWordsByPriority } from '@/lib/spaced-repetition';
 import { loadCollectionWords } from '@/lib/collection-words';
 import {
   applyWordOrderQuestionsToPendingQuiz,
@@ -50,6 +51,14 @@ import {
 } from '@/lib/quiz/quiz-answer';
 import { parseQuizBackgroundDistractorResults } from '@/lib/quiz/background-distractors';
 import { parseReminderPriorityIds, selectReminderQuizWords } from '@/lib/quiz/reminder-quiz';
+import { mapTranslationProgressUpdatesToRow } from '@/lib/quiz/translation-progress';
+import {
+  getQuizTargetCount,
+  hasDueQuizTarget,
+  hasUnmasteredQuizTarget,
+  isTranslationQuizTarget,
+  mergeTranslationProgress,
+} from '@/lib/quiz/translation-targets';
 import { selectPrimaryMeaningWords } from '@/lib/words/memory';
 import { playAnswerFeedbackSound } from '@/lib/audio/answer-feedback';
 import { formatPartOfSpeechLabels } from '@/lib/part-of-speech-labels';
@@ -886,8 +895,8 @@ export default function QuizPage() {
             });
           } else {
             sourceWords = reviewMode
-              ? getWordsDueForReview(allFlat)
-              : allFlat.filter((w) => w.status !== 'mastered');
+              ? allFlat.filter((w) => hasDueQuizTarget(w, { primaryOnly: !isPro }))
+              : allFlat.filter((w) => hasUnmasteredQuizTarget(w, { primaryOnly: !isPro }));
           }
         } else if (collectionId) {
           sourceWords = await loadCollectionWords(collectionId);
@@ -906,7 +915,7 @@ export default function QuizPage() {
         }
 
         if (!reviewMode && !learnMode && !wrongMode && !favoritesMode && !reminderMode) {
-          const nonMastered = sourceWords.filter((w) => w.status !== 'mastered');
+          const nonMastered = sourceWords.filter((w) => hasUnmasteredQuizTarget(w, { primaryOnly: !isPro }));
           if (nonMastered.length > 0) sourceWords = nonMastered;
         }
 
@@ -919,7 +928,8 @@ export default function QuizPage() {
         const prioritized = reminderMode ? sourceWords : sortWordsByPriority(sourceWords);
         setAllWords(prioritized);
 
-        const resolvedCount = Math.max(1, Math.min(questionCount ?? prioritized.length, prioritized.length, MAX_NORMAL_QUIZ_QUESTION_COUNT));
+        const targetCount = getQuizTargetCount(prioritized, { primaryOnly: !isPro });
+        const resolvedCount = Math.max(1, Math.min(questionCount ?? targetCount, targetCount, MAX_NORMAL_QUIZ_QUESTION_COUNT));
         if (questionCount !== resolvedCount) setQuestionCount(resolvedCount);
 
         if (resolvedCount) {
@@ -945,12 +955,12 @@ export default function QuizPage() {
     const syncRemote = async () => {
       try {
         const remoteWords = await remoteRepository.getWords(projectId);
-        const pending = remoteWords.filter((w) => w.status !== 'mastered');
+        const pending = remoteWords.filter((w) => hasUnmasteredQuizTarget(w, { primaryOnly: !isPro }));
         if (pending.length > 0) setAllWords((prev) => pending.length > prev.length ? sortWordsByPriority(pending) : prev);
       } catch { /* silent */ }
     };
     syncRemote();
-  }, [authLoading, user, projectId, reviewMode, learnMode, wrongMode, favoritesMode, reminderMode, collectionId]);
+  }, [authLoading, user, projectId, reviewMode, learnMode, wrongMode, favoritesMode, reminderMode, collectionId, isPro]);
 
   useEffect(() => {
     if (!restoredFromStorage.current) return;
@@ -1010,9 +1020,36 @@ export default function QuizPage() {
     recordActivity();
     try {
       const updates = outcomePlan.wordUpdates;
-      await repository.updateWord(word.id, updates);
-      setQuestions((prev) => prev.map((q, i) => i === currentIndex ? { ...q, word: { ...q.word, ...updates } } : q));
-      setAllWords((prev) => prev.map((w) => w.id === word.id ? { ...w, ...updates } : w));
+      if (isTranslationQuizTarget(word) && word.quizTarget) {
+        const target = word.quizTarget;
+        const translationUpdates = {
+          status: updates.status,
+          lastReviewedAt: updates.lastReviewedAt,
+          nextReviewAt: updates.nextReviewAt,
+          easeFactor: updates.easeFactor,
+          intervalDays: updates.intervalDays,
+          repetition: updates.repetition,
+        };
+
+        if (target.translationId) {
+          const { error } = await createBrowserClient()
+            .from('word_translations')
+            .update(mapTranslationProgressUpdatesToRow(translationUpdates))
+            .eq('id', target.translationId);
+          if (error) throw new Error(error.message);
+        }
+
+        setQuestions((prev) => prev.map((q, i) => i === currentIndex ? { ...q, word: { ...q.word, ...updates } } : q));
+        setAllWords((prev) => prev.map((w) => (
+          w.id === target.wordId
+            ? mergeTranslationProgress(w, target, translationUpdates)
+            : w
+        )));
+      } else {
+        await repository.updateWord(word.id, updates);
+        setQuestions((prev) => prev.map((q, i) => i === currentIndex ? { ...q, word: { ...q.word, ...updates } } : q));
+        setAllWords((prev) => prev.map((w) => w.id === word.id ? { ...w, ...updates } : w));
+      }
       if (user) {
         fetch('/api/quiz-sessions/events', {
           method: 'POST',
@@ -1110,7 +1147,8 @@ export default function QuizPage() {
 
   const handleRestart = async () => {
     clearQuizState();
-    const count = Math.max(1, Math.min(questionCount ?? allWords.length ?? DEFAULT_QUESTION_COUNT, allWords.length || DEFAULT_QUESTION_COUNT, MAX_NORMAL_QUIZ_QUESTION_COUNT));
+    const targetCount = getQuizTargetCount(allWords, { primaryOnly: !isPro });
+    const count = Math.max(1, Math.min(questionCount ?? targetCount ?? DEFAULT_QUESTION_COUNT, targetCount || DEFAULT_QUESTION_COUNT, MAX_NORMAL_QUIZ_QUESTION_COUNT));
     if (allWords.some((w) => needsDistractors(w) || needsWordOrderQuiz(w))) await startQuizWithDistractors(allWords, count);
     else setQuestions(generateQuestions(allWords, count, quizDirection));
     setCurrentIndex(0); setSelectedIndex(null); setWordOrderSelectedTokens([]); setWordOrderResult(null); setIsRevealed(false);
@@ -1169,7 +1207,7 @@ export default function QuizPage() {
 
   /* ---------- Question count selection ---------- */
   if (!questionCount) {
-    const maxQ = Math.min(allWords.length, MAX_NORMAL_QUIZ_QUESTION_COUNT);
+    const maxQ = Math.min(getQuizTargetCount(allWords, { primaryOnly: !isPro }), MAX_NORMAL_QUIZ_QUESTION_COUNT);
     const { parsedInput: parsed, isValidInput: isValid } = parseQuizQuestionCountInput(inputCount, maxQ);
     return (
       <div className="flex min-h-screen flex-col bg-[var(--color-background)] pt-3">

--- a/src/components/home/PwaInstallBanner.tsx
+++ b/src/components/home/PwaInstallBanner.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useState } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { Icon } from '@/components/ui/Icon';
 import {
@@ -18,24 +18,30 @@ function isDismissed(): boolean {
   }
 }
 
+function getInitialBannerState(): {
+  visible: boolean;
+  variant: 'native' | 'ios' | null;
+} {
+  if (pwaPromptUtils.isStandalone() || pwaPromptUtils.isInstalled() || isDismissed()) {
+    return { visible: false, variant: null };
+  }
+
+  if (pwaPromptUtils.hasDeferredPrompt()) {
+    return { visible: true, variant: 'native' };
+  }
+
+  if (pwaPromptUtils.isIos()) {
+    return { visible: true, variant: 'ios' };
+  }
+
+  return { visible: false, variant: null };
+}
+
 export function PwaInstallBanner() {
-  const [visible, setVisible] = useState(false);
-  const [variant, setVariant] = useState<'native' | 'ios' | null>(null);
-
-  useEffect(() => {
-    if (pwaPromptUtils.isStandalone() || pwaPromptUtils.isInstalled() || isDismissed()) return;
-
-    if (pwaPromptUtils.hasDeferredPrompt()) {
-      setVariant('native');
-      setVisible(true);
-    } else if (pwaPromptUtils.isIos()) {
-      setVariant('ios');
-      setVisible(true);
-    }
-  }, []);
+  const [{ visible, variant }, setBannerState] = useState(getInitialBannerState);
 
   const dismiss = useCallback(() => {
-    setVisible(false);
+    setBannerState((state) => ({ ...state, visible: false }));
     try {
       localStorage.setItem(DISMISSED_KEY, '1');
     } catch { /* ignore */ }
@@ -43,7 +49,7 @@ export function PwaInstallBanner() {
 
   const handleInstall = useCallback(async () => {
     await triggerNativeInstall();
-    setVisible(false);
+    setBannerState((state) => ({ ...state, visible: false }));
     try {
       localStorage.setItem(DISMISSED_KEY, '1');
     } catch { /* ignore */ }

--- a/src/lib/quiz/quiz-state.test.ts
+++ b/src/lib/quiz/quiz-state.test.ts
@@ -137,6 +137,82 @@ test('generateQuizQuestions primaryOnly skips explicit distinct non-primary mean
   assert.deepEqual(questions.map((question) => question.word.id), ['free-primary']);
 });
 
+test('generateQuizQuestions expands distinct translations without splitting stored words', () => {
+  const questions = generateQuizQuestions([
+    createWord({
+      id: 'word-free',
+      english: 'free',
+      japanese: '自由な',
+      lexiconEntryId: 'lex-free',
+      lexiconSenseId: 'sense-primary',
+      lexiconSenseIsPrimary: true,
+      translations: [
+        {
+          id: 'translation-primary',
+          wordId: 'word-free',
+          lexiconSenseId: 'sense-primary',
+          translationJa: '自由な',
+          normalizedTranslationJa: '自由な',
+          meaningRank: 1,
+          position: 0,
+          isPrimary: true,
+          lexiconSenseIsPrimary: true,
+          status: 'mastered',
+        },
+        {
+          id: 'translation-cost',
+          wordId: 'word-free',
+          lexiconSenseId: 'sense-cost',
+          distinctKey: 'cost',
+          translationJa: '無料の',
+          normalizedTranslationJa: '無料の',
+          meaningRank: 2,
+          position: 1,
+          isPrimary: false,
+          lexiconSenseIsPrimary: false,
+          status: 'new',
+        },
+      ],
+    }),
+    createWord({ id: 'plain', english: 'plain', japanese: '明白な' }),
+  ], 3, 'en-to-ja', identityShuffle, { preserveOrder: true });
+
+  assert.deepEqual(questions.map((question) => question.word.japanese), ['自由な', '無料の', '明白な']);
+  assert.deepEqual(questions.map((question) => question.word.id), ['word-free', 'word-free', 'plain']);
+  assert.equal(questions[1]?.word.quizTarget?.kind, 'translation');
+  assert.equal(questions[1]?.word.quizTarget?.translationId, 'translation-cost');
+  assert.equal(questions[1]?.word.status, 'new');
+});
+
+test('generateQuizQuestions primaryOnly does not expand distinct translations', () => {
+  const questions = generateQuizQuestions([
+    createWord({
+      id: 'word-free',
+      english: 'free',
+      japanese: '自由な',
+      translations: [
+        {
+          translationJa: '自由な',
+          normalizedTranslationJa: '自由な',
+          meaningRank: 1,
+          position: 0,
+          isPrimary: true,
+        },
+        {
+          distinctKey: 'cost',
+          translationJa: '無料の',
+          normalizedTranslationJa: '無料の',
+          meaningRank: 2,
+          position: 1,
+          isPrimary: false,
+        },
+      ],
+    }),
+  ], 3, 'en-to-ja', identityShuffle, { preserveOrder: true, primaryOnly: true });
+
+  assert.deepEqual(questions.map((question) => question.word.japanese), ['自由な']);
+});
+
 test('generateQuizQuestions allows distinct meanings of the same word as distractors', () => {
   const [question] = generateQuizQuestions([
     createWord({

--- a/src/lib/quiz/quiz-state.ts
+++ b/src/lib/quiz/quiz-state.ts
@@ -10,6 +10,11 @@ import {
   isSameWordMeaning,
   selectPrimaryMeaningWords,
 } from '@/lib/words/memory';
+import {
+  expandWordsForQuizTargets,
+  getQuizTargetKey,
+  isTranslationQuizTarget,
+} from '@/lib/quiz/translation-targets';
 
 export type QuizDirection = 'en-to-ja' | 'ja-to-en';
 
@@ -43,12 +48,13 @@ export function generateQuizQuestions(
   settings: { allowPendingWordOrderFallback?: boolean; preserveOrder?: boolean; primaryOnly?: boolean } = {},
 ): QuizQuestion[] {
   const questions: QuizQuestion[] = [];
-  const quizWords = settings.primaryOnly ? selectPrimaryMeaningWords(words) : words;
+  const sourceWords = settings.primaryOnly ? selectPrimaryMeaningWords(words) : words;
+  const quizWords = expandWordsForQuizTargets(sourceWords, { primaryOnly: settings.primaryOnly });
 
   for (const word of settings.preserveOrder ? quizWords : sortWordsByPriority(quizWords)) {
     if (questions.length >= count) break;
 
-    if (!isActiveQuizWord(word) && isWordOrderEligible(word)) {
+    if (!isTranslationQuizTarget(word) && !isActiveQuizWord(word) && isWordOrderEligible(word)) {
       const wordOrderQuestion = buildWordOrderQuestion(word, shuffle);
       if (wordOrderQuestion) {
         questions.push(wordOrderQuestion);
@@ -60,7 +66,8 @@ export function generateQuizQuestions(
 
     if (direction === 'ja-to-en') {
       const correctEn = word.english.trim().toLowerCase();
-      const otherWords = quizWords.filter((item) => item.id !== word.id && !isSameWordMeaning(item, word));
+      const wordTargetKey = getQuizTargetKey(word);
+      const otherWords = quizWords.filter((item) => getQuizTargetKey(item) !== wordTargetKey && !isSameWordMeaning(item, word));
       let englishDistractors = shuffle(otherWords)
         .map((item) => item.english)
         .filter((english) => english.trim().toLowerCase() !== correctEn);
@@ -94,16 +101,17 @@ export function generateQuizQuestions(
     }
 
     const correctJa = word.japanese.trim().toLowerCase();
+    const wordTargetKey = getQuizTargetKey(word);
     const sameMeaningTranslations = new Set(
       quizWords
-        .filter((item) => item.id !== word.id && isSameWordMeaning(item, word))
+        .filter((item) => getQuizTargetKey(item) !== wordTargetKey && isSameWordMeaning(item, word))
         .map((item) => item.japanese.trim().toLowerCase())
         .filter(Boolean),
     );
     let distractors: string[] = [...(word.distractors || [])];
 
     if (distractors.length === 0 || (distractors.length === 3 && distractors[0] === '選択肢1')) {
-      const otherWords = quizWords.filter((item) => item.id !== word.id && !isSameWordMeaning(item, word));
+      const otherWords = quizWords.filter((item) => getQuizTargetKey(item) !== wordTargetKey && !isSameWordMeaning(item, word));
       distractors = shuffle(otherWords)
         .map((item) => item.japanese)
         .filter((japanese) => japanese.trim().toLowerCase() !== correctJa);
@@ -147,11 +155,13 @@ export function applyWordOrderQuestionsToPendingQuiz(
   currentIndex: number,
   shuffle: <T>(items: T[]) => T[] = shuffleArray,
 ): QuizQuestion[] {
-  const wordById = new Map(words.map((word) => [word.id, word]));
+  const wordByTargetKey = new Map(
+    expandWordsForQuizTargets(words).map((word) => [getQuizTargetKey(word), word]),
+  );
   const wordOrderQuestionWordIds = new Set(
     questions
       .filter((question) => question.type === 'word-order')
-      .map((question) => question.word.id),
+      .map((question) => getQuizTargetKey(question.word)),
   );
   const insertAfterCurrent: QuizQuestion[] = [];
   let changed = false;
@@ -165,7 +175,12 @@ export function applyWordOrderQuestionsToPendingQuiz(
       return question;
     }
 
-    const updatedWord = wordById.get(question.word.id);
+    if (isTranslationQuizTarget(question.word)) {
+      return question;
+    }
+
+    const questionTargetKey = getQuizTargetKey(question.word);
+    const updatedWord = wordByTargetKey.get(questionTargetKey);
     if (!updatedWord) {
       return question;
     }
@@ -179,16 +194,16 @@ export function applyWordOrderQuestionsToPendingQuiz(
     }
 
     if (index <= currentIndex) {
-      if (!wordOrderQuestionWordIds.has(question.word.id)) {
+      if (!wordOrderQuestionWordIds.has(questionTargetKey)) {
         insertAfterCurrent.push(wordOrderQuestion);
-        wordOrderQuestionWordIds.add(question.word.id);
+        wordOrderQuestionWordIds.add(questionTargetKey);
         changed = true;
       }
       return question;
     }
 
     changed = true;
-    wordOrderQuestionWordIds.add(question.word.id);
+    wordOrderQuestionWordIds.add(questionTargetKey);
     return wordOrderQuestion;
   });
 

--- a/src/lib/quiz/translation-progress.ts
+++ b/src/lib/quiz/translation-progress.ts
@@ -1,0 +1,19 @@
+import type { WordTranslation } from '@/types';
+
+export type TranslationProgressUpdates = Pick<
+  WordTranslation,
+  'status' | 'lastReviewedAt' | 'nextReviewAt' | 'easeFactor' | 'intervalDays' | 'repetition'
+>;
+
+export function mapTranslationProgressUpdatesToRow(
+  updates: TranslationProgressUpdates,
+): Record<string, unknown> {
+  const row: Record<string, unknown> = {};
+  if (updates.status !== undefined) row.status = updates.status;
+  if (updates.lastReviewedAt !== undefined) row.last_reviewed_at = updates.lastReviewedAt;
+  if (updates.nextReviewAt !== undefined) row.next_review_at = updates.nextReviewAt;
+  if (updates.easeFactor !== undefined) row.ease_factor = updates.easeFactor;
+  if (updates.intervalDays !== undefined) row.interval_days = updates.intervalDays;
+  if (updates.repetition !== undefined) row.repetition = updates.repetition;
+  return row;
+}

--- a/src/lib/quiz/translation-targets.ts
+++ b/src/lib/quiz/translation-targets.ts
@@ -1,0 +1,165 @@
+import type { Word, WordStatus, WordTranslation } from '@/types';
+import { getDefaultSpacedRepetitionFields } from '@/lib/spaced-repetition';
+
+type QuizTargetOptions = {
+  primaryOnly?: boolean;
+};
+
+const DEFAULT_SR = getDefaultSpacedRepetitionFields();
+
+function normalizeKeyPart(value: string | undefined): string {
+  return (value ?? '').trim().toLowerCase().replace(/\s+/g, ' ');
+}
+
+function getTranslationStatus(translation: WordTranslation): WordStatus {
+  return translation.status ?? 'new';
+}
+
+function getTranslationTargetKey(word: Word, translation: WordTranslation): string {
+  if (translation.id) return `translation:${translation.id}`;
+  if (translation.lexiconSenseId) return `sense:${translation.lexiconSenseId}`;
+  if (translation.distinctKey) return `distinct:${normalizeKeyPart(translation.distinctKey)}`;
+  return `translation-text:${word.id}:${normalizeKeyPart(translation.normalizedTranslationJa || translation.translationJa)}`;
+}
+
+export function getQuizTargetKey(word: Word): string {
+  return word.quizTarget?.key ?? `word:${word.id}`;
+}
+
+export function isTranslationQuizTarget(word: Pick<Word, 'quizTarget'>): boolean {
+  return word.quizTarget?.kind === 'translation';
+}
+
+export function isDistinctQuizTranslation(translation: WordTranslation): boolean {
+  return Boolean(normalizeKeyPart(translation.distinctKey)) && !translation.isPrimary;
+}
+
+function buildTranslationQuizWord(word: Word, translation: WordTranslation): Word {
+  const key = getTranslationTargetKey(word, translation);
+  return {
+    ...word,
+    japanese: translation.translationJa,
+    lexiconSenseId: translation.lexiconSenseId ?? word.lexiconSenseId,
+    lexiconDistinctKey: translation.distinctKey,
+    lexiconSenseIsPrimary: translation.lexiconSenseIsPrimary ?? false,
+    status: getTranslationStatus(translation),
+    lastReviewedAt: translation.lastReviewedAt,
+    nextReviewAt: translation.nextReviewAt,
+    easeFactor: translation.easeFactor ?? DEFAULT_SR.easeFactor,
+    intervalDays: translation.intervalDays ?? DEFAULT_SR.intervalDays,
+    repetition: translation.repetition ?? DEFAULT_SR.repetition,
+    wordOrderQuiz: undefined,
+    translations: [{
+      ...translation,
+      isPrimary: true,
+      meaningRank: 1,
+      position: 0,
+    }],
+    quizTarget: {
+      kind: 'translation',
+      key,
+      wordId: word.id,
+      translationId: translation.id,
+      lexiconSenseId: translation.lexiconSenseId,
+      distinctKey: translation.distinctKey,
+    },
+  };
+}
+
+export function expandWordForQuizTargets(
+  word: Word,
+  options: QuizTargetOptions = {},
+): Word[] {
+  const primaryWord: Word = {
+    ...word,
+    quizTarget: {
+      kind: 'word',
+      key: `word:${word.id}`,
+      wordId: word.id,
+      lexiconSenseId: word.lexiconSenseId,
+      distinctKey: word.lexiconDistinctKey,
+    },
+  };
+
+  if (options.primaryOnly) {
+    return [primaryWord];
+  }
+
+  const targets: Word[] = [primaryWord];
+  const seen = new Set<string>([getQuizTargetKey(primaryWord)]);
+
+  for (const translation of word.translations ?? []) {
+    if (!isDistinctQuizTranslation(translation)) continue;
+    const target = buildTranslationQuizWord(word, translation);
+    const targetKey = getQuizTargetKey(target);
+    if (seen.has(targetKey)) continue;
+    seen.add(targetKey);
+    targets.push(target);
+  }
+
+  return targets;
+}
+
+export function expandWordsForQuizTargets(
+  words: readonly Word[],
+  options: QuizTargetOptions = {},
+): Word[] {
+  return words.flatMap((word) => expandWordForQuizTargets(word, options));
+}
+
+export function getQuizTargetCount(
+  words: readonly Word[],
+  options: QuizTargetOptions = {},
+): number {
+  return expandWordsForQuizTargets(words, options).length;
+}
+
+export function hasUnmasteredQuizTarget(
+  word: Word,
+  options: QuizTargetOptions = {},
+): boolean {
+  return expandWordForQuizTargets(word, options).some((target) => target.status !== 'mastered');
+}
+
+export function isQuizTargetDueForReview(word: Word, now: Date = new Date()): boolean {
+  if (!word.nextReviewAt) {
+    return Boolean(word.lastReviewedAt) || word.status !== 'new';
+  }
+
+  const nextReview = new Date(word.nextReviewAt);
+  return nextReview <= now;
+}
+
+export function hasDueQuizTarget(
+  word: Word,
+  options: QuizTargetOptions = {},
+  now: Date = new Date(),
+): boolean {
+  return expandWordForQuizTargets(word, options).some((target) => isQuizTargetDueForReview(target, now));
+}
+
+export function mergeTranslationProgress(
+  word: Word,
+  target: NonNullable<Word['quizTarget']>,
+  updates: {
+    status: WordStatus;
+    lastReviewedAt?: string;
+    nextReviewAt?: string;
+    easeFactor?: number;
+    intervalDays?: number;
+    repetition?: number;
+  },
+): Word {
+  if (target.kind !== 'translation') return word;
+
+  const translations = (word.translations ?? []).map((translation) => {
+    const matches = target.translationId
+      ? translation.id === target.translationId
+      : target.lexiconSenseId
+        ? translation.lexiconSenseId === target.lexiconSenseId
+        : normalizeKeyPart(translation.distinctKey) === normalizeKeyPart(target.distinctKey);
+    return matches ? { ...translation, ...updates } : translation;
+  });
+
+  return { ...word, translations };
+}

--- a/src/lib/words/memory.test.ts
+++ b/src/lib/words/memory.test.ts
@@ -115,3 +115,43 @@ test('groupWordsByMemory treats linked non-primary senses as one memory-rate wor
   assert.equal(group?.memoryRate, 50);
   assert.deepEqual(selectPrimaryMeaningWords(words).map((item) => item.id), ['sense-primary']);
 });
+
+test('groupWordsByMemory computes memory rate from distinct translations on one word', () => {
+  const words = [
+    word({
+      id: 'word-free',
+      english: 'free',
+      japanese: '自由な',
+      status: 'mastered',
+      lexiconEntryId: 'lex-free',
+      lexiconSenseId: 'sense-primary',
+      lexiconSenseIsPrimary: true,
+      translations: [
+        {
+          translationJa: '自由な',
+          normalizedTranslationJa: '自由な',
+          isPrimary: true,
+          lexiconSenseId: 'sense-primary',
+          lexiconSenseIsPrimary: true,
+          status: 'mastered',
+        },
+        {
+          translationJa: '無料の',
+          normalizedTranslationJa: '無料の',
+          distinctKey: 'cost',
+          isPrimary: false,
+          lexiconSenseId: 'sense-cost',
+          lexiconSenseIsPrimary: false,
+          status: 'new',
+        },
+      ],
+    }),
+  ];
+
+  const [group] = groupWordsByMemory(words);
+
+  assert.equal(group?.isDistinctGroup, true);
+  assert.equal(group?.memoryRate, 50);
+  assert.equal(group?.status, 'review');
+  assert.deepEqual(group?.senses.map((sense) => sense.japanese), ['自由な', '無料の']);
+});

--- a/src/lib/words/memory.ts
+++ b/src/lib/words/memory.ts
@@ -6,6 +6,15 @@ export interface WordMemoryInput {
   english: string;
   japanese: string;
   status?: WordStatus;
+  translations?: Array<{
+    translationJa: string;
+    normalizedTranslationJa?: string;
+    distinctKey?: string;
+    lexiconSenseId?: string;
+    lexiconSenseIsPrimary?: boolean;
+    isPrimary?: boolean;
+    status?: WordStatus;
+  }>;
   lexiconEntryId?: string;
   lexiconSenseId?: string;
   lexiconDistinctKey?: string;
@@ -93,6 +102,55 @@ export function isSameWordMeaning(a: WordMemoryInput, b: WordMemoryInput): boole
     && getWordMemorySenseKey(a) === getWordMemorySenseKey(b);
 }
 
+function getTranslationMemorySenseKey(
+  translation: NonNullable<WordMemoryInput['translations']>[number],
+): string {
+  const distinctKey = normalizeKeyPart(translation.distinctKey);
+  if (distinctKey) return `distinct:${distinctKey}`;
+  if (translation.lexiconSenseIsPrimary) return 'primary';
+  if (translation.lexiconSenseId) return `sense:${translation.lexiconSenseId}`;
+  return `ja:${normalizeKeyPart(translation.normalizedTranslationJa || translation.translationJa)}`;
+}
+
+function isPrimaryTranslation(
+  translation: NonNullable<WordMemoryInput['translations']>[number],
+): boolean {
+  if (translation.lexiconSenseIsPrimary === true) return true;
+  if (translation.lexiconSenseIsPrimary === false) return false;
+  return Boolean(translation.isPrimary) && !normalizeKeyPart(translation.distinctKey);
+}
+
+function getWordMemorySenses<T extends WordMemoryInput>(word: T): WordMemorySense<T>[] {
+  const senses: WordMemorySense<T>[] = [{
+    key: getWordMemorySenseKey(word),
+    word,
+    japanese: word.japanese,
+    status: word.status ?? 'new',
+    memoryRate: getWordMemoryRate(word),
+    isPrimary: isPrimaryMeaningWord(word),
+  }];
+  const seen = new Set(senses.map((sense) => sense.key));
+
+  for (const translation of word.translations ?? []) {
+    const distinctKey = normalizeKeyPart(translation.distinctKey);
+    if (!distinctKey) continue;
+    const key = getTranslationMemorySenseKey(translation);
+    if (seen.has(key)) continue;
+    seen.add(key);
+    const status = translation.status ?? 'new';
+    senses.push({
+      key,
+      word,
+      japanese: translation.translationJa,
+      status,
+      memoryRate: getWordMemoryRate({ status }),
+      isPrimary: isPrimaryTranslation(translation),
+    });
+  }
+
+  return senses;
+}
+
 function pickBestSenseWord<T extends WordMemoryInput>(current: T | undefined, incoming: T): T {
   if (!current) return incoming;
   const currentRank = STATUS_RANK[current.status ?? 'new'];
@@ -116,9 +174,11 @@ export function groupWordsByMemory<T extends WordMemoryInput>(words: readonly T[
     const hasExplicitDistinct = bucketWords.some((word) =>
       normalizeKeyPart(word.lexiconDistinctKey).length > 0 ||
       Boolean(word.lexiconSenseId) ||
-      typeof word.lexiconSenseIsPrimary === 'boolean'
+      typeof word.lexiconSenseIsPrimary === 'boolean' ||
+      (word.translations ?? []).some((translation) => normalizeKeyPart(translation.distinctKey).length > 0)
     );
-    const uniqueSenseKeys = new Set(bucketWords.map(getWordMemorySenseKey));
+    const bucketSenses = bucketWords.flatMap(getWordMemorySenses);
+    const uniqueSenseKeys = new Set(bucketSenses.map((sense) => sense.key));
     const isDistinctGroup = hasExplicitDistinct && uniqueSenseKeys.size > 1;
 
     if (!isDistinctGroup) {
@@ -144,23 +204,23 @@ export function groupWordsByMemory<T extends WordMemoryInput>(words: readonly T[
       continue;
     }
 
-    const bestWordBySense = new Map<string, T>();
-    for (const word of bucketWords) {
-      const senseKey = getWordMemorySenseKey(word);
-      bestWordBySense.set(senseKey, pickBestSenseWord(bestWordBySense.get(senseKey), word));
+    const bestSenseByKey = new Map<string, WordMemorySense<T>>();
+    for (const sense of bucketSenses) {
+      const current = bestSenseByKey.get(sense.key);
+      if (!current) {
+        bestSenseByKey.set(sense.key, sense);
+        continue;
+      }
+      const pickedWord = pickBestSenseWord(current.word, sense.word);
+      const currentRank = STATUS_RANK[current.status];
+      const incomingRank = STATUS_RANK[sense.status];
+      bestSenseByKey.set(
+        sense.key,
+        incomingRank > currentRank || pickedWord === sense.word ? sense : current,
+      );
     }
 
-    const senses = [...bestWordBySense.entries()].map(([senseKey, word]) => {
-      const status = word.status ?? 'new';
-      return {
-        key: senseKey,
-        word,
-        japanese: word.japanese,
-        status,
-        memoryRate: getWordMemoryRate(word),
-        isPrimary: isPrimaryMeaningWord(word),
-      };
-    });
+    const senses = [...bestSenseByKey.values()];
     const memoryRate = Math.round(
       senses.reduce((sum, sense) => sum + sense.memoryRate, 0) / Math.max(1, senses.length),
     );

--- a/src/lib/words/resolved.ts
+++ b/src/lib/words/resolved.ts
@@ -7,7 +7,10 @@ export const LEXICON_SENSE_SELECT_COLUMNS =
   'id, lexicon_entry_id, translation_ja, normalized_translation_ja, distinct_key, meaning_summary, usage_notes, example_sentence, example_sentence_ja, translation_source, is_primary, created_at, updated_at' as const;
 
 export const WORD_TRANSLATION_SELECT_COLUMNS =
-  'id, word_id, lexicon_sense_id, translation_ja, normalized_translation_ja, source, meaning_rank, position, is_primary, created_at, updated_at' as const;
+  'id, word_id, lexicon_sense_id, translation_ja, normalized_translation_ja, source, meaning_rank, position, is_primary, status, last_reviewed_at, next_review_at, ease_factor, interval_days, repetition, created_at, updated_at' as const;
+
+export const WORD_TRANSLATION_WITH_SENSE_SELECT_COLUMNS =
+  `${WORD_TRANSLATION_SELECT_COLUMNS}, lexicon_senses(${LEXICON_SENSE_SELECT_COLUMNS})` as const;
 
 export const RESOLVED_WORD_BASE_SELECT_COLUMNS =
   'id, project_id, english, japanese, japanese_source, vocabulary_type, lexicon_entry_id, lexicon_sense_id, distractors, example_sentence, example_sentence_ja, pronunciation, part_of_speech_tags, related_words, usage_patterns, insights_generated_at, insights_version, word_order_quiz, status, created_at, last_reviewed_at, next_review_at, ease_factor, interval_days, repetition, is_favorite, custom_sections' as const;
@@ -31,7 +34,7 @@ export const RESOLVED_WORD_MINIMAL_SELECT_COLUMNS =
   'id, project_id, english, japanese, distractors, status, created_at' as const;
 
 export const RESOLVED_WORD_SELECT_COLUMNS =
-  `${RESOLVED_WORD_BASE_SELECT_COLUMNS}, word_translations(${WORD_TRANSLATION_SELECT_COLUMNS}), lexicon_entries(${LEXICON_ENTRY_SELECT_COLUMNS}), lexicon_senses(${LEXICON_SENSE_SELECT_COLUMNS})` as const;
+  `${RESOLVED_WORD_BASE_SELECT_COLUMNS}, word_translations(${WORD_TRANSLATION_WITH_SENSE_SELECT_COLUMNS}), lexicon_entries(${LEXICON_ENTRY_SELECT_COLUMNS}), lexicon_senses(${LEXICON_SENSE_SELECT_COLUMNS})` as const;
 
 export const RESOLVED_WORD_SELECT_COLUMNS_WITHOUT_SENSES =
   `${RESOLVED_WORD_BASE_SELECT_COLUMNS}, word_translations(${WORD_TRANSLATION_SELECT_COLUMNS}), lexicon_entries(${LEXICON_ENTRY_SELECT_COLUMNS})` as const;
@@ -40,7 +43,7 @@ export const RESOLVED_WORD_SELECT_COLUMNS_BASIC =
   RESOLVED_WORD_BASE_SELECT_COLUMNS;
 
 export const RESOLVED_WORD_TEXT_SELECT_COLUMNS =
-  `${RESOLVED_WORD_TEXT_BASE_SELECT_COLUMNS}, word_translations(${WORD_TRANSLATION_SELECT_COLUMNS}), lexicon_entries(${LEXICON_ENTRY_SELECT_COLUMNS}), lexicon_senses(${LEXICON_SENSE_SELECT_COLUMNS})` as const;
+  `${RESOLVED_WORD_TEXT_BASE_SELECT_COLUMNS}, word_translations(${WORD_TRANSLATION_WITH_SENSE_SELECT_COLUMNS}), lexicon_entries(${LEXICON_ENTRY_SELECT_COLUMNS}), lexicon_senses(${LEXICON_SENSE_SELECT_COLUMNS})` as const;
 
 export const RESOLVED_WORD_TEXT_SELECT_COLUMNS_WITHOUT_SENSES =
   `${RESOLVED_WORD_TEXT_BASE_SELECT_COLUMNS}, word_translations(${WORD_TRANSLATION_SELECT_COLUMNS}), lexicon_entries(${LEXICON_ENTRY_SELECT_COLUMNS})` as const;
@@ -52,7 +55,7 @@ export const RESOLVED_WORD_TEXT_SELECT_COLUMNS_MINIMAL =
   RESOLVED_WORD_MINIMAL_SELECT_COLUMNS;
 
 export const SHARE_VIEW_WORD_SELECT_COLUMNS =
-  `${SHARE_VIEW_WORD_BASE_SELECT_COLUMNS}, word_translations(${WORD_TRANSLATION_SELECT_COLUMNS}), lexicon_entries(${LEXICON_ENTRY_SELECT_COLUMNS}), lexicon_senses(${LEXICON_SENSE_SELECT_COLUMNS})` as const;
+  `${SHARE_VIEW_WORD_BASE_SELECT_COLUMNS}, word_translations(${WORD_TRANSLATION_WITH_SENSE_SELECT_COLUMNS}), lexicon_entries(${LEXICON_ENTRY_SELECT_COLUMNS}), lexicon_senses(${LEXICON_SENSE_SELECT_COLUMNS})` as const;
 
 export const SHARE_VIEW_WORD_SELECT_COLUMNS_WITHOUT_SENSES =
   `${SHARE_VIEW_WORD_BASE_SELECT_COLUMNS}, word_translations(${WORD_TRANSLATION_SELECT_COLUMNS}), lexicon_entries(${LEXICON_ENTRY_SELECT_COLUMNS})` as const;

--- a/src/lib/words/translation-persistence.test.ts
+++ b/src/lib/words/translation-persistence.test.ts
@@ -1,41 +1,36 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 
-import { expandWordsByTranslationsForPersistence } from './translation-persistence';
+import { normalizeWordForTranslationPersistence } from './translation-persistence';
 
-test('expandWordsByTranslationsForPersistence creates one persisted word per translation', () => {
-  const words = expandWordsByTranslationsForPersistence([
-    {
-      english: 'sense',
-      japanese: '感覚;分別',
-      japaneseSource: 'scan' as const,
-      distractors: [],
-      translations: [
-        { japanese: '感覚;分別', source: 'scan', meaningRank: 1 },
-      ],
-      partOfSpeechTags: ['noun'],
-    },
-  ]);
+test('normalizeWordForTranslationPersistence keeps one word with multiple translations', () => {
+  const word = normalizeWordForTranslationPersistence({
+    english: 'sense',
+    japanese: '感覚;分別',
+    japaneseSource: 'scan' as const,
+    distractors: [],
+    translations: [
+      { japanese: '感覚;分別', source: 'scan', meaningRank: 1 },
+    ],
+    partOfSpeechTags: ['noun'],
+  });
 
-  assert.equal(words.length, 2);
-  assert.deepEqual(words.map((word) => word.japanese), ['感覚', '分別']);
-  assert.deepEqual(words.map((word) => word.translations?.[0]?.translationJa), ['感覚', '分別']);
-  assert.deepEqual(words.map((word) => word.translations?.[0]?.isPrimary), [true, true]);
-  assert.deepEqual(words.map((word) => word.translations?.[0]?.position), [0, 0]);
+  assert.equal(word.japanese, '感覚');
+  assert.deepEqual(word.translations?.map((translation) => translation.translationJa), ['感覚', '分別']);
+  assert.deepEqual(word.translations?.map((translation) => translation.isPrimary), [true, false]);
+  assert.deepEqual(word.translations?.map((translation) => translation.position), [0, 1]);
 });
 
-test('expandWordsByTranslationsForPersistence keeps explicit id words as one row for sync upserts', () => {
-  const [word] = expandWordsByTranslationsForPersistence([
-    {
-      id: 'word-1',
-      english: 'sense',
-      japanese: '感覚;分別',
-      japaneseSource: 'scan' as const,
-      translations: [
-        { japanese: '感覚;分別', source: 'scan', meaningRank: 1 },
-      ],
-    },
-  ]);
+test('normalizeWordForTranslationPersistence keeps explicit id words as one row for sync upserts', () => {
+  const word = normalizeWordForTranslationPersistence({
+    id: 'word-1',
+    english: 'sense',
+    japanese: '感覚;分別',
+    japaneseSource: 'scan' as const,
+    translations: [
+      { japanese: '感覚;分別', source: 'scan', meaningRank: 1 },
+    ],
+  });
 
   assert.equal(word?.id, 'word-1');
   assert.equal(word?.japanese, '感覚');

--- a/src/lib/words/translation-persistence.ts
+++ b/src/lib/words/translation-persistence.ts
@@ -73,53 +73,6 @@ export function normalizeWordForTranslationPersistence<T extends WordTranslation
   };
 }
 
-function getTranslationJapaneseSource(
-  translation: WordTranslation,
-  fallback?: 'scan' | 'ai',
-): 'scan' | 'ai' | undefined {
-  return translation.source === 'scan' || translation.source === 'ai'
-    ? translation.source
-    : fallback;
-}
-
-export function expandWordsByTranslationsForPersistence<T extends WordTranslationInput>(
-  words: readonly T[],
-): Array<ReturnType<typeof normalizeWordForTranslationPersistence<T>>> {
-  const expanded: Array<ReturnType<typeof normalizeWordForTranslationPersistence<T>>> = [];
-
-  for (const word of words) {
-    const normalizedWord = normalizeWordForTranslationPersistence(word);
-    const translations = normalizedWord.translations ?? [];
-
-    if (word.id || translations.length <= 1) {
-      expanded.push(normalizedWord);
-      continue;
-    }
-
-    const seen = new Set<string>();
-    for (const translation of translations) {
-      const normalizedTranslation = (translation.normalizedTranslationJa || translation.translationJa).trim().toLowerCase();
-      if (!normalizedTranslation || seen.has(normalizedTranslation)) continue;
-      seen.add(normalizedTranslation);
-
-      expanded.push({
-        ...normalizedWord,
-        japanese: translation.translationJa,
-        japaneseSource: getTranslationJapaneseSource(translation, normalizedWord.japaneseSource),
-        lexiconSenseId: translation.lexiconSenseId ?? (translation.isPrimary ? normalizedWord.lexiconSenseId : undefined),
-        translations: [{
-          ...translation,
-          meaningRank: 1,
-          position: 0,
-          isPrimary: true,
-        }],
-      });
-    }
-  }
-
-  return expanded;
-}
-
 export function buildWordTranslationInsertRows(
   words: readonly WordTranslationInput[],
   insertedWordIds: readonly string[],

--- a/supabase/migrations/20260626090000_add_word_translation_progress.sql
+++ b/supabase/migrations/20260626090000_add_word_translation_progress.sql
@@ -1,0 +1,14 @@
+-- Track spaced-repetition progress for distinct translation quiz targets.
+-- The derived word memory rate stays application-computed and is not stored.
+
+ALTER TABLE public.word_translations
+  ADD COLUMN IF NOT EXISTS status text NOT NULL DEFAULT 'new'
+    CHECK (status IN ('new', 'review', 'mastered')),
+  ADD COLUMN IF NOT EXISTS last_reviewed_at timestamptz NULL,
+  ADD COLUMN IF NOT EXISTS next_review_at timestamptz NULL,
+  ADD COLUMN IF NOT EXISTS ease_factor double precision NOT NULL DEFAULT 2.5,
+  ADD COLUMN IF NOT EXISTS interval_days integer NOT NULL DEFAULT 0 CHECK (interval_days >= 0),
+  ADD COLUMN IF NOT EXISTS repetition integer NOT NULL DEFAULT 0 CHECK (repetition >= 0);
+
+CREATE INDEX IF NOT EXISTS idx_word_translations_next_review
+  ON public.word_translations (next_review_at);


### PR DESCRIPTION
## Summary
- Stop expanding split translations into separate persisted word rows during scan/manual word creation
- Keep words as one row with multiple word_translations, and expand only quiz targets for distinct translations
- Add translation-level progress columns so distinct meaning mastery can be tracked without storing a derived word memory rate
- Read translation lexicon sense distinct keys and compute memory rates from distinct translations
- Fix latest-main PWA install banner lint error introduced upstream

## Verification
- npm test -- src/lib/words/translation-persistence.test.ts src/lib/quiz/quiz-state.test.ts src/lib/words/memory.test.ts src/app/api/words/create/route.test.ts src/app/api/scan-jobs/process/route.contract.test.ts src/lib/db/remote-repository.test.ts src/lib/projects/load-helpers.test.ts src/lib/project/project-page-selectors.test.ts
- npm run lint:web
- npm run build

## Notes
- Includes migration: supabase/migrations/20260626090000_add_word_translation_progress.sql
- No mobile/iOS files touched