### PR TITLE
アカウントページを階層構造に分割し、ID変更の導線を追加

### DIFF
--- a/src/app/settings/account/delete/page.tsx
+++ b/src/app/settings/account/delete/page.tsx
@@ -1,0 +1,155 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { Icon, Modal, useToast } from '@/components/ui';
+import { useAuth } from '@/hooks/use-auth';
+
+type ApiPayload = {
+  success?: boolean;
+  error?: string;
+  message?: string;
+  code?: string;
+};
+
+function getAccountDeleteError(payload: ApiPayload | null): string {
+  if (payload?.code === 'active_appstore_subscription') {
+    return 'App Storeでサブスクリプションを解約してから、もう一度お試しください。';
+  }
+
+  if (payload?.code === 'missing_stripe_subscription_id') {
+    return '課金情報を確認できないため自動削除できません。お問い合わせからご連絡ください。';
+  }
+
+  return payload?.error || 'アカウント削除に失敗しました';
+}
+
+export default function DeleteAccountPage() {
+  const router = useRouter();
+  const { isPro, subscription, signOut } = useAuth();
+  const { showToast } = useToast();
+  const [showConfirm, setShowConfirm] = useState(false);
+  const [deleteLoading, setDeleteLoading] = useState(false);
+  const [deleteError, setDeleteError] = useState<string | null>(null);
+
+  const isAppStorePro = isPro && subscription?.proSource === 'appstore';
+
+  const closeModal = () => {
+    if (deleteLoading) return;
+    setShowConfirm(false);
+    setDeleteError(null);
+  };
+
+  const handleDeleteAccount = async () => {
+    if (deleteLoading) return;
+
+    setDeleteLoading(true);
+    setDeleteError(null);
+
+    try {
+      const response = await fetch('/api/account/delete', { method: 'DELETE' });
+      const payload = await response.json().catch(() => null) as ApiPayload | null;
+
+      if (!response.ok || !payload?.success) {
+        throw new Error(getAccountDeleteError(payload));
+      }
+
+      showToast({
+        type: 'success',
+        message: 'アカウントを削除しました',
+        duration: 5000,
+      });
+      await signOut();
+      router.replace('/');
+    } catch (error) {
+      setDeleteError(
+        error instanceof Error ? error.message : 'アカウント削除に失敗しました'
+      );
+    } finally {
+      setDeleteLoading(false);
+    }
+  };
+
+  return (
+    <div className="relative min-h-screen bg-[var(--color-background)] pb-[110px] pt-3 font-[var(--font-body)] lg:hidden">
+      <div className="px-[18px] pb-[14px] pt-1">
+        <button
+          type="button"
+          onClick={() => router.push('/settings/account')}
+          className="mb-2 inline-flex items-center gap-0.5 font-display text-[12px] font-bold text-[var(--color-muted)]"
+        >
+          <Icon name="chevron_left" size={16} />
+          アカウント
+        </button>
+        <div className="font-mono text-[10px] font-bold uppercase tracking-[0.08em] text-[var(--color-error)]">DANGER ZONE</div>
+        <div className="mt-0.5 font-display text-[26px] font-extrabold leading-[1.1] tracking-[-0.02em] text-[var(--solid-ink)]">アカウント削除</div>
+      </div>
+
+      <div className="px-[18px] pb-4">
+        <div className="overflow-hidden rounded-[12px] border-2 border-[var(--color-error)] bg-white p-4">
+          <div className="space-y-2 text-[13px] leading-[1.7] text-[var(--color-muted)]">
+            <p>アカウントを削除すると、以下のデータが完全に削除されます：</p>
+            <ul className="ml-4 list-disc space-y-1">
+              <li>ログイン情報</li>
+              <li>クラウド上の学習データ</li>
+              <li>プロジェクト・単語帳</li>
+            </ul>
+            <p>Stripe課金中の場合は、削除時にサブスクリプションも停止します。</p>
+            {isAppStorePro && (
+              <p className="font-bold text-[var(--color-error)]">
+                App Store課金中の場合は、先にApp Storeでサブスクリプションを解約してください。
+              </p>
+            )}
+          </div>
+
+          <button
+            type="button"
+            onClick={() => setShowConfirm(true)}
+            className="mt-4 w-full rounded-[10px] border-2 border-[var(--color-error)] bg-white py-3 font-display text-[13px] font-bold text-[var(--color-error)] transition-all duration-100 active:translate-x-px active:translate-y-px"
+          >
+            アカウントを削除する
+          </button>
+        </div>
+      </div>
+
+      <Modal isOpen={showConfirm} onClose={closeModal} showCloseButton={false} closeOnBackdrop={!deleteLoading}>
+        <div className="p-5">
+          <div className="mb-4 flex items-center gap-3">
+            <span className="inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-[10px] bg-[rgba(239,68,68,0.1)] text-[var(--color-error)]">
+              <Icon name="delete" size={20} />
+            </span>
+            <div>
+              <div className="font-display text-[17px] font-extrabold text-[var(--solid-ink)]">本当に削除しますか？</div>
+              <div className="mt-0.5 text-[11px] text-[var(--color-muted)]">この操作は取り消せません</div>
+            </div>
+          </div>
+
+          {deleteError && (
+            <p className="mt-3 rounded-[9px] border border-[var(--color-error)] bg-[rgba(239,68,68,0.08)] px-3 py-2 text-[12px] font-bold text-[var(--color-error)]">
+              {deleteError}
+            </p>
+          )}
+
+          <div className="mt-5 flex gap-2">
+            <button
+              type="button"
+              onClick={closeModal}
+              disabled={deleteLoading}
+              className="flex-1 rounded-[10px] border-2 border-[var(--solid-ink)] bg-white py-3 font-display text-[13px] font-bold text-[var(--solid-ink)] disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              戻る
+            </button>
+            <button
+              type="button"
+              onClick={handleDeleteAccount}
+              disabled={deleteLoading}
+              className="flex-1 rounded-[10px] border-2 border-[var(--color-error)] bg-[var(--color-error)] py-3 font-display text-[13px] font-bold text-white transition-all duration-100 disabled:cursor-not-allowed disabled:opacity-60 active:translate-x-px active:translate-y-px"
+            >
+              {deleteLoading ? '削除中...' : '削除する'}
+            </button>
+          </div>
+        </div>
+      </Modal>
+    </div>
+  );
+}

--- a/src/app/settings/account/page.tsx
+++ b/src/app/settings/account/page.tsx
@@ -1,32 +1,12 @@
 'use client';
 
-import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import Link from 'next/link';
-import { Icon, Modal, useToast } from '@/components/ui';
+import { Icon } from '@/components/ui';
 import { useAuth } from '@/hooks/use-auth';
+import { useProfile } from '@/hooks/use-profile';
 import { isBillingEnabled } from '@/lib/billing/feature';
 import type { Subscription } from '@/types';
-
-type SettingsActionModal = 'cancel-subscription' | 'delete-account' | null;
-
-type ApiPayload = {
-  success?: boolean;
-  error?: string;
-  message?: string;
-  code?: string;
-};
-
-function formatDate(value?: string | null): string | null {
-  if (!value) return null;
-  const date = new Date(value);
-  if (Number.isNaN(date.getTime())) return null;
-  return date.toLocaleDateString('ja-JP', {
-    year: 'numeric',
-    month: 'long',
-    day: 'numeric',
-  });
-}
 
 function getPlanHint(subscription: Subscription | null, isPro: boolean): string {
   if (!isPro) return 'FREE';
@@ -36,101 +16,12 @@ function getPlanHint(subscription: Subscription | null, isPro: boolean): string 
   return 'PRO';
 }
 
-function getAccountDeleteError(payload: ApiPayload | null): string {
-  if (payload?.code === 'active_appstore_subscription') {
-    return 'App Storeでサブスクリプションを解約してから、もう一度お試しください。';
-  }
-
-  if (payload?.code === 'missing_stripe_subscription_id') {
-    return '課金情報を確認できないため自動削除できません。お問い合わせからご連絡ください。';
-  }
-
-  return payload?.error || 'アカウント削除に失敗しました';
-}
-
 export default function AccountSettingsPage() {
   const router = useRouter();
-  const { subscription, isPro, signOut, refresh } = useAuth();
-  const { showToast } = useToast();
-  const [activeModal, setActiveModal] = useState<SettingsActionModal>(null);
-  const [subscriptionActionLoading, setSubscriptionActionLoading] = useState(false);
-  const [accountDeleteLoading, setAccountDeleteLoading] = useState(false);
-  const [subscriptionActionError, setSubscriptionActionError] = useState<string | null>(null);
-  const [accountDeleteError, setAccountDeleteError] = useState<string | null>(null);
-
-  const isBillingPro = isPro && subscription?.proSource === 'billing';
-  const isAppStorePro = isPro && subscription?.proSource === 'appstore';
+  const { subscription, isPro } = useAuth();
+  const { username, accountId, loading: profileLoading } = useProfile();
   const billingEnabled = isBillingEnabled();
-  const isCancelScheduled = Boolean(subscription?.cancelAtPeriodEnd);
-  const periodEndLabel = formatDate(subscription?.currentPeriodEnd);
   const planHint = getPlanHint(subscription, isPro);
-
-  const closeModal = () => {
-    if (subscriptionActionLoading || accountDeleteLoading) return;
-    setActiveModal(null);
-    setSubscriptionActionError(null);
-    setAccountDeleteError(null);
-  };
-
-  const handleCancelSubscription = async () => {
-    if (subscriptionActionLoading || !isBillingPro || isCancelScheduled) return;
-
-    setSubscriptionActionLoading(true);
-    setSubscriptionActionError(null);
-
-    try {
-      const response = await fetch('/api/subscription/cancel', { method: 'POST' });
-      const payload = await response.json().catch(() => null) as ApiPayload | null;
-
-      if (!response.ok || !payload?.success) {
-        throw new Error(payload?.error || '解約処理に失敗しました');
-      }
-
-      await refresh();
-      setActiveModal(null);
-      showToast({
-        type: 'success',
-        message: payload.message || '次回更新をキャンセルしました',
-        duration: 5000,
-      });
-    } catch (error) {
-      setSubscriptionActionError(
-        error instanceof Error ? error.message : '解約処理に失敗しました'
-      );
-    } finally {
-      setSubscriptionActionLoading(false);
-    }
-  };
-
-  const handleDeleteAccount = async () => {
-    if (accountDeleteLoading) return;
-
-    setAccountDeleteLoading(true);
-    setAccountDeleteError(null);
-
-    try {
-      const response = await fetch('/api/account/delete', { method: 'DELETE' });
-      const payload = await response.json().catch(() => null) as ApiPayload | null;
-
-      if (!response.ok || !payload?.success) {
-        throw new Error(getAccountDeleteError(payload));
-      }
-
-      showToast({
-        type: 'success',
-        message: 'アカウントを削除しました',
-        duration: 5000,
-      });
-      await signOut();
-      router.replace('/');
-    } catch (error) {
-      setAccountDeleteError(
-        error instanceof Error ? error.message : 'アカウント削除に失敗しました'
-      );
-    } finally {
-      setAccountDeleteLoading(false);
-    }
-  };
 
   return (
     <div className="relative min-h-screen bg-[var(--color-background)] pb-[110px] pt-3 font-[var(--font-body)] lg:hidden">
@@ -147,31 +38,27 @@ export default function AccountSettingsPage() {
         <div className="mt-0.5 font-display text-[26px] font-extrabold leading-[1.1] tracking-[-0.02em] text-[var(--solid-ink)]">アカウント</div>
       </div>
 
+      <SettingsGroup label="プロフィール">
+        <SettingsRow
+          icon="person"
+          label="ID・ユーザー名の変更"
+          hint={profileLoading ? '...' : (accountId ? `@${accountId}` : (username ?? '未設定'))}
+          href="/settings/account/profile"
+        />
+      </SettingsGroup>
+
       <SettingsGroup label="プラン">
-        <SettingsRow icon="credit_card" label="現在のプラン" hint={planHint} />
+        <SettingsRow
+          icon="credit_card"
+          label="プラン・サブスクリプション"
+          hint={planHint}
+          href="/settings/account/plan"
+        />
         {billingEnabled && !isPro && (
           <SettingsRow
             icon="auto_awesome"
             label="Proにアップグレード"
             href="/subscription"
-          />
-        )}
-        {isBillingPro && (
-          <SettingsRow
-            icon="receipt_long"
-            label="サブスクリプション管理"
-            hint={isCancelScheduled ? '解約予定' : '更新停止'}
-            onClick={isCancelScheduled ? undefined : () => setActiveModal('cancel-subscription')}
-            disabled={isCancelScheduled}
-          />
-        )}
-        {isAppStorePro && (
-          <SettingsRow
-            icon="open_in_new"
-            label="App Storeで管理"
-            onClick={() => {
-              window.open('https://apps.apple.com/account/subscriptions', '_blank', 'noopener,noreferrer');
-            }}
           />
         )}
       </SettingsGroup>
@@ -181,100 +68,9 @@ export default function AccountSettingsPage() {
           icon="delete"
           label="アカウント削除"
           tone="danger"
-          onClick={() => setActiveModal('delete-account')}
+          href="/settings/account/delete"
         />
       </SettingsGroup>
-
-      <Modal isOpen={activeModal === 'cancel-subscription'} onClose={closeModal} showCloseButton={false} closeOnBackdrop={!subscriptionActionLoading}>
-        <div className="p-5">
-          <div className="mb-4 flex items-center gap-3">
-            <span className="inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-[10px] bg-[rgba(26,26,26,0.05)] text-[var(--solid-ink)]">
-              <Icon name="receipt_long" size={20} />
-            </span>
-            <div>
-              <div className="font-display text-[17px] font-extrabold text-[var(--solid-ink)]">次回更新を停止</div>
-              <div className="mt-0.5 text-[11px] text-[var(--color-muted)]">Merken Pro</div>
-            </div>
-          </div>
-
-          <p className="text-[13px] leading-[1.7] text-[var(--color-muted)]">
-            解約後も契約期間終了日まではPro機能を利用できます。
-            {periodEndLabel ? ` 現在の利用期限は${periodEndLabel}です。` : ''}
-          </p>
-
-          {subscriptionActionError && (
-            <p className="mt-3 rounded-[9px] border border-[var(--color-error)] bg-[rgba(239,68,68,0.08)] px-3 py-2 text-[12px] font-bold text-[var(--color-error)]">
-              {subscriptionActionError}
-            </p>
-          )}
-
-          <div className="mt-5 flex gap-2">
-            <button
-              type="button"
-              onClick={closeModal}
-              disabled={subscriptionActionLoading}
-              className="flex-1 rounded-[10px] border-2 border-[var(--solid-ink)] bg-white py-3 font-display text-[13px] font-bold text-[var(--solid-ink)] disabled:cursor-not-allowed disabled:opacity-50"
-            >
-              戻る
-            </button>
-            <button
-              type="button"
-              onClick={handleCancelSubscription}
-              disabled={subscriptionActionLoading}
-              className="flex-1 rounded-[10px] border-2 border-[var(--solid-ink)] bg-[var(--solid-ink)] py-3 font-display text-[13px] font-bold text-white shadow-[2px_2px_0_var(--color-accent)] transition-all duration-100 disabled:cursor-not-allowed disabled:opacity-60 active:translate-x-px active:translate-y-px"
-            >
-              {subscriptionActionLoading ? '処理中...' : '更新停止'}
-            </button>
-          </div>
-        </div>
-      </Modal>
-
-      <Modal isOpen={activeModal === 'delete-account'} onClose={closeModal} showCloseButton={false} closeOnBackdrop={!accountDeleteLoading}>
-        <div className="p-5">
-          <div className="mb-4 flex items-center gap-3">
-            <span className="inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-[10px] bg-[rgba(239,68,68,0.1)] text-[var(--color-error)]">
-              <Icon name="delete" size={20} />
-            </span>
-            <div>
-              <div className="font-display text-[17px] font-extrabold text-[var(--solid-ink)]">アカウント削除</div>
-              <div className="mt-0.5 text-[11px] text-[var(--color-muted)]">この操作は取り消せません</div>
-            </div>
-          </div>
-
-          <div className="space-y-2 text-[13px] leading-[1.7] text-[var(--color-muted)]">
-            <p>ログイン情報とクラウド上の学習データを削除します。</p>
-            <p>Stripe課金中の場合は、削除時にサブスクリプションも停止します。</p>
-            {isAppStorePro && (
-              <p>App Store課金中の場合は、先にApp Storeでサブスクリプションを解約してください。</p>
-            )}
-          </div>
-
-          {accountDeleteError && (
-            <p className="mt-3 rounded-[9px] border border-[var(--color-error)] bg-[rgba(239,68,68,0.08)] px-3 py-2 text-[12px] font-bold text-[var(--color-error)]">
-              {accountDeleteError}
-            </p>
-          )}
-
-          <div className="mt-5 flex gap-2">
-            <button
-              type="button"
-              onClick={closeModal}
-              disabled={accountDeleteLoading}
-              className="flex-1 rounded-[10px] border-2 border-[var(--solid-ink)] bg-white py-3 font-display text-[13px] font-bold text-[var(--solid-ink)] disabled:cursor-not-allowed disabled:opacity-50"
-            >
-              戻る
-            </button>
-            <button
-              type="button"
-              onClick={handleDeleteAccount}
-              disabled={accountDeleteLoading}
-              className="flex-1 rounded-[10px] border-2 border-[var(--color-error)] bg-[var(--color-error)] py-3 font-display text-[13px] font-bold text-white transition-all duration-100 disabled:cursor-not-allowed disabled:opacity-60 active:translate-x-px active:translate-y-px"
-            >
-              {accountDeleteLoading ? '削除中...' : '削除する'}
-            </button>
-          </div>
-        </div>
-      </Modal>
     </div>
   );
 }
@@ -295,45 +91,26 @@ function SettingsRow({
   label,
   hint,
   href,
-  onClick,
-  disabled,
   tone = 'default',
 }: {
   icon: string;
   label: string;
   hint?: string;
-  href?: string;
-  onClick?: () => void;
-  disabled?: boolean;
+  href: string;
   tone?: 'default' | 'danger';
 }) {
-  const isInteractive = Boolean(href || onClick);
   const labelClass = tone === 'danger' ? 'text-[var(--color-error)]' : 'text-[var(--solid-ink)]';
   const iconClass = tone === 'danger' ? 'text-[var(--color-error)]' : 'text-[var(--solid-ink)]';
-  const inner = (
-    <div className={`flex items-center gap-2.5 px-3 py-[11px] ${disabled ? 'opacity-55' : ''} ${isInteractive && !disabled ? 'cursor-pointer' : ''}`}>
-      <span className={`inline-flex h-[26px] w-[26px] shrink-0 items-center justify-center rounded-[7px] bg-[rgba(26,26,26,0.05)] ${iconClass}`}>
-        <Icon name={icon} size={16} />
-      </span>
-      <span className={`flex-1 text-[13px] font-bold ${labelClass}`}>{label}</span>
-      {hint && <span className="font-mono text-[10px] text-[var(--color-muted)]">{hint}</span>}
-      {href && <Icon name="chevron_right" size={14} className="text-[var(--color-muted)]" />}
-      {onClick && !disabled && <Icon name="chevron_right" size={14} className="text-[var(--color-muted)]" />}
-    </div>
+  return (
+    <Link href={href} className="block w-full">
+      <div className="flex cursor-pointer items-center gap-2.5 px-3 py-[11px]">
+        <span className={`inline-flex h-[26px] w-[26px] shrink-0 items-center justify-center rounded-[7px] bg-[rgba(26,26,26,0.05)] ${iconClass}`}>
+          <Icon name={icon} size={16} />
+        </span>
+        <span className={`flex-1 text-[13px] font-bold ${labelClass}`}>{label}</span>
+        {hint && <span className="font-mono text-[10px] text-[var(--color-muted)]">{hint}</span>}
+        <Icon name="chevron_right" size={14} className="text-[var(--color-muted)]" />
+      </div>
+    </Link>
   );
-
-  if (href) return <Link href={href} className="block w-full">{inner}</Link>;
-  if (onClick) {
-    return (
-      <button
-        type="button"
-        onClick={onClick}
-        disabled={disabled}
-        className="block w-full bg-transparent p-0 text-left disabled:cursor-not-allowed"
-      >
-        {inner}
-      </button>
-    );
-  }
-  return inner;
 }

--- a/src/app/settings/account/plan/page.tsx
+++ b/src/app/settings/account/plan/page.tsx
@@ -1,0 +1,251 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import Link from 'next/link';
+import { Icon, Modal, useToast } from '@/components/ui';
+import { useAuth } from '@/hooks/use-auth';
+import { isBillingEnabled } from '@/lib/billing/feature';
+import type { Subscription } from '@/types';
+
+type ApiPayload = {
+  success?: boolean;
+  error?: string;
+  message?: string;
+  code?: string;
+};
+
+function formatDate(value?: string | null): string | null {
+  if (!value) return null;
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return null;
+  return date.toLocaleDateString('ja-JP', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  });
+}
+
+function getPlanHint(subscription: Subscription | null, isPro: boolean): string {
+  if (!isPro) return 'FREE';
+  if (subscription?.proSource === 'billing') return 'PRO';
+  if (subscription?.proSource === 'appstore') return 'APP STORE';
+  if (subscription?.proSource === 'test') return 'TEST';
+  return 'PRO';
+}
+
+export default function PlanSettingsPage() {
+  const router = useRouter();
+  const { subscription, isPro, refresh } = useAuth();
+  const { showToast } = useToast();
+  const [showCancelModal, setShowCancelModal] = useState(false);
+  const [cancelLoading, setCancelLoading] = useState(false);
+  const [cancelError, setCancelError] = useState<string | null>(null);
+
+  const isBillingPro = isPro && subscription?.proSource === 'billing';
+  const isAppStorePro = isPro && subscription?.proSource === 'appstore';
+  const billingEnabled = isBillingEnabled();
+  const isCancelScheduled = Boolean(subscription?.cancelAtPeriodEnd);
+  const periodEndLabel = formatDate(subscription?.currentPeriodEnd);
+  const planHint = getPlanHint(subscription, isPro);
+
+  const closeModal = () => {
+    if (cancelLoading) return;
+    setShowCancelModal(false);
+    setCancelError(null);
+  };
+
+  const handleCancelSubscription = async () => {
+    if (cancelLoading || !isBillingPro || isCancelScheduled) return;
+
+    setCancelLoading(true);
+    setCancelError(null);
+
+    try {
+      const response = await fetch('/api/subscription/cancel', { method: 'POST' });
+      const payload = await response.json().catch(() => null) as ApiPayload | null;
+
+      if (!response.ok || !payload?.success) {
+        throw new Error(payload?.error || '解約処理に失敗しました');
+      }
+
+      await refresh();
+      setShowCancelModal(false);
+      showToast({
+        type: 'success',
+        message: payload.message || '次回更新をキャンセルしました',
+        duration: 5000,
+      });
+    } catch (error) {
+      setCancelError(
+        error instanceof Error ? error.message : '解約処理に失敗しました'
+      );
+    } finally {
+      setCancelLoading(false);
+    }
+  };
+
+  return (
+    <div className="relative min-h-screen bg-[var(--color-background)] pb-[110px] pt-3 font-[var(--font-body)] lg:hidden">
+      <div className="px-[18px] pb-[14px] pt-1">
+        <button
+          type="button"
+          onClick={() => router.push('/settings/account')}
+          className="mb-2 inline-flex items-center gap-0.5 font-display text-[12px] font-bold text-[var(--color-muted)]"
+        >
+          <Icon name="chevron_left" size={16} />
+          アカウント
+        </button>
+        <div className="font-mono text-[10px] font-bold uppercase tracking-[0.08em] text-[var(--color-muted)]">PLAN</div>
+        <div className="mt-0.5 font-display text-[26px] font-extrabold leading-[1.1] tracking-[-0.02em] text-[var(--solid-ink)]">プラン</div>
+      </div>
+
+      <SettingsGroup label="現在のプラン">
+        <SettingsRow icon="credit_card" label="プラン" hint={planHint} />
+        {periodEndLabel && isBillingPro && (
+          <SettingsRow
+            icon="event"
+            label={isCancelScheduled ? '利用期限' : '次回更新日'}
+            hint={periodEndLabel}
+          />
+        )}
+      </SettingsGroup>
+
+      {billingEnabled && !isPro && (
+        <div className="px-[18px] pb-4">
+          <Link href="/subscription" className="flex items-center gap-2.5 rounded-[12px] border-2 border-[var(--solid-ink)] bg-gradient-to-br from-[oklch(0.94_0.06_130)] to-white p-[12px_14px]">
+            <div className="flex-1">
+              <div className="flex items-center gap-1.5">
+                <span className="font-mono text-[9px] font-bold tracking-[0.06em] text-[var(--color-accent)]">UPGRADE</span>
+                <span className="h-[3px] w-[3px] rounded-full bg-[var(--color-muted)]" />
+                <span className="font-mono text-[9px] text-[var(--color-muted)]">月額プラン</span>
+              </div>
+              <div className="mt-[3px] font-display text-sm font-bold text-[var(--solid-ink)]">Pro でぜんぶ使う</div>
+              <div className="mt-0.5 text-[10px] text-[var(--color-muted)]">スキャン無制限・デバイス無制限</div>
+            </div>
+            <div className="rounded-[8px] border-2 border-[var(--solid-ink)] bg-[var(--solid-ink)] px-[14px] py-2 font-display text-xs font-bold text-white shadow-[2px_2px_0_var(--color-accent)]">見る</div>
+          </Link>
+        </div>
+      )}
+
+      {isBillingPro && (
+        <SettingsGroup label="サブスクリプション">
+          <SettingsRow
+            icon="receipt_long"
+            label={isCancelScheduled ? '解約予定' : 'サブスクリプション管理'}
+            hint={isCancelScheduled ? '自動更新停止済み' : '更新停止'}
+            onClick={isCancelScheduled ? undefined : () => setShowCancelModal(true)}
+            disabled={isCancelScheduled}
+          />
+        </SettingsGroup>
+      )}
+
+      {isAppStorePro && (
+        <SettingsGroup label="サブスクリプション">
+          <SettingsRow
+            icon="open_in_new"
+            label="App Storeで管理"
+            onClick={() => {
+              window.open('https://apps.apple.com/account/subscriptions', '_blank', 'noopener,noreferrer');
+            }}
+          />
+        </SettingsGroup>
+      )}
+
+      <Modal isOpen={showCancelModal} onClose={closeModal} showCloseButton={false} closeOnBackdrop={!cancelLoading}>
+        <div className="p-5">
+          <div className="mb-4 flex items-center gap-3">
+            <span className="inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-[10px] bg-[rgba(26,26,26,0.05)] text-[var(--solid-ink)]">
+              <Icon name="receipt_long" size={20} />
+            </span>
+            <div>
+              <div className="font-display text-[17px] font-extrabold text-[var(--solid-ink)]">次回更新を停止</div>
+              <div className="mt-0.5 text-[11px] text-[var(--color-muted)]">Merken Pro</div>
+            </div>
+          </div>
+
+          <p className="text-[13px] leading-[1.7] text-[var(--color-muted)]">
+            解約後も契約期間終了日まではPro機能を利用できます。
+            {periodEndLabel ? ` 現在の利用期限は${periodEndLabel}です。` : ''}
+          </p>
+
+          {cancelError && (
+            <p className="mt-3 rounded-[9px] border border-[var(--color-error)] bg-[rgba(239,68,68,0.08)] px-3 py-2 text-[12px] font-bold text-[var(--color-error)]">
+              {cancelError}
+            </p>
+          )}
+
+          <div className="mt-5 flex gap-2">
+            <button
+              type="button"
+              onClick={closeModal}
+              disabled={cancelLoading}
+              className="flex-1 rounded-[10px] border-2 border-[var(--solid-ink)] bg-white py-3 font-display text-[13px] font-bold text-[var(--solid-ink)] disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              戻る
+            </button>
+            <button
+              type="button"
+              onClick={handleCancelSubscription}
+              disabled={cancelLoading}
+              className="flex-1 rounded-[10px] border-2 border-[var(--solid-ink)] bg-[var(--solid-ink)] py-3 font-display text-[13px] font-bold text-white shadow-[2px_2px_0_var(--color-accent)] transition-all duration-100 disabled:cursor-not-allowed disabled:opacity-60 active:translate-x-px active:translate-y-px"
+            >
+              {cancelLoading ? '処理中...' : '更新停止'}
+            </button>
+          </div>
+        </div>
+      </Modal>
+    </div>
+  );
+}
+
+function SettingsGroup({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div className="px-[18px] pb-3">
+      <div className="px-1 pb-1.5 font-mono text-[9px] font-bold uppercase tracking-[0.08em] text-[var(--color-muted)]">{label}</div>
+      <div className="divide-y divide-[var(--color-border)] overflow-hidden rounded-[12px] border-2 border-[var(--solid-ink)] bg-white">
+        {children}
+      </div>
+    </div>
+  );
+}
+
+function SettingsRow({
+  icon,
+  label,
+  hint,
+  onClick,
+  disabled,
+}: {
+  icon: string;
+  label: string;
+  hint?: string;
+  onClick?: () => void;
+  disabled?: boolean;
+}) {
+  const isInteractive = Boolean(onClick);
+  const inner = (
+    <div className={`flex items-center gap-2.5 px-3 py-[11px] ${disabled ? 'opacity-55' : ''} ${isInteractive && !disabled ? 'cursor-pointer' : ''}`}>
+      <span className="inline-flex h-[26px] w-[26px] shrink-0 items-center justify-center rounded-[7px] bg-[rgba(26,26,26,0.05)] text-[var(--solid-ink)]">
+        <Icon name={icon} size={16} />
+      </span>
+      <span className="flex-1 text-[13px] font-bold text-[var(--solid-ink)]">{label}</span>
+      {hint && <span className="font-mono text-[10px] text-[var(--color-muted)]">{hint}</span>}
+      {onClick && !disabled && <Icon name="chevron_right" size={14} className="text-[var(--color-muted)]" />}
+    </div>
+  );
+
+  if (onClick) {
+    return (
+      <button
+        type="button"
+        onClick={onClick}
+        disabled={disabled}
+        className="block w-full bg-transparent p-0 text-left disabled:cursor-not-allowed"
+      >
+        {inner}
+      </button>
+    );
+  }
+  return inner;
+}

--- a/src/app/settings/account/profile/page.tsx
+++ b/src/app/settings/account/profile/page.tsx
@@ -1,0 +1,149 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { Icon, useToast } from '@/components/ui';
+import { useProfile } from '@/hooks/use-profile';
+
+export default function ProfileSettingsPage() {
+  const router = useRouter();
+  const { showToast } = useToast();
+  const {
+    username,
+    accountId,
+    loading: profileLoading,
+    saving: profileSaving,
+    error: profileError,
+    setUsername,
+  } = useProfile();
+  const [usernameInput, setUsernameInput] = useState<string | null>(null);
+
+  const isEditing = usernameInput !== null;
+  const displayValue = usernameInput ?? username ?? '';
+
+  const startEditing = () => {
+    setUsernameInput(username ?? '');
+  };
+
+  const cancelEditing = () => {
+    setUsernameInput(null);
+  };
+
+  const handleSave = async () => {
+    if (profileSaving || !displayValue.trim()) return;
+    const success = await setUsername(displayValue);
+    if (success) {
+      setUsernameInput(null);
+      showToast({ type: 'success', message: 'ユーザー名を変更しました' });
+    }
+  };
+
+  return (
+    <div className="relative min-h-screen bg-[var(--color-background)] pb-[110px] pt-3 font-[var(--font-body)] lg:hidden">
+      <div className="px-[18px] pb-[14px] pt-1">
+        <button
+          type="button"
+          onClick={() => router.push('/settings/account')}
+          className="mb-2 inline-flex items-center gap-0.5 font-display text-[12px] font-bold text-[var(--color-muted)]"
+        >
+          <Icon name="chevron_left" size={16} />
+          アカウント
+        </button>
+        <div className="font-mono text-[10px] font-bold uppercase tracking-[0.08em] text-[var(--color-muted)]">PROFILE</div>
+        <div className="mt-0.5 font-display text-[26px] font-extrabold leading-[1.1] tracking-[-0.02em] text-[var(--solid-ink)]">プロフィール変更</div>
+      </div>
+
+      <div className="px-[18px] pb-4">
+        <div className="overflow-hidden rounded-[12px] border-2 border-[var(--solid-ink)] bg-white">
+          {/* ユーザー名 */}
+          <div className="px-4 py-3.5">
+            <div className="flex items-center justify-between">
+              <label htmlFor="profile-username" className="font-mono text-[9px] font-bold uppercase tracking-[0.08em] text-[var(--color-muted)]">
+                USERNAME
+              </label>
+              {!isEditing && (
+                <button
+                  type="button"
+                  onClick={startEditing}
+                  disabled={profileLoading}
+                  className="inline-flex items-center gap-0.5 font-display text-[11px] font-bold text-[var(--color-accent)] disabled:opacity-50"
+                >
+                  <Icon name="edit" size={13} />
+                  編集
+                </button>
+              )}
+            </div>
+
+            {isEditing ? (
+              <>
+                <input
+                  id="profile-username"
+                  type="text"
+                  value={displayValue}
+                  onChange={(event) => setUsernameInput(event.target.value)}
+                  onKeyDown={(event) => {
+                    if (event.key === 'Enter') {
+                      event.preventDefault();
+                      void handleSave();
+                    }
+                    if (event.key === 'Escape') {
+                      cancelEditing();
+                    }
+                  }}
+                  maxLength={20}
+                  autoFocus
+                  placeholder="ユーザー名を入力"
+                  className="mt-1.5 w-full rounded-[10px] border-2 border-[var(--solid-ink)] bg-white px-3 py-2.5 font-display text-[15px] font-bold text-[var(--solid-ink)] outline-none transition-shadow placeholder:text-[var(--color-muted)] focus:shadow-[2px_2px_0_var(--color-accent)]"
+                />
+                <div className="mt-1.5 flex items-center justify-between gap-2">
+                  <p className="font-mono text-[9px] text-[var(--color-muted)]">1-20文字</p>
+                  <p className="font-mono text-[9px] text-[var(--color-muted)]">{displayValue.length}/20</p>
+                </div>
+                {profileError && (
+                  <p className="mt-2 rounded-[8px] border border-[var(--color-error)] bg-[rgba(239,68,68,0.08)] px-2.5 py-2 text-[11px] font-bold text-[var(--color-error)]">
+                    {profileError}
+                  </p>
+                )}
+                <div className="mt-3 flex gap-2">
+                  <button
+                    type="button"
+                    onClick={handleSave}
+                    disabled={profileSaving || !displayValue.trim()}
+                    className="flex-1 rounded-[9px] border-2 border-[var(--solid-ink)] bg-[var(--solid-ink)] px-3 py-2.5 font-display text-[13px] font-bold text-white shadow-[2px_2px_0_var(--color-accent)] transition-all duration-100 disabled:cursor-not-allowed disabled:opacity-50 active:translate-x-px active:translate-y-px"
+                  >
+                    {profileSaving ? '保存中...' : '保存'}
+                  </button>
+                  <button
+                    type="button"
+                    onClick={cancelEditing}
+                    disabled={profileSaving}
+                    className="flex-1 rounded-[9px] border-2 border-[var(--solid-ink)] bg-white px-3 py-2.5 font-display text-[13px] font-bold text-[var(--solid-ink)] transition-colors disabled:cursor-not-allowed disabled:opacity-50"
+                  >
+                    キャンセル
+                  </button>
+                </div>
+              </>
+            ) : (
+              <p className="mt-1 font-display text-[15px] font-bold text-[var(--solid-ink)]">
+                {profileLoading ? '読み込み中...' : (username ?? 'ユーザー名未設定')}
+              </p>
+            )}
+          </div>
+
+          {/* アカウントID */}
+          <div className="border-t border-[var(--color-border)] px-4 py-3.5">
+            <div className="font-mono text-[9px] font-bold uppercase tracking-[0.08em] text-[var(--color-muted)]">
+              ACCOUNT ID
+            </div>
+            <p className="mt-1 font-mono text-[14px] font-bold text-[var(--solid-ink)]">
+              {profileLoading ? '...' : accountId ? `@${accountId}` : '未設定'}
+            </p>
+            <p className="mt-1 text-[10px] leading-4 text-[var(--color-muted)]">
+              ユーザー名を設定すると自動的に生成されます
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import Link from 'next/link';
 import { DesktopSettingsView } from '@/components/desktop/DesktopAccount';
@@ -23,12 +22,7 @@ export default function SettingsPage() {
     username,
     accountId,
     loading: profileLoading,
-    saving: profileSaving,
-    error: profileError,
-    setUsername,
   } = useProfile();
-  const [isEditingUsername, setIsEditingUsername] = useState(false);
-  const [usernameInput, setUsernameInput] = useState('');
 
   const billingEnabled = isBillingEnabled();
 
@@ -36,24 +30,6 @@ export default function SettingsPage() {
     if (!window.confirm('ログアウトしますか？')) return;
     await signOut();
     router.push('/');
-  };
-
-  const startEditingUsername = () => {
-    setUsernameInput(username ?? '');
-    setIsEditingUsername(true);
-  };
-
-  const cancelEditingUsername = () => {
-    setUsernameInput(username ?? '');
-    setIsEditingUsername(false);
-  };
-
-  const handleSaveUsername = async () => {
-    if (profileSaving || !usernameInput.trim()) return;
-    const success = await setUsername(usernameInput);
-    if (success) {
-      setIsEditingUsername(false);
-    }
   };
 
   return (
@@ -64,9 +40,6 @@ export default function SettingsPage() {
         accountId={accountId}
         isPro={isPro}
         onSignOut={() => void handleSignOut()}
-        onUsernameChange={setUsername}
-        usernameSaving={profileSaving}
-        usernameError={profileError}
       />
       <div className="relative min-h-screen bg-[var(--color-background)] pb-[110px] pt-3 font-[var(--font-body)] lg:hidden">
       {/* Header */}
@@ -106,72 +79,15 @@ export default function SettingsPage() {
                     {isPro ? 'PRO PLAN' : 'FREE PLAN'}
                   </div>
                 </div>
-                {!isEditingUsername && (
-                  <button
-                    type="button"
-                    onClick={startEditingUsername}
-                    disabled={profileLoading}
-                    className="inline-flex h-9 shrink-0 items-center gap-1 rounded-[8px] border-2 border-[var(--solid-ink)] bg-white px-3 font-display text-[12px] font-bold text-[var(--solid-ink)] transition-all duration-100 disabled:cursor-not-allowed disabled:opacity-50 active:translate-x-px active:translate-y-px"
-                  >
-                    <Icon name="edit" size={14} />
-                    変更
-                  </button>
-                )}
+                <Link
+                  href="/settings/account/profile"
+                  className="inline-flex h-9 shrink-0 items-center gap-1 rounded-[8px] border-2 border-[var(--solid-ink)] bg-white px-3 font-display text-[12px] font-bold text-[var(--solid-ink)] transition-all duration-100 active:translate-x-px active:translate-y-px"
+                >
+                  <Icon name="edit" size={14} />
+                  変更
+                </Link>
               </div>
 
-              {isEditingUsername && (
-                <div className="mt-3 border-t border-[var(--color-border)] pt-3">
-                  <label htmlFor="settings-username" className="font-mono text-[9px] font-bold uppercase tracking-[0.08em] text-[var(--color-muted)]">
-                    USERNAME
-                  </label>
-                  <input
-                    id="settings-username"
-                    type="text"
-                    value={usernameInput}
-                    onChange={(event) => setUsernameInput(event.target.value)}
-                    onKeyDown={(event) => {
-                      if (event.key === 'Enter') {
-                        event.preventDefault();
-                        void handleSaveUsername();
-                      }
-                      if (event.key === 'Escape') {
-                        cancelEditingUsername();
-                      }
-                    }}
-                    maxLength={20}
-                    autoFocus
-                    placeholder="ユーザー名を入力"
-                    className="mt-1.5 w-full rounded-[10px] border-2 border-[var(--solid-ink)] bg-white px-3 py-2.5 font-display text-[15px] font-bold text-[var(--solid-ink)] outline-none transition-shadow placeholder:text-[var(--color-muted)] focus:shadow-[2px_2px_0_var(--color-accent)]"
-                  />
-                  <div className="mt-1.5 flex items-center justify-between gap-2">
-                    <p className="font-mono text-[9px] text-[var(--color-muted)]">1-20文字</p>
-                    <p className="font-mono text-[9px] text-[var(--color-muted)]">{usernameInput.length}/20</p>
-                  </div>
-                  {profileError && (
-                    <p className="mt-2 rounded-[8px] border border-[var(--color-error)] bg-[rgba(239,68,68,0.08)] px-2.5 py-2 text-[11px] font-bold text-[var(--color-error)]">
-                      {profileError}
-                    </p>
-                  )}
-                  <div className="mt-3 flex gap-2">
-                    <button
-                      type="button"
-                      onClick={handleSaveUsername}
-                      disabled={profileSaving || !usernameInput.trim()}
-                      className="flex-1 rounded-[9px] border-2 border-[var(--solid-ink)] bg-[var(--solid-ink)] px-3 py-2.5 font-display text-[13px] font-bold text-white shadow-[2px_2px_0_var(--color-accent)] transition-all duration-100 disabled:cursor-not-allowed disabled:opacity-50 active:translate-x-px active:translate-y-px"
-                    >
-                      {profileSaving ? '保存中...' : '保存'}
-                    </button>
-                    <button
-                      type="button"
-                      onClick={cancelEditingUsername}
-                      disabled={profileSaving}
-                      className="flex-1 rounded-[9px] border-2 border-[var(--solid-ink)] bg-white px-3 py-2.5 font-display text-[13px] font-bold text-[var(--solid-ink)] transition-colors disabled:cursor-not-allowed disabled:opacity-50"
-                    >
-                      キャンセル
-                    </button>
-                  </div>
-                </div>
-              )}
             </div>
           </SolidPanel>
         ) : (


### PR DESCRIPTION
## Summary

- `/settings/account` をナビゲーションハブに変更（プロフィール / プラン / アカウント削除への導線）
- `/settings/account/profile` を新設 — ユーザー名・アカウントID変更ページ
- `/settings/account/plan` を新設 — プラン確認、サブスクリプション管理、解約モーダル
- `/settings/account/delete` を新設 — アカウント削除（説明 + 確認モーダル）
- メイン設定ページのプロフィールカード「変更」ボタンをプロフィールページへのリンクに変更（インライン編集を削除）

## Test plan

- [ ] `/settings` のプロフィールカード「変更」ボタンが `/settings/account/profile` に遷移する
- [ ] `/settings/account` でプロフィール・プラン・アカウント削除へのナビリンクが表示される
- [ ] `/settings/account/profile` でユーザー名の編集・保存が正常に動作する
- [ ] `/settings/account/plan` でプラン表示・サブスク管理が正常に動作する
- [ ] `/settings/account/delete` でアカウント削除の説明表示・確認モーダルが正常に動作する
- [ ] 各サブページの「← アカウント」ボタンで親ページに戻れる
- [ ] デスクトップ表示（lg以上）は変更なし
- [ ] `npm run build` / `npm run lint` パス確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014zzLYpYLoi57bBpgsjUWUq

---
_Generated by [Claude Code](https://claude.ai/code/session_014zzLYpYLoi57bBpgsjUWUq)_