### PR TITLE
戻るボタン統一 & アカウントID編集機能

### DIFF
--- a/src/app/api/profile/route.ts
+++ b/src/app/api/profile/route.ts
@@ -10,8 +10,17 @@ const updateSchema = z.object({
     .string()
     .trim()
     .min(1, 'ユーザー名は1文字以上で入力してください')
-    .max(20, 'ユーザー名は20文字以内で入力してください'),
-}).strict();
+    .max(20, 'ユーザー名は20文字以内で入力してください')
+    .optional(),
+  accountId: z
+    .string()
+    .trim()
+    .regex(/^[a-z0-9_]{4,24}$/, 'IDは半角英小文字・数字・アンダースコアで4〜24文字にしてください')
+    .optional(),
+}).strict().refine(
+  data => data.username !== undefined || data.accountId !== undefined,
+  { message: 'username または accountId を指定してください' },
+);
 
 type ProfileRow = {
   username: string | null;
@@ -134,7 +143,7 @@ export async function handleProfilePut(
     }
 
     const parsed = await parseJsonWithSchema(request, updateSchema, {
-      invalidMessage: 'ユーザー名が不正です',
+      invalidMessage: '入力内容が不正です',
     });
     if (!parsed.ok) {
       return parsed.response;
@@ -143,30 +152,28 @@ export async function handleProfilePut(
     const admin = (deps.getAdmin ?? getSupabaseAdmin)();
     const ensureProfile = deps.ensureProfile ?? ensureFriendProfile;
     const ensuredProfile = await ensureProfile(userId, admin);
+
+    const upsertData: Record<string, string> = { user_id: userId };
+    if (parsed.data.username !== undefined) {
+      upsertData.username = parsed.data.username;
+      upsertData.display_name = parsed.data.username;
+    }
+    upsertData.account_id = parsed.data.accountId ?? ensuredProfile.accountId;
+
     let { data, error } = await admin
       .from('profiles')
-      .upsert(
-        {
-          user_id: userId,
-          username: parsed.data.username,
-          display_name: parsed.data.username,
-          account_id: ensuredProfile.accountId,
-        },
-        { onConflict: 'user_id' }
-      )
+      .upsert(upsertData, { onConflict: 'user_id' })
       .select('username,display_name,user_handle,account_id')
       .single<ProfileRow>();
 
     if (error && isMissingProfileColumn(error)) {
+      const fallbackData: Record<string, string> = { user_id: userId };
+      if (parsed.data.username !== undefined) {
+        fallbackData.username = parsed.data.username;
+      }
       const fallback = await admin
         .from('profiles')
-        .upsert(
-          {
-            user_id: userId,
-            username: parsed.data.username,
-          },
-          { onConflict: 'user_id' }
-        )
+        .upsert(fallbackData, { onConflict: 'user_id' })
         .select('username')
         .single<ProfileRow>();
 
@@ -175,6 +182,10 @@ export async function handleProfilePut(
     }
 
     if (error || !data) {
+      const pgError = error as { code?: string } | null;
+      if (pgError?.code === '23505') {
+        return NextResponse.json({ error: 'このIDは既に使用されています' }, { status: 409 });
+      }
       console.error('Failed to update profile:', error);
       return NextResponse.json({ error: 'Failed to update profile' }, { status: 500 });
     }

--- a/src/app/settings/account/delete/page.tsx
+++ b/src/app/settings/account/delete/page.tsx
@@ -76,10 +76,10 @@ export default function DeleteAccountPage() {
         <button
           type="button"
           onClick={() => router.push('/settings/account')}
-          className="mb-2 inline-flex items-center gap-0.5 font-display text-[12px] font-bold text-[var(--color-muted)]"
+          aria-label="アカウントへ戻る"
+          className="mb-2 flex h-[38px] w-[38px] items-center justify-center rounded-[19px] border-2 border-[var(--solid-ink)] bg-white text-[var(--solid-ink)] transition-all duration-100 active:translate-x-px active:translate-y-px"
         >
-          <Icon name="chevron_left" size={16} />
-          アカウント
+          <Icon name="chevron_left" size={20} />
         </button>
         <div className="font-mono text-[10px] font-bold uppercase tracking-[0.08em] text-[var(--color-error)]">DANGER ZONE</div>
         <div className="mt-0.5 font-display text-[26px] font-extrabold leading-[1.1] tracking-[-0.02em] text-[var(--solid-ink)]">アカウント削除</div>

--- a/src/app/settings/account/page.tsx
+++ b/src/app/settings/account/page.tsx
@@ -29,10 +29,10 @@ export default function AccountSettingsPage() {
         <button
           type="button"
           onClick={() => router.push('/settings')}
-          className="mb-2 inline-flex items-center gap-0.5 font-display text-[12px] font-bold text-[var(--color-muted)]"
+          aria-label="設定へ戻る"
+          className="mb-2 flex h-[38px] w-[38px] items-center justify-center rounded-[19px] border-2 border-[var(--solid-ink)] bg-white text-[var(--solid-ink)] transition-all duration-100 active:translate-x-px active:translate-y-px"
         >
-          <Icon name="chevron_left" size={16} />
-          設定
+          <Icon name="chevron_left" size={20} />
         </button>
         <div className="font-mono text-[10px] font-bold uppercase tracking-[0.08em] text-[var(--color-muted)]">ACCOUNT</div>
         <div className="mt-0.5 font-display text-[26px] font-extrabold leading-[1.1] tracking-[-0.02em] text-[var(--solid-ink)]">アカウント</div>

--- a/src/app/settings/account/plan/page.tsx
+++ b/src/app/settings/account/plan/page.tsx
@@ -91,10 +91,10 @@ export default function PlanSettingsPage() {
         <button
           type="button"
           onClick={() => router.push('/settings/account')}
-          className="mb-2 inline-flex items-center gap-0.5 font-display text-[12px] font-bold text-[var(--color-muted)]"
+          aria-label="アカウントへ戻る"
+          className="mb-2 flex h-[38px] w-[38px] items-center justify-center rounded-[19px] border-2 border-[var(--solid-ink)] bg-white text-[var(--solid-ink)] transition-all duration-100 active:translate-x-px active:translate-y-px"
         >
-          <Icon name="chevron_left" size={16} />
-          アカウント
+          <Icon name="chevron_left" size={20} />
         </button>
         <div className="font-mono text-[10px] font-bold uppercase tracking-[0.08em] text-[var(--color-muted)]">PLAN</div>
         <div className="mt-0.5 font-display text-[26px] font-extrabold leading-[1.1] tracking-[-0.02em] text-[var(--solid-ink)]">プラン</div>

--- a/src/app/settings/account/profile/page.tsx
+++ b/src/app/settings/account/profile/page.tsx
@@ -15,11 +15,17 @@ export default function ProfileSettingsPage() {
     saving: profileSaving,
     error: profileError,
     setUsername,
+    setAccountId: saveAccountId,
   } = useProfile();
   const [usernameInput, setUsernameInput] = useState<string | null>(null);
+  const [accountIdInput, setAccountIdInput] = useState<string | null>(null);
 
   const isEditing = usernameInput !== null;
   const displayValue = usernameInput ?? username ?? '';
+
+  const isEditingAccountId = accountIdInput !== null;
+  const displayAccountIdValue = accountIdInput ?? accountId ?? '';
+  const isAccountIdValid = /^[a-z0-9_]{4,24}$/.test(displayAccountIdValue);
 
   const startEditing = () => {
     setUsernameInput(username ?? '');
@@ -38,16 +44,33 @@ export default function ProfileSettingsPage() {
     }
   };
 
+  const startEditingAccountId = () => {
+    setAccountIdInput(accountId ?? '');
+  };
+
+  const cancelEditingAccountId = () => {
+    setAccountIdInput(null);
+  };
+
+  const handleSaveAccountId = async () => {
+    if (profileSaving || !isAccountIdValid) return;
+    const success = await saveAccountId(displayAccountIdValue);
+    if (success) {
+      setAccountIdInput(null);
+      showToast({ type: 'success', message: 'IDを変更しました' });
+    }
+  };
+
   return (
     <div className="relative min-h-screen bg-[var(--color-background)] pb-[110px] pt-3 font-[var(--font-body)] lg:hidden">
       <div className="px-[18px] pb-[14px] pt-1">
         <button
           type="button"
           onClick={() => router.push('/settings/account')}
-          className="mb-2 inline-flex items-center gap-0.5 font-display text-[12px] font-bold text-[var(--color-muted)]"
+          aria-label="アカウントへ戻る"
+          className="mb-2 flex h-[38px] w-[38px] items-center justify-center rounded-[19px] border-2 border-[var(--solid-ink)] bg-white text-[var(--solid-ink)] transition-all duration-100 active:translate-x-px active:translate-y-px"
         >
-          <Icon name="chevron_left" size={16} />
-          アカウント
+          <Icon name="chevron_left" size={20} />
         </button>
         <div className="font-mono text-[10px] font-bold uppercase tracking-[0.08em] text-[var(--color-muted)]">PROFILE</div>
         <div className="mt-0.5 font-display text-[26px] font-extrabold leading-[1.1] tracking-[-0.02em] text-[var(--solid-ink)]">プロフィール変更</div>
@@ -132,15 +155,80 @@ export default function ProfileSettingsPage() {
 
           {/* アカウントID */}
           <div className="border-t border-[var(--color-border)] px-4 py-3.5">
-            <div className="font-mono text-[9px] font-bold uppercase tracking-[0.08em] text-[var(--color-muted)]">
-              ACCOUNT ID
+            <div className="flex items-center justify-between">
+              <label htmlFor="profile-account-id" className="font-mono text-[9px] font-bold uppercase tracking-[0.08em] text-[var(--color-muted)]">
+                ACCOUNT ID
+              </label>
+              {!isEditingAccountId && (
+                <button
+                  type="button"
+                  onClick={startEditingAccountId}
+                  disabled={profileLoading}
+                  className="inline-flex items-center gap-0.5 font-display text-[11px] font-bold text-[var(--color-accent)] disabled:opacity-50"
+                >
+                  <Icon name="edit" size={13} />
+                  編集
+                </button>
+              )}
             </div>
-            <p className="mt-1 font-mono text-[14px] font-bold text-[var(--solid-ink)]">
-              {profileLoading ? '...' : accountId ? `@${accountId}` : '未設定'}
-            </p>
-            <p className="mt-1 text-[10px] leading-4 text-[var(--color-muted)]">
-              ユーザー名を設定すると自動的に生成されます
-            </p>
+
+            {isEditingAccountId ? (
+              <>
+                <div className="relative mt-1.5">
+                  <span className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 font-mono text-[15px] font-bold text-[var(--color-muted)]">@</span>
+                  <input
+                    id="profile-account-id"
+                    type="text"
+                    value={displayAccountIdValue}
+                    onChange={(event) => setAccountIdInput(event.target.value.toLowerCase().replace(/[^a-z0-9_]/g, ''))}
+                    onKeyDown={(event) => {
+                      if (event.key === 'Enter') {
+                        event.preventDefault();
+                        void handleSaveAccountId();
+                      }
+                      if (event.key === 'Escape') {
+                        cancelEditingAccountId();
+                      }
+                    }}
+                    maxLength={24}
+                    autoFocus
+                    placeholder="account_id"
+                    className="w-full rounded-[10px] border-2 border-[var(--solid-ink)] bg-white py-2.5 pl-8 pr-3 font-mono text-[15px] font-bold text-[var(--solid-ink)] outline-none transition-shadow placeholder:text-[var(--color-muted)] focus:shadow-[2px_2px_0_var(--color-accent)]"
+                  />
+                </div>
+                <div className="mt-1.5 flex items-center justify-between gap-2">
+                  <p className="font-mono text-[9px] text-[var(--color-muted)]">半角英小文字・数字・_ / 4〜24文字</p>
+                  <p className="font-mono text-[9px] text-[var(--color-muted)]">{displayAccountIdValue.length}/24</p>
+                </div>
+                {profileError && (
+                  <p className="mt-2 rounded-[8px] border border-[var(--color-error)] bg-[rgba(239,68,68,0.08)] px-2.5 py-2 text-[11px] font-bold text-[var(--color-error)]">
+                    {profileError}
+                  </p>
+                )}
+                <div className="mt-3 flex gap-2">
+                  <button
+                    type="button"
+                    onClick={handleSaveAccountId}
+                    disabled={profileSaving || !isAccountIdValid}
+                    className="flex-1 rounded-[9px] border-2 border-[var(--solid-ink)] bg-[var(--solid-ink)] px-3 py-2.5 font-display text-[13px] font-bold text-white shadow-[2px_2px_0_var(--color-accent)] transition-all duration-100 disabled:cursor-not-allowed disabled:opacity-50 active:translate-x-px active:translate-y-px"
+                  >
+                    {profileSaving ? '保存中...' : '保存'}
+                  </button>
+                  <button
+                    type="button"
+                    onClick={cancelEditingAccountId}
+                    disabled={profileSaving}
+                    className="flex-1 rounded-[9px] border-2 border-[var(--solid-ink)] bg-white px-3 py-2.5 font-display text-[13px] font-bold text-[var(--solid-ink)] transition-colors disabled:cursor-not-allowed disabled:opacity-50"
+                  >
+                    キャンセル
+                  </button>
+                </div>
+              </>
+            ) : (
+              <p className="mt-1 font-mono text-[14px] font-bold text-[var(--solid-ink)]">
+                {profileLoading ? '...' : accountId ? `@${accountId}` : '未設定'}
+              </p>
+            )}
           </div>
         </div>
       </div>

--- a/src/app/settings/customize/page.tsx
+++ b/src/app/settings/customize/page.tsx
@@ -14,10 +14,10 @@ export default function CustomizePage() {
         <button
           type="button"
           onClick={() => router.push('/settings')}
-          className="mb-2 inline-flex items-center gap-0.5 font-display text-[12px] font-bold text-[var(--color-muted)]"
+          aria-label="設定へ戻る"
+          className="mb-2 flex h-[38px] w-[38px] items-center justify-center rounded-[19px] border-2 border-[var(--solid-ink)] bg-white text-[var(--solid-ink)] transition-all duration-100 active:translate-x-px active:translate-y-px"
         >
-          <Icon name="chevron_left" size={16} />
-          設定
+          <Icon name="chevron_left" size={20} />
         </button>
         <div className="font-mono text-[10px] font-bold uppercase tracking-[0.08em] text-[var(--color-muted)]">CUSTOMIZE</div>
         <div className="mt-0.5 font-display text-[26px] font-extrabold leading-[1.1] tracking-[-0.02em] text-[var(--solid-ink)]">カスタマイズ</div>

--- a/src/hooks/use-profile.ts
+++ b/src/hooks/use-profile.ts
@@ -60,12 +60,13 @@ interface ProfileState {
   error: string | null;
   refresh: () => Promise<void>;
   setUsername: (username: string) => Promise<boolean>;
+  setAccountId: (accountId: string) => Promise<boolean>;
 }
 
 export function useProfile(): ProfileState {
   const { user, isAuthenticated, loading: authLoading } = useAuth();
   const [username, setUsernameState] = useState<string | null>(null);
-  const [accountId, setAccountId] = useState<string | null>(null);
+  const [accountId, setAccountIdState] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -74,7 +75,7 @@ export function useProfile(): ProfileState {
     if (authLoading) return;
     if (!isAuthenticated || !user?.id) {
       setUsernameState(null);
-      setAccountId(null);
+      setAccountIdState(null);
       setLoading(false);
       setError(null);
       clearCache();
@@ -85,7 +86,7 @@ export function useProfile(): ProfileState {
     const hasCachedValue = cachedValue !== undefined;
     if (hasCachedValue) {
       setUsernameState(cachedValue.username);
-      setAccountId(cachedValue.accountId);
+      setAccountIdState(cachedValue.accountId);
       setLoading(false);
     } else {
       setLoading(true);
@@ -106,7 +107,7 @@ export function useProfile(): ProfileState {
       const normalized = typeof data.username === 'string' ? data.username : null;
       const normalizedAccountId = typeof data.accountId === 'string' ? data.accountId : null;
       setUsernameState(normalized);
-      setAccountId(normalizedAccountId);
+      setAccountIdState(normalizedAccountId);
       writeCache(user.id, normalized, normalizedAccountId);
     } catch (err) {
       setError(err instanceof Error ? err.message : 'プロフィールの取得に失敗しました');
@@ -146,14 +147,53 @@ export function useProfile(): ProfileState {
       const normalized = typeof data.username === 'string' ? data.username : null;
       const normalizedAccountId = typeof data.accountId === 'string' ? data.accountId : accountId;
       setUsernameState(normalized);
-      setAccountId(normalizedAccountId);
+      setAccountIdState(normalizedAccountId);
       writeCache(user.id, normalized, normalizedAccountId);
       return true;
     } catch (err) {
       setUsernameState(previousValue);
-      setAccountId(previousAccountId);
+      setAccountIdState(previousAccountId);
       writeCache(user.id, previousValue, previousAccountId);
       setError(err instanceof Error ? err.message : 'ユーザー名の保存に失敗しました');
+      return false;
+    } finally {
+      setSaving(false);
+    }
+  }, [accountId, username, isAuthenticated, user?.id]);
+
+  const setAccountId = useCallback(async (newAccountId: string): Promise<boolean> => {
+    if (!isAuthenticated || !user?.id) return false;
+
+    const previousAccountId = accountId;
+    const trimmed = newAccountId.trim();
+    setAccountIdState(trimmed);
+    writeCache(user.id, username, trimmed);
+    setSaving(true);
+    setError(null);
+
+    try {
+      const response = await fetch('/api/profile', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ accountId: trimmed }),
+      });
+
+      if (!response.ok) {
+        const data = await response.json().catch(() => ({}));
+        throw new Error(data?.error ?? 'IDの保存に失敗しました');
+      }
+
+      const data = await response.json() as { username: string | null; accountId?: string | null };
+      const normalizedUsername = typeof data.username === 'string' ? data.username : username;
+      const normalizedAccountId = typeof data.accountId === 'string' ? data.accountId : trimmed;
+      setUsernameState(normalizedUsername);
+      setAccountIdState(normalizedAccountId);
+      writeCache(user.id, normalizedUsername, normalizedAccountId);
+      return true;
+    } catch (err) {
+      setAccountIdState(previousAccountId);
+      writeCache(user.id, username, previousAccountId);
+      setError(err instanceof Error ? err.message : 'IDの保存に失敗しました');
       return false;
     } finally {
       setSaving(false);
@@ -168,5 +208,6 @@ export function useProfile(): ProfileState {
     error,
     refresh,
     setUsername,
+    setAccountId,
   };
 }


### PR DESCRIPTION
## Summary

- 設定サブページ5箇所（customize, account, profile, plan, delete）の戻るボタンを `/project/*` ページと同じ38x38丸ボタンスタイルに統一
- アカウントIDをユーザーが自分で設定・変更できるように対応
  - `PUT /api/profile` で `accountId` フィールドを受け付け（`^[a-z0-9_]{4,24}$`）
  - `useProfile` フックに `setAccountId` メソッドを追加
  - プロフィール設定ページにインライン編集UI（入力フィルタ、バリデーション、重複エラー表示）を追加

## Test plan

- [ ] 各設定サブページで戻るボタンが丸ボタン（38x38, border, 白背景）で表示されること
- [ ] 戻るボタン押下で親ページに遷移すること
- [ ] プロフィール設定ページでアカウントIDの「編集」ボタンが表示されること
- [ ] ID編集時、入力が英小文字・数字・アンダースコアのみに制限されること
- [ ] 4〜24文字の範囲外では保存ボタンが無効になること
- [ ] 有効なIDで保存が成功し、トースト表示されること
- [ ] 既存IDと重複する場合、エラーメッセージが表示されること
- [ ] キャンセルボタンで編集モードを抜けること

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014zzLYpYLoi57bBpgsjUWUq

---
_Generated by [Claude Code](https://claude.ai/code/session_014zzLYpYLoi57bBpgsjUWUq)_