### PR TITLE
Move follow notifications to home

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -6,6 +6,7 @@ import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { Icon } from '@/components/ui/Icon';
 import { DesktopHomeView } from '@/components/desktop/DesktopHome';
+import { FollowNotificationsButton } from '@/components/notifications/FollowNotificationsButton';
 import { SolidEmpty, SolidPanel } from '@/components/redesign/SolidPage';
 import { ScanCaptureModal } from '@/components/home/ScanCaptureModal';
 import { LpDemoSection } from '@/components/home/LpDemoSection';
@@ -464,13 +465,7 @@ export default function HomePage() {
           <span className="ml-1 inline-block h-[5px] w-[5px] -translate-y-2 bg-[var(--color-accent)]" />
         </div>
         <div className="flex items-center gap-2">
-          <Link
-            href="/favorites"
-            className="flex h-[34px] w-[34px] items-center justify-center rounded-full border-2 border-[var(--solid-ink)] bg-[var(--color-surface)] text-[var(--color-accent)]"
-            aria-label="保存済み"
-          >
-            <Icon name="bookmark" size={16} filled />
-          </Link>
+          <FollowNotificationsButton variant="mobile" />
           <div className="flex items-center gap-[5px] rounded-full border-2 border-[var(--solid-ink)] bg-[var(--color-surface)] px-2.5 py-1.5">
             <span className="inline-flex text-[var(--color-warning)]">
               <Icon name="local_fire_department" size={13} filled />

--- a/src/app/shared/SharedPageClient.tsx
+++ b/src/app/shared/SharedPageClient.tsx
@@ -4,7 +4,6 @@ import { startTransition, useCallback, useEffect, useMemo, useRef, useState, typ
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { DesktopSharedView } from '@/components/desktop/DesktopShared';
-import { FollowNotificationsButton } from '@/components/notifications/FollowNotificationsButton';
 import { Icon } from '@/components/ui';
 import { useAuth } from '@/hooks/use-auth';
 import { useToast } from '@/components/ui/toast';
@@ -362,17 +361,14 @@ export default function SharedPageClient({ initialDiscover }: SharedPageClientPr
                 共有単語帳
               </div>
             </div>
-            <div className="flex shrink-0 items-center gap-2">
-              <FollowNotificationsButton variant="mobile" />
-              <button
-                type="button"
-                onClick={handleOpenShareSheet}
-                aria-label="単語帳を共有"
-                className="inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-[12px] border-2 border-[var(--solid-ink)] bg-[var(--solid-ink)] text-white transition-all duration-100 active:translate-x-px active:translate-y-px"
-              >
-                <Icon name="add" size={20} />
-              </button>
-            </div>
+            <button
+              type="button"
+              onClick={handleOpenShareSheet}
+              aria-label="単語帳を共有"
+              className="inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-[12px] border-2 border-[var(--solid-ink)] bg-[var(--solid-ink)] text-white transition-all duration-100 active:translate-x-px active:translate-y-px"
+            >
+              <Icon name="add" size={20} />
+            </button>
           </div>
         </div>
 

--- a/src/components/desktop/DesktopShared.tsx
+++ b/src/components/desktop/DesktopShared.tsx
@@ -2,7 +2,6 @@
 
 import Link from 'next/link';
 import { DesktopButton, DesktopSearchBox } from '@/components/desktop/DesktopChrome';
-import { FollowNotificationsButton } from '@/components/notifications/FollowNotificationsButton';
 import { desktopThumbColor } from '@/components/desktop/desktop-data';
 import { Icon } from '@/components/ui/Icon';
 import { formatSharedTag } from '../../../shared/shared-tags';
@@ -68,8 +67,7 @@ export function DesktopSharedView({
           onChange={(event) => onQueryChange(event.target.value)}
           style={{ width: '100%', minWidth: 0 }}
         />
-        <div style={{ justifySelf: 'end', display: 'flex', alignItems: 'center', gap: 8 }}>
-          <FollowNotificationsButton />
+        <div style={{ justifySelf: 'end' }}>
           <DesktopButton variant="dark" icon="add" onClick={onOpenShareSheet}>
             共有
           </DesktopButton>

--- a/src/components/notifications/FollowNotificationsButton.tsx
+++ b/src/components/notifications/FollowNotificationsButton.tsx
@@ -114,7 +114,7 @@ export function FollowNotificationsButton({ variant = 'desktop' }: FollowNotific
 
   const buttonClassName = useMemo(() => {
     if (variant === 'mobile') {
-      return 'relative inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-[12px] border-2 border-[var(--solid-ink)] bg-white text-[var(--solid-ink)] transition-all duration-100 active:translate-x-px active:translate-y-px';
+      return 'relative inline-flex h-[34px] w-[34px] shrink-0 items-center justify-center rounded-full border-2 border-[var(--solid-ink)] bg-[var(--color-surface)] text-[var(--color-accent)] transition-all duration-100 active:translate-x-px active:translate-y-px';
     }
     return 'ds-btn ds-btn--icon relative';
   }, [variant]);
@@ -150,7 +150,7 @@ export function FollowNotificationsButton({ variant = 'desktop' }: FollowNotific
         <div
           className={cn(
             'absolute right-0 z-[120] w-[min(340px,calc(100vw-28px))] border-2 border-[var(--solid-ink)] bg-white shadow-[6px_6px_0_var(--solid-ink)]',
-            variant === 'mobile' ? 'top-12 rounded-[14px]' : 'top-[calc(100%+10px)] rounded-[12px]',
+            variant === 'mobile' ? 'top-10 rounded-[14px]' : 'top-[calc(100%+10px)] rounded-[12px]',
           )}
         >
           <div className="flex items-center justify-between border-b border-[var(--color-border)] px-3 py-2.5">


### PR DESCRIPTION
## Summary
- move the follow notification button from the shared page to the home header
- replace the mobile home saved-items button with the notification button
- keep the mobile notification button aligned with the old circular header button size

## Verification
- npx eslint src/app/page.tsx src/app/shared/SharedPageClient.tsx src/components/desktop/DesktopShared.tsx src/components/notifications/FollowNotificationsButton.tsx
- npm test
- npm run build