### PR TITLE
fix: フィードの単語一覧・メトリクスチップを既存部品の見た目に統一

### DIFF
--- a/src/app/friends/page.tsx
+++ b/src/app/friends/page.tsx
@@ -374,8 +374,6 @@ function TimelineItem({
   expanded: boolean;
   onToggle: () => void;
 }) {
-  const color = avatarColor(session.profile.accountId);
-
   return (
     <article className="border-b border-[var(--color-border)] transition-colors hover:bg-[var(--color-surface-secondary)]">
       <button
@@ -403,16 +401,16 @@ function TimelineItem({
         <div className="border-t border-[var(--color-border)] bg-[var(--color-surface-secondary)] px-[18px] py-4">
           <div className="pl-[52px]">
             {session.words.length > 0 ? (
-              <div className="flex flex-col gap-2">
+              <div className="divide-y divide-[var(--color-border)]">
                 {session.words.map((word) => (
-                  <div key={word.id} className="rounded-[12px] border border-[var(--color-accent-light)] bg-[var(--color-accent-subtle)] px-4 py-3">
-                    <div className="font-display text-[15px] font-extrabold text-[var(--solid-ink)]">{word.english}</div>
-                    <div className="mt-0.5 text-[13px] font-bold text-[var(--color-muted)]">{word.japanese}</div>
+                  <div key={word.id} className="py-3">
+                    <div className="font-semibold text-[var(--color-foreground)]">{word.english}</div>
+                    <p className="mt-0.5 text-sm text-[var(--color-muted)]">{word.japanese}</p>
                   </div>
                 ))}
               </div>
             ) : (
-              <div className="px-4 py-4 text-center text-[13px] font-bold text-[var(--color-muted)]">
+              <div className="py-4 text-center text-sm text-[var(--color-muted)]">
                 習得済みに変わった単語はありません
               </div>
             )}
@@ -499,14 +497,14 @@ function MetricChip({
   label: string;
   variant?: 'quiz' | 'mastered' | 'default';
 }) {
-  const styles = {
-    quiz: 'border-[var(--color-accent-light)] bg-[var(--color-accent-light)] text-[var(--color-accent)]',
-    mastered: 'border-[var(--color-warning-light)] bg-[var(--color-warning-light)] text-[var(--color-warning)]',
-    default: 'border-[var(--color-border)] bg-[var(--color-surface-secondary)] text-[var(--solid-ink)]',
-  };
+  const iconColor = {
+    quiz: 'text-[var(--color-muted)]',
+    mastered: 'text-[var(--color-success)]',
+    default: 'text-[var(--color-muted)]',
+  }[variant];
   return (
-    <span className={`inline-flex items-center gap-1 rounded-full border px-2.5 py-1 text-[11px] font-extrabold ${styles[variant]}`}>
-      <Icon name={icon} size={13} />
+    <span className="inline-flex items-center gap-[5px] rounded-full border-2 border-[var(--color-border)] bg-[var(--color-surface)] px-2.5 py-1.5 text-[12px] font-semibold text-[var(--color-ink-muted)]">
+      <Icon name={icon} size={12} className={iconColor} />
       {label}
     </span>
   );

--- a/src/app/stats/page.tsx
+++ b/src/app/stats/page.tsx
@@ -356,16 +356,16 @@ function TimelineItem({
         <div className="border-t border-[var(--color-border)] bg-[var(--color-surface-secondary)] px-[18px] py-4">
           <div className="pl-[52px]">
             {session.words.length > 0 ? (
-              <div className="flex flex-col gap-2">
+              <div className="divide-y divide-[var(--color-border)]">
                 {session.words.map((word) => (
-                  <div key={word.id} className="rounded-[12px] border border-[var(--color-accent-light)] bg-[var(--color-accent-subtle)] px-4 py-3">
-                    <div className="font-display text-[15px] font-extrabold text-[var(--solid-ink)]">{word.english}</div>
-                    <div className="mt-0.5 text-[13px] font-bold text-[var(--color-muted)]">{word.japanese}</div>
+                  <div key={word.id} className="py-3">
+                    <div className="font-semibold text-[var(--color-foreground)]">{word.english}</div>
+                    <p className="mt-0.5 text-sm text-[var(--color-muted)]">{word.japanese}</p>
                   </div>
                 ))}
               </div>
             ) : (
-              <div className="px-4 py-4 text-center text-[13px] font-bold text-[var(--color-muted)]">
+              <div className="py-4 text-center text-sm text-[var(--color-muted)]">
                 習得済みに変わった単語はありません
               </div>
             )}
@@ -398,14 +398,14 @@ function MetricChip({
   label: string;
   variant?: 'quiz' | 'mastered' | 'default';
 }) {
-  const styles = {
-    quiz: 'border-[var(--color-accent-light)] bg-[var(--color-accent-light)] text-[var(--color-accent)]',
-    mastered: 'border-[var(--color-warning-light)] bg-[var(--color-warning-light)] text-[var(--color-warning)]',
-    default: 'border-[var(--color-border)] bg-[var(--color-surface-secondary)] text-[var(--solid-ink)]',
-  };
+  const iconColor = {
+    quiz: 'text-[var(--color-muted)]',
+    mastered: 'text-[var(--color-success)]',
+    default: 'text-[var(--color-muted)]',
+  }[variant];
   return (
-    <span className={`inline-flex items-center gap-1 rounded-full border px-2.5 py-1 text-[11px] font-extrabold ${styles[variant]}`}>
-      <Icon name={icon} size={13} />
+    <span className="inline-flex items-center gap-[5px] rounded-full border-2 border-[var(--color-border)] bg-[var(--color-surface)] px-2.5 py-1.5 text-[12px] font-semibold text-[var(--color-ink-muted)]">
+      <Icon name={icon} size={12} className={iconColor} />
       {label}
     </span>
   );


### PR DESCRIPTION
## 概要

[#261](https://github.com/carlos0768/vocabularytest/pull/261) の続き。フィードページ(`/friends`)・統計ページの**展開時の単語一覧**と**メトリクスチップ（○問 / ○語習得）**が、他ページに存在しない独自のコンポーネント・配色になっていたため、既存の標準部品の見た目に揃えました。

## 変更点

### 1. 展開時の単語一覧 → `/project` の単語一覧と同じ区切り線リストに
緑のカード（角丸 + accentボーダー + 塗りつぶし、`font-display font-extrabold`）をやめ、`src/components/home/WordList.tsx` の `WordItem` と同じスタイルに統一：
- 英語: `font-semibold text-[var(--color-foreground)]`
- 日本語: `text-sm text-[var(--color-muted)]`
- 単語ごとに四角で囲まず、`divide-y divide-[var(--color-border)]` の**線で区切り**

### 2. メトリクスチップ → `/project` の `ToolChip` と同じ中立ピルに
緑（quiz）・琥珀（mastered）の塗りつぶしをやめ、`src/app/project/[id]/page.tsx` の `ToolChip` と同じ中立的なピルに統一：
- `rounded-full border-2 border-[var(--color-border)] bg-[var(--color-surface)]` / `font-semibold` / muted文字
- 習得チップのアイコンのみ習得色 `--color-success`（`StackedBar` の 習得=success と統一）で軽く区別

### その他
- 未使用変数 `color` を削除（lint warning解消）

## 対象ファイル
- `src/app/friends/page.tsx`
- `src/app/stats/page.tsx`（同一のフィードタイムライン部品が重複しているため合わせて統一）

## 検証
- `eslint` … 編集ファイルにエラーなし（既存の `FormEvent` / `formatTimeOnly` 未使用警告のみ残存）
- `tsc --noEmit` … 編集ファイルは型エラーなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013uUGsKYMkgTNinYpQhrgfy

---
_Generated by [Claude Code](https://claude.ai/code/session_013uUGsKYMkgTNinYpQhrgfy)_