### PR TITLE
fix: フィードの単語一覧をproject単語行と同一にし左余白を除去

### DIFF
--- a/src/app/friends/page.tsx
+++ b/src/app/friends/page.tsx
@@ -398,23 +398,21 @@ function TimelineItem({
         <Icon name={expanded ? 'expand_less' : 'expand_more'} size={22} className="mt-1.5 shrink-0 text-[var(--color-muted)]" />
       </button>
       {expanded && (
-        <div className="border-t border-[var(--color-border)] bg-[var(--color-surface-secondary)] px-[18px] py-4">
-          <div className="pl-[52px]">
-            {session.words.length > 0 ? (
-              <div className="divide-y divide-[var(--color-border)]">
-                {session.words.map((word) => (
-                  <div key={word.id} className="py-3">
-                    <div className="font-semibold text-[var(--color-foreground)]">{word.english}</div>
-                    <p className="mt-0.5 text-sm text-[var(--color-muted)]">{word.japanese}</p>
-                  </div>
-                ))}
-              </div>
-            ) : (
-              <div className="py-4 text-center text-sm text-[var(--color-muted)]">
-                習得済みに変わった単語はありません
-              </div>
-            )}
-          </div>
+        <div className="border-t border-[var(--color-border)] bg-[var(--color-surface-secondary)] px-[18px] py-2">
+          {session.words.length > 0 ? (
+            <div className="divide-y divide-[var(--color-border)]">
+              {session.words.map((word) => (
+                <div key={word.id} className="px-1 py-2.5">
+                  <div className="truncate font-display text-[15px] font-bold text-[var(--solid-ink)]">{word.english}</div>
+                  <div className="mt-px truncate text-[11px] text-[var(--color-muted)]">{word.japanese}</div>
+                </div>
+              ))}
+            </div>
+          ) : (
+            <div className="py-4 text-center text-sm text-[var(--color-muted)]">
+              習得済みに変わった単語はありません
+            </div>
+          )}
         </div>
       )}
     </article>

--- a/src/app/stats/page.tsx
+++ b/src/app/stats/page.tsx
@@ -353,23 +353,21 @@ function TimelineItem({
         <Icon name={expanded ? 'expand_less' : 'expand_more'} size={20} className="mt-1 shrink-0 text-[var(--color-muted)]" />
       </button>
       {expanded && (
-        <div className="border-t border-[var(--color-border)] bg-[var(--color-surface-secondary)] px-[18px] py-4">
-          <div className="pl-[52px]">
-            {session.words.length > 0 ? (
-              <div className="divide-y divide-[var(--color-border)]">
-                {session.words.map((word) => (
-                  <div key={word.id} className="py-3">
-                    <div className="font-semibold text-[var(--color-foreground)]">{word.english}</div>
-                    <p className="mt-0.5 text-sm text-[var(--color-muted)]">{word.japanese}</p>
-                  </div>
-                ))}
-              </div>
-            ) : (
-              <div className="py-4 text-center text-sm text-[var(--color-muted)]">
-                習得済みに変わった単語はありません
-              </div>
-            )}
-          </div>
+        <div className="border-t border-[var(--color-border)] bg-[var(--color-surface-secondary)] px-[18px] py-2">
+          {session.words.length > 0 ? (
+            <div className="divide-y divide-[var(--color-border)]">
+              {session.words.map((word) => (
+                <div key={word.id} className="px-1 py-2.5">
+                  <div className="truncate font-display text-[15px] font-bold text-[var(--solid-ink)]">{word.english}</div>
+                  <div className="mt-px truncate text-[11px] text-[var(--color-muted)]">{word.japanese}</div>
+                </div>
+              ))}
+            </div>
+          ) : (
+            <div className="py-4 text-center text-sm text-[var(--color-muted)]">
+              習得済みに変わった単語はありません
+            </div>
+          )}
         </div>
       )}
     </article>


### PR DESCRIPTION
## 概要

フィードページ(`/friends`)・統計ページの**展開時の単語一覧**を、`/project/*` の単語一覧（`WordRow`）と**全く同じ見た目**に統一し、左側に出ていた謎の空白を除去しました。

## 変更点

### 1. 単語一覧を `/project` の `WordRow` と同一スタイルに
`src/app/project/[id]/page.tsx` の `WordRow`（非選択モード）と同じマークアップに統一：
- 英語: `truncate font-display text-[15px] font-bold text-[var(--solid-ink)]`
- 日本語: `mt-px truncate text-[11px] text-[var(--color-muted)]`
- 各行: `px-1 py-2.5`、`divide-y divide-[var(--color-border)]` の線区切り

**※ ご指定どおり、3段階チェックボックス(`StatusSquares`)は表示しません。** フレンドの学習履歴は読み取り専用のため、ステータス変更UIは付けていません。

### 2. 左側の謎の空白を除去
単語リストをアバター幅ぶん右にずらしていた `pl-[52px]` のインデントを削除。これが左側の不要な余白の原因でした。展開パネルの `px-[18px]` 基準に揃います。

## 対象ファイル
- `src/app/friends/page.tsx`
- `src/app/stats/page.tsx`（同一のフィードタイムライン部品が重複しているため合わせて統一）

## 検証
- `eslint` … 編集ファイルにエラーなし（既存の未使用警告のみ）
- `tsc --noEmit` … 編集ファイルは型エラーなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013uUGsKYMkgTNinYpQhrgfy

---
_Generated by [Claude Code](https://claude.ai/code/session_013uUGsKYMkgTNinYpQhrgfy)_