### PR TITLE
Fix notification dropdown overflowing off the left edge on mobile

### DIFF
--- a/src/components/notifications/FollowNotificationsButton.tsx
+++ b/src/components/notifications/FollowNotificationsButton.tsx
@@ -44,6 +44,12 @@ export function FollowNotificationsButton({ variant = 'desktop' }: FollowNotific
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [respondingId, setRespondingId] = useState<string | null>(null);
+  // On mobile the button sits mid-header (left of the streak chip), so anchoring the
+  // panel to the button's right edge pushes it off the left of the screen. Pin the panel
+  // to the viewport's right edge instead, measuring the button only for vertical offset.
+  const [mobilePanelPos, setMobilePanelPos] = useState<{ top: number; right: number }>({ top: 58, right: 14 });
+
+  const isMobile = variant === 'mobile';
 
   const unreadCount = notifications.length;
 
@@ -87,6 +93,24 @@ export function FollowNotificationsButton({ variant = 'desktop' }: FollowNotific
     document.addEventListener('pointerdown', handlePointerDown);
     return () => document.removeEventListener('pointerdown', handlePointerDown);
   }, [open]);
+
+  useEffect(() => {
+    if (!open || !isMobile) return;
+
+    const updatePosition = () => {
+      const rect = rootRef.current?.getBoundingClientRect();
+      if (!rect) return;
+      setMobilePanelPos({ top: rect.bottom + 8, right: 14 });
+    };
+
+    updatePosition();
+    window.addEventListener('resize', updatePosition);
+    window.addEventListener('scroll', updatePosition, true);
+    return () => {
+      window.removeEventListener('resize', updatePosition);
+      window.removeEventListener('scroll', updatePosition, true);
+    };
+  }, [open, isMobile]);
 
   async function respond(followId: string, action: 'accept' | 'decline') {
     if (respondingId) return;
@@ -149,9 +173,10 @@ export function FollowNotificationsButton({ variant = 'desktop' }: FollowNotific
       {open && (
         <div
           className={cn(
-            'absolute right-0 z-[120] w-[min(340px,calc(100vw-28px))] border-2 border-[var(--solid-ink)] bg-white shadow-[6px_6px_0_var(--solid-ink)]',
-            variant === 'mobile' ? 'top-10 rounded-[14px]' : 'top-[calc(100%+10px)] rounded-[12px]',
+            'z-[120] w-[min(340px,calc(100vw-28px))] border-2 border-[var(--solid-ink)] bg-white shadow-[6px_6px_0_var(--solid-ink)]',
+            isMobile ? 'fixed rounded-[14px]' : 'absolute right-0 top-[calc(100%+10px)] rounded-[12px]',
           )}
+          style={isMobile ? { top: mobilePanelPos.top, right: mobilePanelPos.right } : undefined}
         >
           <div className="flex items-center justify-between border-b border-[var(--color-border)] px-3 py-2.5">
             <div className="font-display text-[14px] font-extrabold text-[var(--solid-ink)]">通知</div>


### PR DESCRIPTION
## 問題

モバイル版で通知ボタンをタップすると、ドロップダウンパネルが画面の左端からはみ出していました。

## 原因

モバイルの通知ボタンはヘッダーの中央寄り（連続日数チップの左）に配置されています。ドロップダウンは `absolute right-0` でボタンの右端を基準にしていたため、340px 幅のパネルがボタンの右端から左に伸び、画面左端を突き抜けて表示されていました。

## 修正

- モバイル版ではパネルを `fixed` でビューポートの右端（`right: 14px`）に固定するように変更
- ボタンの位置は縦方向のオフセット（パネルの `top`）の算出にのみ使用し、`resize` / `scroll` に追従して再計算
- デスクトップ版の挙動（`absolute right-0`）は変更なし

これによりパネルは常に画面右上に収まり、左へはみ出さなくなります。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vnogk5w6XnvWgGd7q6YEmk)_