### PR TITLE
Enlarge flashcard bottom navigation buttons to 1.3x

### DIFF
--- a/src/app/desktop.css
+++ b/src/app/desktop.css
@@ -553,9 +553,9 @@
 .ds-fc-face .ph { font-family: var(--font-mono); font-size: 15px; color: var(--color-muted); }
 .ds-fc-face .ja { font-size: 30px; font-weight: 700; }
 .ds-fc-face .hint { position: absolute; bottom: 18px; font-family: var(--font-mono); font-size: 11px; color: var(--color-muted); display: flex; align-items: center; gap: 5px; }
-.ds-fc-controls { display: flex; gap: 14px; margin-top: 26px; }
-.ds-fc-big { display: flex; align-items: center; justify-content: center; gap: 10px; padding: 16px 40px; border-radius: var(--radius-lg); font-family: var(--font-display); font-weight: 700; font-size: 16px; cursor: pointer; border: 1.5px solid var(--solid-ink); box-shadow: 3px 4px 0 var(--solid-ink); transition: transform var(--dur-fast), box-shadow var(--dur-fast); }
-.ds-fc-big:hover { transform: translate(1px,1px); box-shadow: 2px 3px 0 var(--solid-ink); }
+.ds-fc-controls { display: flex; gap: 32px; margin-top: 26px; }
+.ds-fc-big { display: flex; align-items: center; justify-content: center; gap: 10px; padding: 16px 40px; border-radius: var(--radius-lg); font-family: var(--font-display); font-weight: 700; font-size: 16px; cursor: pointer; border: 1.5px solid var(--solid-ink); box-shadow: 3px 4px 0 var(--solid-ink); transition: transform var(--dur-fast), box-shadow var(--dur-fast); transform: scale(1.3); transform-origin: center; }
+.ds-fc-big:hover { transform: scale(1.3) translate(1px,1px); box-shadow: 2px 3px 0 var(--solid-ink); }
 .ds-fc-big.know { background: var(--color-accent); color: #fff; border-color: var(--color-accent-ink); box-shadow: 3px 4px 0 var(--color-accent-ink); }
 .ds-fc-big.dunno { background: #fff; color: var(--color-ink); }
 

--- a/src/app/flashcard/[projectId]/page.tsx
+++ b/src/app/flashcard/[projectId]/page.tsx
@@ -111,7 +111,7 @@ function NavBtn({
       type="button"
       onClick={onClick}
       aria-label={ariaLabel}
-      className="flex h-[42px] w-[42px] items-center justify-center rounded-[21px] border-2 border-[var(--solid-ink)] bg-white text-[var(--solid-ink)] transition-all duration-100 active:translate-x-px active:translate-y-px"
+      className="flex h-[42px] w-[42px] scale-[1.3] items-center justify-center rounded-[21px] border-2 border-[var(--solid-ink)] bg-white text-[var(--solid-ink)] transition-all duration-100 active:translate-x-px active:translate-y-px"
     >
       {children}
     </button>


### PR DESCRIPTION
## Summary

Makes the three bottom navigation buttons on the flashcard screen (prev / flip / next) **1.3× larger**, while leaving the flashcard body's position completely unchanged.

## Approach

Scaling is done with CSS `transform: scale(1.3)` rather than by changing dimensions/padding. A `transform` enlarges the buttons **visually** but keeps their layout box the same size, so surrounding layout — and therefore the flashcard body position — is unaffected.

## Changes

- **Mobile (`lg:hidden`)** — `src/app/flashcard/[projectId]/page.tsx`: added `scale-[1.3]` to the `NavBtn` component (its only three uses are the bottom prev/flip/next row). Tailwind composes this with the existing `active:translate` press animation.
- **Desktop (`lg:flex`)** — `src/app/desktop.css`: added `transform: scale(1.3)` to `.ds-fc-big` (updating `:hover` to preserve the press feedback), and widened `.ds-fc-controls` gap from `14px` to `32px` so the larger buttons don't visually collide. The gap change is horizontal-only within the controls row and does not move the card.

## Notes

- The 5-chip action row was intentionally left untouched — the request specified the *three* bottom buttons.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JnHqCi1PZfkHUDz7cSDe4x)_