### PR TITLE
Add subtle haptic feedback to flashcard navigation buttons

### DIFF
--- a/src/app/flashcard/[projectId]/page.tsx
+++ b/src/app/flashcard/[projectId]/page.tsx
@@ -14,6 +14,13 @@ import { getCachedProjectWords, getHasLoaded } from '@/lib/home-cache';
 import { formatPartOfSpeechLabels, getPartOfSpeechLabel } from '@/lib/part-of-speech-labels';
 import type { Word, SubscriptionStatus } from '@/types';
 
+/* ---------- Haptic feedback (PWA Vibration API) ---------- */
+function triggerHaptic() {
+  if (typeof navigator !== 'undefined' && typeof navigator.vibrate === 'function') {
+    navigator.vibrate(12); // subtle tap on supported devices (mainly Android)
+  }
+}
+
 /* ---------- Mastery level (mirrors iOS) ---------- */
 function getMasteryLevel(repetition: number): number {
   if (repetition === 0) return 0;
@@ -109,7 +116,7 @@ function NavBtn({
   return (
     <button
       type="button"
-      onClick={onClick}
+      onClick={() => { triggerHaptic(); onClick?.(); }}
       aria-label={ariaLabel}
       className="flex h-[42px] w-[42px] scale-[1.3] items-center justify-center rounded-[21px] border-2 border-[var(--solid-ink)] bg-white text-[var(--solid-ink)] transition-all duration-100 active:translate-x-px active:translate-y-px"
     >
@@ -601,13 +608,13 @@ export default function FlashcardPage() {
         </div>
 
         <div className="ds-fc-controls">
-          <button type="button" className="ds-fc-big dunno" onClick={() => handlePrev()}>
+          <button type="button" className="ds-fc-big dunno" onClick={() => { triggerHaptic(); handlePrev(); }}>
             <Icon name="chevron_left" />前へ
           </button>
-          <button type="button" className="ds-fc-big know" onClick={handleFlip} aria-label="カードを回転">
+          <button type="button" className="ds-fc-big know" onClick={() => { triggerHaptic(); handleFlip(); }} aria-label="カードを回転">
             <Icon name="cached" />回転
           </button>
-          <button type="button" className="ds-fc-big dunno" onClick={() => handleNext()}>
+          <button type="button" className="ds-fc-big dunno" onClick={() => { triggerHaptic(); handleNext(); }}>
             次へ<Icon name="chevron_right" />
           </button>
         </div>

--- a/src/app/flashcard/[projectId]/page.tsx
+++ b/src/app/flashcard/[projectId]/page.tsx
@@ -12,14 +12,8 @@ import { loadCollectionWords } from '@/lib/collection-words';
 import { useAuth } from '@/hooks/use-auth';
 import { getCachedProjectWords, getHasLoaded } from '@/lib/home-cache';
 import { formatPartOfSpeechLabels, getPartOfSpeechLabel } from '@/lib/part-of-speech-labels';
+import { triggerHaptic } from '@/lib/haptics';
 import type { Word, SubscriptionStatus } from '@/types';
-
-/* ---------- Haptic feedback (PWA Vibration API) ---------- */
-function triggerHaptic() {
-  if (typeof navigator !== 'undefined' && typeof navigator.vibrate === 'function') {
-    navigator.vibrate(12); // subtle tap on supported devices (mainly Android)
-  }
-}
 
 /* ---------- Mastery level (mirrors iOS) ---------- */
 function getMasteryLevel(repetition: number): number {

--- a/src/lib/haptics.ts
+++ b/src/lib/haptics.ts
@@ -1,0 +1,60 @@
+/**
+ * Lightweight haptic feedback helper (PWA-friendly, no native wrapper).
+ *
+ * - Android / Chromium browsers: uses the standard Vibration API
+ *   (`navigator.vibrate`).
+ * - iOS Safari: the Vibration API was never implemented, so we fall back to
+ *   toggling a hidden `<input type="checkbox" switch>` via its `<label>`,
+ *   which emits a subtle Taptic Engine pulse. This works on iOS 18–26.4;
+ *   Apple patched the *programmatic* trigger in iOS 26.5, where it simply
+ *   becomes a no-op (no errors, no behaviour change).
+ *
+ * All paths are guarded so the helper is a safe no-op on unsupported
+ * platforms and during SSR.
+ */
+
+let iosHapticLabel: HTMLLabelElement | null = null;
+
+function getIosHapticLabel(): HTMLLabelElement | null {
+  if (typeof document === 'undefined') return null;
+  if (iosHapticLabel?.isConnected) return iosHapticLabel;
+
+  const label = document.createElement('label');
+  label.setAttribute('aria-hidden', 'true');
+  // Keep it rendered (required for the haptic to fire) but invisible and
+  // non-interactive so it never affects layout or pointer events.
+  label.style.cssText =
+    'position:fixed;top:0;left:0;width:1px;height:1px;opacity:0;pointer-events:none;overflow:hidden;z-index:-1;';
+
+  const input = document.createElement('input');
+  input.type = 'checkbox';
+  input.setAttribute('switch', ''); // Safari-specific switch control
+  input.tabIndex = -1;
+  label.appendChild(input);
+
+  document.body.appendChild(label);
+  iosHapticLabel = label;
+  return label;
+}
+
+/**
+ * Fire a brief haptic pulse. Must be called from within a user gesture
+ * (e.g. a click/tap handler) to satisfy browser activation requirements.
+ *
+ * @param durationMs Vibration length for the Vibration API path (ms).
+ */
+export function triggerHaptic(durationMs = 12): void {
+  if (typeof navigator === 'undefined') return;
+
+  if (typeof navigator.vibrate === 'function') {
+    navigator.vibrate(durationMs);
+    return;
+  }
+
+  // iOS Safari fallback.
+  try {
+    getIosHapticLabel()?.click();
+  } catch {
+    /* no-op where unsupported */
+  }
+}


### PR DESCRIPTION
## Summary

Adds a slight vibration (haptic) effect when the three flashcard navigation buttons (prev / flip / next) are pressed, with cross-platform support.

## Approach

Introduced a shared, SSR-safe helper `triggerHaptic()` in `src/lib/haptics.ts` and wired it into both layouts (mobile `NavBtn` component and the three desktop `.ds-fc-big` buttons), running before the original `onClick`.

The helper picks the best available mechanism:

- **Android / Chromium browsers** — standard PWA **Vibration API** (`navigator.vibrate(12)`), a subtle ~12ms tap.
- **iOS Safari** — the Vibration API was never implemented, so it falls back to toggling a hidden `<input type="checkbox" switch>` via its `<label>`, which emits a subtle Taptic Engine pulse.

All paths are guarded, so the helper is a safe no-op on unsupported platforms and during SSR.

## iOS support caveat

The iOS switch-toggle trick works on **iOS 18 – 26.4**. Apple patched the *programmatic* trigger in **iOS 26.5**, where it gracefully degrades to a no-op (no errors, no behavior change). Genuine system-level haptics on the very latest iOS would require a native wrapper, which is out of scope for this PWA-only change.

## Files

- `src/lib/haptics.ts` — new shared helper (Vibration API + iOS fallback)
- `src/app/flashcard/[projectId]/page.tsx` — wires `triggerHaptic()` into the prev/flip/next buttons (mobile + desktop)

🤖 Generated with [Claude Code](https://claude.com/claude-code)