### PR TITLE
feat(home): add quiz play button to wordbook cards

### DIFF
--- a/src/app/desktop.css
+++ b/src/app/desktop.css
@@ -241,7 +241,7 @@
 .ds-prow:hover { transform: translate(1px,1px); box-shadow: 2px 3px 0 var(--solid-ink); }
 .ds-prow-main { flex: 1; min-width: 0; display: flex; align-items: center; gap: 18px; }
 .ds-prow-play {
-  flex-shrink: 0; width: 44px; height: 44px; border-radius: 999px;
+  flex-shrink: 0; width: 37px; height: 37px; border-radius: 999px;
   border: 1.5px solid var(--solid-ink); background: var(--color-accent); color: #fff;
   display: inline-flex; align-items: center; justify-content: center;
   box-shadow: 2px 2px 0 var(--solid-ink);

--- a/src/app/desktop.css
+++ b/src/app/desktop.css
@@ -239,6 +239,15 @@
   transition: transform var(--dur-fast) var(--ease-out), box-shadow var(--dur-fast) var(--ease-out);
 }
 .ds-prow:hover { transform: translate(1px,1px); box-shadow: 2px 3px 0 var(--solid-ink); }
+.ds-prow-main { flex: 1; min-width: 0; display: flex; align-items: center; gap: 18px; }
+.ds-prow-play {
+  flex-shrink: 0; width: 44px; height: 44px; border-radius: 999px;
+  border: 1.5px solid var(--solid-ink); background: var(--color-accent); color: #fff;
+  display: inline-flex; align-items: center; justify-content: center;
+  box-shadow: 2px 2px 0 var(--solid-ink);
+  transition: transform var(--dur-fast) var(--ease-out), box-shadow var(--dur-fast) var(--ease-out);
+}
+.ds-prow-play:hover { transform: translate(1px,1px); box-shadow: 1px 1px 0 var(--solid-ink); }
 .ds-prow .tn {
   width: 52px; height: 52px; aspect-ratio: 1 / 1; border-radius: 10px; flex-shrink: 0;
   border: 1.5px solid var(--solid-ink); color: #fff; position: relative; overflow: hidden;

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1245,13 +1245,17 @@ function LegendItem({ color, label, count }: { color: string; label: string; cou
 
 function ProjectRow({ project }: { project: HomeProjectStats }) {
   const bg = thumbColor(project.id);
+  const hasWords = project.totalWords > 0;
   return (
-    <Link href={`/project/${project.id}`}>
-      <SolidPanel
-        className="!rounded-[14px] transition-all duration-100 active:translate-x-px active:translate-y-px"
-        faceClassName="!p-[13px]"
-      >
-        <div className="flex items-center gap-[13px]">
+    <SolidPanel
+      className="!rounded-[14px]"
+      faceClassName="!p-[13px]"
+    >
+      <div className="flex items-center gap-[13px]">
+        <Link
+          href={`/project/${project.id}`}
+          className="flex min-w-0 flex-1 items-center gap-[13px] transition-all duration-100 active:translate-x-px active:translate-y-px"
+        >
           <div
             className="flex h-12 w-12 shrink-0 items-center justify-center rounded-[10px] border-2 border-[var(--solid-ink)] font-display text-xl font-extrabold text-white"
             style={{ background: project.iconImage ? `center / cover url(${project.iconImage})` : bg }}
@@ -1270,9 +1274,18 @@ function ProjectRow({ project }: { project: HomeProjectStats }) {
               <DotLabel color="rgba(26,26,26,0.2)" label={`未 ${project.newWords}`} />
             </div>
           </div>
-        </div>
-      </SolidPanel>
-    </Link>
+        </Link>
+        {hasWords && (
+          <Link
+            href={`/quiz/${project.id}?from=${encodeURIComponent('/')}`}
+            aria-label={`${project.title}のクイズを開始`}
+            className="flex h-11 w-11 shrink-0 items-center justify-center rounded-full border-2 border-[var(--solid-ink)] bg-[var(--color-accent)] text-white shadow-[2px_2px_0_var(--solid-ink)] transition-all duration-100 active:translate-x-px active:translate-y-px active:shadow-[1px_1px_0_var(--solid-ink)]"
+          >
+            <Icon name="play_arrow" size={24} filled />
+          </Link>
+        )}
+      </div>
+    </SolidPanel>
   );
 }
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1279,9 +1279,9 @@ function ProjectRow({ project }: { project: HomeProjectStats }) {
           <Link
             href={`/quiz/${project.id}?from=${encodeURIComponent('/')}`}
             aria-label={`${project.title}のクイズを開始`}
-            className="flex h-11 w-11 shrink-0 items-center justify-center rounded-full border-2 border-[var(--solid-ink)] bg-[var(--color-accent)] text-white shadow-[2px_2px_0_var(--solid-ink)] transition-all duration-100 active:translate-x-px active:translate-y-px active:shadow-[1px_1px_0_var(--solid-ink)]"
+            className="flex h-[37px] w-[37px] shrink-0 items-center justify-center rounded-full border-2 border-[var(--solid-ink)] bg-[var(--color-accent)] text-white shadow-[2px_2px_0_var(--solid-ink)] transition-all duration-100 active:translate-x-px active:translate-y-px active:shadow-[1px_1px_0_var(--solid-ink)]"
           >
-            <Icon name="play_arrow" size={24} filled />
+            <Icon name="play_arrow" size={20} filled />
           </Link>
         )}
       </div>

--- a/src/components/desktop/DesktopHome.tsx
+++ b/src/components/desktop/DesktopHome.tsx
@@ -306,25 +306,38 @@ function DesktopGeneratingProjectRow({ scan }: { scan: DesktopPendingScan }) {
 }
 
 function DesktopProjectRow({ project }: { project: DesktopHomeProject }) {
+  const hasWords = project.totalWords > 0;
   return (
-    <Link href={`/project/${project.id}`} className="ds-prow">
-      <div
-        className="tn"
-        style={{
-          background: desktopThumbColor(project.id),
-          backgroundImage: project.iconImage ? `url(${project.iconImage})` : undefined,
-          backgroundSize: 'cover',
-          backgroundPosition: 'center',
-        }}
-      >
-        {!project.iconImage && project.title.charAt(0)}
-      </div>
-      <div className="body">
-        <div className="ttl">{project.title}</div>
-        <div className="sub">{desktopSourceLabel(project)} · 更新 {desktopUpdatedLabel(project.lastUsedAt ?? project.createdAt)}</div>
-      </div>
-      <div className="count">{project.totalWords}<span className="u">語</span></div>
+    <div className="ds-prow">
+      <Link href={`/project/${project.id}`} className="ds-prow-main">
+        <div
+          className="tn"
+          style={{
+            background: desktopThumbColor(project.id),
+            backgroundImage: project.iconImage ? `url(${project.iconImage})` : undefined,
+            backgroundSize: 'cover',
+            backgroundPosition: 'center',
+          }}
+        >
+          {!project.iconImage && project.title.charAt(0)}
+        </div>
+        <div className="body">
+          <div className="ttl">{project.title}</div>
+          <div className="sub">{desktopSourceLabel(project)} · 更新 {desktopUpdatedLabel(project.lastUsedAt ?? project.createdAt)}</div>
+        </div>
+        <div className="count">{project.totalWords}<span className="u">語</span></div>
+      </Link>
+      {hasWords && (
+        <Link
+          href={`/quiz/${project.id}?from=/`}
+          className="ds-prow-play"
+          aria-label={`${project.title}のクイズを開始`}
+          title="クイズを開始"
+        >
+          <Icon name="play_arrow" filled />
+        </Link>
+      )}
       <Icon name="chevron_right" style={{ color: 'var(--color-muted)' }} />
-    </Link>
+    </div>
   );
 }

--- a/src/components/desktop/DesktopHome.tsx
+++ b/src/components/desktop/DesktopHome.tsx
@@ -334,7 +334,7 @@ function DesktopProjectRow({ project }: { project: DesktopHomeProject }) {
           aria-label={`${project.title}のクイズを開始`}
           title="クイズを開始"
         >
-          <Icon name="play_arrow" filled />
+          <Icon name="play_arrow" size={20} filled />
         </Link>
       )}
       <Icon name="chevron_right" style={{ color: 'var(--color-muted)' }} />


### PR DESCRIPTION
## 概要

単語帳カードの右側にプレイボタンを追加し、押すとその単語帳のクイズが始まるようにしました。

## 変更内容

- **モバイルホーム (`src/app/page.tsx` の `ProjectRow`)**: 単語帳カードの右端にアクセントカラーの丸いプレイボタン（▶）を追加。タップすると `/quiz/{projectId}` でクイズを開始します。
- **デスクトップホーム (`DesktopHome.tsx` の `DesktopProjectRow`)**: 同様にプレイボタンを追加。対応するスタイルを `desktop.css` に追加。
- カード本体は従来どおり単語帳詳細 (`/project/{id}`) へのリンクのまま、プレイボタンだけクイズへ遷移するようカードを分割（anchor の入れ子を回避）。
- プレイボタンは単語が1語以上ある単語帳でのみ表示します。

## 動作

- カード本体タップ → 単語帳詳細（従来通り）
- プレイボタンタップ → クイズ開始

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015tmYsfnPDkmaWpVmwS8Lrs)_