### PR TITLE
フラッシュカードの編集ボタンを英辞郎検索ボタンに変更

### DIFF
--- a/src/app/flashcard/[projectId]/page.tsx
+++ b/src/app/flashcard/[projectId]/page.tsx
@@ -203,12 +203,6 @@ export default function FlashcardPage() {
   const [sortOrder, setSortOrder] = useState<FlashcardSortOrder>('mastery');
   const [sortMenuOpen, setSortMenuOpen] = useState(false);
 
-  /* Edit modal */
-  const [isEditModalOpen, setIsEditModalOpen] = useState(false);
-  const [editEnglish, setEditEnglish] = useState('');
-  const [editJapanese, setEditJapanese] = useState('');
-  const [isSaving, setIsSaving] = useState(false);
-
   /* Swipe state */
   const [swipeX, setSwipeX] = useState(0);
   const [isAnimating, setIsAnimating] = useState(false);
@@ -454,7 +448,6 @@ export default function FlashcardPage() {
   /* Keyboard nav */
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
-      if (isEditModalOpen) return;
       const tag = (e.target as HTMLElement)?.tagName;
       if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return;
       if (isAnimating) return;
@@ -467,7 +460,7 @@ export default function FlashcardPage() {
     };
     window.addEventListener('keydown', handleKeyDown);
     return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [isAnimating, isEditModalOpen, currentIndex, words.length, isFlipped, handlePrev, handleNext, handleFlip, backToProject]);
+  }, [isAnimating, currentIndex, words.length, isFlipped, handlePrev, handleNext, handleFlip, backToProject]);
 
   const handleToggleFavorite = async () => {
     if (!currentWord) return;
@@ -503,21 +496,12 @@ export default function FlashcardPage() {
     }
   }
 
-  const handleOpenEditModal = () => {
-    if (currentWord) {
-      setEditEnglish(currentWord.english); setEditJapanese(currentWord.japanese); setIsEditModalOpen(true);
-    }
-  };
-
-  const handleSaveEdit = async () => {
-    if (!currentWord || !editEnglish.trim() || !editJapanese.trim()) return;
-    setIsSaving(true);
-    try {
-      await repository.updateWord(currentWord.id, { english: editEnglish.trim(), japanese: editJapanese.trim() });
-      setWords(prev => prev.map((w, i) => i === currentIndex ? { ...w, english: editEnglish.trim(), japanese: editJapanese.trim() } : w));
-      setIsEditModalOpen(false);
-    } catch (error) { console.error('Failed to update word:', error); }
-    finally { setIsSaving(false); }
+  const handleSearchEijiro = () => {
+    const term = currentWord?.english?.trim();
+    if (!term || typeof window === 'undefined') return;
+    triggerHaptic();
+    const url = `https://eow.alc.co.jp/search?q=${encodeURIComponent(term)}`;
+    window.open(url, '_blank', 'noopener,noreferrer');
   };
 
   /* Card transform */
@@ -824,7 +808,7 @@ export default function FlashcardPage() {
 
       {/* 5 Action chips */}
       <div className="flex shrink-0 justify-center gap-3 px-5 pt-3.5">
-        <ActionChip icon="edit" label="編集" onClick={handleOpenEditModal} />
+        <ActionChip icon="search" label="英辞郎" onClick={handleSearchEijiro} />
         <ActionChip icon="volume_up" label="発音" onClick={speakWord} />
         <ActionChip
           icon="task_alt"
@@ -857,47 +841,6 @@ export default function FlashcardPage() {
         </NavBtn>
       </div>
 
-      {/* Edit modal */}
-      {isEditModalOpen && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
-          <div className="w-full max-w-sm rounded-[18px] border-2 border-[var(--solid-ink)] bg-[var(--color-background)] p-6">
-            <h2 className="mb-4 font-display text-lg font-black text-[var(--solid-ink)]">単語を編集</h2>
-            <div className="space-y-4">
-              <div>
-                <label className="mb-1 block font-mono text-[9px] font-bold tracking-[0.06em] text-[var(--color-muted)]">英単語</label>
-                <input
-                  type="text" value={editEnglish} onChange={(e) => setEditEnglish(e.target.value)}
-                  className="w-full rounded-lg border-2 border-[var(--solid-ink)] bg-white px-3 py-2.5 font-display text-sm font-bold text-[var(--solid-ink)] focus:outline-none"
-                  placeholder="英単語"
-                />
-              </div>
-              <div>
-                <label className="mb-1 block font-mono text-[9px] font-bold tracking-[0.06em] text-[var(--color-muted)]">日本語訳</label>
-                <input
-                  type="text" value={editJapanese} onChange={(e) => setEditJapanese(e.target.value)}
-                  className="w-full rounded-lg border-2 border-[var(--solid-ink)] bg-white px-3 py-2.5 text-sm text-[var(--solid-ink)] focus:outline-none"
-                  placeholder="日本語訳"
-                />
-              </div>
-            </div>
-            <div className="mt-6 flex gap-3">
-              <button
-                type="button" onClick={() => setIsEditModalOpen(false)} disabled={isSaving}
-                className="flex-1 rounded-lg border border-[var(--color-border)] bg-white px-4 py-2.5 text-sm font-bold text-[var(--color-muted)]"
-              >
-                キャンセル
-              </button>
-              <button
-                type="button" onClick={handleSaveEdit}
-                disabled={isSaving || !editEnglish.trim() || !editJapanese.trim()}
-                className="flex-1 rounded-lg border border-[var(--solid-ink)] bg-[var(--solid-ink)] px-4 py-2.5 text-sm font-bold text-white disabled:opacity-50"
-              >
-                {isSaving ? '保存中...' : '保存'}
-              </button>
-            </div>
-          </div>
-        </div>
-      )}
     </div>
     </>
   );


### PR DESCRIPTION
## 概要

フラッシュカード画面（`src/app/flashcard/[projectId]/page.tsx`）のアクションチップを「編集」から「英辞郎」検索に変更しました。

## 変更内容

- アクションチップのアイコン/ラベルを `edit`「編集」→ `search`「英辞郎」に変更
- タップすると、表示中の単語（英語）を**英辞郎 on the WEB**（`https://eow.alc.co.jp/search?q=<word>`）で新しいタブで検索
  - `window.open(..., '_blank', 'noopener,noreferrer')` で安全に開く
  - `encodeURIComponent` でクエリをエスケープ
- 不要になった編集モーダルと関連 state（`isEditModalOpen` / `editEnglish` / `editJapanese` / `isSaving`）、`handleOpenEditModal` / `handleSaveEdit` を削除
- キーボードハンドラから編集モーダル参照を除去

> 注: 編集ボタンはモバイルレイアウトのみに存在していたため、変更はモバイルビューに対するものです。デスクトップビューには元々編集ボタンはありません。

## テスト

- `npm run lint` — 変更ファイルに新規エラー・警告なし（既存エラーは無関係なファイルの `require()` インポート）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TRQrwv42YotweXuFMZFxo1)_