### PR TITLE
グループページのヘッダーを固定（sticky）化

### DIFF
--- a/src/app/groups/[groupId]/page.tsx
+++ b/src/app/groups/[groupId]/page.tsx
@@ -107,8 +107,11 @@ export default function GroupPage() {
   );
 
   return (
-    <div className="relative mx-auto min-h-screen w-full max-w-[560px] bg-[var(--color-background)] pb-[120px] pt-3 font-[var(--font-body)]">
-      <div className="flex items-center gap-2 px-[18px] pb-1 pt-1">
+    <div className="relative mx-auto min-h-screen w-full max-w-[560px] bg-[var(--color-background)] pb-[120px] font-[var(--font-body)]">
+      <header
+        className="sticky top-0 z-40 flex items-center gap-2 border-b-2 border-[var(--solid-ink)] bg-[var(--color-background)]/95 px-[18px] py-2.5 backdrop-blur-sm"
+        style={{ paddingTop: 'max(0.625rem, env(safe-area-inset-top))' }}
+      >
         <Link
           href="/shared"
           aria-label="共有に戻る"
@@ -116,10 +119,17 @@ export default function GroupPage() {
         >
           <Icon name="arrow_back" size={16} />
         </Link>
-        <div className="font-mono text-[10px] font-bold tracking-[0.08em] text-[var(--color-muted)]">
-          STUDY GROUP
+        <div className="min-w-0 flex-1">
+          <div className="font-mono text-[10px] font-bold tracking-[0.08em] text-[var(--color-muted)]">
+            STUDY GROUP
+          </div>
+          {group?.name && (
+            <div className="truncate font-display text-[15px] font-extrabold leading-tight text-[var(--solid-ink)]">
+              {group.name}
+            </div>
+          )}
         </div>
-      </div>
+      </header>
 
       {authLoading || loading ? (
         <LoadingState />


### PR DESCRIPTION
## 概要
グループページ（`/groups/[groupId]`）のヘッダーを固定（sticky）化しました。これまでヘッダー（戻るボタン + "STUDY GROUP" ラベル）はコンテンツと一緒にスクロールして画面外に消えていましたが、画面上部に固定されるようにしました。

## 変更内容
- ヘッダーを `<header>` に変更し、`sticky top-0 z-40` でスクロール時も上部に固定
- 背景に `bg-[var(--color-background)]/95 backdrop-blur-sm` と下境界線を追加して、スクロール中のコンテンツと視覚的に区別
- `env(safe-area-inset-top)` を考慮した上部パディング（ノッチ対応）
- グループ読み込み後はヘッダーにグループ名も表示（スクロールでメインのタイトルカードが隠れても名前が分かる）

## 確認
- 編集ファイル固有の型エラーなし（`next/server` 等の未解決エラーは `node_modules` 未インストールの環境要因）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SmVKUqQazz2oughhk2EoQ6)_