### PR TITLE
Add follow/unfollow button to user profile page

### DIFF
--- a/src/app/api/users/[accountId]/route.ts
+++ b/src/app/api/users/[accountId]/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { requireAuthenticatedUser } from '@/app/api/shared-projects/shared';
 import { getSupabaseAdmin } from '@/lib/supabase/admin';
-import { resolvePublicProfile, getProfilesByUserIds } from '@/lib/follows/server';
+import { resolvePublicProfile, getProfilesByUserIds, getFollowRelationship } from '@/lib/follows/server';
 import { getPublicUserStats } from '@/lib/profile/stats-server';
 
 type RouteContext = {
@@ -28,7 +28,7 @@ export async function GET(request: NextRequest, context: RouteContext) {
     const userId = profile.userId;
     const isSelf = userId === auth.user.id;
 
-    const [stats, createdAtRow, followingRows, followersRows, friendsCount] = await Promise.all([
+    const [stats, createdAtRow, followingRows, followersRows, friendsCount, relationship] = await Promise.all([
       getPublicUserStats(userId, admin),
       admin
         .from('profiles')
@@ -50,6 +50,9 @@ export async function GET(request: NextRequest, context: RouteContext) {
         .select('id', { count: 'exact', head: true })
         .eq('status', 'accepted')
         .or(`requester_id.eq.${userId},addressee_id.eq.${userId}`),
+      isSelf
+        ? Promise.resolve({ relationship: 'none' as const, followId: null })
+        : getFollowRelationship(auth.user.id, userId, admin),
     ]);
 
     const followingIds = (followingRows.data ?? []).map((r) => (r as { following_id: string }).following_id);
@@ -62,6 +65,8 @@ export async function GET(request: NextRequest, context: RouteContext) {
       success: true,
       isSelf,
       profile,
+      relationship: relationship.relationship,
+      followId: relationship.followId,
       joinedAt: createdAtRow.data?.created_at ?? null,
       counts: {
         following: followingIds.length,

--- a/src/app/profile/[accountId]/page.tsx
+++ b/src/app/profile/[accountId]/page.tsx
@@ -4,9 +4,11 @@ import { useEffect, useState } from 'react';
 import { useParams } from 'next/navigation';
 import { Icon } from '@/components/ui/Icon';
 import { ProfileView, profileAvatarColor, type ProfileCounts } from '@/components/profile/ProfileView';
+import { FollowButton } from '@/components/profile/FollowButton';
 import { useAuth } from '@/hooks/use-auth';
 import type { CachedStats } from '@/lib/stats-cache';
 import type { FriendProfile } from '@/lib/friends/types';
+import type { FollowRelationship } from '@/lib/follows/types';
 
 function formatJoined(value: string | null): string | null {
   if (!value) return null;
@@ -19,6 +21,8 @@ type UserProfileResponse = {
   success?: boolean;
   isSelf?: boolean;
   profile?: FriendProfile;
+  relationship?: FollowRelationship;
+  followId?: string | null;
   joinedAt?: string | null;
   counts?: ProfileCounts;
   stats?: CachedStats | null;
@@ -31,6 +35,7 @@ export default function FriendProfilePage() {
   const { isAuthenticated, loading: authLoading } = useAuth();
 
   const [data, setData] = useState<UserProfileResponse | null>(null);
+  const [counts, setCounts] = useState<ProfileCounts | null>(null);
   const [error, setError] = useState(false);
   const [fetched, setFetched] = useState(false);
 
@@ -45,8 +50,10 @@ export default function FriendProfilePage() {
         if (!payload?.success || !payload.profile) {
           setError(true);
           setData(null);
+          setCounts(null);
         } else {
           setData(payload);
+          setCounts(payload.counts ?? null);
         }
       })
       .catch(() => {
@@ -104,10 +111,24 @@ export default function FriendProfilePage() {
       color={color}
       joined={joined}
       planLabel={null}
-      counts={data.counts ?? null}
+      counts={counts}
       followingHref={`/profile/${encodeURIComponent(profile.accountId)}/follows?tab=following`}
       followersHref={`/profile/${encodeURIComponent(profile.accountId)}/follows?tab=followers`}
       friendsHref={`/profile/${encodeURIComponent(profile.accountId)}/follows?tab=following`}
+      actions={
+        data.isSelf ? undefined : (
+          <FollowButton
+            accountId={profile.accountId}
+            initialRelationship={data.relationship ?? 'none'}
+            initialFollowId={data.followId ?? null}
+            onRelationshipChange={(delta) =>
+              setCounts((prev) =>
+                prev ? { ...prev, followers: Math.max(0, prev.followers + delta) } : prev,
+              )
+            }
+          />
+        )
+      }
       stats={data.stats ?? null}
       statsLoading={false}
     />

--- a/src/components/profile/FollowButton.tsx
+++ b/src/components/profile/FollowButton.tsx
@@ -1,0 +1,121 @@
+'use client';
+
+import { useState } from 'react';
+import { Icon } from '@/components/ui/Icon';
+import type { FollowRelationship } from '@/lib/follows/types';
+
+type FollowApiResponse = {
+  success?: boolean;
+  error?: string;
+  follow?: { id: string; status: 'active' | 'pending' };
+};
+
+export function FollowButton({
+  accountId,
+  initialRelationship,
+  initialFollowId,
+  onRelationshipChange,
+}: {
+  accountId: string;
+  initialRelationship: FollowRelationship;
+  initialFollowId: string | null;
+  /** Notified with +1 / -1 when the active-follow state changes, to keep follower counts in sync. */
+  onRelationshipChange?: (delta: number) => void;
+}) {
+  const [relationship, setRelationship] = useState<FollowRelationship>(initialRelationship);
+  const [followId, setFollowId] = useState<string | null>(initialFollowId);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(false);
+
+  const isFollowing = relationship === 'following' || relationship === 'mutual';
+  const isPending = relationship === 'pending';
+
+  const follow = async () => {
+    setLoading(true);
+    setError(false);
+    try {
+      const response = await fetch('/api/follows', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ accountId }),
+      });
+      const payload = (await response.json().catch(() => null)) as FollowApiResponse | null;
+      if (!response.ok || !payload?.success || !payload.follow) {
+        throw new Error(payload?.error || 'follow_failed');
+      }
+      const nextRelationship: FollowRelationship = payload.follow.status === 'active' ? 'following' : 'pending';
+      setFollowId(payload.follow.id);
+      setRelationship(nextRelationship);
+      if (nextRelationship === 'following') onRelationshipChange?.(1);
+    } catch {
+      setError(true);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const unfollow = async () => {
+    if (!followId) return;
+    const wasFollowing = isFollowing;
+    setLoading(true);
+    setError(false);
+    try {
+      const response = await fetch('/api/follows', {
+        method: 'DELETE',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ followId }),
+      });
+      const payload = (await response.json().catch(() => null)) as FollowApiResponse | null;
+      if (!response.ok || !payload?.success) {
+        throw new Error(payload?.error || 'unfollow_failed');
+      }
+      setFollowId(null);
+      setRelationship('none');
+      if (wasFollowing) onRelationshipChange?.(-1);
+    } catch {
+      setError(true);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const onClick = () => {
+    if (loading) return;
+    if (isFollowing || isPending) {
+      void unfollow();
+    } else {
+      void follow();
+    }
+  };
+
+  const label = isFollowing ? 'フォロー中' : isPending ? '申請中' : 'フォロー';
+  const icon = loading
+    ? 'progress_activity'
+    : isFollowing
+      ? 'how_to_reg'
+      : isPending
+        ? 'hourglass_empty'
+        : 'person_add';
+
+  // Filled solid-ink style for the primary "follow" CTA; outlined for the
+  // already-following / pending states so unfollowing reads as secondary.
+  const active = isFollowing || isPending;
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={loading}
+      aria-label={label}
+      aria-pressed={active}
+      className={`inline-flex h-11 flex-1 items-center justify-center gap-1.5 rounded-[12px] border-2 border-[var(--solid-ink)] font-display text-[14px] font-bold transition-all duration-100 active:translate-x-px active:translate-y-px disabled:opacity-60 ${
+        active
+          ? 'bg-white text-[var(--solid-ink)]'
+          : 'bg-[var(--solid-ink)] text-white'
+      }`}
+    >
+      <Icon name={icon} size={18} className={loading ? 'animate-spin' : ''} />
+      {error ? '再試行' : label}
+    </button>
+  );
+}

--- a/src/lib/follows/server.ts
+++ b/src/lib/follows/server.ts
@@ -394,6 +394,53 @@ export async function resolvePublicProfile(
   return toProfile(data);
 }
 
+/**
+ * Compute the viewer's follow relationship toward a target user.
+ * Used by the public profile page to render the follow/unfollow button.
+ */
+export async function getFollowRelationship(
+  viewerUserId: string,
+  targetUserId: string,
+  admin: SupabaseAdminClient = getSupabaseAdmin(),
+): Promise<{ relationship: FollowRelationship; followId: string | null }> {
+  if (viewerUserId === targetUserId) {
+    return { relationship: 'none', followId: null };
+  }
+
+  const { data, error } = await admin
+    .from('user_follows')
+    .select(FOLLOW_SELECT)
+    .or(
+      `and(follower_id.eq.${viewerUserId},following_id.eq.${targetUserId}),`
+        + `and(follower_id.eq.${targetUserId},following_id.eq.${viewerUserId})`,
+    );
+
+  if (error) {
+    if (getFriendSchemaIssue(error) === 'user_follows') {
+      return { relationship: 'none', followId: null };
+    }
+    throw new Error(error.message || 'follow_relationship_lookup_failed');
+  }
+
+  let outRow: FollowRow | undefined;
+  let inRow: FollowRow | undefined;
+  for (const row of (data ?? []) as FollowRow[]) {
+    if (row.follower_id === viewerUserId && row.following_id === targetUserId) outRow = row;
+    if (row.follower_id === targetUserId && row.following_id === viewerUserId) inRow = row;
+  }
+
+  if (outRow && outRow.status === 'active' && inRow && inRow.status === 'active') {
+    return { relationship: 'mutual', followId: outRow.id };
+  }
+  if (outRow?.status === 'active') {
+    return { relationship: 'following', followId: outRow.id };
+  }
+  if (outRow?.status === 'pending') {
+    return { relationship: 'pending', followId: outRow.id };
+  }
+  return { relationship: 'none', followId: null };
+}
+
 export async function unfollowUser(
   userId: string,
   followId: string,


### PR DESCRIPTION
## Summary

The follow system already existed at the API/server layer (`/api/follows`, `lib/follows/server.ts`), but the public profile page (`/profile/[accountId]`) had no UI to actually follow or unfollow a user — it only showed follow counts. This adds the missing follow/unfollow button.

## Changes

- **`lib/follows/server.ts`** — Add `getFollowRelationship(viewer, target)` which computes the viewer's relationship toward a user (`none` / `following` / `pending` / `mutual`) and the corresponding `followId`, reusing the same logic as the follow search. Gracefully degrades to `none` when the `user_follows` table is absent.
- **`GET /api/users/[accountId]`** — Return `relationship` and `followId` for the viewer (skipped and defaulted when viewing own profile).
- **`components/profile/FollowButton.tsx`** — New reusable client component. POSTs/DELETEs `/api/follows`, with optimistic state for `フォロー` → `フォロー中` / `申請中` (for private accounts that require approval), a loading spinner, and a retry affordance on error.
- **`/profile/[accountId]` page** — Render the button in the `ProfileView` actions slot (hidden when `isSelf`), and keep the follower count in sync locally on follow/unfollow.

## Notes

- Follower-count adjustment happens only when a follow becomes `active` (public accounts), not for `pending` requests on private accounts, matching server behavior.
- No new follow API endpoints were needed — the existing `POST`/`DELETE /api/follows` handle create/remove and approval-vs-immediate status.

## Testing

- `npm test` — all 620 unit tests pass
- `tsc --noEmit` and `eslint` clean on all changed files (one unrelated pre-existing `tsc` error remains in `scan-jobs/process/route.contract.test.ts`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01WFmBbJfJPQevhWPFJ7pPLY)_