### PR TITLE
Fix profile back button to return to previous page

### DIFF
--- a/src/components/profile/ProfileView.tsx
+++ b/src/components/profile/ProfileView.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import Link from 'next/link';
-import type { ReactNode } from 'react';
+import { useRouter } from 'next/navigation';
+import type { MouseEvent, ReactNode } from 'react';
 import { Icon } from '@/components/ui/Icon';
 import { SolidPanel } from '@/components/redesign/SolidPage';
 import type { CachedStats } from '@/lib/stats-cache';
@@ -68,6 +69,21 @@ export function ProfileView({
   stats: CachedStats | null;
   statsLoading: boolean;
 }) {
+  const router = useRouter();
+
+  // Prefer returning to the actual previous page (e.g. the group the user came
+  // from) when we arrived here via in-app navigation. Fall back to backHref on
+  // direct loads / fresh PWA launches where there is no in-app history to pop.
+  const handleBack = (event: MouseEvent<HTMLAnchorElement>) => {
+    if (event.metaKey || event.ctrlKey || event.shiftKey || event.altKey || event.button !== 0) {
+      return;
+    }
+    if (typeof window !== 'undefined' && window.history.length > 1) {
+      event.preventDefault();
+      router.back();
+    }
+  };
+
   const recentWeek = stats?.weeklyStats.slice(-7) ?? [];
   const weekTotal = recentWeek.reduce((sum, item) => sum + item.totalCount, 0);
   const maxWeekValue = Math.max(1, ...recentWeek.map((item) => item.totalCount));
@@ -88,6 +104,7 @@ export function ProfileView({
         <div className="flex items-center gap-2 px-[18px] pb-1 pt-1">
           <Link
             href={backHref}
+            onClick={handleBack}
             aria-label="戻る"
             className="inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-full text-[var(--solid-ink)] active:bg-[var(--color-surface-secondary)]"
           >


### PR DESCRIPTION
## Summary

When a user opened another user's profile from inside a group and tapped the back arrow, they were dropped on the feed (`/friends`) instead of returning to the group. This happened because `ProfileView`'s back arrow was a plain link to a hardcoded `backHref` (`/friends` for other users' profiles), regardless of where the user actually came from.

## Changes

- `src/components/profile/ProfileView.tsx`: The back arrow now pops in-app navigation history via `router.back()` when history exists, so it returns to the actual previous page (e.g. the group). It falls back to the existing `backHref` on direct loads / fresh PWA launches where there is no in-app history to pop. Modifier-clicks (cmd/ctrl/shift/alt) and non-primary mouse buttons keep the plain `<Link href={backHref}>` behavior so open-in-new-tab still works.

## Notes

This affects every page that renders `ProfileView` (both the self profile `/profile` and other users' profiles `/profile/[accountId]`). In all cases "go back to where I came from" is the desired behavior, with `backHref` as a safe fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014WWa6gYXjjyVVBg1JmiWKL)_