### PR TITLE
グループページのヘッダ余白を詰め、設定にグループ削除導線を追加

### DIFF
--- a/src/app/api/shared-projects/groups/[groupId]/route.ts
+++ b/src/app/api/shared-projects/groups/[groupId]/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { z } from 'zod';
 import { parseJsonWithSchema } from '@/lib/api/validation';
 import { requireAuthenticatedUser } from '../../shared';
-import { getStudyGroupOverview, renameStudyGroup, StudyGroupAccessError } from '../shared';
+import { deleteStudyGroup, getStudyGroupOverview, renameStudyGroup, StudyGroupAccessError } from '../shared';
 
 const updateStudyGroupSchema = z.object({
   name: z.string().trim().min(1).max(40),
@@ -16,6 +16,11 @@ type StudyGroupOverviewGetDeps = {
 type StudyGroupUpdateDeps = {
   requireAuthenticatedUser?: typeof requireAuthenticatedUser;
   renameStudyGroup?: typeof renameStudyGroup;
+};
+
+type StudyGroupDeleteDeps = {
+  requireAuthenticatedUser?: typeof requireAuthenticatedUser;
+  deleteStudyGroup?: typeof deleteStudyGroup;
 };
 
 export async function handleStudyGroupOverviewGet(
@@ -94,4 +99,40 @@ export async function PATCH(
   context: { params: Promise<{ groupId: string }> },
 ) {
   return handleStudyGroupUpdatePatch(request, context);
+}
+
+export async function handleStudyGroupDelete(
+  request: NextRequest,
+  context: { params: Promise<{ groupId: string }> },
+  deps: StudyGroupDeleteDeps = {},
+) {
+  const requireAuthenticated = deps.requireAuthenticatedUser ?? requireAuthenticatedUser;
+  const remove = deps.deleteStudyGroup ?? deleteStudyGroup;
+
+  try {
+    const auth = await requireAuthenticated(request);
+    if (!auth.ok) return auth.response;
+
+    const { groupId } = await context.params;
+    const deleted = await remove(groupId, auth.user.id);
+    if (!deleted) {
+      return NextResponse.json({ success: false, error: 'グループにアクセスできません。' }, { status: 403 });
+    }
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    if (error instanceof StudyGroupAccessError && error.code === 'owner_required') {
+      return NextResponse.json({ success: false, error: 'オーナーのみ削除できます。' }, { status: 403 });
+    }
+
+    console.error('study-group delete error:', error);
+    return NextResponse.json({ success: false, error: 'グループの削除に失敗しました。' }, { status: 500 });
+  }
+}
+
+export async function DELETE(
+  request: NextRequest,
+  context: { params: Promise<{ groupId: string }> },
+) {
+  return handleStudyGroupDelete(request, context);
 }

--- a/src/app/api/shared-projects/groups/settings-route.test.ts
+++ b/src/app/api/shared-projects/groups/settings-route.test.ts
@@ -2,7 +2,7 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 import { NextRequest } from 'next/server';
 
-import { handleStudyGroupUpdatePatch } from './[groupId]/route';
+import { handleStudyGroupDelete, handleStudyGroupUpdatePatch } from './[groupId]/route';
 import { handleStudyGroupMemberDelete } from './[groupId]/members/[userId]/route';
 import { StudyGroupAccessError } from './shared';
 
@@ -88,6 +88,43 @@ test('member DELETE removes a member for the owner', async () => {
   assert.equal(removedTarget, 'member-9');
   const payload = await res.json();
   assert.equal(payload.success, true);
+});
+
+test('group DELETE removes the group for the owner', async () => {
+  let removedGroup = '';
+  const req = new NextRequest('http://localhost/api/shared-projects/groups/group-1', {
+    method: 'DELETE',
+  });
+
+  const res = await handleStudyGroupDelete(req, groupContext, {
+    requireAuthenticatedUser: async () => ({ ok: true as const, user: { id: 'owner-1' } as never }),
+    deleteStudyGroup: async (groupId) => {
+      removedGroup = groupId;
+      return true;
+    },
+  });
+
+  assert.equal(res.status, 200);
+  assert.equal(removedGroup, 'group-1');
+  const payload = await res.json();
+  assert.equal(payload.success, true);
+});
+
+test('group DELETE returns 403 when a non-owner attempts deletion', async () => {
+  const req = new NextRequest('http://localhost/api/shared-projects/groups/group-1', {
+    method: 'DELETE',
+  });
+
+  const res = await handleStudyGroupDelete(req, groupContext, {
+    requireAuthenticatedUser: async () => ({ ok: true as const, user: { id: 'member-1' } as never }),
+    deleteStudyGroup: async () => {
+      throw new StudyGroupAccessError('owner_required');
+    },
+  });
+
+  assert.equal(res.status, 403);
+  const payload = await res.json();
+  assert.equal(payload.success, false);
 });
 
 test('member DELETE refuses to remove the owner', async () => {

--- a/src/app/api/shared-projects/groups/shared.ts
+++ b/src/app/api/shared-projects/groups/shared.ts
@@ -945,6 +945,34 @@ export async function removeStudyGroupMember(
   return true;
 }
 
+/**
+ * Deletes a study group entirely. Owner-only. Membership, project links and
+ * feed events cascade away via the `ON DELETE CASCADE` foreign keys. Returns
+ * `false` when the requester is not a member of the group.
+ */
+export async function deleteStudyGroup(
+  groupId: string,
+  userId: string,
+  admin: SupabaseAdminClient = getSupabaseAdmin(),
+): Promise<boolean> {
+  const membership = await getStudyGroupMembership(groupId, userId, admin);
+  if (!membership) return false;
+  if (membership.role !== 'owner') {
+    throw new StudyGroupAccessError('owner_required');
+  }
+
+  const { error } = await admin
+    .from('study_groups')
+    .delete()
+    .eq('id', groupId);
+
+  if (error) {
+    throw new Error(error.message || 'study_group_delete_failed');
+  }
+
+  return true;
+}
+
 async function getStudyGroupSummaryForUser(
   groupId: string,
   userId: string,

--- a/src/app/groups/[groupId]/page.tsx
+++ b/src/app/groups/[groupId]/page.tsx
@@ -130,7 +130,7 @@ export default function GroupPage() {
     <div
       className="relative mx-auto min-h-screen w-full max-w-[560px] bg-[var(--color-background)] font-[var(--font-body)]"
       style={{
-        paddingTop: 'max(0.75rem, env(safe-area-inset-top))',
+        paddingTop: '0.75rem',
         paddingBottom: 'max(2rem, env(safe-area-inset-bottom))',
       }}
     >

--- a/src/app/groups/[groupId]/settings/page.tsx
+++ b/src/app/groups/[groupId]/settings/page.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useState } from 'react';
 import Link from 'next/link';
-import { useParams } from 'next/navigation';
+import { useParams, useRouter } from 'next/navigation';
 import { Icon } from '@/components/ui';
 import { useAuth } from '@/hooks/use-auth';
 import { useToast } from '@/components/ui/toast';
@@ -24,6 +24,7 @@ type OverviewResponse = {
 
 export default function GroupSettingsPage() {
   const params = useParams<{ groupId: string }>();
+  const router = useRouter();
   const groupId = params?.groupId ?? '';
   const { loading: authLoading, isAuthenticated } = useAuth();
   const { showToast } = useToast();
@@ -38,6 +39,7 @@ export default function GroupSettingsPage() {
   const [savingName, setSavingName] = useState(false);
   const [pendingMemberId, setPendingMemberId] = useState<string | null>(null);
   const [pendingProjectId, setPendingProjectId] = useState<string | null>(null);
+  const [deleting, setDeleting] = useState(false);
 
   const load = useCallback(async () => {
     if (!groupId) return;
@@ -149,13 +151,35 @@ export default function GroupSettingsPage() {
     }
   }, [group, pendingProjectId, showToast]);
 
+  const handleDeleteGroup = useCallback(async () => {
+    if (!group || deleting) return;
+    if (typeof window !== 'undefined' && !window.confirm(`「${group.name}」を削除しますか？メンバー・共有単語帳の紐付けもすべて解除され、元に戻せません。`)) return;
+    triggerHaptic();
+    setDeleting(true);
+    try {
+      const response = await fetch(`/api/shared-projects/groups/${encodeURIComponent(group.id)}`, {
+        method: 'DELETE',
+      });
+      const payload = await response.json().catch(() => null) as { success?: boolean; error?: string } | null;
+      if (!response.ok || !payload?.success) {
+        throw new Error(payload?.error || 'group_delete_failed');
+      }
+      showToast({ message: 'グループを削除しました', type: 'success' });
+      router.replace('/shared');
+    } catch (deleteError) {
+      const message = deleteError instanceof Error ? deleteError.message : '削除に失敗しました。';
+      showToast({ message, type: 'error' });
+      setDeleting(false);
+    }
+  }, [group, deleting, router, showToast]);
+
   const backHref = `/groups/${encodeURIComponent(groupId)}`;
 
   return (
     <div
       className="relative mx-auto min-h-screen w-full max-w-[560px] bg-[var(--color-background)] font-[var(--font-body)]"
       style={{
-        paddingTop: 'max(0.75rem, env(safe-area-inset-top))',
+        paddingTop: '0.75rem',
         paddingBottom: 'max(2rem, env(safe-area-inset-bottom))',
       }}
     >
@@ -318,6 +342,23 @@ export default function GroupSettingsPage() {
               </div>
             )}
           </SectionCard>
+
+          {isOwner && (
+            <SectionCard icon="warning" title="グループを削除" subtitle="この操作は元に戻せません" accent="#CC4D59">
+              <p className="mb-3 text-[12px] font-bold leading-relaxed text-[var(--color-muted)]">
+                グループを削除すると、メンバーや共有単語帳の紐付けがすべて解除されます。単語帳自体は各オーナーの手元に残ります。
+              </p>
+              <button
+                type="button"
+                disabled={deleting}
+                onClick={() => void handleDeleteGroup()}
+                className="flex w-full items-center justify-center gap-2 rounded-[12px] border-2 border-[#CC4D59] bg-[#CC4D59] px-4 py-3 font-display text-[14px] font-extrabold text-white shadow-[3px_3px_0_#7d2730] transition-all duration-100 active:translate-x-[3px] active:translate-y-[3px] active:shadow-none disabled:opacity-55"
+              >
+                <Icon name={deleting ? 'progress_activity' : 'delete_forever'} size={18} className={deleting ? 'animate-spin' : undefined} />
+                {deleting ? '削除中...' : 'グループを削除'}
+              </button>
+            </SectionCard>
+          )}
 
           {!isOwner && (
             <p className="px-1 pb-2 text-[11px] font-bold leading-relaxed text-[var(--color-muted)]">


### PR DESCRIPTION
## 概要

グループページ（`/groups/[groupId]`）と設定ページ（`/groups/[groupId]/settings`）でヘッダ上部に生じていた余白を解消し、あわせて設定ページにグループ削除導線を追加しました。

## 変更内容

### 1. ヘッダ余白の解消
両ページのラッパーは `paddingTop: 'max(0.75rem, env(safe-area-inset-top))'` を使っていたため、ノッチ端末ではコンテンツがセーフエリア分（〜47px）まで押し下げられ、上部に余白の帯ができていました。`StatusBarCover` がノッチ部分のフロスト表示を担っており、`/shared` や `/favorites` など他ページは `pt-3`（12px）で詰めています。これに合わせて固定値 `0.75rem` に変更しました。

- カメラ領域（`MultiShotCaptureView`）は操作 UI がノッチ下に来る必要があるため **据え置き**（指示どおり詰めていません）。

### 2. グループ削除導線
- 設定ページにオーナー限定の削除セクション（赤系のダンガーゾーン）を追加。確認ダイアログ → `DELETE` → `/shared` へ遷移。
- `DELETE /api/shared-projects/groups/[groupId]` と `deleteStudyGroup()` を実装。オーナーのみ実行可能。`study_group_members` / `study_group_projects` / `study_group_feed_events` は FK の `ON DELETE CASCADE` で自動的に解除されます（単語帳本体は各オーナーの手元に残ります）。

## テスト
- `settings-route.test.ts` に削除ハンドラのテスト（オーナーの削除成功 / 非オーナーの 403）を追加。
- `npm test`（該当スイート 7 件 pass）、変更ファイルの ESLint、`npm run build` をローカルで確認済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CKgxYFvDnSkFax9o5RTbp4)_