### PR TITLE
Fix group shared wordbook links

### DIFF
--- a/src/app/api/shared-projects/share-preview.route.test.ts
+++ b/src/app/api/shared-projects/share-preview.route.test.ts
@@ -49,10 +49,13 @@ test('shared project preview route returns preview payload without auth', async 
     { params: Promise.resolve({ shareId: 'share-1' }) },
     {
       extractShareCode: (input) => input,
-      getSharedProjectPreviewByShareCode: async (shareCode, limit) => {
+      getSharedWordbookPreview: async (shareCode, limit) => {
         assert.equal(shareCode, 'share-1');
         assert.equal(limit, 5);
         return makePreviewPayload();
+      },
+      getSharedProjectPreviewByShareCode: async () => {
+        throw new Error('project fallback should not be called');
       },
     },
   );
@@ -65,12 +68,38 @@ test('shared project preview route returns preview payload without auth', async 
   assert.equal(payload.totalWordCount, 12);
 });
 
+test('shared project preview route falls back to legacy project share ids', async () => {
+  const res = await handleSharedProjectPreviewGet(
+    request(),
+    { params: Promise.resolve({ shareId: 'share-1' }) },
+    {
+      extractShareCode: (input) => input,
+      getSharedWordbookPreview: async (shareCode, limit) => {
+        assert.equal(shareCode, 'share-1');
+        assert.equal(limit, 5);
+        return null;
+      },
+      getSharedProjectPreviewByShareCode: async (shareCode, limit) => {
+        assert.equal(shareCode, 'share-1');
+        assert.equal(limit, 5);
+        return makePreviewPayload();
+      },
+    },
+  );
+
+  assert.equal(res.status, 200);
+  const payload = await res.json();
+  assert.equal(payload.success, true);
+  assert.equal(payload.project.id, 'project-1');
+});
+
 test('shared project preview route returns 404 for an unknown share code', async () => {
   const res = await handleSharedProjectPreviewGet(
     request(),
     { params: Promise.resolve({ shareId: 'missing' }) },
     {
       extractShareCode: (input) => input,
+      getSharedWordbookPreview: async () => null,
       getSharedProjectPreviewByShareCode: async () => null,
     },
   );

--- a/src/app/api/shared-projects/share/[shareId]/route.ts
+++ b/src/app/api/shared-projects/share/[shareId]/route.ts
@@ -1,11 +1,15 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { extractShareCode } from '../../shared';
-import { getSharedWordbookPreview as getSharedProjectPreviewByShareCode } from '../../shared-wordbooks';
+import {
+  extractShareCode,
+  getSharedProjectPreviewByShareCode,
+} from '../../shared';
+import { getSharedWordbookPreview } from '../../shared-wordbooks';
 
 type Params = { params: Promise<{ shareId: string }> };
 
 type SharedProjectPreviewGetDeps = {
   extractShareCode?: typeof extractShareCode;
+  getSharedWordbookPreview?: typeof getSharedWordbookPreview;
   getSharedProjectPreviewByShareCode?: typeof getSharedProjectPreviewByShareCode;
 };
 
@@ -15,7 +19,8 @@ export async function handleSharedProjectPreviewGet(
   deps: SharedProjectPreviewGetDeps = {},
 ) {
   const parseShareCode = deps.extractShareCode ?? extractShareCode;
-  const fetchPreview = deps.getSharedProjectPreviewByShareCode ?? getSharedProjectPreviewByShareCode;
+  const fetchSharedWordbookPreview = deps.getSharedWordbookPreview ?? getSharedWordbookPreview;
+  const fetchSharedProjectPreview = deps.getSharedProjectPreviewByShareCode ?? getSharedProjectPreviewByShareCode;
 
   try {
     const { shareId } = await params;
@@ -25,7 +30,9 @@ export async function handleSharedProjectPreviewGet(
     }
 
     const limit = Number(request.nextUrl.searchParams.get('limit') ?? '');
-    const preview = await fetchPreview(shareCode, Number.isFinite(limit) ? limit : undefined);
+    const wordLimit = Number.isFinite(limit) ? limit : undefined;
+    const preview = await fetchSharedWordbookPreview(shareCode, wordLimit)
+      ?? await fetchSharedProjectPreview(shareCode, wordLimit);
     if (!preview) {
       return NextResponse.json({ success: false, error: '共有単語帳が見つかりません。' }, { status: 404 });
     }

--- a/src/app/api/shared-projects/share/[shareId]/words/route.ts
+++ b/src/app/api/shared-projects/share/[shareId]/words/route.ts
@@ -1,7 +1,14 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { extractShareCode, requireAuthenticatedUser } from '../../../shared';
+import {
+  extractShareCode,
+  getSharedProjectWordsByShareCode,
+  requireAuthenticatedUser,
+} from '../../../shared';
 import { isUserActivePro } from '../../../pro';
-import { getSharedWordbookWords } from '../../../shared-wordbooks';
+import {
+  getSharedWordbookByShareId,
+  getSharedWordbookWords,
+} from '../../../shared-wordbooks';
 
 type Params = { params: Promise<{ shareId: string }> };
 
@@ -25,7 +32,10 @@ export async function GET(request: NextRequest, { params }: Params) {
       return NextResponse.json({ success: false, error: 'Proプラン限定です。' }, { status: 403 });
     }
 
-    const words = await getSharedWordbookWords(shareCode);
+    const sharedWordbook = await getSharedWordbookByShareId(shareCode);
+    const words = sharedWordbook
+      ? await getSharedWordbookWords(shareCode)
+      : await getSharedProjectWordsByShareCode(shareCode);
     return NextResponse.json({ success: true, words }, { headers: { 'Cache-Control': 'no-store' } });
   } catch (error) {
     console.error('shared-wordbook words error:', error);

--- a/src/app/api/shared-projects/shared.test.ts
+++ b/src/app/api/shared-projects/shared.test.ts
@@ -6,6 +6,7 @@ import {
   extractShareCode,
   getAccessibleSharedProject,
   getSharedProjectPreviewByShareCode,
+  getSharedProjectWordsByShareCode,
   getSharedProjectMetrics,
   listAccessibleSharedProjects,
   listPublicSharedProjects,
@@ -694,6 +695,22 @@ test('getSharedProjectPreviewByShareCode falls back when relation embeds are una
   assert.equal(preview.words[0]?.pronunciation, '/wɜːd/');
   assert.deepEqual(preview.words[0]?.partOfSpeechTags, ['noun']);
   assert.equal(preview.totalWordCount, 1);
+});
+
+test('getSharedProjectWordsByShareCode returns all words for legacy share ids', async () => {
+  const project = makeProjectRow('project-1', 'owner-1', { share_id: 'share-1' });
+  const admin = new FakeSharedProjectsAdmin({
+    shareCodeProject: project,
+    previewWordRows: [
+      makeWordRow('word-1', project.id, { english: 'first', created_at: '2026-01-01T00:00:00.000Z' }),
+      makeWordRow('word-2', project.id, { english: 'second', created_at: '2026-01-02T00:00:00.000Z' }),
+    ],
+    previewWordSelectErrorIncludes: 'word_translations(',
+  });
+
+  const words = await getSharedProjectWordsByShareCode('share-1', admin as never);
+
+  assert.deepEqual(words.map((word) => word.english), ['second', 'first']);
 });
 
 test('getSharedProjectMetrics uses RPC results when available', async () => {

--- a/src/app/api/shared-projects/shared.ts
+++ b/src/app/api/shared-projects/shared.ts
@@ -21,6 +21,7 @@ import {
   SHARE_VIEW_WORD_SELECT_COLUMNS_WITHOUT_SENSES,
 } from '@/lib/words/resolved';
 import { createSharedSearchEmbedding } from '@/lib/shared-projects/tag-embeddings';
+import type { Word } from '@/types';
 import { mapProjectFromRow, mapWordFromRow, type ProjectRow, type WordRow } from '../../../../shared/db';
 import { formatSharedTag } from '../../../../shared/shared-tags';
 
@@ -192,6 +193,33 @@ async function selectSharePreviewWordsWithFallback(
   return lastResult ?? { data: null, error: { message: 'shared_project_preview_words_failed' } };
 }
 
+async function selectShareWordsWithFallback(
+  admin: SupabaseAdminClient,
+  projectId: string,
+): Promise<{ data: WordRow[] | null; error: SupabaseLikeError | null }> {
+  let lastResult: { data: WordRow[] | null; error: SupabaseLikeError | null } | null = null;
+
+  for (const fallback of SHARE_PREVIEW_WORD_SELECT_FALLBACKS) {
+    const result = await admin
+      .from('words')
+      .select(fallback.columns)
+      .eq('project_id', projectId)
+      .order('created_at', { ascending: false }) as { data: WordRow[] | null; error: SupabaseLikeError | null };
+
+    if (!shouldRetrySharedPreviewWordSelect(result.error)) {
+      return result;
+    }
+
+    lastResult = result;
+    console.warn(`[shared-projects] share words select fallback: ${fallback.label}`, {
+      code: result.error?.code,
+      message: result.error?.message,
+    });
+  }
+
+  return lastResult ?? { data: null, error: { message: 'shared_project_words_failed' } };
+}
+
 export async function getProjectByShareCode(
   shareCode: string,
   admin: SupabaseAdminClient = getSupabaseAdmin(),
@@ -237,6 +265,21 @@ export async function getSharedProjectPreviewByShareCode(
     ownerUsername: ownerProfile?.username ?? null,
     ownerAccountId: ownerProfile?.accountId ?? null,
   };
+}
+
+export async function getSharedProjectWordsByShareCode(
+  shareCode: string,
+  admin: SupabaseAdminClient = getSupabaseAdmin(),
+): Promise<Word[]> {
+  const projectRow = await getProjectByShareCode(shareCode, admin);
+  if (!projectRow) return [];
+
+  const wordsResult = await selectShareWordsWithFallback(admin, projectRow.id);
+  if (wordsResult.error) {
+    throw new Error(wordsResult.error.message || 'shared_project_words_failed');
+  }
+
+  return ((wordsResult.data ?? []) as WordRow[]).map(mapWordFromRow);
 }
 
 export async function getAccessibleSharedProject(


### PR DESCRIPTION
## Summary
- Fix `/share/:shareId` to fall back from published `shared_wordbooks` snapshots to legacy `projects.share_id` links.
- Fix the Pro full-word endpoint to use the same fallback so old group-shared project links do not get overwritten with an empty word list.
- Add regression coverage for the preview fallback and legacy share full-word lookup.

## Root cause
Group sharing creates and displays `projects.share_id`, but the current share page API only looked up `shared_wordbooks.share_id`. Group-shared projects that were never published as shared-wordbook snapshots therefore rendered as "共有単語帳が見つかりません".

## Validation
- `./node_modules/.bin/eslint src/app/api/shared-projects/share-preview.route.test.ts 'src/app/api/shared-projects/share/[shareId]/route.ts' 'src/app/api/shared-projects/share/[shareId]/words/route.ts' src/app/api/shared-projects/shared.test.ts src/app/api/shared-projects/shared.ts`
- `./node_modules/.bin/tsx --test src/app/api/shared-projects/share-preview.route.test.ts src/app/api/shared-projects/shared.test.ts`
- `npm run build`
