### PR TITLE
Prevent stale shared wordbook cards

### DIFF
--- a/src/app/api/shared-projects/discover/route.test.ts
+++ b/src/app/api/shared-projects/discover/route.test.ts
@@ -24,6 +24,7 @@ test('shared-projects/discover GET searches across all categories by default', a
   });
 
   assert.equal(res.status, 200);
+  assert.equal(res.headers.get('Cache-Control'), 'no-store');
   assert.deepEqual(calls.sort(), ['projects:toeic:6', 'users:toeic:6']);
   const payload = await res.json();
   assert.equal(payload.category, 'all');

--- a/src/app/api/shared-projects/discover/route.ts
+++ b/src/app/api/shared-projects/discover/route.ts
@@ -7,6 +7,8 @@ import {
 
 const DISCOVER_CATEGORIES = new Set<SharedDiscoverCategory>(['all', 'users', 'projects']);
 
+export const dynamic = 'force-dynamic';
+
 type DiscoverGetDeps = {
   listPublicSharedProjects?: typeof listPublicSharedProjects;
   listPublicSharedUsers?: typeof listPublicSharedUsers;
@@ -53,7 +55,7 @@ export async function handleSharedProjectsDiscoverGet(
 
     return NextResponse.json(payload, {
       headers: {
-        'Cache-Control': 'public, s-maxage=60, stale-while-revalidate=300',
+        'Cache-Control': 'no-store',
       },
     });
   } catch (error) {

--- a/src/app/shared/SharedPageClient.tsx
+++ b/src/app/shared/SharedPageClient.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { startTransition, useEffect, useRef, useState } from 'react';
+import { startTransition, useEffect, useRef, useState, type MouseEvent } from 'react';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { DesktopSharedView } from '@/components/desktop/DesktopShared';
@@ -10,6 +10,7 @@ import { useAuth } from '@/hooks/use-auth';
 import { useToast } from '@/components/ui/toast';
 import { ShareTypeChooser } from './ShareTypeChooser';
 import { triggerHaptic } from '@/lib/haptics';
+import { removeProjectFromDiscover } from './shared-page-utils';
 import type {
   SharedDiscoverCategory,
   SharedDiscoverPayload,
@@ -107,6 +108,7 @@ function isDiscoverPayload(payload: DiscoverResponse | null): payload is SharedD
 export default function SharedPageClient({ initialDiscover }: SharedPageClientProps) {
   const router = useRouter();
   const { user } = useAuth();
+  const { showToast } = useToast();
 
   const [category, setCategory] = useState<SharedDiscoverCategory | 'groups'>('all');
   const [query, setQuery] = useState('');
@@ -192,6 +194,11 @@ export default function SharedPageClient({ initialDiscover }: SharedPageClientPr
     setChooserOpen(true);
   }
 
+  function handleProjectMissing(projectId: string) {
+    startTransition(() => setDiscover((current) => removeProjectFromDiscover(current, projectId)));
+    showToast({ message: 'この単語帳は共有が停止されています', type: 'warning' });
+  }
+
   function handleSelectCategory(nextCategory: PageCategory) {
     setCategory(nextCategory);
     setError(null);
@@ -262,6 +269,7 @@ export default function SharedPageClient({ initialDiscover }: SharedPageClientPr
         onBackToAll={handleBackToAll}
         onLoadMore={() => void handleLoadMore()}
         onOpenShareSheet={handleOpenShareSheet}
+        onProjectMissing={handleProjectMissing}
       />
 
       <div className="flex min-h-screen flex-col bg-[var(--color-background)] pb-[110px] pt-3 font-[var(--font-body)] lg:hidden">
@@ -366,11 +374,11 @@ export default function SharedPageClient({ initialDiscover }: SharedPageClientPr
             ) : category === 'all' ? (
               <>
                 <UserSection users={discover.users} />
-                <ProjectSection projects={discover.projects} />
+                <ProjectSection projects={discover.projects} onProjectMissing={handleProjectMissing} />
               </>
             ) : (
               <>
-                {category === 'projects' && <ProjectSection projects={discover.projects} />}
+                {category === 'projects' && <ProjectSection projects={discover.projects} onProjectMissing={handleProjectMissing} />}
                 {discover.nextCursor && (
                   <button
                     type="button"
@@ -569,19 +577,50 @@ function UserSection({ users }: { users: SharedDiscoverPayload['users'] }) {
   );
 }
 
-function ProjectSection({ projects }: { projects: SharedProjectCard[] }) {
+async function sharedProjectStillExists(shareId: string): Promise<boolean | null> {
+  try {
+    const response = await fetch(`/api/shared-projects/share/${encodeURIComponent(shareId)}?limit=0`, {
+      cache: 'no-store',
+    });
+    if (response.status === 404) return false;
+    return response.ok ? true : null;
+  } catch {
+    return null;
+  }
+}
+
+function ProjectSection({
+  projects,
+  onProjectMissing,
+}: {
+  projects: SharedProjectCard[];
+  onProjectMissing: (projectId: string) => void;
+}) {
   if (projects.length === 0) return null;
   return (
     <section>
       <SectionLabel icon="menu_book" label="単語帳" count={projects.length} />
       <div className="flex flex-col gap-2">
-        {projects.map((project) => <ProjectCard key={project.project.id} project={project} />)}
+        {projects.map((project) => (
+          <ProjectCard
+            key={project.project.id}
+            project={project}
+            onProjectMissing={onProjectMissing}
+          />
+        ))}
       </div>
     </section>
   );
 }
 
-function ProjectCard({ project }: { project: SharedProjectCard }) {
+function ProjectCard({
+  project,
+  onProjectMissing,
+}: {
+  project: SharedProjectCard;
+  onProjectMissing: (projectId: string) => void;
+}) {
+  const router = useRouter();
   const href = project.project.shareId ? `/share/${project.project.shareId}` : '/shared';
   const bg = thumbColor(project.project.id);
   const ownerLabel = project.accessRole === 'owner'
@@ -590,10 +629,23 @@ function ProjectCard({ project }: { project: SharedProjectCard }) {
       ? `@${project.ownerAccountId}`
     : project.ownerUsername
       ? `@${project.ownerUsername}`
-      : '共有ユーザー';
+    : '共有ユーザー';
+
+  const handleClick = async (event: MouseEvent<HTMLAnchorElement>) => {
+    const shareId = project.project.shareId;
+    if (!shareId) return;
+
+    event.preventDefault();
+    const exists = await sharedProjectStillExists(shareId);
+    if (exists === false) {
+      onProjectMissing(project.project.id);
+      return;
+    }
+    router.push(href);
+  };
 
   return (
-    <Link href={href} className="block">
+    <Link href={href} onClick={(event) => void handleClick(event)} className="block">
       <div className="rounded-xl border-2 border-[var(--solid-ink)] bg-white p-3 transition-all duration-100 active:translate-x-px active:translate-y-px">
         <div className="flex items-center gap-[11px]">
           <div
@@ -913,10 +965,13 @@ function GroupSearchSection({
 }) {
   const { isAuthenticated, loading: authLoading } = useAuth();
   const [joinedIds, setJoinedIds] = useState<Set<string>>(new Set());
+  const searchedInitiallyRef = useRef(false);
 
   useEffect(() => {
+    if (searchedInitiallyRef.current) return;
+    searchedInitiallyRef.current = true;
     onSearch();
-  }, []);
+  }, [onSearch]);
 
   useEffect(() => {
     if (authLoading || !isAuthenticated) return;

--- a/src/app/shared/page.tsx
+++ b/src/app/shared/page.tsx
@@ -6,7 +6,8 @@ import {
 import { readSingleLineEnv } from '@/lib/env';
 import type { SharedDiscoverPayload } from '@/lib/shared-projects/types';
 
-export const revalidate = 60;
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
 
 export default async function SharedPage() {
   let initialDiscover: SharedDiscoverPayload = {

--- a/src/app/shared/shared-page-utils.test.ts
+++ b/src/app/shared/shared-page-utils.test.ts
@@ -6,6 +6,7 @@ import {
   collectMetricProjectIds,
   mergeMetricsIntoCards,
   mergeUniqueProjectCards,
+  removeProjectFromDiscover,
 } from './shared-page-utils';
 import {
   formatSharedTag,
@@ -47,6 +48,20 @@ test('mergeMetricsIntoCards replaces placeholder counts', () => {
 
   assert.equal(merged[0]?.wordCount, 12);
   assert.equal(merged[0]?.collaboratorCount, 3);
+});
+
+test('removeProjectFromDiscover removes stale shared cards', () => {
+  const payload = {
+    category: 'projects' as const,
+    users: [],
+    projects: [makeCard('project-1'), makeCard('project-2')],
+    groups: [],
+    nextCursor: null,
+  };
+
+  const next = removeProjectFromDiscover(payload, 'project-1');
+
+  assert.deepEqual(next.projects.map((card) => card.project.id), ['project-2']);
 });
 
 test('collectMetricProjectIds skips cards that already have counts', () => {

--- a/src/app/shared/shared-page-utils.ts
+++ b/src/app/shared/shared-page-utils.ts
@@ -1,4 +1,4 @@
-import type { SharedProjectCard, SharedProjectMetricsMap } from '@/lib/shared-projects/types';
+import type { SharedDiscoverPayload, SharedProjectCard, SharedProjectMetricsMap } from '@/lib/shared-projects/types';
 
 export function mergeUniqueProjectCards(
   existing: SharedProjectCard[],
@@ -48,6 +48,14 @@ export function mergeMetricsIntoCards(
   });
 
   return changed ? nextCards : cards;
+}
+
+export function removeProjectFromDiscover(
+  payload: SharedDiscoverPayload,
+  projectId: string,
+): SharedDiscoverPayload {
+  const projects = payload.projects.filter((card) => card.project.id !== projectId);
+  return projects.length === payload.projects.length ? payload : { ...payload, projects };
 }
 
 export function collectMetricProjectIds(

--- a/src/components/desktop/DesktopShared.tsx
+++ b/src/components/desktop/DesktopShared.tsx
@@ -1,7 +1,8 @@
 'use client';
 
-import type { CSSProperties } from 'react';
+import type { CSSProperties, MouseEvent } from 'react';
 import Link from 'next/link';
+import { useRouter } from 'next/navigation';
 import { DesktopButton, DesktopSearchBox } from '@/components/desktop/DesktopChrome';
 import { FollowNotificationsButton } from '@/components/notifications/FollowNotificationsButton';
 import { desktopThumbColor } from '@/components/desktop/desktop-data';
@@ -31,6 +32,7 @@ export function DesktopSharedView({
   onBackToAll,
   onLoadMore,
   onOpenShareSheet,
+  onProjectMissing,
 }: {
   category: SharedDiscoverCategory;
   query: string;
@@ -43,6 +45,7 @@ export function DesktopSharedView({
   onBackToAll: () => void;
   onLoadMore: () => void;
   onOpenShareSheet: () => void;
+  onProjectMissing: (projectId: string) => void;
 }) {
   const isCategory = category !== 'all';
   const activeMeta = isCategory ? CATEGORY_META[category] : null;
@@ -144,11 +147,12 @@ export function DesktopSharedView({
                 payload={payload}
                 onLoadMore={onLoadMore}
                 loadingMore={loadingMore}
+                onProjectMissing={onProjectMissing}
               />
             ) : hasQuery ? (
               <div style={{ display: 'flex', flexDirection: 'column', gap: 26 }}>
                 <UserGrid users={payload.users} />
-                <ProjectGrid projects={payload.projects} />
+                <ProjectGrid projects={payload.projects} onProjectMissing={onProjectMissing} />
               </div>
             ) : null}
           </>
@@ -163,16 +167,18 @@ function CategoryResults({
   payload,
   loadingMore,
   onLoadMore,
+  onProjectMissing,
 }: {
   category: Exclude<SharedDiscoverCategory, 'all'>;
   payload: SharedDiscoverPayload;
   loadingMore: boolean;
   onLoadMore: () => void;
+  onProjectMissing: (projectId: string) => void;
 }) {
   return (
     <>
       {category === 'users' && <UserGrid users={payload.users} />}
-      {category === 'projects' && <ProjectGrid projects={payload.projects} />}
+      {category === 'projects' && <ProjectGrid projects={payload.projects} onProjectMissing={onProjectMissing} />}
       {payload.nextCursor && (
         <button type="button" onClick={onLoadMore} disabled={loadingMore} className="ds-btn" style={{ marginTop: 18 }}>
           <Icon name={loadingMore ? 'progress_activity' : 'expand_more'} className={loadingMore ? 'animate-spin' : undefined} />
@@ -248,20 +254,51 @@ function UserGrid({ users }: { users: SharedUserSummary[] }) {
   );
 }
 
-function ProjectGrid({ projects }: { projects: SharedProjectCard[] }) {
+async function sharedProjectStillExists(shareId: string): Promise<boolean | null> {
+  try {
+    const response = await fetch(`/api/shared-projects/share/${encodeURIComponent(shareId)}?limit=0`, {
+      cache: 'no-store',
+    });
+    if (response.status === 404) return false;
+    return response.ok ? true : null;
+  } catch {
+    return null;
+  }
+}
+
+function ProjectGrid({
+  projects,
+  onProjectMissing,
+}: {
+  projects: SharedProjectCard[];
+  onProjectMissing: (projectId: string) => void;
+}) {
   return (
     <section>
       <SectionTitle count={projects.length}>単語帳</SectionTitle>
       {projects.length === 0 ? <EmptyCard label="該当する単語帳はありません" /> : (
         <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3,1fr)', gap: 16 }}>
-          {projects.map((project) => <DesktopSharedCard key={project.project.id} project={project} />)}
+          {projects.map((project) => (
+            <DesktopSharedCard
+              key={project.project.id}
+              project={project}
+              onProjectMissing={onProjectMissing}
+            />
+          ))}
         </div>
       )}
     </section>
   );
 }
 
-function DesktopSharedCard({ project }: { project: SharedProjectCard }) {
+function DesktopSharedCard({
+  project,
+  onProjectMissing,
+}: {
+  project: SharedProjectCard;
+  onProjectMissing: (projectId: string) => void;
+}) {
+  const router = useRouter();
   const href = project.project.shareId ? `/share/${project.project.shareId}` : '/shared';
   const ownerLabel = project.accessRole === 'owner'
     ? '自分'
@@ -271,8 +308,21 @@ function DesktopSharedCard({ project }: { project: SharedProjectCard }) {
       ? `@${project.ownerUsername}`
       : '共有ユーザー';
 
+  const handleClick = async (event: MouseEvent<HTMLAnchorElement>) => {
+    const shareId = project.project.shareId;
+    if (!shareId) return;
+
+    event.preventDefault();
+    const exists = await sharedProjectStillExists(shareId);
+    if (exists === false) {
+      onProjectMissing(project.project.id);
+      return;
+    }
+    router.push(href);
+  };
+
   return (
-    <Link href={href} className="ds-card" style={{ padding: 18, display: 'flex', flexDirection: 'column', gap: 14, color: 'inherit', textDecoration: 'none' }}>
+    <Link href={href} onClick={(event) => void handleClick(event)} className="ds-card" style={{ padding: 18, display: 'flex', flexDirection: 'column', gap: 14, color: 'inherit', textDecoration: 'none' }}>
       <div style={{ display: 'flex', gap: 14 }}>
         <div
           className="ds-project-icon ds-project-icon--lg"


### PR DESCRIPTION
## Summary
- Make the public shared page and discover API no-store so unpublished wordbooks do not remain visible from ISR or stale API cache.
- Guard shared wordbook cards on desktop and mobile: before navigating, verify the share target still exists; if it is gone, remove the card in-place instead of opening the not-found screen.
- Add tests for no-store discover responses and stale-card removal utility.

## Root cause
`/shared` was ISR cached for 60 seconds and `/api/shared-projects/discover` returned `stale-while-revalidate=300`. After stopping a share, the deleted `shared_wordbooks` row could still be rendered from cached shared-page data, so tapping it then hit `/share/:shareId` and showed "共有単語帳が見つかりません".

## Validation
- `./node_modules/.bin/eslint src/app/shared/SharedPageClient.tsx src/components/desktop/DesktopShared.tsx src/app/shared/page.tsx src/app/api/shared-projects/discover/route.ts src/app/api/shared-projects/discover/route.test.ts src/app/shared/shared-page-utils.ts src/app/shared/shared-page-utils.test.ts`
- `./node_modules/.bin/tsx --test src/app/api/shared-projects/discover/route.test.ts src/app/shared/shared-page-utils.test.ts`
- `npm run build`
