### PR TITLE
グループ苦戦ランキングを2人以上間違えた単語のみに変更

### DIFF
--- a/src/app/api/shared-projects/groups/shared.ts
+++ b/src/app/api/shared-projects/groups/shared.ts
@@ -87,6 +87,7 @@ const CREATE_INVITE_CODE_RETRIES = 5;
 const DEFAULT_PUBLIC_GROUP_PAGE_SIZE = 12;
 const MAX_PUBLIC_GROUP_PAGE_SIZE = 36;
 export const STUDY_GROUP_STRUGGLING_PREVIEW_LIMIT = 5;
+export const STUDY_GROUP_STRUGGLING_MIN_LEARNERS = 2;
 
 export function normalizeGroupInviteCode(input: string): string | null {
   const normalized = input.trim().replace(/[\s-]+/g, '');
@@ -642,7 +643,8 @@ async function getStudyGroupMissedWordSummary(
     throw new Error(error.message || 'study_group_missed_words_lookup_failed');
   }
 
-  const allWords = aggregateStudyGroupStrugglingWords((data ?? []) as StudyGroupMissedWordRow[]);
+  const allWords = aggregateStudyGroupStrugglingWords((data ?? []) as StudyGroupMissedWordRow[])
+    .filter((w) => w.learnerCount >= STUDY_GROUP_STRUGGLING_MIN_LEARNERS);
   const normalizedLimit = typeof limit === 'number' && Number.isFinite(limit)
     ? Math.max(0, Math.floor(limit))
     : null;

--- a/src/app/groups/[groupId]/page.tsx
+++ b/src/app/groups/[groupId]/page.tsx
@@ -422,9 +422,9 @@ function MissedWordsSection({
   const max = missedWords[0]?.missCount ?? 1;
   const hasMore = totalCount > missedWords.length;
   return (
-    <SectionCard icon="local_fire_department" title="みんなが苦戦中" subtitle="グループでよく間違える単語・上位5件" accent="#CC4D59">
+    <SectionCard icon="local_fire_department" title="みんなが苦戦中" subtitle="2人以上が間違えた単語・上位5件" accent="#CC4D59">
       {missedWords.length === 0 ? (
-        <EmptyRow message="まだデータがありません。クイズを解くと集計されます" />
+        <EmptyRow message="2人以上が間違えた単語がまだありません" />
       ) : (
         <>
           <div className="flex flex-col gap-1.5">

--- a/src/app/groups/[groupId]/struggling/GroupStrugglingClient.tsx
+++ b/src/app/groups/[groupId]/struggling/GroupStrugglingClient.tsx
@@ -95,7 +95,7 @@ export default function GroupStrugglingClient() {
           ) : error ? (
             <div className="py-8 text-center text-sm font-bold text-[var(--color-error)]">{error}</div>
           ) : words.length === 0 ? (
-            <div className="py-8 text-center text-sm font-bold text-[var(--color-muted)]">まだ苦戦中の単語はありません</div>
+            <div className="py-8 text-center text-sm font-bold text-[var(--color-muted)]">2人以上が間違えた単語がまだありません</div>
           ) : (
             <div className="divide-y divide-[var(--color-border)]">
               {words.map((word, index) => (


### PR DESCRIPTION
## Summary

- グループの「みんなが苦戦中」ランキングに表示される単語の閾値を変更し、**2人以上のメンバーが間違えた単語のみ**をランキングに表示するようにしました
- `STUDY_GROUP_STRUGGLING_MIN_LEARNERS = 2` 定数を追加し、`getStudyGroupMissedWordSummary` でフィルタリング
- グループトップページのプレビューと苦戦ページの両方で、subtitleと空状態メッセージを「2人以上が間違えた単語」と明示するよう更新

## Changes

| File | Change |
|------|--------|
| `src/app/api/shared-projects/groups/shared.ts` | `STUDY_GROUP_STRUGGLING_MIN_LEARNERS` 定数追加、`learnerCount >= 2` フィルタ適用 |
| `src/app/groups/[groupId]/page.tsx` | subtitle・空メッセージを更新 |
| `src/app/groups/[groupId]/struggling/GroupStrugglingClient.tsx` | 空メッセージを更新 |

## Test plan

- [x] 既存テスト (`aggregateStudyGroupStrugglingWords`) パス確認
- [x] lint エラーなし（既存のもののみ）
- [x] ビルド成功
- [ ] グループで1人だけが間違えた単語がランキングに表示されないことを確認
- [ ] 2人以上が間違えた単語がランキングに正しく表示されることを確認
- [ ] 誰も間違えていない場合に空状態メッセージが正しく表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LJk8JsveVFKataDVBBwgmB

---
_Generated by [Claude Code](https://claude.ai/code/session_01LJk8JsveVFKataDVBBwgmB)_