### PR TITLE
Add active status between review and mastered

### DIFF
--- a/shared/db/mappers.ts
+++ b/shared/db/mappers.ts
@@ -247,7 +247,7 @@ function normalizeDistractors(value: unknown): string[] {
 }
 
 function normalizeWordStatus(value: unknown): Word['status'] | undefined {
-  return value === 'new' || value === 'review' || value === 'mastered'
+  return value === 'new' || value === 'review' || value === 'active' || value === 'mastered'
     ? value
     : undefined;
 }

--- a/shared/types/index.ts
+++ b/shared/types/index.ts
@@ -3,7 +3,7 @@
 
 // ============ Core Domain Types ============
 
-export type WordStatus = 'new' | 'review' | 'mastered';
+export type WordStatus = 'new' | 'review' | 'active' | 'mastered';
 export type VocabularyType = 'active' | 'passive';
 export type ProjectShareScope = 'private' | 'public';
 

--- a/src/app/api/words/create/route.ts
+++ b/src/app/api/words/create/route.ts
@@ -87,7 +87,7 @@ const wordInputSchema = z.object({
   insightsVersion: z.number().int().min(1).max(100).optional(),
   wordOrderQuiz: wordOrderQuizSchema.optional(),
   customSections: z.array(customSectionSchema).max(20).optional(),
-  status: z.enum(['new', 'review', 'mastered']).optional(),
+  status: z.enum(['new', 'review', 'active', 'mastered']).optional(),
   createdAt: z.string().datetime().optional(),
   lastReviewedAt: z.string().datetime().optional(),
   nextReviewAt: z.string().datetime().optional(),

--- a/src/app/desktop.css
+++ b/src/app/desktop.css
@@ -183,6 +183,7 @@
 /* status dot */
 .ds-sdot { width: 8px; height: 8px; border-radius: 50%; display: inline-block; flex-shrink: 0; }
 .c-mastered { background: var(--color-success); }
+.c-active { background: #3b82f6; }
 .c-review { background: var(--color-warning); }
 .c-new { background: var(--color-border); }
 .c-wrong { background: var(--color-error); }
@@ -190,6 +191,7 @@
 /* status pill (text + dot) */
 .ds-status { display: inline-flex; align-items: center; gap: 6px; font-size: 12.5px; font-weight: 600; }
 .ds-status.mastered { color: var(--color-accent-ink); }
+.ds-status.active { color: #1d4ed8; }
 .ds-status.review { color: #92400e; }
 .ds-status.new { color: var(--color-muted); }
 

--- a/src/app/favorites/page.tsx
+++ b/src/app/favorites/page.tsx
@@ -30,6 +30,7 @@ function StatusPill({ kind }: { kind: Word['status'] }) {
   const config = {
     new: { t: '未学習', bg: '#fff', fg: 'var(--color-muted)', bd: 'var(--color-border)' },
     review: { t: '学習中', bg: 'rgba(19,127,236,0.1)', fg: '#137fec', bd: '#137fec' },
+    active: { t: '定着中', bg: 'rgba(59,130,246,0.1)', fg: '#3b82f6', bd: '#3b82f6' },
     mastered: { t: '習得', bg: 'rgba(61,122,78,0.12)', fg: 'var(--color-success)', bd: 'var(--color-success)' },
   }[kind];
 
@@ -119,7 +120,7 @@ function FavoritesPageContent() {
   }, [mode]);
 
   const sortedFavorites = useMemo(() => {
-    const statusOrder: Record<Word['status'], number> = { review: 0, new: 1, mastered: 2 };
+    const statusOrder: Record<Word['status'], number> = { review: 0, new: 1, active: 2, mastered: 3 };
     return [...favorites].sort((a, b) => {
       if (activeSort === 'status') return statusOrder[a.status] - statusOrder[b.status];
       if (activeSort === 'project') return a.projectTitle.localeCompare(b.projectTitle, 'ja') || a.english.localeCompare(b.english);
@@ -129,9 +130,10 @@ function FavoritesPageContent() {
 
   const counts = useMemo(() => {
     const mastered = favorites.filter((word) => word.status === 'mastered').length;
+    const active = favorites.filter((word) => word.status === 'active').length;
     const review = favorites.filter((word) => word.status === 'review').length;
     const newCount = favorites.filter((word) => word.status === 'new').length;
-    return { mastered, review, newCount };
+    return { mastered, active, review, newCount };
   }, [favorites]);
 
   const handleToggleFavorite = async (word: FavoriteWord) => {
@@ -257,12 +259,14 @@ function FavoritesPageContent() {
 
                 <div className="mt-3 flex h-1.5 overflow-hidden rounded-sm border border-[var(--color-border)]">
                   <div style={{ flex: counts.mastered, background: 'var(--color-success)' }} />
+                  <div style={{ flex: counts.active, background: '#3b82f6' }} />
                   <div style={{ flex: counts.review, background: '#137fec' }} />
                   <div style={{ flex: counts.newCount, background: 'rgba(26,26,26,0.15)' }} />
                 </div>
 
-                <div className="mt-2 flex gap-3 font-mono text-[10px]">
+                <div className="mt-2 flex flex-wrap gap-3 font-mono text-[10px]">
                   <span className="font-bold text-[var(--color-success)]">● 習得 {counts.mastered}</span>
+                  <span className="font-bold text-[#3b82f6]">● 定着中 {counts.active}</span>
                   <span className="font-bold text-[#137fec]">● 学習中 {counts.review}</span>
                   <span className="font-bold text-[var(--color-muted)]">● 未学習 {counts.newCount}</span>
                 </div>

--- a/src/app/flashcard/[projectId]/page.tsx
+++ b/src/app/flashcard/[projectId]/page.tsx
@@ -519,9 +519,9 @@ export default function FlashcardPage() {
   };
 
   /* Status label */
-  const statusLabel = (s: string) => ({ new: '未学習', review: '学習中', mastered: '習得' }[s] ?? s);
+  const statusLabel = (s: string) => ({ new: '未学習', review: '学習中', active: '定着中', mastered: '習得' }[s] ?? s);
   const statusColor = (s: string) =>
-    s === 'mastered' ? 'var(--color-success)' : s === 'review' ? '#137fec' : 'var(--color-muted)';
+    s === 'mastered' ? 'var(--color-success)' : s === 'active' ? '#3b82f6' : s === 'review' ? '#137fec' : 'var(--color-muted)';
 
   /* ---------- Loading ---------- */
   if (loading) {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -143,6 +143,7 @@ type HomeStats = {
   streakDays: number;
   totalWords: number;
   mastered: number;
+  activeW: number;
   review: number;
   newW: number;
 };
@@ -212,6 +213,7 @@ function buildHomeStats(allWords: Word[]): HomeStats {
     streakDays: getStreakDays(),
     totalWords: memorySummary.total,
     mastered: statusCounts.masteredTotal,
+    activeW: statusCounts.activeTotal,
     review: statusCounts.learningTotal,
     newW: statusCounts.unlearnedTotal,
   };
@@ -298,6 +300,7 @@ const EMPTY_STATS: HomeStats = {
   streakDays: 0,
   totalWords: 0,
   mastered: 0,
+  activeW: 0,
   review: 0,
   newW: 0,
 };

--- a/src/app/project/[id]/page.tsx
+++ b/src/app/project/[id]/page.tsx
@@ -219,6 +219,7 @@ export default function ProjectPage() {
     return {
       total: wordStats.total,
       mastered: wordStats.mastered,
+      active: wordStats.active,
       learning: wordStats.learning,
       newCount: wordStats.unlearned,
     };
@@ -1022,7 +1023,7 @@ export default function ProjectPage() {
       </div>
 
       <div className="px-5 pb-3.5">
-        <StackedBar total={counts.total} m={counts.mastered} l={counts.learning} n={counts.newCount} />
+        <StackedBar total={counts.total} m={counts.mastered} a={counts.active} l={counts.learning} n={counts.newCount} />
       </div>
 
       <div className="flex items-center gap-2 px-[18px] pb-4">
@@ -1654,8 +1655,9 @@ function ToolChip({ icon, label }: { icon: string; label: string }) {
   );
 }
 
-function StackedBar({ total, m, l, n }: { total: number; m: number; l: number; n: number }) {
+function StackedBar({ total, m, a, l, n }: { total: number; m: number; a: number; l: number; n: number }) {
   const pctM = total ? (m / total) * 100 : 0;
+  const pctA = total ? (a / total) * 100 : 0;
   const pctL = total ? (l / total) * 100 : 0;
   const pctN = total ? (n / total) * 100 : 0;
 
@@ -1663,11 +1665,13 @@ function StackedBar({ total, m, l, n }: { total: number; m: number; l: number; n
     <div>
       <div className="flex h-2.5 overflow-hidden rounded-full border-2 border-[var(--solid-ink)] bg-white">
         <div style={{ width: `${pctM}%`, background: 'var(--color-success)' }} />
+        <div style={{ width: `${pctA}%`, background: '#3b82f6' }} />
         <div style={{ width: `${pctL}%`, background: 'var(--color-warning)' }} />
         <div style={{ width: `${pctN}%`, background: 'rgba(26,26,26,0.12)' }} />
       </div>
-      <div className="mt-[7px] flex gap-3.5 font-[var(--font-body)]">
+      <div className="mt-[7px] flex flex-wrap gap-3.5 font-[var(--font-body)]">
         <BarDot color="var(--color-success)" label="習得" count={m} />
+        <BarDot color="#3b82f6" label="定着中" count={a} />
         <BarDot color="var(--color-warning)" label="学習中" count={l} />
         <BarDot color="rgba(26,26,26,0.35)" label="未学習" count={n} />
       </div>
@@ -1707,7 +1711,9 @@ function posShort(tag: string): string {
   return `(${jp[0]})`;
 }
 
-const STATUS_MID_PREFIX = 'notion_cb_mid_';
+const PP_FILLED: Record<WordStatus, number> = { new: 0, review: 1, active: 2, mastered: 3 };
+const PP_STATUS: WordStatus[] = ['new', 'review', 'active', 'mastered'];
+const PP_ARIA: Record<WordStatus, string> = { new: '未学習', review: '学習中', active: '定着中', mastered: '習得済み' };
 
 function StatusSquares({
   wordId,
@@ -1718,16 +1724,7 @@ function StatusSquares({
   status: WordStatus;
   onStatusChange: (newStatus: WordStatus) => void;
 }) {
-  const [filledCount, setFilledCount] = useState(() => {
-    if (status === 'mastered') return 3;
-    if (status === 'new') return 0;
-    try {
-      const val = localStorage.getItem(STATUS_MID_PREFIX + wordId);
-      if (val === 'down2' || val === '1') return 2;
-      if (val === 'down1') return 1;
-    } catch { /* ignore */ }
-    return 1;
-  });
+  const [filledCount, setFilledCount] = useState(() => PP_FILLED[status] ?? 0);
   const [direction, setDirection] = useState<'up' | 'down'>(() =>
     status === 'mastered' ? 'down' : 'up'
   );
@@ -1736,59 +1733,36 @@ function StatusSquares({
     let cancelled = false;
     queueMicrotask(() => {
       if (cancelled) return;
-      if (status === 'new') { setFilledCount(0); setDirection('up'); return; }
-      if (status === 'mastered') { setFilledCount(3); setDirection('down'); return; }
-      try {
-        const val = localStorage.getItem(STATUS_MID_PREFIX + wordId);
-        if (val === 'down2') { setFilledCount(2); setDirection('down'); }
-        else if (val === 'down1') { setFilledCount(1); setDirection('down'); }
-        else if (val === '1') { setFilledCount(2); setDirection('up'); }
-        else { setFilledCount(1); setDirection('up'); }
-      } catch { setFilledCount(1); setDirection('up'); }
+      setFilledCount(PP_FILLED[status] ?? 0);
+      setDirection(status === 'mastered' ? 'down' : 'up');
     });
     return () => { cancelled = true; };
   }, [status, wordId]);
 
   const handleClick = useCallback((e: React.MouseEvent) => {
     e.stopPropagation();
-    try {
-      if (direction === 'up') {
-        if (filledCount === 0) {
-          localStorage.setItem(STATUS_MID_PREFIX + wordId, '0');
-          setFilledCount(1);
-          onStatusChange('review');
-        } else if (filledCount === 1) {
-          localStorage.setItem(STATUS_MID_PREFIX + wordId, '1');
-          setFilledCount(2);
-        } else if (filledCount === 2) {
-          localStorage.removeItem(STATUS_MID_PREFIX + wordId);
-          setFilledCount(3);
-          setDirection('down');
-          onStatusChange('mastered');
-        }
-      } else {
-        if (filledCount === 3) {
-          localStorage.setItem(STATUS_MID_PREFIX + wordId, 'down2');
-          setFilledCount(2);
-          onStatusChange('review');
-        } else if (filledCount === 2) {
-          localStorage.setItem(STATUS_MID_PREFIX + wordId, 'down1');
-          setFilledCount(1);
-        } else if (filledCount === 1) {
-          localStorage.removeItem(STATUS_MID_PREFIX + wordId);
-          setFilledCount(0);
-          setDirection('up');
-          onStatusChange('new');
-        }
+    if (direction === 'up') {
+      if (filledCount < 3) {
+        const next = filledCount + 1;
+        setFilledCount(next);
+        if (next === 3) setDirection('down');
+        onStatusChange(PP_STATUS[next]);
       }
-    } catch { /* localStorage unavailable */ }
-  }, [filledCount, direction, onStatusChange, wordId]);
+    } else {
+      if (filledCount > 0) {
+        const next = filledCount - 1;
+        setFilledCount(next);
+        if (next === 0) setDirection('up');
+        onStatusChange(PP_STATUS[next]);
+      }
+    }
+  }, [filledCount, direction, onStatusChange]);
 
   return (
     <button
       type="button"
       onClick={handleClick}
-      aria-label={`ステータス: ${status === 'new' ? '未学習' : status === 'review' ? '学習中' : '習得済み'}`}
+      aria-label={`ステータス: ${PP_ARIA[status] ?? status}`}
       className="shrink-0 rounded transition-colors active:bg-[rgba(26,26,26,0.06)]"
     >
       <div className="flex flex-col gap-[1.5px]">
@@ -1808,6 +1782,7 @@ function StatusPill({ kind }: { kind: WordStatus }) {
   const config = {
     new: { t: '未学習', bg: '#fff', fg: 'var(--color-muted)', bd: 'var(--color-border)' },
     review: { t: '学習中', bg: 'rgba(19,127,236,0.1)', fg: '#137fec', bd: '#137fec' },
+    active: { t: '定着中', bg: 'rgba(59,130,246,0.1)', fg: '#3b82f6', bd: '#3b82f6' },
     mastered: { t: '習得', bg: 'rgba(61,122,78,0.12)', fg: 'var(--color-success)', bd: 'var(--color-success)' },
   }[kind];
 

--- a/src/components/desktop/DesktopFavorites.tsx
+++ b/src/components/desktop/DesktopFavorites.tsx
@@ -47,6 +47,7 @@ export function DesktopFavoritesView({
   );
   const counts = useMemo(() => ({
     mastered: favorites.filter((word) => word.status === 'mastered').length,
+    active: favorites.filter((word) => word.status === 'active').length,
     review: favorites.filter((word) => word.status === 'review').length,
     newCount: favorites.filter((word) => word.status === 'new').length,
   }), [favorites]);
@@ -69,6 +70,7 @@ export function DesktopFavoritesView({
           <span className="muted" style={{ fontSize: 13 }}>をお気に入り登録中</span>
           <div style={{ display: 'flex', gap: 12, marginLeft: 8 }}>
             <span className="ds-status mastered"><span className="ds-sdot c-mastered" />習得 {counts.mastered}</span>
+            <span className="ds-status active"><span className="ds-sdot c-active" />定着中 {counts.active}</span>
             <span className="ds-status review"><span className="ds-sdot c-review" />学習中 {counts.review}</span>
             <span className="ds-status new"><span className="ds-sdot c-new" />未学習 {counts.newCount}</span>
           </div>

--- a/src/components/desktop/DesktopHome.tsx
+++ b/src/components/desktop/DesktopHome.tsx
@@ -30,6 +30,7 @@ type DesktopHomeStats = {
   streakDays: number;
   totalWords: number;
   mastered: number;
+  activeW: number;
   review: number;
   newW: number;
 };

--- a/src/components/desktop/DesktopProjectDetail.tsx
+++ b/src/components/desktop/DesktopProjectDetail.tsx
@@ -136,7 +136,7 @@ export function DesktopProjectDetailView({
     if (sortKey === 'order') {
       return sortDir === 1 ? filteredWords : [...filteredWords].reverse();
     }
-    const order: Record<WordStatus, number> = { new: 0, review: 1, mastered: 2 };
+    const order: Record<WordStatus, number> = { new: 0, review: 1, active: 2, mastered: 3 };
     return [...filteredWords].sort((a, b) => {
       let result = 0;
       if (sortKey === 'en') result = a.english.localeCompare(b.english);

--- a/src/components/desktop/DesktopStats.tsx
+++ b/src/components/desktop/DesktopStats.tsx
@@ -22,6 +22,7 @@ export function DesktopStatsView({
   const weekTotal = chartData.reduce((sum, item) => sum + item.count, 0);
   const totalWords = stats?.totalWords ?? 0;
   const mastered = stats?.masteredWords ?? 0;
+  const activeW = stats?.activeWords ?? 0;
   const review = stats?.reviewWords ?? 0;
   const newWords = stats?.newWords ?? 0;
   const accuracy = stats?.quizStats.todayCount
@@ -35,6 +36,7 @@ export function DesktopStatsView({
         streakDays: stats.quizStats.streakDays,
         totalWords,
         mastered,
+        activeW,
         review,
         newW: newWords,
       }
@@ -96,6 +98,7 @@ export function DesktopStatsView({
                 <div className="v" style={{ color: 'var(--color-accent-ink)' }}>{mastered}</div>
                 <div className="ds-prog" style={{ marginTop: 4 }}><div className="fi" style={{ width: `${masteryPercent}%` }} /></div>
               </div>
+              <div className="ds-card ds-kpi"><div className="l" style={{ marginBottom: 2 }}>定着中</div><div className="v" style={{ color: '#1d4ed8' }}>{activeW}</div><div className="mono muted" style={{ fontSize: 11 }}>もう少し</div></div>
               <div className="ds-card ds-kpi"><div className="l" style={{ marginBottom: 2 }}>復習中</div><div className="v" style={{ color: '#92400e' }}>{review}</div><div className="mono muted" style={{ fontSize: 11 }}>要レビュー</div></div>
               <div className="ds-card ds-kpi"><div className="l" style={{ marginBottom: 2 }}>未学習</div><div className="v muted">{newWords}</div><div className="mono muted" style={{ fontSize: 11 }}>これから</div></div>
               <div className="ds-card ds-kpi"><div className="l" style={{ marginBottom: 2 }}>間違えた問題</div><div className="v" style={{ color: 'var(--color-error)' }}>{stats.wrongAnswersCount}</div><div className="mono muted" style={{ fontSize: 11 }}>復習推奨</div></div>
@@ -106,11 +109,13 @@ export function DesktopStatsView({
               <div style={{ flex: 1 }}>
                 <div className="ds-dist" style={{ marginBottom: 18 }}>
                   <span className="c-mastered" style={{ flex: mastered || 0.0001 }} />
+                  <span className="c-active" style={{ flex: activeW || 0.0001 }} />
                   <span className="c-review" style={{ flex: review || 0.0001 }} />
                   <span className="c-new" style={{ flex: newWords || 0.0001 }} />
                 </div>
                 <div className="ds-legend">
                   <div className="row"><span className="ds-sdot c-mastered" /><span className="lb">習得</span><span className="ct tnum">{mastered}</span></div>
+                  <div className="row"><span className="ds-sdot c-active" /><span className="lb">定着中</span><span className="ct tnum">{activeW}</span></div>
                   <div className="row"><span className="ds-sdot c-review" /><span className="lb">学習中</span><span className="ct tnum">{review}</span></div>
                   <div className="row"><span className="ds-sdot c-new" /><span className="lb">未学習</span><span className="ct tnum">{newWords}</span></div>
                 </div>

--- a/src/components/desktop/DesktopStudySidebar.tsx
+++ b/src/components/desktop/DesktopStudySidebar.tsx
@@ -41,6 +41,7 @@ export function DesktopStudySidebar({
         <DesktopDonut mastered={stats.mastered} review={stats.review} total={stats.totalWords} size={130} stroke={17} percent={masteryPercent} />
         <div className="ds-legend" style={{ alignSelf: 'stretch' }}>
           <div className="row"><span className="ds-sdot c-mastered" /><span className="lb">習得</span><span className="ct tnum">{stats.mastered}</span></div>
+          <div className="row"><span className="ds-sdot c-active" /><span className="lb">定着中</span><span className="ct tnum">{stats.activeW}</span></div>
           <div className="row"><span className="ds-sdot c-review" /><span className="lb">学習中</span><span className="ct tnum">{stats.review}</span></div>
           <div className="row"><span className="ds-sdot c-new" /><span className="lb">未学習</span><span className="ct tnum">{stats.newW}</span></div>
         </div>

--- a/src/components/desktop/desktop-data.ts
+++ b/src/components/desktop/desktop-data.ts
@@ -13,6 +13,7 @@ export const DESKTOP_THUMBS = [
 
 export const DESKTOP_STATUS_LABEL: Record<WordStatus, string> = {
   mastered: '習得',
+  active: '定着中',
   review: '学習中',
   new: '未学習',
 };
@@ -129,11 +130,12 @@ export function desktopCountWords(words: Word[]) {
     (acc, word) => {
       acc.total += 1;
       if (word.status === 'mastered') acc.mastered += 1;
+      else if (word.status === 'active') acc.active += 1;
       else if (word.status === 'review') acc.review += 1;
       else acc.neww += 1;
       if (word.isFavorite) acc.favorite += 1;
       return acc;
     },
-    { total: 0, mastered: 0, review: 0, neww: 0, favorite: 0 },
+    { total: 0, mastered: 0, active: 0, review: 0, neww: 0, favorite: 0 },
   );
 }

--- a/src/components/home/WordList.tsx
+++ b/src/components/home/WordList.tsx
@@ -10,17 +10,15 @@ import type { Word, WordStatus } from '@/types';
 
 export function nextStatus(current: WordStatus): WordStatus {
   if (current === 'new') return 'review';
-  if (current === 'review') return 'mastered';
+  if (current === 'review') return 'active';
+  if (current === 'active') return 'mastered';
   return 'new';
 }
 
-const STORAGE_PREFIX = 'notion_cb_mid_';
+const STATUS_TO_FILLED: Record<WordStatus, number> = { new: 0, review: 1, active: 2, mastered: 3 };
+const FILLED_TO_STATUS: WordStatus[] = ['new', 'review', 'active', 'mastered'];
+const STATUS_ARIA: Record<WordStatus, string> = { new: '未学習', review: '学習中', active: '定着中', mastered: '習得済' };
 
-/**
- * iOS と同じ 6 段階サイクルの NotionCheckbox。
- * new(0) → review(1) → review(2) → mastered(3) → review(2) → review(1) → new(0) → …
- * review 内の中間状態は localStorage で管理。
- */
 export function NotionCheckbox({
   wordId,
   status,
@@ -30,92 +28,40 @@ export function NotionCheckbox({
   status: WordStatus;
   onStatusChange: (newStatus: WordStatus) => void;
 }) {
-  // filledCount: 0-3, direction: 'up' (ascending) or 'down' (descending)
-  const [filledCount, setFilledCount] = useState(0);
-  const [direction, setDirection] = useState<'up' | 'down'>('up');
+  const [filledCount, setFilledCount] = useState(() => STATUS_TO_FILLED[status] ?? 0);
+  const [direction, setDirection] = useState<'up' | 'down'>(() => status === 'mastered' ? 'down' : 'up');
 
   useEffect(() => {
     const timer = window.setTimeout(() => {
-      if (status === 'new') {
-        setFilledCount(0);
-        setDirection('up');
-      } else if (status === 'mastered') {
-        setFilledCount(3);
-        setDirection('down');
-      } else {
-        // review: read mid state from localStorage
-        try {
-          const val = localStorage.getItem(STORAGE_PREFIX + wordId);
-          if (val === 'down2') {
-            setFilledCount(2);
-            setDirection('down');
-          } else if (val === 'down1') {
-            setFilledCount(1);
-            setDirection('down');
-          } else if (val === '1') {
-            setFilledCount(2);
-            setDirection('up');
-          } else {
-            setFilledCount(1);
-            setDirection('up');
-          }
-        } catch {
-          setFilledCount(1);
-          setDirection('up');
-        }
-      }
+      setFilledCount(STATUS_TO_FILLED[status] ?? 0);
+      setDirection(status === 'mastered' ? 'down' : 'up');
     }, 0);
     return () => window.clearTimeout(timer);
   }, [status, wordId]);
 
   const handleClick = useCallback((e: React.MouseEvent) => {
     e.stopPropagation();
-    try {
-      if (direction === 'up') {
-        if (filledCount === 0) {
-          // 0 → 1 (new → review)
-          localStorage.setItem(STORAGE_PREFIX + wordId, '0');
-          setFilledCount(1);
-          onStatusChange('review');
-        } else if (filledCount === 1) {
-          // 1 → 2
-          localStorage.setItem(STORAGE_PREFIX + wordId, '1');
-          setFilledCount(2);
-        } else if (filledCount === 2) {
-          // 2 → 3 (review → mastered)
-          localStorage.removeItem(STORAGE_PREFIX + wordId);
-          setFilledCount(3);
-          setDirection('down');
-          onStatusChange('mastered');
-        }
-      } else {
-        // direction === 'down'
-        if (filledCount === 3) {
-          // 3 → 2 (mastered → review)
-          localStorage.setItem(STORAGE_PREFIX + wordId, 'down2');
-          setFilledCount(2);
-          onStatusChange('review');
-        } else if (filledCount === 2) {
-          // 2 → 1
-          localStorage.setItem(STORAGE_PREFIX + wordId, 'down1');
-          setFilledCount(1);
-        } else if (filledCount === 1) {
-          // 1 → 0 (review → new)
-          localStorage.removeItem(STORAGE_PREFIX + wordId);
-          setFilledCount(0);
-          setDirection('up');
-          onStatusChange('new');
-        }
+    if (direction === 'up') {
+      if (filledCount < 3) {
+        const next = filledCount + 1;
+        setFilledCount(next);
+        if (next === 3) setDirection('down');
+        onStatusChange(FILLED_TO_STATUS[next]);
       }
-    } catch {
-      // localStorage unavailable
+    } else {
+      if (filledCount > 0) {
+        const next = filledCount - 1;
+        setFilledCount(next);
+        if (next === 0) setDirection('up');
+        onStatusChange(FILLED_TO_STATUS[next]);
+      }
     }
-  }, [filledCount, direction, onStatusChange, wordId]);
+  }, [filledCount, direction, onStatusChange]);
 
   return (
     <button
       onClick={handleClick}
-      aria-label={`ステータス: ${status === 'new' ? '未学習' : status === 'review' ? '学習中' : '習得済'}`}
+      aria-label={`ステータス: ${STATUS_ARIA[status] ?? status}`}
       className="flex-shrink-0 rounded hover:bg-[var(--color-surface)] transition-colors"
       style={{ lineHeight: 0, padding: 2 }}
     >

--- a/src/components/project/ProjectDetailSheet.tsx
+++ b/src/components/project/ProjectDetailSheet.tsx
@@ -43,19 +43,21 @@ function posShort(tag: string): string {
   return `(${jp[0]})`;
 }
 
-function StackedBar({ total, m, l, n }: { total: number; m: number; l: number; n: number }) {
+function StackedBar({ total, m, a, l, n }: { total: number; m: number; a: number; l: number; n: number }) {
   const pctM = total ? (m / total) * 100 : 0;
+  const pctA = total ? (a / total) * 100 : 0;
   const pctL = total ? (l / total) * 100 : 0;
   const pctN = total ? (n / total) * 100 : 0;
   return (
     <div>
       <div className="flex h-2.5 overflow-hidden rounded-full border-2 border-[var(--solid-ink)] bg-white">
         <div style={{ width: `${pctM}%`, background: 'var(--color-success)' }} />
+        <div style={{ width: `${pctA}%`, background: '#3b82f6' }} />
         <div style={{ width: `${pctL}%`, background: 'var(--color-warning)' }} />
         <div style={{ width: `${pctN}%`, background: 'rgba(26,26,26,0.12)' }} />
       </div>
-      <div className="mt-[7px] flex gap-3.5">
-        {[['var(--color-success)', '習得', m], ['var(--color-warning)', '学習中', l], ['rgba(26,26,26,0.35)', '未学習', n]].map(([color, label, count]) => (
+      <div className="mt-[7px] flex flex-wrap gap-3.5">
+        {[['var(--color-success)', '習得', m], ['#3b82f6', '定着中', a], ['var(--color-warning)', '学習中', l], ['rgba(26,26,26,0.35)', '未学習', n]].map(([color, label, count]) => (
           <span key={label as string} className="inline-flex items-center gap-[5px]">
             <span className="h-[7px] w-[7px] rounded-[3.5px]" style={{ background: color as string }} />
             <span className="text-[11px] font-semibold text-[#4a4a4a]">{label as string}</span>
@@ -67,58 +69,48 @@ function StackedBar({ total, m, l, n }: { total: number; m: number; l: number; n
   );
 }
 
-const STATUS_MID_PREFIX = 'notion_cb_mid_';
+const SS_FILLED: Record<WordStatus, number> = { new: 0, review: 1, active: 2, mastered: 3 };
+const SS_STATUS: WordStatus[] = ['new', 'review', 'active', 'mastered'];
+const SS_ARIA: Record<WordStatus, string> = { new: '未学習', review: '学習中', active: '定着中', mastered: '習得済み' };
 
 function StatusSquares({ wordId, status, onStatusChange }: {
   wordId: string; status: WordStatus; onStatusChange: (s: WordStatus) => void;
 }) {
-  const [filledCount, setFilledCount] = useState(() => {
-    if (status === 'mastered') return 3;
-    if (status === 'new') return 0;
-    try {
-      const val = localStorage.getItem(STATUS_MID_PREFIX + wordId);
-      if (val === 'down2' || val === '1') return 2;
-      if (val === 'down1') return 1;
-    } catch { /* ignore */ }
-    return 1;
-  });
+  const [filledCount, setFilledCount] = useState(() => SS_FILLED[status] ?? 0);
   const [direction, setDirection] = useState<'up' | 'down'>(() => status === 'mastered' ? 'down' : 'up');
 
   useEffect(() => {
     let cancelled = false;
     queueMicrotask(() => {
       if (cancelled) return;
-      if (status === 'new') { setFilledCount(0); setDirection('up'); return; }
-      if (status === 'mastered') { setFilledCount(3); setDirection('down'); return; }
-      try {
-        const val = localStorage.getItem(STATUS_MID_PREFIX + wordId);
-        if (val === 'down2') { setFilledCount(2); setDirection('down'); }
-        else if (val === 'down1') { setFilledCount(1); setDirection('down'); }
-        else if (val === '1') { setFilledCount(2); setDirection('up'); }
-        else { setFilledCount(1); setDirection('up'); }
-      } catch { setFilledCount(1); setDirection('up'); }
+      setFilledCount(SS_FILLED[status] ?? 0);
+      setDirection(status === 'mastered' ? 'down' : 'up');
     });
     return () => { cancelled = true; };
   }, [status, wordId]);
 
   const handleClick = useCallback((e: React.MouseEvent) => {
     e.stopPropagation();
-    try {
-      if (direction === 'up') {
-        if (filledCount === 0) { localStorage.setItem(STATUS_MID_PREFIX + wordId, '0'); setFilledCount(1); onStatusChange('review'); }
-        else if (filledCount === 1) { localStorage.setItem(STATUS_MID_PREFIX + wordId, '1'); setFilledCount(2); }
-        else if (filledCount === 2) { localStorage.removeItem(STATUS_MID_PREFIX + wordId); setFilledCount(3); setDirection('down'); onStatusChange('mastered'); }
-      } else {
-        if (filledCount === 3) { localStorage.setItem(STATUS_MID_PREFIX + wordId, 'down2'); setFilledCount(2); onStatusChange('review'); }
-        else if (filledCount === 2) { localStorage.setItem(STATUS_MID_PREFIX + wordId, 'down1'); setFilledCount(1); }
-        else if (filledCount === 1) { localStorage.removeItem(STATUS_MID_PREFIX + wordId); setFilledCount(0); setDirection('up'); onStatusChange('new'); }
+    if (direction === 'up') {
+      if (filledCount < 3) {
+        const next = filledCount + 1;
+        setFilledCount(next);
+        if (next === 3) setDirection('down');
+        onStatusChange(SS_STATUS[next]);
       }
-    } catch { /* localStorage unavailable */ }
-  }, [filledCount, direction, onStatusChange, wordId]);
+    } else {
+      if (filledCount > 0) {
+        const next = filledCount - 1;
+        setFilledCount(next);
+        if (next === 0) setDirection('up');
+        onStatusChange(SS_STATUS[next]);
+      }
+    }
+  }, [filledCount, direction, onStatusChange]);
 
   return (
     <button type="button" onClick={handleClick}
-      aria-label={`ステータス: ${status === 'new' ? '未学習' : status === 'review' ? '学習中' : '習得済み'}`}
+      aria-label={`ステータス: ${SS_ARIA[status] ?? status}`}
       className="shrink-0 rounded transition-colors active:bg-[rgba(26,26,26,0.06)]"
     >
       <div className="flex flex-col gap-[1.5px]">
@@ -260,6 +252,7 @@ export function ProjectDetailSheet({ projectId, onClose }: { projectId: string; 
     return {
       total: summary.total,
       mastered: summary.mastered,
+      active: summary.active,
       learning: summary.learning,
       newCount: summary.unlearned,
     };
@@ -395,7 +388,7 @@ export function ProjectDetailSheet({ projectId, onClose }: { projectId: string; 
           {/* Stats bar */}
           {project && (
             <div className="px-5 pb-3">
-              <StackedBar total={counts.total} m={counts.mastered} l={counts.learning} n={counts.newCount} />
+              <StackedBar total={counts.total} m={counts.mastered} a={counts.active} l={counts.learning} n={counts.newCount} />
             </div>
           )}
 

--- a/src/lib/desktop-study-summary.ts
+++ b/src/lib/desktop-study-summary.ts
@@ -10,6 +10,7 @@ export type DesktopStudySummaryStats = {
   streakDays: number;
   totalWords: number;
   mastered: number;
+  activeW: number;
   review: number;
   newW: number;
 };
@@ -20,6 +21,7 @@ export const EMPTY_DESKTOP_STUDY_SUMMARY: DesktopStudySummaryStats = {
   streakDays: 0,
   totalWords: 0,
   mastered: 0,
+  activeW: 0,
   review: 0,
   newW: 0,
 };
@@ -35,6 +37,7 @@ export function buildDesktopStudySummaryStats(words: Word[]): DesktopStudySummar
     streakDays: getStreakDays(),
     totalWords: memorySummary.total,
     mastered: statusCounts.masteredTotal,
+    activeW: statusCounts.activeTotal,
     review: statusCounts.learningTotal,
     newW: statusCounts.unlearnedTotal,
   };

--- a/src/lib/home/home-page-selectors.test.ts
+++ b/src/lib/home/home-page-selectors.test.ts
@@ -46,6 +46,7 @@ test('countHomeWordStatuses counts mastered, review, and unlearned words', () =>
 
   assert.deepEqual(counts, {
     masteredTotal: 2,
+    activeTotal: 0,
     learningTotal: 1,
     unlearnedTotal: 2,
   });

--- a/src/lib/home/home-page-selectors.ts
+++ b/src/lib/home/home-page-selectors.ts
@@ -3,6 +3,7 @@ import { summarizeWordMemory } from '@/lib/words/memory';
 
 export interface HomeWordStatusCounts {
   masteredTotal: number;
+  activeTotal: number;
   learningTotal: number;
   unlearnedTotal: number;
 }
@@ -29,6 +30,7 @@ export function countHomeWordStatuses(words: readonly Partial<Word>[]): HomeWord
 
   return {
     masteredTotal: summary.mastered,
+    activeTotal: summary.active,
     learningTotal: summary.learning,
     unlearnedTotal: summary.unlearned,
   };

--- a/src/lib/profile/stats-server.ts
+++ b/src/lib/profile/stats-server.ts
@@ -105,6 +105,7 @@ export async function getPublicUserStats(
       totalProjects: s.total_projects ?? 0,
       totalWords: s.total_words ?? 0,
       masteredWords: s.mastered_words ?? 0,
+      activeWords: s.active_words ?? 0,
       reviewWords: s.review_words ?? 0,
       newWords: s.new_words ?? 0,
       favoriteWords: s.favorite_words ?? 0,

--- a/src/lib/project/project-page-selectors.test.ts
+++ b/src/lib/project/project-page-selectors.test.ts
@@ -94,6 +94,7 @@ test('countProjectWordStats counts mastered, review, new, and missing status wor
   assert.deepEqual(stats, {
     total: 4,
     mastered: 1,
+    active: 0,
     learning: 1,
     unlearned: 2,
   });
@@ -124,6 +125,7 @@ test('countProjectWordStats treats distinct sense progress as one memory-rate wo
   assert.deepEqual(stats, {
     total: 1,
     mastered: 0,
+    active: 0,
     learning: 1,
     unlearned: 0,
   });

--- a/src/lib/project/project-page-selectors.ts
+++ b/src/lib/project/project-page-selectors.ts
@@ -7,6 +7,7 @@ export type ProjectWordActivenessFilter = 'all' | 'active' | 'passive';
 export interface ProjectWordStats {
   total: number;
   mastered: number;
+  active: number;
   learning: number;
   unlearned: number;
 }
@@ -40,7 +41,8 @@ export interface ProjectPageWord {
 const STATUS_SORT_ORDER: Record<WordStatus, number> = {
   new: 0,
   review: 1,
-  mastered: 2,
+  active: 2,
+  mastered: 3,
 };
 
 const POS_LABELS: Record<string, string> = {
@@ -68,6 +70,7 @@ export function countProjectWordStats(words: readonly Partial<ProjectPageWord>[]
   return {
     total: summary.total,
     mastered: summary.mastered,
+    active: summary.active,
     learning: summary.learning,
     unlearned: summary.unlearned,
   };

--- a/src/lib/quiz/quiz-answer.test.ts
+++ b/src/lib/quiz/quiz-answer.test.ts
@@ -52,7 +52,7 @@ test('buildQuizAnswerOutcomePlan builds update payload for correct answers', () 
     recordProjectId: 'project-record',
   });
 
-  assert.equal(plan.wordUpdates.status, 'mastered');
+  assert.equal(plan.wordUpdates.status, 'active');
   assert.equal(plan.wordUpdates.repetition, 2);
   assert.equal(plan.wrongAnswer, undefined);
 });

--- a/src/lib/spaced-repetition.test.ts
+++ b/src/lib/spaced-repetition.test.ts
@@ -48,6 +48,7 @@ test('calculateNextReview remains compatible with boolean API', () => {
 test('getStatusAfterQuality treats low quality as failed recall', () => {
   assert.equal(getStatusAfterQuality('new', 2), 'new');
   assert.equal(getStatusAfterQuality('review', 2), 'new');
-  assert.equal(getStatusAfterQuality('mastered', 2), 'review');
+  assert.equal(getStatusAfterQuality('active', 2), 'review');
+  assert.equal(getStatusAfterQuality('mastered', 2), 'active');
   assert.equal(getStatusAfterQuality('review', 3), 'review');
 });

--- a/src/lib/spaced-repetition.ts
+++ b/src/lib/spaced-repetition.ts
@@ -59,19 +59,24 @@ export function getStatusAfterQuality(currentStatus: WordStatus, qualityInput: n
   const quality = clampQuality(qualityInput);
 
   if (quality <= 2) {
-    if (currentStatus === 'mastered') return 'review';
+    if (currentStatus === 'mastered') return 'active';
+    if (currentStatus === 'active') return 'review';
     return 'new';
   }
 
   if (quality === 3) {
-    return 'review';
+    if (currentStatus === 'new') return 'review';
+    return currentStatus;
   }
 
   if (quality === 4) {
     if (currentStatus === 'new') return 'review';
+    if (currentStatus === 'review') return 'active';
     return 'mastered';
   }
 
+  if (currentStatus === 'new') return 'review';
+  if (currentStatus === 'review') return 'active';
   return 'mastered';
 }
 
@@ -144,16 +149,18 @@ export function calculateNextReviewByQuality(
 /**
  * Determine the next word status based on whether the answer was correct.
  *
- * Correct: new -> review -> mastered (stays mastered)
- * Wrong:   mastered -> review -> new (stays new)
+ * Correct: new -> review -> active -> mastered (stays mastered)
+ * Wrong:   mastered -> active -> review -> new (stays new)
  */
 export function getStatusAfterAnswer(currentStatus: WordStatus, isCorrect: boolean): WordStatus {
   if (isCorrect) {
     if (currentStatus === 'new') return 'review';
-    if (currentStatus === 'review') return 'mastered';
+    if (currentStatus === 'review') return 'active';
+    if (currentStatus === 'active') return 'mastered';
     return 'mastered';
   }
-  if (currentStatus === 'mastered') return 'review';
+  if (currentStatus === 'mastered') return 'active';
+  if (currentStatus === 'active') return 'review';
   if (currentStatus === 'review') return 'new';
   return 'new';
 }
@@ -194,7 +201,8 @@ export function getReviewCount(words: Word[]): number {
 const STATUS_PRIORITY: Record<Word['status'], number> = {
   new: 0,
   review: 1,
-  mastered: 2,
+  active: 2,
+  mastered: 3,
 };
 
 function getReviewBucket(word: Word, nowMs: number): number {

--- a/src/lib/stats-cache.ts
+++ b/src/lib/stats-cache.ts
@@ -26,6 +26,7 @@ export interface CachedStats {
   totalProjects: number;
   totalWords: number;
   masteredWords: number;
+  activeWords: number;
   reviewWords: number;
   newWords: number;
   favoriteWords: number;
@@ -305,6 +306,7 @@ async function fetchStatsViaRpc(userId: string): Promise<{
   totalProjects: number;
   totalWords: number;
   masteredWords: number;
+  activeWords: number;
   reviewWords: number;
   newWords: number;
   favoriteWords: number;
@@ -318,6 +320,7 @@ async function fetchStatsViaRpc(userId: string): Promise<{
     totalProjects: data.total_projects ?? 0,
     totalWords: data.total_words ?? 0,
     masteredWords: data.mastered_words ?? 0,
+    activeWords: data.active_words ?? 0,
     reviewWords: data.review_words ?? 0,
     newWords: data.new_words ?? 0,
     favoriteWords: data.favorite_words ?? 0,
@@ -357,6 +360,7 @@ function buildStatsFromHomeCache(): {
   totalProjects: number;
   totalWords: number;
   masteredWords: number;
+  activeWords: number;
   reviewWords: number;
   newWords: number;
   favoriteWords: number;
@@ -383,6 +387,7 @@ function buildStatsFromHomeCache(): {
     totalProjects: projects.length,
     totalWords: memorySummary.total,
     masteredWords: memorySummary.mastered,
+    activeWords: memorySummary.active,
     reviewWords: memorySummary.learning,
     newWords: memorySummary.unlearned,
     favoriteWords,
@@ -409,6 +414,7 @@ async function fetchStatsData(
       totalProjects: number;
       totalWords: number;
       masteredWords: number;
+      activeWords: number;
       reviewWords: number;
       newWords: number;
       favoriteWords: number;
@@ -428,6 +434,7 @@ async function fetchStatsData(
           totalProjects: projects.length,
           totalWords: memorySummary.total,
           masteredWords: memorySummary.mastered,
+          activeWords: memorySummary.active,
           reviewWords: memorySummary.learning,
           newWords: memorySummary.unlearned,
           favoriteWords: allWords.filter((word) => word.isFavorite).length,
@@ -480,6 +487,7 @@ async function fetchStatsData(
           totalProjects: projects.length,
           totalWords: memorySummary.total,
           masteredWords: memorySummary.mastered,
+          activeWords: memorySummary.active,
           reviewWords: memorySummary.learning,
           newWords: memorySummary.unlearned,
           favoriteWords,

--- a/src/lib/words/memory.test.ts
+++ b/src/lib/words/memory.test.ts
@@ -47,6 +47,7 @@ test('groupWordsByMemory collapses explicit distinct senses into one memory grou
   assert.deepEqual(summarizeWordMemory(words), {
     total: 1,
     mastered: 0,
+    active: 0,
     learning: 1,
     unlearned: 0,
   });

--- a/src/lib/words/memory.ts
+++ b/src/lib/words/memory.ts
@@ -43,20 +43,23 @@ export interface WordMemoryGroup<T extends WordMemoryInput = WordMemoryInput> {
 export interface WordMemorySummary {
   total: number;
   mastered: number;
+  active: number;
   learning: number;
   unlearned: number;
 }
 
 const STATUS_MEMORY_RATE: Record<WordStatus, number> = {
   new: 0,
-  review: 50,
+  review: 33,
+  active: 66,
   mastered: 100,
 };
 
 const STATUS_RANK: Record<WordStatus, number> = {
   new: 0,
   review: 1,
-  mastered: 2,
+  active: 2,
+  mastered: 3,
 };
 
 function normalizeKeyPart(value: string | undefined): string {
@@ -69,6 +72,7 @@ export function getWordMemoryRate(word: Pick<WordMemoryInput, 'status'>): number
 
 export function getMemoryStatusFromRate(rate: number): WordStatus {
   if (rate >= 100) return 'mastered';
+  if (rate >= 66) return 'active';
   if (rate <= 0) return 'new';
   return 'review';
 }
@@ -244,6 +248,7 @@ export function summarizeWordMemory(words: readonly WordMemoryInput[]): WordMemo
   const summary: WordMemorySummary = {
     total: 0,
     mastered: 0,
+    active: 0,
     learning: 0,
     unlearned: 0,
   };
@@ -251,6 +256,7 @@ export function summarizeWordMemory(words: readonly WordMemoryInput[]): WordMemo
   for (const group of groupWordsByMemory(words)) {
     summary.total += 1;
     if (group.status === 'mastered') summary.mastered += 1;
+    else if (group.status === 'active') summary.active += 1;
     else if (group.status === 'review') summary.learning += 1;
     else summary.unlearned += 1;
   }

--- a/supabase/migrations/20260628090000_add_active_word_status.sql
+++ b/supabase/migrations/20260628090000_add_active_word_status.sql
@@ -1,0 +1,11 @@
+-- Add 'active' to word status enum (between 'review' and 'mastered')
+-- Words must now pass through 'active' before reaching 'mastered'
+
+ALTER TABLE words DROP CONSTRAINT IF EXISTS words_status_check;
+ALTER TABLE words ADD CONSTRAINT words_status_check
+  CHECK (status IN ('new', 'review', 'active', 'mastered'));
+
+-- Also update word_translations if it has a status constraint
+ALTER TABLE word_translations DROP CONSTRAINT IF EXISTS word_translations_status_check;
+ALTER TABLE word_translations ADD CONSTRAINT word_translations_status_check
+  CHECK (status IN ('new', 'review', 'active', 'mastered'));


### PR DESCRIPTION
## Summary

- Adds a new `active` (定着中) word status between `review` and `mastered`, requiring words to pass through Active before reaching Mastered
- Status progression is now: `new` → `review` → `active` → `mastered` (correct answers promote one step, wrong answers demote one step)
- Updates SM-2 spaced repetition transitions, memory rate calculations (0/33/66/100 for 4 statuses), and all UI components (NotionCheckbox, StatusSquares, StackedBar, StatusPill, stats displays)
- Includes database migration adding `'active'` to CHECK constraints on `words` and `word_translations` tables

## Changes

- **Core logic**: `spaced-repetition.ts` — updated `getStatusAfterAnswer`, `getStatusAfterQuality`, `STATUS_PRIORITY` for 4-status state machine
- **Memory**: `words/memory.ts` — adjusted `STATUS_MEMORY_RATE` (0/33/66/100), `STATUS_RANK`, `WordMemorySummary`, `getMemoryStatusFromRate`, `summarizeWordMemory`
- **Types**: `shared/types/index.ts` — `WordStatus` union now includes `'active'`; `shared/db/mappers.ts` — `normalizeWordStatus` accepts `'active'`
- **UI**: Updated all status displays across mobile and desktop (home, project, favorites, flashcard, stats pages) with blue (#3b82f6) color for Active
- **Simplified components**: `NotionCheckbox` and `StatusSquares` rewritten with direct status↔filledCount lookup tables (removed localStorage intermediate state)
- **Stats/cache**: `stats-cache.ts`, `home-page-selectors.ts`, `project-page-selectors.ts`, `desktop-study-summary.ts`, `stats-server.ts` — added `activeWords`/`active`/`activeTotal`/`activeW` fields
- **DB migration**: `20260628090000_add_active_word_status.sql`
- **Tests**: All 646 tests pass with updated assertions

## Test plan

- [x] All 646 unit tests pass (`npm test`)
- [ ] Verify quiz flow: answering correctly twice promotes new → review → active (not straight to mastered)
- [ ] Verify wrong answer demotes: mastered → active → review → new
- [ ] Verify NotionCheckbox cycles through all 4 states visually
- [ ] Verify StackedBar shows 4 segments (gray/yellow/blue/green)
- [ ] Run database migration on Supabase and verify CHECK constraint accepts 'active'

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015sDnNnhWMefqyWDYjrWAjJ

---
_Generated by [Claude Code](https://claude.ai/code/session_015sDnNnhWMefqyWDYjrWAjJ)_