### PR TITLE
定着中クイズをタイプ入力に変更 & ステータス色線追加

### DIFF
--- a/src/app/desktop.css
+++ b/src/app/desktop.css
@@ -183,7 +183,7 @@
 /* status dot */
 .ds-sdot { width: 8px; height: 8px; border-radius: 50%; display: inline-block; flex-shrink: 0; }
 .c-mastered { background: var(--color-success); }
-.c-active { background: #3b82f6; }
+.c-active { background: #2563eb; }
 .c-review { background: var(--color-warning); }
 .c-new { background: var(--color-border); }
 .c-wrong { background: var(--color-error); }

--- a/src/app/favorites/page.tsx
+++ b/src/app/favorites/page.tsx
@@ -30,7 +30,7 @@ function StatusPill({ kind }: { kind: Word['status'] }) {
   const config = {
     new: { t: '未学習', bg: '#fff', fg: 'var(--color-muted)', bd: 'var(--color-border)' },
     review: { t: '学習中', bg: 'rgba(19,127,236,0.1)', fg: '#137fec', bd: '#137fec' },
-    active: { t: '定着中', bg: 'rgba(59,130,246,0.1)', fg: '#3b82f6', bd: '#3b82f6' },
+    active: { t: '定着中', bg: 'rgba(37,99,235,0.1)', fg: '#2563eb', bd: '#2563eb' },
     mastered: { t: '習得', bg: 'rgba(61,122,78,0.12)', fg: 'var(--color-success)', bd: 'var(--color-success)' },
   }[kind];
 
@@ -259,14 +259,14 @@ function FavoritesPageContent() {
 
                 <div className="mt-3 flex h-1.5 overflow-hidden rounded-sm border border-[var(--color-border)]">
                   <div style={{ flex: counts.mastered, background: 'var(--color-success)' }} />
-                  <div style={{ flex: counts.active, background: '#3b82f6' }} />
+                  <div style={{ flex: counts.active, background: '#2563eb' }} />
                   <div style={{ flex: counts.review, background: '#137fec' }} />
                   <div style={{ flex: counts.newCount, background: 'rgba(26,26,26,0.15)' }} />
                 </div>
 
                 <div className="mt-2 flex flex-wrap gap-3 font-mono text-[10px]">
                   <span className="font-bold text-[var(--color-success)]">● 習得 {counts.mastered}</span>
-                  <span className="font-bold text-[#3b82f6]">● 定着中 {counts.active}</span>
+                  <span className="font-bold text-[#2563eb]">● 定着中 {counts.active}</span>
                   <span className="font-bold text-[#137fec]">● 学習中 {counts.review}</span>
                   <span className="font-bold text-[var(--color-muted)]">● 未学習 {counts.newCount}</span>
                 </div>

--- a/src/app/flashcard/[projectId]/page.tsx
+++ b/src/app/flashcard/[projectId]/page.tsx
@@ -521,7 +521,7 @@ export default function FlashcardPage() {
   /* Status label */
   const statusLabel = (s: string) => ({ new: '未学習', review: '学習中', active: '定着中', mastered: '習得' }[s] ?? s);
   const statusColor = (s: string) =>
-    s === 'mastered' ? 'var(--color-success)' : s === 'active' ? '#3b82f6' : s === 'review' ? '#137fec' : 'var(--color-muted)';
+    s === 'mastered' ? 'var(--color-success)' : s === 'active' ? '#2563eb' : s === 'review' ? '#137fec' : 'var(--color-muted)';
 
   /* ---------- Loading ---------- */
   if (loading) {

--- a/src/app/project/[id]/page.tsx
+++ b/src/app/project/[id]/page.tsx
@@ -1665,13 +1665,13 @@ function StackedBar({ total, m, a, l, n }: { total: number; m: number; a: number
     <div>
       <div className="flex h-2.5 overflow-hidden rounded-full border-2 border-[var(--solid-ink)] bg-white">
         <div style={{ width: `${pctM}%`, background: 'var(--color-success)' }} />
-        <div style={{ width: `${pctA}%`, background: '#3b82f6' }} />
+        <div style={{ width: `${pctA}%`, background: '#2563eb' }} />
         <div style={{ width: `${pctL}%`, background: 'var(--color-warning)' }} />
         <div style={{ width: `${pctN}%`, background: 'rgba(26,26,26,0.12)' }} />
       </div>
       <div className="mt-[7px] flex flex-wrap gap-3.5 font-[var(--font-body)]">
         <BarDot color="var(--color-success)" label="習得" count={m} />
-        <BarDot color="#3b82f6" label="定着中" count={a} />
+        <BarDot color="#2563eb" label="定着中" count={a} />
         <BarDot color="var(--color-warning)" label="学習中" count={l} />
         <BarDot color="rgba(26,26,26,0.35)" label="未学習" count={n} />
       </div>
@@ -1714,6 +1714,12 @@ function posShort(tag: string): string {
 const PP_FILLED: Record<WordStatus, number> = { new: 0, review: 1, active: 2, mastered: 3 };
 const PP_STATUS: WordStatus[] = ['new', 'review', 'active', 'mastered'];
 const PP_ARIA: Record<WordStatus, string> = { new: '未学習', review: '学習中', active: '定着中', mastered: '習得済み' };
+const STATUS_LINE_COLOR: Record<WordStatus, string> = {
+  new: 'rgba(26,26,26,0.12)',
+  review: 'var(--color-warning)',
+  active: '#2563eb',
+  mastered: 'var(--color-success)',
+};
 
 function StatusSquares({
   wordId,
@@ -1782,7 +1788,7 @@ function StatusPill({ kind }: { kind: WordStatus }) {
   const config = {
     new: { t: '未学習', bg: '#fff', fg: 'var(--color-muted)', bd: 'var(--color-border)' },
     review: { t: '学習中', bg: 'rgba(19,127,236,0.1)', fg: '#137fec', bd: '#137fec' },
-    active: { t: '定着中', bg: 'rgba(59,130,246,0.1)', fg: '#3b82f6', bd: '#3b82f6' },
+    active: { t: '定着中', bg: 'rgba(37,99,235,0.1)', fg: '#2563eb', bd: '#2563eb' },
     mastered: { t: '習得', bg: 'rgba(61,122,78,0.12)', fg: 'var(--color-success)', bd: 'var(--color-success)' },
   }[kind];
 
@@ -1850,6 +1856,7 @@ function WordRow({
           <VocabularyTypeBadge vocabularyType={word.vocabularyType} />
           <BookmarkBadge active={word.isFavorite} />
         </div>
+        <div className="mt-1.5 h-[3px] rounded-full" style={{ background: STATUS_LINE_COLOR[displayStatus] }} />
       </button>
     );
   }
@@ -1884,6 +1891,7 @@ function WordRow({
           <Icon name="bookmark" size={22} filled={word.isFavorite} />
         </button>
       </div>
+      <div className="mt-1.5 h-[3px] rounded-full" style={{ background: STATUS_LINE_COLOR[displayStatus] }} />
     </div>
   );
 }

--- a/src/app/quiz/[projectId]/page.tsx
+++ b/src/app/quiz/[projectId]/page.tsx
@@ -1007,7 +1007,13 @@ export default function QuizPage() {
   const currentQuestion = questions[currentIndex];
   const currentIsWordOrder = isWordOrderQuestion(currentQuestion);
   const isActiveVocab = !currentIsWordOrder && currentQuestion?.word.vocabularyType === 'active';
-  const typeInExpectedAnswer = currentQuestion?.word.english ?? '';
+  const isActiveStatus = !currentIsWordOrder && !isActiveVocab && currentQuestion?.word.status === 'active';
+  const isTypeInMode = isActiveVocab || isActiveStatus;
+  const typeInExpectedAnswer = isActiveVocab
+    ? (currentQuestion?.word.english ?? '')
+    : quizDirection === 'en-to-ja'
+      ? (currentQuestion?.word.japanese ?? '')
+      : (currentQuestion?.word.english ?? '');
 
   const applyAnswerOutcome = async (word: Word, isCorrect: boolean, marker?: QuizAnswerResult) => {
     playAnswerFeedbackSound(isCorrect);
@@ -1091,7 +1097,7 @@ export default function QuizPage() {
   };
 
   const handleSkip = async () => {
-    if (isRevealed || selectedIndex !== null || !isMultipleChoiceQuestion(currentQuestion) || isActiveVocab) return;
+    if (isRevealed || selectedIndex !== null || !isMultipleChoiceQuestion(currentQuestion) || isTypeInMode) return;
     setIsRevealed(true);
     await applyAnswerOutcome(currentQuestion.word, false, 'skip');
   };
@@ -1424,18 +1430,22 @@ export default function QuizPage() {
           ? currentIsWordOrder ? '保存済み単語 · 語順クイズ' : '保存済み単語 · 4択クイズ'
       : currentIsWordOrder
         ? '語順クイズ'
-        : isActiveVocab
+        : isTypeInMode
           ? 'タイプ入力'
           : '4択クイズ';
   const displayJapanese = currentQuestion ? formatJapaneseForDisplay(currentQuestion.word) : undefined;
   const desktopPrompt = currentIsWordOrder
     ? displayJapanese
-    : isActiveVocab
-      ? displayJapanese
+    : isTypeInMode
+      ? (isActiveVocab
+          ? displayJapanese
+          : quizDirection === 'en-to-ja'
+            ? currentQuestion?.word.english
+            : displayJapanese)
       : quizDirection === 'en-to-ja'
         ? currentQuestion?.word.english
         : displayJapanese;
-  const desktopPhonetic = !currentIsWordOrder && !isActiveVocab
+  const desktopPhonetic = !currentIsWordOrder && !isTypeInMode
     ? currentQuestion?.word.pronunciation
     : '';
   const desktopPartOfSpeechLabel = isActiveVocab
@@ -1449,7 +1459,7 @@ export default function QuizPage() {
   const desktopAnswerWrong = typeInResult === 'wrong' || desktopMultipleChoiceWrong || wordOrderResult === 'wrong';
   const desktopCorrectAnswer = currentIsWordOrder
     ? null
-    : isActiveVocab
+    : isTypeInMode
       ? typeInExpectedAnswer
       : isMultipleChoiceQuestion(currentQuestion)
         ? currentQuestion.options[currentQuestion.correctIndex] ?? currentQuestion.word.english
@@ -1503,7 +1513,7 @@ export default function QuizPage() {
             onSelectToken={handleWordOrderTokenSelect}
             onRemoveToken={handleWordOrderTokenRemove}
           />
-        ) : !isActiveVocab && isMultipleChoiceQuestion(currentQuestion) ? (
+        ) : !isTypeInMode && isMultipleChoiceQuestion(currentQuestion) ? (
           <div className="ds-qopts">
             {currentQuestion.options.map((option, i) => {
               let cls = 'ds-qopt';
@@ -1632,9 +1642,9 @@ export default function QuizPage() {
           ) : (
             <>
               <span className="muted mono" style={{ fontSize: 12 }}>
-                {isActiveVocab ? '英単語を入力してください' : '意味として正しいものを選んでください'}
+                {isTypeInMode ? '答えを入力してください' : '意味として正しいものを選んでください'}
               </span>
-              {!isActiveVocab && !currentIsWordOrder && (
+              {!isTypeInMode && !currentIsWordOrder && (
                 <button type="button" className="ds-btn ghost" onClick={handleSkip} style={{ marginLeft: 'auto' }}>
                   わからない
                 </button>
@@ -1701,7 +1711,7 @@ export default function QuizPage() {
       {/* Main content */}
       <div className="flex min-h-0 flex-1 flex-col overflow-y-auto overscroll-contain px-5 pt-2.5">
         <div className="mb-1.5 font-mono text-[10px] font-bold uppercase tracking-[0.08em] text-[var(--color-muted)]">
-          {currentIsWordOrder ? '語順を完成' : isActiveVocab ? 'タイプ入力' : '意味を選ぼう'}
+          {currentIsWordOrder ? '語順を完成' : isTypeInMode ? 'タイプ入力' : '意味を選ぼう'}
         </div>
 
         {/* Word display — big solid plate */}
@@ -1710,13 +1720,17 @@ export default function QuizPage() {
             <div className="font-display text-[34px] font-extrabold leading-[1.1] tracking-[-0.01em] text-[var(--solid-ink)]">
               {currentIsWordOrder
                 ? displayJapanese
-                : isActiveVocab
-                  ? displayJapanese
+                : isTypeInMode
+                  ? (isActiveVocab
+                      ? displayJapanese
+                      : quizDirection === 'en-to-ja'
+                        ? currentQuestion?.word.english
+                        : displayJapanese)
                   : quizDirection === 'en-to-ja'
                     ? currentQuestion?.word.english
                     : displayJapanese}
             </div>
-            {!isActiveVocab && !currentIsWordOrder && (
+            {!isTypeInMode && !currentIsWordOrder && (
               <div className="mt-2.5 flex justify-center">
                 <button
                   type="button"
@@ -1748,7 +1762,7 @@ export default function QuizPage() {
             onRemoveToken={handleWordOrderTokenRemove}
             onSubmit={handleWordOrderSubmit}
           />
-        ) : !isActiveVocab && isMultipleChoiceQuestion(currentQuestion) ? (
+        ) : !isTypeInMode && isMultipleChoiceQuestion(currentQuestion) ? (
           <div className="mt-[18px] flex flex-col gap-2">
             {currentQuestion?.options.map((option, i) => (
               <DSQuizOption

--- a/src/components/project/ProjectDetailSheet.tsx
+++ b/src/components/project/ProjectDetailSheet.tsx
@@ -52,12 +52,12 @@ function StackedBar({ total, m, a, l, n }: { total: number; m: number; a: number
     <div>
       <div className="flex h-2.5 overflow-hidden rounded-full border-2 border-[var(--solid-ink)] bg-white">
         <div style={{ width: `${pctM}%`, background: 'var(--color-success)' }} />
-        <div style={{ width: `${pctA}%`, background: '#3b82f6' }} />
+        <div style={{ width: `${pctA}%`, background: '#2563eb' }} />
         <div style={{ width: `${pctL}%`, background: 'var(--color-warning)' }} />
         <div style={{ width: `${pctN}%`, background: 'rgba(26,26,26,0.12)' }} />
       </div>
       <div className="mt-[7px] flex flex-wrap gap-3.5">
-        {[['var(--color-success)', '習得', m], ['#3b82f6', '定着中', a], ['var(--color-warning)', '学習中', l], ['rgba(26,26,26,0.35)', '未学習', n]].map(([color, label, count]) => (
+        {[['var(--color-success)', '習得', m], ['#2563eb', '定着中', a], ['var(--color-warning)', '学習中', l], ['rgba(26,26,26,0.35)', '未学習', n]].map(([color, label, count]) => (
           <span key={label as string} className="inline-flex items-center gap-[5px]">
             <span className="h-[7px] w-[7px] rounded-[3.5px]" style={{ background: color as string }} />
             <span className="text-[11px] font-semibold text-[#4a4a4a]">{label as string}</span>
@@ -72,6 +72,12 @@ function StackedBar({ total, m, a, l, n }: { total: number; m: number; a: number
 const SS_FILLED: Record<WordStatus, number> = { new: 0, review: 1, active: 2, mastered: 3 };
 const SS_STATUS: WordStatus[] = ['new', 'review', 'active', 'mastered'];
 const SS_ARIA: Record<WordStatus, string> = { new: '未学習', review: '学習中', active: '定着中', mastered: '習得済み' };
+const SS_LINE_COLOR: Record<WordStatus, string> = {
+  new: 'rgba(26,26,26,0.12)',
+  review: 'var(--color-warning)',
+  active: '#2563eb',
+  mastered: 'var(--color-success)',
+};
 
 function StatusSquares({ wordId, status, onStatusChange }: {
   wordId: string; status: WordStatus; onStatusChange: (s: WordStatus) => void;
@@ -135,7 +141,7 @@ function WordRow({ word, memoryGroup, onCycleStatus, onCycleVocabularyType, onTo
   return (
     <div className="relative">
       <div className="absolute inset-0 rounded-xl bg-[var(--solid-ink)]" style={{ transform: 'translate(2px, 2px)' }} />
-      <div className="relative rounded-xl border-2 border-[var(--solid-ink)] bg-white px-[13px] py-2">
+      <div className="relative overflow-hidden rounded-xl border-2 border-[var(--solid-ink)] bg-white px-[13px] py-2">
         <div className="flex items-center gap-2.5">
           <StatusSquares wordId={word.id} status={displayStatus} onStatusChange={onCycleStatus} />
           <Link href={`/word/${word.id}?from=${encodeURIComponent('/projects')}`} className="min-w-0 flex-1">
@@ -157,6 +163,7 @@ function WordRow({ word, memoryGroup, onCycleStatus, onCycleVocabularyType, onTo
             <Icon name="bookmark" size={18} filled={word.isFavorite} />
           </button>
         </div>
+        <div className="absolute inset-x-0 bottom-0 h-[3px]" style={{ background: SS_LINE_COLOR[displayStatus] }} />
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary

- 定着中（active status）の単語はクイズで四択ではなくタイプ入力を要求するように変更。習得への昇格には答えを正しく入力する必要がある
- 各単語行の下部にステータスを示す色付き線（3px）を追加：緑=習得、青=定着中、オレンジ=学習中、グレー=未学習
- 定着中の青色を `#3b82f6` → `#2563eb` に深化（全コンポーネント統一）

## Changes

- **`src/app/quiz/[projectId]/page.tsx`**: `isActiveStatus` / `isTypeInMode` を導入。`status === 'active'` の単語でタイプ入力モードを強制。`vocabularyType === 'active'` 固有の挙動（常に英語回答、スペース正規化）はそのまま維持
- **`src/app/project/[id]/page.tsx`**: `STATUS_LINE_COLOR` マップ追加、WordRow の下部にステータス色線を表示。StackedBar・StatusPill の定着中色を `#2563eb` に更新
- **`src/components/project/ProjectDetailSheet.tsx`**: WordRow にステータス色線追加、StackedBar の定着中色を更新
- **`src/app/favorites/page.tsx`**: 定着中の色を `#2563eb` に統一
- **`src/app/flashcard/[projectId]/page.tsx`**: 定着中の色を `#2563eb` に統一
- **`src/app/desktop.css`**: `.c-active` の色を `#2563eb` に更新

## Test plan

- [x] 全646テスト通過（`npm test`）
- [x] TypeScript型チェック通過（`tsc --noEmit`）
- [ ] 定着中の単語がクイズでタイプ入力になることを確認
- [ ] 四択が表示されないことを確認
- [ ] 単語行の下に色付き線が表示されることを確認
- [ ] 各ステータスの色が正しいことを確認（緑/青/オレンジ/グレー）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015sDnNnhWMefqyWDYjrWAjJ

---
_Generated by [Claude Code](https://claude.ai/code/session_015sDnNnhWMefqyWDYjrWAjJ)_