### PR TITLE
単語帳カードのステータス表示をバーに変更

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1347,11 +1347,14 @@ function ProjectRow({ project }: { project: HomeProjectStats }) {
               <span className="font-display text-lg font-extrabold tabular-nums text-[var(--solid-ink)]">{project.totalWords}</span>
               <span className="ml-px text-[11px] font-bold text-[var(--color-muted)]">語</span>
             </div>
-            <div className="mt-[3px] flex gap-2.5">
-              <DotLabel color="var(--color-success)" label={`習得 ${project.masteredWords}`} />
-              <DotLabel color="var(--color-warning)" label={`学習 ${project.reviewWords}`} />
-              <DotLabel color="rgba(26,26,26,0.2)" label={`未 ${project.newWords}`} />
-            </div>
+            {project.totalWords > 0 && (
+              <div className="mt-[5px] flex h-[4px] overflow-hidden rounded-full bg-[rgba(26,26,26,0.08)]">
+                {project.masteredWords > 0 && <div style={{ flex: project.masteredWords, background: 'var(--color-success)' }} />}
+                {project.activeWords > 0 && <div style={{ flex: project.activeWords, background: '#2563eb' }} />}
+                {project.reviewWords > 0 && <div style={{ flex: project.reviewWords, background: 'var(--color-warning)' }} />}
+                {project.newWords > 0 && <div style={{ flex: project.newWords, background: 'rgba(26,26,26,0.12)' }} />}
+              </div>
+            )}
           </div>
         </Link>
         {hasWords && (

--- a/src/app/projects/page.legacy.tsx
+++ b/src/app/projects/page.legacy.tsx
@@ -37,6 +37,7 @@ function withEmptyStats(projects: Project[]): ProjectWithStats[] {
     ...project,
     totalWords: 0,
     masteredWords: 0,
+    activeWords: 0,
     progress: 0,
     lastUsedAt: null,
   }));

--- a/src/components/project/ProjectCard.tsx
+++ b/src/components/project/ProjectCard.tsx
@@ -51,6 +51,7 @@ export function ProjectCard(props: ProjectCardProps) {
 
   let total: number;
   let mastered: number;
+  let active: number;
   let learning: number;
   let unlearned: number;
 
@@ -58,11 +59,13 @@ export function ProjectCard(props: ProjectCardProps) {
     const summary = summarizeWordMemory(props.words);
     total = summary.total;
     mastered = summary.mastered;
+    active = summary.active;
     learning = summary.learning;
     unlearned = summary.unlearned;
   } else {
     total = props.totalWords;
     mastered = props.masteredWords;
+    active = 0;
     unlearned = Math.max(0, total - mastered);
     learning = 0;
   }
@@ -87,20 +90,14 @@ export function ProjectCard(props: ProjectCardProps) {
           <p className="text-xl font-black text-[var(--color-foreground)]">
             {total} <span className="text-sm font-bold">語</span>
           </p>
-          <div className="mt-2 flex flex-wrap items-center gap-2">
-            <span className="flex items-center gap-1 text-xs text-[var(--color-success)]">
-              <span className="w-2 h-2 rounded-full bg-[var(--color-success)]" />
-              習得 {mastered}
-            </span>
-            <span className="flex items-center gap-1 text-xs text-[var(--color-muted)]">
-              <span className="w-2 h-2 rounded-full bg-[var(--color-muted)]" />
-              学習 {learning}
-            </span>
-            <span className="flex items-center gap-1 text-xs text-[var(--color-muted)]">
-              <span className="w-2 h-2 rounded-full bg-[var(--color-border)]" />
-              未学習 {unlearned}
-            </span>
-          </div>
+          {total > 0 && (
+            <div className="mt-2 flex h-[4px] overflow-hidden rounded-full bg-[rgba(26,26,26,0.08)]">
+              {mastered > 0 && <div style={{ flex: mastered, background: 'var(--color-success)' }} />}
+              {active > 0 && <div style={{ flex: active, background: '#2563eb' }} />}
+              {learning > 0 && <div style={{ flex: learning, background: 'var(--color-warning)' }} />}
+              {unlearned > 0 && <div style={{ flex: unlearned, background: 'rgba(26,26,26,0.12)' }} />}
+            </div>
+          )}
         </div>
         {menuItems && menuItems.length > 0 && (
           <button

--- a/src/lib/projects/load-helpers.ts
+++ b/src/lib/projects/load-helpers.ts
@@ -4,6 +4,7 @@ import { summarizeWordMemory } from '@/lib/words/memory';
 export interface ProjectWithStats extends Project {
   totalWords: number;
   masteredWords: number;
+  activeWords: number;
   progress: number;
   lastUsedAt: string | null; // Most recent lastReviewedAt among words, or null
 }
@@ -103,6 +104,7 @@ export function buildProjectStats(
     const words = wordsByProject[project.id] ?? [];
     const memorySummary = summarizeWordMemory(words);
     const masteredWords = memorySummary.mastered;
+    const activeWords = memorySummary.active;
     const totalWords = memorySummary.total;
     const progress = totalWords > 0 ? Math.round((masteredWords / totalWords) * 100) : 0;
 
@@ -117,6 +119,7 @@ export function buildProjectStats(
       ...project,
       totalWords,
       masteredWords,
+      activeWords,
       progress,
       lastUsedAt,
     };


### PR DESCRIPTION
## Summary

- 単語帳（プロジェクト）カードの「習得x 学習y 未学習z」テキスト表示を、4色のスタックドバーに変更
- ホームページの `ProjectRow` と `ProjectCard` の両方に適用
- 色: 緑=習得、青(#2563eb)=定着中、オレンジ=学習中、グレー=未学習
- `ProjectWithStats` に `activeWords` フィールドを追加

## Changes

- **`src/components/project/ProjectCard.tsx`**: テキストラベルをスタックドバーに置換、`active` カウント追加
- **`src/app/page.tsx`**: `ProjectRow` の `DotLabel` をスタックドバーに置換
- **`src/lib/projects/load-helpers.ts`**: `ProjectWithStats` に `activeWords` 追加、`buildProjectStats` で値をセット
- **`src/app/projects/page.legacy.tsx`**: `withEmptyStats` に `activeWords: 0` 追加

## Test plan

- [x] 全646テスト通過
- [x] TypeScript型チェック通過
- [ ] ホームページの単語帳カードにバーが表示されることを確認
- [ ] 各ステータスの色が正しいことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015sDnNnhWMefqyWDYjrWAjJ

---
_Generated by [Claude Code](https://claude.ai/code/session_015sDnNnhWMefqyWDYjrWAjJ)_