### PR TITLE
Remove status color lines from individual word rows

### DIFF
--- a/src/app/project/[id]/page.tsx
+++ b/src/app/project/[id]/page.tsx
@@ -1714,12 +1714,6 @@ function posShort(tag: string): string {
 const PP_FILLED: Record<WordStatus, number> = { new: 0, review: 1, active: 2, mastered: 3 };
 const PP_STATUS: WordStatus[] = ['new', 'review', 'active', 'mastered'];
 const PP_ARIA: Record<WordStatus, string> = { new: '未学習', review: '学習中', active: '定着中', mastered: '習得済み' };
-const STATUS_LINE_COLOR: Record<WordStatus, string> = {
-  new: 'rgba(26,26,26,0.12)',
-  review: 'var(--color-warning)',
-  active: '#2563eb',
-  mastered: 'var(--color-success)',
-};
 
 function StatusSquares({
   wordId,
@@ -1856,7 +1850,6 @@ function WordRow({
           <VocabularyTypeBadge vocabularyType={word.vocabularyType} />
           <BookmarkBadge active={word.isFavorite} />
         </div>
-        <div className="mt-1.5 h-[3px] rounded-full" style={{ background: STATUS_LINE_COLOR[displayStatus] }} />
       </button>
     );
   }
@@ -1891,7 +1884,6 @@ function WordRow({
           <Icon name="bookmark" size={22} filled={word.isFavorite} />
         </button>
       </div>
-      <div className="mt-1.5 h-[3px] rounded-full" style={{ background: STATUS_LINE_COLOR[displayStatus] }} />
     </div>
   );
 }

--- a/src/components/project/ProjectDetailSheet.tsx
+++ b/src/components/project/ProjectDetailSheet.tsx
@@ -72,12 +72,6 @@ function StackedBar({ total, m, a, l, n }: { total: number; m: number; a: number
 const SS_FILLED: Record<WordStatus, number> = { new: 0, review: 1, active: 2, mastered: 3 };
 const SS_STATUS: WordStatus[] = ['new', 'review', 'active', 'mastered'];
 const SS_ARIA: Record<WordStatus, string> = { new: '未学習', review: '学習中', active: '定着中', mastered: '習得済み' };
-const SS_LINE_COLOR: Record<WordStatus, string> = {
-  new: 'rgba(26,26,26,0.12)',
-  review: 'var(--color-warning)',
-  active: '#2563eb',
-  mastered: 'var(--color-success)',
-};
 
 function StatusSquares({ wordId, status, onStatusChange }: {
   wordId: string; status: WordStatus; onStatusChange: (s: WordStatus) => void;
@@ -141,7 +135,7 @@ function WordRow({ word, memoryGroup, onCycleStatus, onCycleVocabularyType, onTo
   return (
     <div className="relative">
       <div className="absolute inset-0 rounded-xl bg-[var(--solid-ink)]" style={{ transform: 'translate(2px, 2px)' }} />
-      <div className="relative overflow-hidden rounded-xl border-2 border-[var(--solid-ink)] bg-white px-[13px] py-2">
+      <div className="relative rounded-xl border-2 border-[var(--solid-ink)] bg-white px-[13px] py-2">
         <div className="flex items-center gap-2.5">
           <StatusSquares wordId={word.id} status={displayStatus} onStatusChange={onCycleStatus} />
           <Link href={`/word/${word.id}?from=${encodeURIComponent('/projects')}`} className="min-w-0 flex-1">
@@ -163,7 +157,6 @@ function WordRow({ word, memoryGroup, onCycleStatus, onCycleVocabularyType, onTo
             <Icon name="bookmark" size={18} filled={word.isFavorite} />
           </button>
         </div>
-        <div className="absolute inset-x-0 bottom-0 h-[3px]" style={{ background: SS_LINE_COLOR[displayStatus] }} />
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- Removed `STATUS_LINE_COLOR` / `SS_LINE_COLOR` maps and the colored status line `<div>` elements from individual word rows in both `src/app/project/[id]/page.tsx` and `src/components/project/ProjectDetailSheet.tsx`
- Stacked color bars remain on project/wordbook cards (ProjectCard, home page ProjectRow) as intended
- Reverted `overflow-hidden` class on ProjectDetailSheet WordRow that was only needed for the status line

## Test plan
- [x] `npx tsc --noEmit` passes (no type errors)
- [x] All 646 tests pass (`npm test`)
- [ ] Verify word rows no longer show colored status lines at the bottom
- [ ] Verify project/wordbook cards still show the stacked color bar


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015sDnNnhWMefqyWDYjrWAjJ

---
_Generated by [Claude Code](https://claude.ai/code/session_015sDnNnhWMefqyWDYjrWAjJ)_