### PR TITLE
Fix multiple-choice options disappearing after answer selection

### DIFF
--- a/src/app/quiz/[projectId]/page.tsx
+++ b/src/app/quiz/[projectId]/page.tsx
@@ -1513,7 +1513,7 @@ export default function QuizPage() {
             onSelectToken={handleWordOrderTokenSelect}
             onRemoveToken={handleWordOrderTokenRemove}
           />
-        ) : !isTypeInMode && isMultipleChoiceQuestion(currentQuestion) ? (
+        ) : (!isTypeInMode || (isRevealed && selectedIndex !== null)) && isMultipleChoiceQuestion(currentQuestion) ? (
           <div className="ds-qopts">
             {currentQuestion.options.map((option, i) => {
               let cls = 'ds-qopt';
@@ -1762,7 +1762,7 @@ export default function QuizPage() {
             onRemoveToken={handleWordOrderTokenRemove}
             onSubmit={handleWordOrderSubmit}
           />
-        ) : !isTypeInMode && isMultipleChoiceQuestion(currentQuestion) ? (
+        ) : (!isTypeInMode || (isRevealed && selectedIndex !== null)) && isMultipleChoiceQuestion(currentQuestion) ? (
           <div className="mt-[18px] flex flex-col gap-2">
             {currentQuestion?.options.map((option, i) => (
               <DSQuizOption


### PR DESCRIPTION
## Summary

- **Bug**: 4択クイズで選択肢を押すと、選択肢が消えてTypeInフィールド（テキスト入力）が出現するバグを修正
- **原因**: 正解時に `getStatusAfterAnswer('review', true)` が `'active'` を返し、`setQuestions` で即座にReact再レンダリングが発生。`isTypeInMode` が `true` に切り替わり、4択UIがTypeInフィールドに置き換えられていた
- **修正**: 既に回答選択済み（`isRevealed && selectedIndex !== null`）の場合は、ステータス変更に関わらず4択表示を維持するよう条件を追加。デスクトップ版・モバイル版の両方を修正

## Test plan

- [x] `npm run build` passes
- [x] All 646 unit tests pass
- [ ] `review` ステータスの単語で4択クイズに正解し、選択肢が消えずに正解/不正解の表示が維持されることを確認
- [ ] `active` ステータスの単語ではTypeIn入力モードが正常に表示されることを確認
- [ ] デスクトップ版・モバイル版の両方で動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GZKyn3DMZBb5oJ2gsNfSUD

---
_Generated by [Claude Code](https://claude.ai/code/session_01GZKyn3DMZBb5oJ2gsNfSUD)_