### PR TITLE
feat: 4 feature updates for today

### DIFF
--- a/src/app/api/words/create/route.ts
+++ b/src/app/api/words/create/route.ts
@@ -198,7 +198,7 @@ export async function handleWordsCreatePost(request: NextRequest, deps?: WordsCr
         english: word.english,
         japanese: word.japanese,
         japanese_source: word.japaneseSource ?? null,
-        vocabulary_type: word.vocabularyType ?? null,
+        vocabulary_type: word.vocabularyType ?? 'passive',
         lexicon_entry_id: word.lexiconEntryId ?? null,
         lexicon_sense_id: word.lexiconSenseId ?? null,
         distractors: word.distractors,

--- a/src/app/groups/[groupId]/page.tsx
+++ b/src/app/groups/[groupId]/page.tsx
@@ -319,6 +319,8 @@ function SectionCard({
 }
 
 function LeaderboardSection({ leaderboard }: { leaderboard: StudyGroupLeaderboardEntry[] }) {
+  const [showAll, setShowAll] = useState(false);
+
   if (leaderboard.length === 0) {
     return (
       <SectionCard icon="emoji_events" title="ランキング" subtitle="解いたクイズ数で競おう" accent="#FFC800">
@@ -328,7 +330,11 @@ function LeaderboardSection({ leaderboard }: { leaderboard: StudyGroupLeaderboar
   }
 
   const podium = leaderboard.slice(0, 3);
-  const rest = leaderboard.slice(3);
+  const restAll = leaderboard.slice(3);
+  const maxVisible = 2; // ranks 4–5
+  const visibleRest = showAll ? restAll : restAll.slice(0, maxVisible);
+  const hiddenCount = restAll.length - maxVisible;
+  const hiddenTotal = restAll.slice(maxVisible).reduce((s, e) => s + e.quizCount, 0);
 
   return (
     <SectionCard icon="emoji_events" title="ランキング" subtitle="解いたクイズ数で競おう" accent="#FFC800">
@@ -338,11 +344,27 @@ function LeaderboardSection({ leaderboard }: { leaderboard: StudyGroupLeaderboar
         {podium[2] && <PodiumColumn entry={podium[2]} place={3} />}
       </div>
 
-      {rest.length > 0 && (
+      {visibleRest.length > 0 && (
         <div className="mt-3 flex flex-col gap-1.5">
-          {rest.map((entry, index) => (
+          {visibleRest.map((entry, index) => (
             <LeaderboardRow key={entry.userId} entry={entry} rank={index + 4} />
           ))}
+          {!showAll && hiddenCount > 0 && (
+            <button
+              type="button"
+              onClick={() => setShowAll(true)}
+              className="flex items-center gap-3 rounded-[12px] border-2 border-[var(--color-border)] bg-white px-3 py-2 text-left"
+            >
+              <span className="w-5 shrink-0 text-center font-mono text-[13px] font-extrabold tabular-nums text-[var(--color-muted)]">…</span>
+              <div className="min-w-0 flex-1">
+                <div className="text-[13px] font-extrabold text-[var(--color-muted)]">その他 {hiddenCount}人</div>
+              </div>
+              <div className="shrink-0 text-right">
+                <span className="font-mono text-[14px] font-extrabold tabular-nums text-[var(--color-muted)]">{hiddenTotal}</span>
+                <span className="ml-0.5 text-[10px] font-bold text-[var(--color-muted)]">問</span>
+              </div>
+            </button>
+          )}
         </div>
       )}
     </SectionCard>

--- a/src/app/quiz/[projectId]/page.tsx
+++ b/src/app/quiz/[projectId]/page.tsx
@@ -18,6 +18,7 @@ import {
   type WrongAnswer,
 } from '@/lib/utils';
 import { sortWordsByPriority } from '@/lib/spaced-repetition';
+import { triggerHaptic } from '@/lib/haptics';
 import { loadCollectionWords } from '@/lib/collection-words';
 import {
   applyWordOrderQuestionsToPendingQuiz,
@@ -1099,6 +1100,7 @@ export default function QuizPage() {
 
   const handleSelect = async (index: number) => {
     if (isRevealed || selectedIndex !== null || !isMultipleChoiceQuestion(currentQuestion)) return;
+    triggerHaptic();
     setSelectedIndex(index);
     setIsRevealed(true);
     const isCorrect = index === currentQuestion.correctIndex;

--- a/src/components/home/ScanCapturePanel.tsx
+++ b/src/components/home/ScanCapturePanel.tsx
@@ -7,6 +7,7 @@ import { Icon } from '@/components/ui/Icon';
 import { MultiShotCaptureView } from '@/components/home/MultiShotCaptureView';
 import { useAuth } from '@/hooks/use-auth';
 import { processImageToBase64 } from '@/lib/image-utils';
+import { triggerHaptic } from '@/lib/haptics';
 import { createBrowserClient } from '@/lib/supabase';
 import {
   addHomeImmediateScanResult,
@@ -270,9 +271,13 @@ export function ScanCapturePanel({
   // Open the multi-shot tray in its 0-shot state; the pulsing shutter in
   // the tray invites the first shot (the camera is NOT launched here).
   const handleCamera = () => {
+    triggerHaptic();
     setCaptureView(true);
   };
-  const handleLibrary = () => libraryInputRef.current?.click();
+  const handleLibrary = () => {
+    triggerHaptic();
+    libraryInputRef.current?.click();
+  };
   const handleCameraInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const files = Array.from(event.currentTarget.files ?? []);
     event.currentTarget.value = '';

--- a/src/components/project/ProjectShareSheet.tsx
+++ b/src/components/project/ProjectShareSheet.tsx
@@ -157,60 +157,6 @@ export function ProjectShareSheet({
             )}
           </div>
 
-          <div className="mb-3">
-            <div className="mb-2 flex items-center gap-1.5 font-mono text-[9px] font-bold uppercase tracking-[0.08em] text-[var(--color-muted)]">
-              <Icon name="group" size={11} />
-              グループ
-            </div>
-            <div className="flex max-h-[150px] flex-col gap-2 overflow-y-auto pr-1">
-              {groupsLoading ? (
-                <div className="flex h-10 items-center gap-2 rounded-[10px] border border-[var(--color-border)] bg-white px-3 text-[12px] text-[var(--color-muted)]">
-                  <Icon name="progress_activity" size={14} className="animate-spin" />
-                  読み込み中...
-                </div>
-              ) : groups.length === 0 ? (
-                <div className="rounded-[10px] border border-[var(--color-border)] bg-white px-3 py-3 text-[12px] text-[var(--color-muted)]">
-                  所属グループはまだありません
-                </div>
-              ) : (
-                groups.map((group) => {
-                  const updating = groupSharingUpdatingId === group.id;
-                  const shared = Boolean(group.projectShared);
-                  return (
-                    <button
-                      key={group.id}
-                      type="button"
-                      aria-label={`${group.name}のグループ共有を${shared ? '解除' : '掲載'}`}
-                      disabled={preparing || updating || !onToggleGroupShare}
-                      onClick={() => onToggleGroupShare?.(group)}
-                      className="flex items-center gap-2 rounded-[10px] border-2 border-[var(--solid-ink)] bg-white px-3 py-2 text-left disabled:opacity-50"
-                    >
-                      <div
-                        className="flex h-8 w-8 shrink-0 items-center justify-center rounded-[8px] border border-[var(--solid-ink)]"
-                        style={{ background: shared ? 'var(--solid-ink)' : '#fff', color: shared ? '#fff' : 'var(--solid-ink)' }}
-                      >
-                        <Icon name={updating ? 'progress_activity' : shared ? 'check' : 'group'} size={15} className={updating ? 'animate-spin' : undefined} />
-                      </div>
-                      <div className="min-w-0 flex-1">
-                        <div className="truncate text-[13px] font-bold text-[var(--solid-ink)]">{group.name}</div>
-                        <div className="mt-0.5 font-mono text-[9px] text-[var(--color-muted)]">
-                          {group.memberCount}人 · {group.projectCount}冊
-                        </div>
-                      </div>
-                      <span className="shrink-0 rounded-full border border-[var(--solid-ink)] px-2 py-0.5 text-[10px] font-bold text-[var(--solid-ink)]">
-                        {shared ? '共有解除' : '掲載'}
-                      </span>
-                    </button>
-                  );
-                })
-              )}
-            </div>
-            {groupsError && (
-              <div className="mt-2 rounded-[8px] border border-red-200 bg-red-50 px-3 py-2 text-[11px] font-bold text-red-700">
-                {groupsError}
-              </div>
-            )}
-          </div>
           <div className="mb-3 grid grid-cols-2 gap-2">
             <button
               type="button"

--- a/src/lib/db/local-repository.ts
+++ b/src/lib/db/local-repository.ts
@@ -83,6 +83,7 @@ export class LocalWordRepository implements WordRepository {
       createdAt: now,
       isFavorite: false,
       status: 'new' as const,
+      vocabularyType: word.vocabularyType ?? ('passive' as const),
     }));
 
     await db.words.bulkAdd(newWords);


### PR DESCRIPTION
## Summary

- **スキャン時の単語をPassiveにデフォルト設定**: `vocabularyType` を `'passive'` にデフォルト変更（ローカルDB + API両方）
- **共有シートからグループ掲載導線を削除**: `ProjectShareSheet` のグループセクションを完全に除去
- **グループランキングをMAX5人に制限**: Top 3はポディウム表示、4〜5位はリスト表示、6位以降は「その他 N人」ボタンで展開可能
- **クイズ四択ボタン・スキャンボタンにバイブレーション追加**: `triggerHaptic()` をクイズ選択時とカメラ/写真ボタン押下時に追加

## Changed files

| File | Change |
|------|--------|
| `src/lib/db/local-repository.ts` | Default `vocabularyType` to `'passive'` on word creation |
| `src/app/api/words/create/route.ts` | Default `vocabulary_type` to `'passive'` instead of `null` |
| `src/components/project/ProjectShareSheet.tsx` | Remove group posting section |
| `src/app/groups/[groupId]/page.tsx` | Cap ranking at 5 with expandable "その他" |
| `src/app/quiz/[projectId]/page.tsx` | Add haptic on quiz option select |
| `src/components/home/ScanCapturePanel.tsx` | Add haptic on camera/library buttons |

## Test plan

- [ ] スキャンして単語を保存 → 全単語の `vocabularyType` が `'passive'` になっていることを確認
- [ ] プロジェクト詳細ページの共有ボタン → グループ掲載セクションが表示されないことを確認
- [ ] 6人以上のグループでランキング確認 → 5位までが表示され「その他」ボタンが出ること
- [ ] 「その他」ボタンタップ → 残りメンバーが展開されること
- [ ] クイズで四択ボタンタップ → バイブレーションが発生すること（Android/iOS）
- [ ] スキャン画面でカメラ・写真ボタンタップ → バイブレーションが発生すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WjwMFDhTkuEo9aT1YXVLb4

---
_Generated by [Claude Code](https://claude.ai/code/session_01WjwMFDhTkuEo9aT1YXVLb4)_