### PR TITLE
PWA警告文変更、クイズ完了画面ボタン固定、フォロー戻るループ修正

### DIFF
--- a/src/app/quiz/[projectId]/page.tsx
+++ b/src/app/quiz/[projectId]/page.tsx
@@ -1356,66 +1356,70 @@ export default function QuizPage() {
         </div>
       </div>
       {/* Mobile completion */}
-      <div className="fixed inset-0 z-30 flex flex-col overflow-y-auto bg-[var(--color-background)] font-[var(--font-body)] lg:hidden">
-        <div className="mx-auto w-full max-w-sm px-5" style={{ paddingTop: 'max(16px, calc(env(safe-area-inset-top) + 16px))', paddingBottom: 'max(24px, calc(env(safe-area-inset-bottom) + 24px))' }}>
-          {/* Score card */}
-          <div className="rounded-[14px] border-2 border-[var(--solid-ink)] bg-[var(--color-surface)] px-4 py-4">
-            <div className="flex items-center gap-3">
-              <div className="font-display text-[32px] font-black tabular-nums text-[var(--solid-ink)]">
-                {results.correct}<span className="text-[16px] text-[var(--color-muted)]">/{results.total}</span>
-              </div>
-              <div className="flex flex-1 flex-col gap-1">
-                <div className="h-[6px] w-full overflow-hidden rounded-full bg-[rgba(26,26,26,0.08)]">
-                  <div className="h-full rounded-full bg-[var(--color-accent)]" style={{ width: `${percentage}%` }} />
+      <div className="fixed inset-0 z-30 flex flex-col bg-[var(--color-background)] font-[var(--font-body)] lg:hidden">
+        <div className="flex min-h-0 flex-1 flex-col overflow-y-auto" style={{ paddingTop: 'max(16px, calc(env(safe-area-inset-top) + 16px))' }}>
+          <div className="mx-auto w-full max-w-sm px-5 pb-4">
+            {/* Score card */}
+            <div className="rounded-[14px] border-2 border-[var(--solid-ink)] bg-[var(--color-surface)] px-4 py-4">
+              <div className="flex items-center gap-3">
+                <div className="font-display text-[32px] font-black tabular-nums text-[var(--solid-ink)]">
+                  {results.correct}<span className="text-[16px] text-[var(--color-muted)]">/{results.total}</span>
                 </div>
-              </div>
-              <span className="font-display text-[20px] font-black tabular-nums text-[var(--solid-ink)]">{percentage}%</span>
-            </div>
-            <p className="mt-2.5 text-[13px] font-bold text-[var(--color-secondary-text)]">{getQuizCompletionMessage(percentage)}</p>
-            <div className="mt-3 flex gap-3">
-              <span className="flex items-center gap-1 text-[11px] font-bold text-[var(--color-muted)]">
-                <span className="inline-block h-[6px] w-[6px] rounded-full bg-[var(--color-success)]" />正解 {answerResults.filter(r => r === true).length}
-              </span>
-              <span className="flex items-center gap-1 text-[11px] font-bold text-[var(--color-muted)]">
-                <span className="inline-block h-[6px] w-[6px] rounded-full bg-[var(--color-error)]" />不正解 {answerResults.filter(r => r === false).length}
-              </span>
-              <span className="flex items-center gap-1 text-[11px] font-bold text-[var(--color-muted)]">
-                <span className="inline-block h-[6px] w-[6px] rounded-full bg-[var(--color-warning)]" />スキップ {answerResults.filter(r => r === 'skip').length}
-              </span>
-            </div>
-          </div>
-          {/* Word results list */}
-          <div className="mt-3 w-full overflow-hidden rounded-[14px] border-2 border-[var(--solid-ink)] bg-white">
-            <div className="flex items-center gap-2 border-b border-[rgba(26,26,26,0.1)] px-4 py-3">
-              <Icon name="format_list_bulleted" size={16} className="text-[var(--color-muted)]" />
-              <h3 className="font-display text-[14px] font-extrabold text-[var(--solid-ink)]">解答一覧</h3>
-            </div>
-            <div className="divide-y divide-[rgba(26,26,26,0.08)]">
-              {wordResultRows.map((row, i) => (
-                <div key={i} className="flex items-center gap-3 px-4 py-2.5">
-                  <span className="w-5 text-center text-[16px] font-black" style={{ color: row.markerColor }}>
-                    {row.marker}
-                  </span>
-                  <div className="min-w-0 flex-1">
-                    <span
-                      className="text-[14px] font-bold"
-                      style={{ color: row.isIncorrect ? 'var(--color-error)' : 'var(--solid-ink)' }}
-                    >
-                      {row.word.english}
-                    </span>
-                    <span
-                      className="ml-2 text-[12px]"
-                      style={{ color: row.isIncorrect ? 'var(--color-error)' : 'var(--color-muted)', opacity: row.isIncorrect ? 0.8 : 1 }}
-                    >
-                      {formatJapaneseForDisplay(row.word)}
-                    </span>
+                <div className="flex flex-1 flex-col gap-1">
+                  <div className="h-[6px] w-full overflow-hidden rounded-full bg-[rgba(26,26,26,0.08)]">
+                    <div className="h-full rounded-full bg-[var(--color-accent)]" style={{ width: `${percentage}%` }} />
                   </div>
                 </div>
-              ))}
+                <span className="font-display text-[20px] font-black tabular-nums text-[var(--solid-ink)]">{percentage}%</span>
+              </div>
+              <p className="mt-2.5 text-[13px] font-bold text-[var(--color-secondary-text)]">{getQuizCompletionMessage(percentage)}</p>
+              <div className="mt-3 flex gap-3">
+                <span className="flex items-center gap-1 text-[11px] font-bold text-[var(--color-muted)]">
+                  <span className="inline-block h-[6px] w-[6px] rounded-full bg-[var(--color-success)]" />正解 {answerResults.filter(r => r === true).length}
+                </span>
+                <span className="flex items-center gap-1 text-[11px] font-bold text-[var(--color-muted)]">
+                  <span className="inline-block h-[6px] w-[6px] rounded-full bg-[var(--color-error)]" />不正解 {answerResults.filter(r => r === false).length}
+                </span>
+                <span className="flex items-center gap-1 text-[11px] font-bold text-[var(--color-muted)]">
+                  <span className="inline-block h-[6px] w-[6px] rounded-full bg-[var(--color-warning)]" />スキップ {answerResults.filter(r => r === 'skip').length}
+                </span>
+              </div>
+            </div>
+            {/* Word results list */}
+            <div className="mt-3 w-full overflow-hidden rounded-[14px] border-2 border-[var(--solid-ink)] bg-white">
+              <div className="flex items-center gap-2 border-b border-[rgba(26,26,26,0.1)] px-4 py-3">
+                <Icon name="format_list_bulleted" size={16} className="text-[var(--color-muted)]" />
+                <h3 className="font-display text-[14px] font-extrabold text-[var(--solid-ink)]">解答一覧</h3>
+              </div>
+              <div className="divide-y divide-[rgba(26,26,26,0.08)]">
+                {wordResultRows.map((row, i) => (
+                  <div key={i} className="flex items-center gap-3 px-4 py-2.5">
+                    <span className="w-5 text-center text-[16px] font-black" style={{ color: row.markerColor }}>
+                      {row.marker}
+                    </span>
+                    <div className="min-w-0 flex-1">
+                      <span
+                        className="text-[14px] font-bold"
+                        style={{ color: row.isIncorrect ? 'var(--color-error)' : 'var(--solid-ink)' }}
+                      >
+                        {row.word.english}
+                      </span>
+                      <span
+                        className="ml-2 text-[12px]"
+                        style={{ color: row.isIncorrect ? 'var(--color-error)' : 'var(--color-muted)', opacity: row.isIncorrect ? 0.8 : 1 }}
+                      >
+                        {formatJapaneseForDisplay(row.word)}
+                      </span>
+                    </div>
+                  </div>
+                ))}
+              </div>
             </div>
           </div>
-          {/* Action buttons */}
-          <div className="mt-3 space-y-3">
+        </div>
+        {/* Fixed bottom buttons */}
+        <div className="shrink-0 border-t border-[rgba(26,26,26,0.1)] bg-[var(--color-background)]" style={{ paddingBottom: 'max(16px, calc(env(safe-area-inset-bottom) + 16px))' }}>
+          <div className="mx-auto w-full max-w-sm space-y-2 px-5 pt-3">
             <SolidButton variant="accent" onClick={reviewMode || learnMode ? goToNextReviewQuiz : handleRestart} iconRight="arrow_forward" className="w-full justify-center">次へ</SolidButton>
             <SolidButton onClick={backToProject} className="w-full justify-center">終了する</SolidButton>
           </div>

--- a/src/components/home/PwaInstallBanner.tsx
+++ b/src/components/home/PwaInstallBanner.tsx
@@ -107,7 +107,7 @@ export function PwaInstallBanner() {
                   ホーム画面に追加
                 </h3>
                 <p className="mt-1 text-[12px] leading-[1.5] text-[var(--solid-ink)]/70">
-                  ブラウザを開かずに1タップで起動できます。
+                  ホーム画面に追加しないと、プッシュ通知やオフライン利用など一部の機能が制限されます。
                 </p>
               </div>
             </div>

--- a/src/components/profile/FollowsList.tsx
+++ b/src/components/profile/FollowsList.tsx
@@ -2,6 +2,8 @@
 
 import { useState } from 'react';
 import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import type { MouseEvent } from 'react';
 import { Icon } from '@/components/ui/Icon';
 import { profileAvatarColor } from '@/components/profile/ProfileView';
 import type { FriendProfile } from '@/lib/friends/types';
@@ -27,8 +29,19 @@ export function FollowsList({
   followers: FriendProfile[];
   loading: boolean;
 }) {
+  const router = useRouter();
   const [tab, setTab] = useState<FollowsTab>(initialTab);
   const list = tab === 'following' ? following : followers;
+
+  const handleBack = (event: MouseEvent<HTMLAnchorElement>) => {
+    if (event.metaKey || event.ctrlKey || event.shiftKey || event.altKey || event.button !== 0) {
+      return;
+    }
+    if (typeof window !== 'undefined' && window.history.length > 1) {
+      event.preventDefault();
+      router.back();
+    }
+  };
 
   return (
     <div className="relative min-h-screen bg-[var(--color-background)] pb-[max(24px,env(safe-area-inset-bottom))] pt-3 font-[var(--font-body)]">
@@ -37,6 +50,7 @@ export function FollowsList({
         <div className="flex items-center gap-2 px-[18px] pb-1 pt-1">
           <Link
             href={backHref}
+            onClick={handleBack}
             aria-label="戻る"
             className="inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-full text-[var(--solid-ink)] active:bg-[var(--color-surface-secondary)]"
           >


### PR DESCRIPTION
## Summary\n\n- **PWAバナー文言変更**: ホーム画面のPWA解説テキストを「ブラウザを開かずに1タップで起動できます」から「ホーム画面に追加しないと、プッシュ通知やオフライン利用など一部の機能が制限されます」に変更\n- **クイズ完了モバイルレイアウト修正**: 「次へ」「終了する」ボタンを画面下部に固定し、解答一覧は枠内のみでスクロールする仕様に変更\n- **フォロー画面の戻るナビゲーション修正**: FollowsListの戻るボタンに`router.back()`を追加し、フォロー中→プロフィール間のページ遷移無限ループを解消\n\n## Changed files\n\n| File | Change |\n|------|--------|\n| `src/components/home/PwaInstallBanner.tsx` | 説明文を機能制限の警告に変更 |\n| `src/app/quiz/[projectId]/page.tsx` | モバイル完了画面のレイアウトをflex構造に変更し、ボタンを固定フッターに移動 |\n| `src/components/profile/FollowsList.tsx` | ProfileViewと同様の`router.back()`ロジックを追加 |\n\n## Test plan\n\n- [ ] ホーム画面でPWAバナーが表示され、新しい警告文が正しく表示されること\n- [ ] クイズ完了画面（モバイル）で「次へ」「終了する」ボタンが画面下部に固定されること\n- [ ] 解答数が多い場合、解答一覧がボタンの上で枠内スクロールすること\n- [ ] フォロー中一覧→プロフィール→戻るの操作で無限ループが発生しないこと\n- [ ] プロフィール→フォロー中→戻るの操作も正常に動作すること\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)\n\nhttps://claude.ai/code/session_01LHtAYXvAJ21CcSBdoCgEQM

---
_Generated by [Claude Code](https://claude.ai/code/session_01LHtAYXvAJ21CcSBdoCgEQM)_