### PR TITLE
[codex] Split onboarding profile and level steps

### DIFF
--- a/src/app/api/auth/otp.contract.test.ts
+++ b/src/app/api/auth/otp.contract.test.ts
@@ -6,7 +6,7 @@ import { handleSendOtpPost } from './send-otp/route';
 import { handleSignupVerifyPost } from './signup-verify/route';
 import { handleVerifyOtpPost } from './verify-otp/route';
 
-type QueryAction = 'select' | 'insert' | 'update' | 'delete';
+type QueryAction = 'select' | 'insert' | 'update' | 'upsert' | 'delete';
 
 interface QueryFilter {
   field: string;
@@ -22,6 +22,7 @@ interface QueryOperation {
   table: string;
   action: QueryAction;
   payload?: unknown;
+  options?: unknown;
   columns?: string;
   filters: QueryFilter[];
   orders: QueryOrder[];
@@ -86,6 +87,11 @@ class FakeOtpQuery {
 
   limit(count: number) {
     this.operation.limitCount = count;
+    return this;
+  }
+
+  select(columns = '*') {
+    this.operation.columns = columns;
     return this;
   }
 
@@ -165,6 +171,7 @@ class FakeOtpAdminClient {
       select: (columns = '*') => this.createOperation(table, 'select', undefined, columns),
       insert: (payload: unknown) => this.createOperation(table, 'insert', payload),
       update: (payload: unknown) => this.createOperation(table, 'update', payload),
+      upsert: (payload: unknown, options?: unknown) => this.createOperation(table, 'upsert', payload, undefined, options),
       delete: () => this.createOperation(table, 'delete'),
     };
   }
@@ -174,11 +181,13 @@ class FakeOtpAdminClient {
     action: QueryAction,
     payload?: unknown,
     columns?: string,
+    options?: unknown,
   ) {
     const operation: QueryOperation = {
       table,
       action,
       payload,
+      options,
       columns,
       filters: [],
       orders: [],
@@ -204,6 +213,14 @@ class FakeOtpAdminClient {
 
       return {
         data: this.options.otpRecord as T,
+        error: null,
+      };
+    }
+
+    if (operation.table === 'profiles' && operation.action === 'upsert') {
+      const payload = isRecord(operation.payload) ? operation.payload : {};
+      return {
+        data: { user_id: payload.user_id } as T,
         error: null,
       };
     }
@@ -536,6 +553,59 @@ test('signup-verify valid OTP still returns 409 for an existing email after veri
   assert.deepEqual(cleanup.filters, [{ field: 'email', value: 'user@example.com' }]);
   assert.deepEqual(adminClient.createUserCalls, []);
   assert.deepEqual(adminClient.generateLinkCalls, []);
+});
+
+test('signup-verify valid OTP saves onboarding profile fields by upsert', async () => {
+  const adminClient = new FakeOtpAdminClient({
+    users: [],
+    otpRecord: otpRecord({ id: 'otp-signup-profile' }),
+    createdUser: { id: 'created-user-1', email: 'new@example.com' },
+  });
+  const serverClient = new FakeServerClient({
+    sessionUser: { id: 'created-user-1', email: 'new@example.com' },
+  });
+
+  const response = await handleSignupVerifyPost(
+    jsonRequest('/api/auth/signup-verify', {
+      email: 'New@Example.COM',
+      code: '123456',
+      password: 'password123',
+      display_name: '山田太郎',
+      user_handle: 'kenta_123',
+      eiken_level: 'pre2',
+    }),
+    {
+      getAdminClient: () => adminClient as never,
+      getServerClient: async () => serverClient as never,
+    },
+  );
+
+  assert.equal(response.status, 200);
+  assert.deepEqual(await jsonPayload(response), {
+    success: true,
+    user: {
+      id: 'created-user-1',
+      email: 'new@example.com',
+    },
+  });
+
+  const profileUpsert = findOperation(adminClient, (operation) =>
+    operation.table === 'profiles' &&
+    operation.action === 'upsert'
+  );
+  assert.deepEqual(profileUpsert.options, { onConflict: 'user_id' });
+  assert.equal(profileUpsert.columns, 'user_id');
+  assert.deepEqual(profileUpsert.payload, {
+    user_id: 'created-user-1',
+    onboarding_step: 'signed_up',
+    username: '山田太郎',
+    display_name: '山田太郎',
+    user_handle: 'kenta_123',
+    eiken_level: 'pre2',
+  });
+
+  const cleanup = findOtpDelete(adminClient, 'email', 'new@example.com');
+  assert.deepEqual(cleanup.filters, [{ field: 'email', value: 'new@example.com' }]);
 });
 
 test('reset-password set-password uses verified OTP grace, updates password, cleans OTPs, and signs in best-effort', async () => {

--- a/src/app/api/auth/signup-verify/route.ts
+++ b/src/app/api/auth/signup-verify/route.ts
@@ -50,10 +50,88 @@ const requestSchema = z.object({
   eiken_level: z.enum(['5', '4', '3', 'pre2', '2', 'pre1', '1']).nullable().optional(),
 });
 
+type SignupVerifyBody = z.infer<typeof requestSchema>;
+type SignupProfileFields = Pick<SignupVerifyBody, 'display_name' | 'user_handle' | 'eiken_level'>;
+
 export type SignupVerifyRouteDeps = {
   getAdminClient?: typeof getAdminClient;
   getServerClient?: typeof getServerClient;
 };
+
+function buildDefaultAccountId(userId: string): string {
+  const compact = userId.replace(/[^a-fA-F0-9]/g, '').toLowerCase();
+  return `mk${compact.slice(0, 12)}`.slice(0, 24);
+}
+
+function hasSignupProfileFields(fields: SignupProfileFields): boolean {
+  return fields.display_name !== undefined
+    || fields.user_handle !== undefined
+    || fields.eiken_level !== undefined;
+}
+
+function isMissingAccountIdError(error: { code?: string | null; message?: string | null; details?: string | null } | null): boolean {
+  if (!error || error.code !== '23502') return false;
+  const text = `${error.message ?? ''} ${error.details ?? ''}`;
+  return text.includes('account_id');
+}
+
+function isUniqueViolation(error: { code?: string | null } | null): boolean {
+  return error?.code === '23505';
+}
+
+function buildSignupProfilePayload(
+  userId: string,
+  fields: SignupProfileFields,
+  includeAccountId: boolean,
+) {
+  const payload: {
+    user_id: string;
+    onboarding_step: 'signed_up';
+    username?: string;
+    display_name?: string;
+    user_handle?: string;
+    eiken_level?: SignupVerifyBody['eiken_level'];
+    account_id?: string;
+  } = {
+    user_id: userId,
+    onboarding_step: 'signed_up',
+  };
+
+  if (fields.display_name !== undefined) {
+    payload.username = fields.display_name;
+    payload.display_name = fields.display_name;
+  }
+  if (fields.user_handle !== undefined) payload.user_handle = fields.user_handle;
+  if (fields.eiken_level !== undefined) payload.eiken_level = fields.eiken_level;
+  if (includeAccountId) payload.account_id = buildDefaultAccountId(userId);
+
+  return payload;
+}
+
+async function saveSignupProfileFields(
+  adminClient: ReturnType<typeof getAdminClient>,
+  userId: string,
+  fields: SignupProfileFields,
+): Promise<{ code?: string | null; message?: string | null; details?: string | null } | null> {
+  const upsertProfile = (includeAccountId: boolean) => adminClient
+    .from('profiles')
+    .upsert(
+      buildSignupProfilePayload(userId, fields, includeAccountId),
+      { onConflict: 'user_id' },
+    )
+    .select('user_id')
+    .single();
+
+  const { error } = await upsertProfile(false);
+  if (!error) return null;
+
+  if (isMissingAccountIdError(error)) {
+    const retry = await upsertProfile(true);
+    return retry.error ?? null;
+  }
+
+  return error;
+}
 
 export async function POST(request: Request) {
   return handleSignupVerifyPost(request);
@@ -175,6 +253,31 @@ export async function handleSignupVerifyPost(
       );
     }
 
+    // Save onboarding profile fields if provided. Use upsert so the data is
+    // persisted even if the auth trigger did not create a profile row.
+    const userId = newUser.user.id;
+    const profileFields = { display_name, user_handle, eiken_level };
+    if (hasSignupProfileFields(profileFields)) {
+      const profileError = await saveSignupProfileFields(adminClient, userId, profileFields);
+      if (profileError) {
+        console.error('Failed to save signup profile:', profileError);
+
+        await adminClient
+          .from('otp_requests')
+          .delete()
+          .eq('email', normalizedEmail);
+
+        return NextResponse.json(
+          {
+            error: isUniqueViolation(profileError)
+              ? 'このIDは既に使われています'
+              : 'プロフィール情報の保存に失敗しました',
+          },
+          { status: isUniqueViolation(profileError) ? 409 : 500 },
+        );
+      }
+    }
+
     // マジックリンクトークンを生成してセッションを作成
     const { data: linkData, error: linkError } = await adminClient.auth.admin.generateLink({
       type: 'magiclink',
@@ -204,26 +307,6 @@ export async function handleSignupVerifyPost(
       );
     }
 
-    // Save onboarding profile fields if provided
-    const userId = sessionData.user?.id;
-    if (userId && (display_name || user_handle || eiken_level !== undefined)) {
-      const profileUpdate: Record<string, unknown> = { user_id: userId };
-      if (display_name) profileUpdate.username = display_name;
-      if (display_name) profileUpdate.display_name = display_name;
-      if (user_handle) profileUpdate.user_handle = user_handle;
-      if (eiken_level !== undefined) profileUpdate.eiken_level = eiken_level;
-
-      const { error: profileError } = await adminClient
-        .from('profiles')
-        .upsert(profileUpdate, { onConflict: 'user_id' });
-
-      if (profileError && display_name) {
-        await adminClient
-          .from('profiles')
-          .upsert({ user_id: userId, username: display_name }, { onConflict: 'user_id' });
-      }
-    }
-
     // 使用済みOTPを削除
     await adminClient
       .from('otp_requests')
@@ -234,7 +317,7 @@ export async function handleSignupVerifyPost(
       success: true,
       user: {
         id: userId,
-        email: sessionData.user?.email,
+        email: sessionData.user?.email ?? newUser.user.email,
       },
     });
   } catch (error) {

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -50,7 +50,7 @@ function SignupForm() {
   const searchParams = useSearchParams();
   const redirect = searchParams.get('redirect') || '/';
 
-  const [step, setStep] = useState<SignupStep>('onboarding');
+  const [step, setStep] = useState<SignupStep>('profile');
 
   // Onboarding state
   const [displayName, setDisplayName] = useState('');
@@ -106,7 +106,7 @@ function SignupForm() {
     checkHandleAvailability(normalized);
   };
 
-  const handleOnboardingSubmit = () => {
+  const handleProfileSubmit = () => {
     setError(null);
     const onboarding: OnboardingData = { displayName, userHandle, eikenLevel };
     const validation = validateOnboardingData(onboarding);
@@ -118,6 +118,11 @@ function SignupForm() {
       setError('このIDは既に使われています');
       return;
     }
+    setStep('level');
+  };
+
+  const handleLevelSubmit = () => {
+    setError(null);
     setStep('form');
   };
 
@@ -215,8 +220,8 @@ function SignupForm() {
     }
   };
 
-  const stepIndex = step === 'onboarding' ? 1 : step === 'form' ? 2 : 3;
-  const totalSteps = 3;
+  const stepIndex = step === 'profile' ? 1 : step === 'level' ? 2 : step === 'form' ? 3 : 4;
+  const totalSteps = 4;
 
   // ── OTP Step ─────────────────────────────────────────────
   if (step === 'otp') {
@@ -438,7 +443,7 @@ function SignupForm() {
             title="アカウント情報"
             description="メールアドレスとパスワードを入力してください。"
             onBack={() => {
-              setStep('onboarding');
+              setStep('level');
               setError(null);
             }}
           >
@@ -529,7 +534,115 @@ function SignupForm() {
     );
   }
 
-  // ── Onboarding Step ──────────────────────────────────────
+  // ── Level Step ───────────────────────────────────────────
+  if (step === 'level') {
+    return (
+      <>
+        <DesktopAuthShell
+          title="受検レベル"
+          description="目標の級を選ぶと、学習レベルの初期設定に使われます。"
+        >
+          {error && <DesktopAuthError>{error}</DesktopAuthError>}
+          <div className="ds-field">
+            <label>英検レベル</label>
+            <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8, marginTop: 4 }}>
+              <button
+                type="button"
+                onClick={() => setEikenLevel(null)}
+                className={`ds-chip ${eikenLevel === null ? 'active' : ''}`}
+              >
+                未定
+              </button>
+              {EIKEN_LEVELS.map((level) => (
+                <button
+                  key={level.value}
+                  type="button"
+                  onClick={() => setEikenLevel(level.value)}
+                  className={`ds-chip ${eikenLevel === level.value ? 'active' : ''}`}
+                >
+                  {level.label}
+                </button>
+              ))}
+            </div>
+            <div style={{ fontSize: 11, color: 'var(--color-muted)', marginTop: 8 }}>
+              あとから設定画面で変更できます。
+            </div>
+          </div>
+          <DesktopAuthPrimaryButton
+            type="button"
+            variant="accent"
+            onClick={handleLevelSubmit}
+          >
+            アカウント情報へ
+          </DesktopAuthPrimaryButton>
+          <button
+            type="button"
+            onClick={() => {
+              setStep('profile');
+              setError(null);
+            }}
+            style={{ display: 'block', margin: '14px auto 0', color: 'var(--color-muted)', fontSize: 12.5, fontWeight: 700 }}
+          >
+            ユーザー名とIDを修正
+          </button>
+        </DesktopAuthShell>
+
+        <div className="lg:hidden">
+          <SignupShell
+            stepIndex={stepIndex}
+            totalSteps={totalSteps}
+            title="受検レベル"
+            description="目標の級を選択してください。"
+            onBack={() => {
+              setStep('profile');
+              setError(null);
+            }}
+          >
+            <div className="flex flex-col gap-3 px-6 pb-3">
+              {error && <ErrorMessage>{error}</ErrorMessage>}
+
+              <div>
+                <div className="mb-[5px] pl-0.5 font-mono text-[9px] font-bold tracking-[0.06em] text-[var(--color-muted)]">
+                  英検レベル
+                </div>
+                <div className="flex flex-wrap gap-[7px]">
+                  <LevelChip
+                    active={eikenLevel === null}
+                    onClick={() => setEikenLevel(null)}
+                  >
+                    未定
+                  </LevelChip>
+                  {EIKEN_LEVELS.map((level) => (
+                    <LevelChip
+                      key={level.value}
+                      active={eikenLevel === level.value}
+                      onClick={() => setEikenLevel(level.value)}
+                    >
+                      {level.label}
+                    </LevelChip>
+                  ))}
+                </div>
+                <div className="mt-2 pl-0.5 text-[10px] leading-relaxed text-[var(--color-muted)]">
+                  あとから設定画面で変更できます。
+                </div>
+              </div>
+            </div>
+
+            <div className="px-6 pb-4 pt-2">
+              <PrimaryAction
+                type="button"
+                onClick={handleLevelSubmit}
+              >
+                アカウント情報へ
+              </PrimaryAction>
+            </div>
+          </SignupShell>
+        </div>
+      </>
+    );
+  }
+
+  // ── Profile Step ────────────────────────────────────────
   const onboardingValid =
     displayName.trim().length >= 1 &&
     /^[a-z0-9_]{3,20}$/.test(userHandle) &&
@@ -540,7 +653,7 @@ function SignupForm() {
       {/* Desktop */}
       <DesktopAuthShell
         title="プロフィール設定"
-        description=""
+        description="ユーザー名とユーザーIDを設定してください。"
       >
         {error && <DesktopAuthError>{error}</DesktopAuthError>}
         <DesktopAuthField
@@ -577,29 +690,11 @@ function SignupForm() {
             半角英小文字・数字・アンダースコア（3〜20文字）
           </div>
         </div>
-        <div className="ds-field">
-          <label>英検レベル（任意）</label>
-          <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8, marginTop: 4 }}>
-            {EIKEN_LEVELS.map((level) => (
-              <button
-                key={level.value}
-                type="button"
-                onClick={() => setEikenLevel(eikenLevel === level.value ? null : level.value)}
-                className={`ds-chip ${eikenLevel === level.value ? 'active' : ''}`}
-              >
-                {level.label}
-              </button>
-            ))}
-          </div>
-          <div style={{ fontSize: 11, color: 'var(--color-muted)', marginTop: 8 }}>
-            英検の級に合わせて学習レベルを調整します。あとから変更できます。
-          </div>
-        </div>
         <DesktopAuthPrimaryButton
           type="button"
           variant="accent"
           disabled={!onboardingValid}
-          onClick={handleOnboardingSubmit}
+          onClick={handleProfileSubmit}
         >
           次へ進む
         </DesktopAuthPrimaryButton>
@@ -620,7 +715,7 @@ function SignupForm() {
           stepIndex={stepIndex}
           totalSteps={totalSteps}
           title="プロフィール設定"
-          description=""
+          description="ユーザー名とユーザーIDを設定してください。"
           backHref="/"
         >
           <div className="flex flex-col gap-3 px-6 pb-3">
@@ -661,38 +756,13 @@ function SignupForm() {
                 半角英小文字・数字・_（3〜20文字）
               </div>
             </div>
-
-            <div>
-              <div className="mb-[5px] pl-0.5 font-mono text-[9px] font-bold tracking-[0.06em] text-[var(--color-muted)]">
-                英検レベル（任意）
-              </div>
-              <div className="flex flex-wrap gap-[7px]">
-                {EIKEN_LEVELS.map((level) => (
-                  <button
-                    key={level.value}
-                    type="button"
-                    onClick={() => setEikenLevel(eikenLevel === level.value ? null : level.value)}
-                    className={`rounded-[10px] border-2 px-3.5 py-2 text-[12px] font-bold transition-all ${
-                      eikenLevel === level.value
-                        ? 'border-[var(--solid-ink)] bg-[var(--solid-ink)] text-white shadow-[2px_3px_0_var(--solid-ink)]'
-                        : 'border-[var(--solid-ink)] bg-white text-[var(--solid-ink)]'
-                    }`}
-                  >
-                    {level.label}
-                  </button>
-                ))}
-              </div>
-              <div className="mt-2 pl-0.5 text-[10px] leading-relaxed text-[var(--color-muted)]">
-                英検の級に合わせて学習レベルを調整します。あとから変更できます。
-              </div>
-            </div>
           </div>
 
           <div className="px-6 pb-4 pt-2">
             <PrimaryAction
               type="button"
               disabled={!onboardingValid}
-              onClick={handleOnboardingSubmit}
+              onClick={handleProfileSubmit}
             >
               次へ進む
             </PrimaryAction>
@@ -830,6 +900,30 @@ function PrimaryAction({
       <div className="flex items-center justify-center gap-2 rounded-[14px] border-2 border-[var(--solid-ink)] bg-[var(--solid-ink)] py-3.5 text-center text-sm font-bold text-white shadow-[3px_4px_0_#000] transition-all active:translate-x-0.5 active:translate-y-0.5 active:shadow-[1px_1px_0_#000]">
         {children}
       </div>
+    </button>
+  );
+}
+
+function LevelChip({
+  active,
+  onClick,
+  children,
+}: {
+  active: boolean;
+  onClick: () => void;
+  children: ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={`rounded-[10px] border-2 px-3.5 py-2 text-[12px] font-bold transition-all ${
+        active
+          ? 'border-[var(--solid-ink)] bg-[var(--solid-ink)] text-white shadow-[2px_3px_0_var(--solid-ink)]'
+          : 'border-[var(--solid-ink)] bg-white text-[var(--solid-ink)]'
+      }`}
+    >
+      {children}
     </button>
   );
 }

--- a/src/lib/auth/signup-flow.test.ts
+++ b/src/lib/auth/signup-flow.test.ts
@@ -13,8 +13,8 @@ import {
   validateOnboardingData,
 } from './signup-flow';
 
-test('signup flow includes onboarding, form, then otp steps', () => {
-  assert.deepEqual(SIGNUP_STEPS, ['onboarding', 'form', 'otp']);
+test('signup flow splits profile and level before form and otp steps', () => {
+  assert.deepEqual(SIGNUP_STEPS, ['profile', 'level', 'form', 'otp']);
   assert.equal(SIGNUP_OTP_LENGTH, 6);
   assert.equal(SIGNUP_RESEND_COOLDOWN_SECONDS, 60);
 });

--- a/src/lib/auth/signup-flow.ts
+++ b/src/lib/auth/signup-flow.ts
@@ -1,4 +1,4 @@
-export const SIGNUP_STEPS = ['onboarding', 'form', 'otp'] as const;
+export const SIGNUP_STEPS = ['profile', 'level', 'form', 'otp'] as const;
 export type SignupStep = typeof SIGNUP_STEPS[number];
 
 export const SIGNUP_OTP_LENGTH = 6;


### PR DESCRIPTION
## Summary
- Split signup onboarding into separate profile and exam-level steps before account creation.
- Persist onboarding profile fields through a profiles upsert so missing profile rows do not drop display_name, username, user_handle, or eiken_level.
- Added contract coverage for the signup profile upsert payload.

## Validation
- npx tsx --test src/lib/auth/signup-flow.test.ts src/app/api/auth/otp.contract.test.ts
- npm run lint -- src/app/signup/page.tsx src/app/api/auth/signup-verify/route.ts src/app/api/auth/otp.contract.test.ts src/lib/auth/signup-flow.ts src/lib/auth/signup-flow.test.ts
- npx tsc --noEmit --pretty false
- npm run build