### PR TITLE
Unify desktop/mobile frontend with responsive components

### DIFF
--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -1,18 +1,16 @@
 'use client';
 
 import { useRouter } from 'next/navigation';
-import { DesktopContactView } from '@/components/desktop/DesktopSupport';
 import { Icon } from '@/components/ui/Icon';
 
 export default function ContactPage() {
   const router = useRouter();
 
   return (
-    <>
-      <DesktopContactView onBack={() => router.back()} />
-      <div className="relative min-h-screen bg-[var(--color-background)] pt-3 font-[var(--font-body)] lg:hidden">
+      <div className="relative min-h-screen bg-[var(--color-background)] pt-3 font-[var(--font-body)] lg:min-h-0 lg:flex-1 lg:overflow-y-auto lg:pb-10">
+      <div className="lg:mx-auto lg:max-w-3xl lg:px-8 lg:pt-7">
       {/* Header */}
-      <div className="px-[18px] pb-3.5 pt-1">
+      <div className="px-[18px] pb-3.5 pt-1 lg:px-0">
         <div className="mb-0.5 flex items-center gap-2">
           <button
             type="button"
@@ -28,7 +26,7 @@ export default function ContactPage() {
       </div>
 
       {/* Hero card */}
-      <div className="px-[18px] pb-3.5">
+      <div className="px-[18px] pb-3.5 lg:px-0">
         <div>
           <div
             className="rounded-xl border-2 border-[var(--solid-ink)] p-3.5"
@@ -48,7 +46,7 @@ export default function ContactPage() {
       </div>
 
       {/* Contact */}
-      <div className="px-[18px] pb-3">
+      <div className="px-[18px] pb-3 lg:px-0">
         <div className="pb-1.5 pl-1 font-mono text-[9px] font-bold uppercase tracking-[0.08em] text-[var(--color-muted)]">連絡先</div>
         <a
           href="mailto:support@merken.jp"
@@ -69,19 +67,19 @@ export default function ContactPage() {
         <FaqRow q="アカウントを削除したい" a="お問い合わせメールにてご連絡ください。アカウント削除時にすべての関連データを削除します。" last />
       </Section>
 
-      <div className="px-[18px] pb-[110px] pt-1">
+      <div className="px-[18px] pb-[110px] pt-1 lg:px-0">
         <div className="text-center font-mono text-[9px] tracking-[0.04em] text-[var(--color-muted)]">
           MERKEN
         </div>
       </div>
       </div>
-    </>
+      </div>
   );
 }
 
 function Section({ label, children }: { label: string; children: React.ReactNode }) {
   return (
-    <div className="px-[18px] pb-3">
+    <div className="px-[18px] pb-3 lg:px-0">
       <div className="pb-1.5 pl-1 font-mono text-[9px] font-bold uppercase tracking-[0.08em] text-[var(--color-muted)]">
         {label}
       </div>

--- a/src/app/favorites/page.tsx
+++ b/src/app/favorites/page.tsx
@@ -3,7 +3,6 @@
 import { Suspense, useCallback, useEffect, useMemo, useState } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import Link from 'next/link';
-import { DesktopFavoritesView, DesktopWrongAnswersView } from '@/components/desktop/DesktopFavorites';
 import { Icon } from '@/components/ui/Icon';
 import { WordDetailView } from '@/components/word/WordDetailView';
 import { TranslationDisplay } from '@/components/word/TranslationDisplay';
@@ -204,26 +203,19 @@ function FavoritesPageContent() {
   return (
     <>
       {isWrongMode ? (
-        <DesktopWrongAnswersView wrongAnswers={wrongAnswersWithProjectTitles} returnPath={returnPath} />
-      ) : (
-        <DesktopFavoritesView
-          favorites={sortedFavorites}
-          loading={loading}
-          error={error}
-          isPro={isPro}
-          returnPath={returnPath}
-          onToggleFavorite={(word) => void handleToggleFavorite(word)}
-          onCycleVocabularyType={(word) => void handleCycleVocabularyType(word)}
-        />
-      )}
-      {isWrongMode ? (
         <MobileWrongAnswersView
           wrongAnswers={wrongAnswersWithProjectTitles}
           returnPath={returnPath}
           onBack={() => router.back()}
         />
       ) : (
-        <div className="flex min-h-screen flex-col bg-[var(--color-background)] pt-3 font-[var(--font-body)] lg:hidden">
+        <div className="flex min-h-screen flex-col bg-[var(--color-background)] pt-3 font-[var(--font-body)] lg:min-h-0 lg:flex-1 lg:overflow-y-auto lg:pb-10 lg:pt-0">
+          <div className="hidden items-center gap-4 border-b border-[var(--color-border)] bg-[rgba(246,245,241,0.86)] px-8 py-[18px] backdrop-blur-sm lg:flex">
+            <div className="min-w-0 flex-1">
+              <div className="font-mono text-[11px] tracking-[0.06em] text-[var(--color-muted)]">FAVORITES</div>
+              <h1 className="font-display text-2xl font-extrabold text-[var(--solid-ink)]">お気に入り</h1>
+            </div>
+          </div>
           <div className="flex items-center gap-2.5 px-[14px] pb-2.5 pt-2 lg:hidden">
             <button
               type="button"
@@ -238,7 +230,7 @@ function FavoritesPageContent() {
             </div>
           </div>
 
-          <div className="px-[18px] pb-3.5 pt-1 lg:pt-4">
+          <div className="px-[18px] pb-3.5 pt-1 lg:px-8 lg:pt-7">
             <div>
               <div className="overflow-hidden rounded-2xl border-2 border-[var(--solid-ink)] bg-white p-4">
                 <div className="pointer-events-none absolute -right-3.5 -top-4 opacity-10 text-[var(--color-accent)]">
@@ -279,7 +271,7 @@ function FavoritesPageContent() {
             </div>
           </div>
 
-          <div className="flex gap-1.5 overflow-x-auto px-[14px] pb-2.5">
+          <div className="flex gap-1.5 overflow-x-auto px-[14px] pb-2.5 lg:px-8">
             {([
               { k: 'alpha', label: 'ABC順' },
               { k: 'status', label: 'ステータス順' },
@@ -301,9 +293,9 @@ function FavoritesPageContent() {
             ))}
           </div>
 
-          {error && <p className="px-[14px] pb-2 text-xs font-bold text-[var(--color-error)]">{error}</p>}
+          {error && <p className="px-[14px] pb-2 text-xs font-bold text-[var(--color-error)] lg:px-8">{error}</p>}
 
-          <div className="flex flex-col gap-1.5 px-[14px] pb-[110px]">
+          <div className="flex flex-col gap-1.5 px-[14px] pb-[110px] lg:px-8 lg:grid lg:grid-cols-2 lg:gap-3 xl:grid-cols-3">
             {loading ? (
               <div className="flex items-center justify-center py-16 text-[var(--color-muted)]">
                 <Icon name="progress_activity" size={20} className="animate-spin" />
@@ -463,8 +455,14 @@ function MobileWrongAnswersView({
   const rows = [...wrongAnswers].sort((a, b) => b.wrongCount - a.wrongCount || b.lastWrongAt - a.lastWrongAt);
 
   return (
-    <div className="flex min-h-screen flex-col bg-[var(--color-background)] pt-3 font-[var(--font-body)] lg:hidden">
-      <div className="flex items-center gap-2.5 px-[14px] pb-2.5 pt-2">
+    <div className="flex min-h-screen flex-col bg-[var(--color-background)] pt-3 font-[var(--font-body)] lg:min-h-0 lg:flex-1 lg:overflow-y-auto lg:pb-10 lg:pt-0">
+      <div className="hidden items-center gap-4 border-b border-[var(--color-border)] bg-[rgba(246,245,241,0.86)] px-8 py-[18px] backdrop-blur-sm lg:flex">
+        <div className="min-w-0 flex-1">
+          <div className="font-mono text-[11px] tracking-[0.06em] text-[var(--color-muted)]">FAVORITES</div>
+          <h1 className="font-display text-2xl font-extrabold text-[var(--solid-ink)]">お気に入り</h1>
+        </div>
+      </div>
+      <div className="flex items-center gap-2.5 px-[14px] pb-2.5 pt-2 lg:hidden">
         <button
           type="button"
           onClick={onBack}
@@ -478,7 +476,7 @@ function MobileWrongAnswersView({
         </div>
       </div>
 
-      <div className="px-[18px] pb-3.5 pt-1">
+      <div className="px-[18px] pb-3.5 pt-1 lg:px-8 lg:pt-7">
         <div>
           <div className="overflow-hidden rounded-2xl border-2 border-[var(--solid-ink)] bg-white p-4">
             <div className="flex items-center gap-1.5 text-[var(--color-error)]">
@@ -508,7 +506,7 @@ function MobileWrongAnswersView({
         </div>
       </div>
 
-      <div className="flex flex-col gap-1.5 px-[14px] pb-[110px]">
+      <div className="flex flex-col gap-1.5 px-[14px] pb-[110px] lg:px-8 lg:grid lg:grid-cols-2 lg:gap-3 xl:grid-cols-3">
         {rows.length === 0 ? (
           <div className="rounded-[10px] border-2 border-[var(--color-border)] bg-white px-4 py-10 text-center text-sm text-[var(--color-muted)]">
             間違えた問題はまだありません

--- a/src/app/friends/page.tsx
+++ b/src/app/friends/page.tsx
@@ -2,7 +2,6 @@
 
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import Link from 'next/link';
-import { DesktopButton, DesktopTopbar } from '@/components/desktop/DesktopChrome';
 import { SolidPanel } from '@/components/redesign/SolidPage';
 import { Icon } from '@/components/ui';
 import { useAuth } from '@/hooks/use-auth';
@@ -271,25 +270,25 @@ export default function FriendsPage() {
 
   return (
     <>
-      <div className="hidden h-full min-h-0 flex-col lg:flex">
-        <DesktopTopbar title="フィード" crumb="学習タイムライン">
-          <DesktopButton href="/shared" icon="hub" variant="ghost">共有ライブラリ</DesktopButton>
-        </DesktopTopbar>
-        <div className="ds-scroll">
-          {renderContent()}
+      <div className="hidden items-center gap-4 border-b border-[var(--color-border)] bg-[rgba(246,245,241,0.86)] px-8 py-[18px] backdrop-blur-sm lg:flex">
+        <div className="min-w-0 flex-1">
+          <div className="font-mono text-[11px] tracking-[0.06em] text-[var(--color-muted)]">SOCIAL</div>
+          <h1 className="font-display text-2xl font-extrabold text-[var(--solid-ink)]">フィード</h1>
         </div>
       </div>
 
-      <div className="relative min-h-screen bg-[var(--color-background)] pb-[110px] pt-3 font-[var(--font-body)] lg:hidden">
-        <div className="px-[18px] pb-2 pt-1">
-          <div className="font-mono text-[10px] font-bold tracking-[0.08em] text-[var(--color-muted)]">
+      <div className="relative min-h-screen bg-[var(--color-background)] pb-[110px] pt-3 font-[var(--font-body)] lg:min-h-0 lg:flex-1 lg:overflow-y-auto lg:pb-10 lg:pt-0">
+        <div className="px-[18px] pb-2 pt-1 lg:px-0">
+          <div className="font-mono text-[10px] font-bold tracking-[0.08em] text-[var(--color-muted)] lg:hidden">
             FEED
           </div>
-          <div className="mt-0.5 font-display text-[26px] font-extrabold leading-[1.1] text-[var(--solid-ink)]">
+          <div className="mt-0.5 font-display text-[26px] font-extrabold leading-[1.1] text-[var(--solid-ink)] lg:hidden">
             フィード
           </div>
         </div>
-        {renderContent()}
+        <div className="lg:mx-auto lg:max-w-3xl lg:px-8 lg:pt-7">
+          {renderContent()}
+        </div>
       </div>
     </>
   );

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -4,13 +4,6 @@ import { Suspense, useState } from 'react';
 import Link from 'next/link';
 import { useSearchParams } from 'next/navigation';
 import { OAuthProviderButtons } from '@/components/auth/OAuthProviderButtons';
-import {
-  DesktopAuthError,
-  DesktopAuthField,
-  DesktopAuthOAuth,
-  DesktopAuthPrimaryButton,
-  DesktopAuthShell,
-} from '@/components/desktop/DesktopAuth';
 import { Icon } from '@/components/ui/Icon';
 import { useAuth } from '@/hooks/use-auth';
 
@@ -43,70 +36,9 @@ function LoginForm() {
   };
 
   return (
-    <>
-      <DesktopAuthShell
-        title="おかえりなさい"
-        description="アカウントにログインして学習を続けましょう"
-      >
-        <form onSubmit={handleSubmit}>
-          {error && <DesktopAuthError>{error}</DesktopAuthError>}
-          <DesktopAuthField
-            label="メールアドレス"
-            placeholder="you@example.com"
-            type="email"
-            value={email}
-            onChange={setEmail}
-            autoComplete="email"
-            disabled={loading}
-          />
-          <DesktopAuthField
-            label="パスワード"
-            placeholder="••••••••"
-            type={showPassword ? 'text' : 'password'}
-            value={password}
-            onChange={setPassword}
-            autoComplete="current-password"
-            disabled={loading}
-            labelExtra={
-              <Link href="/reset-password" style={{ fontSize: 12.5, color: 'var(--color-accent)', fontWeight: 700, textDecoration: 'none' }}>
-                お忘れですか？
-              </Link>
-            }
-            trailing={
-              <button
-                type="button"
-                onClick={() => setShowPassword((value) => !value)}
-                style={{ fontFamily: 'var(--font-mono)', fontSize: 10, fontWeight: 800, color: 'var(--color-muted)' }}
-                aria-label={showPassword ? 'パスワードを隠す' : 'パスワードを表示'}
-              >
-                {showPassword ? '非表示' : '表示'}
-              </button>
-            }
-          />
-          <DesktopAuthPrimaryButton disabled={loading || email.trim().length === 0 || password.length === 0}>
-            {loading ? 'ログイン中...' : 'ログイン'}
-          </DesktopAuthPrimaryButton>
-        </form>
-
-        <DesktopAuthOAuth
-          redirectPath={redirect}
-          disabled={loading}
-          onError={(message) => setError(message || null)}
-        />
-
-        <div className="muted" style={{ fontSize: 13.5, textAlign: 'center', marginTop: 24 }}>
-          アカウントをお持ちでない方は{' '}
-          <Link
-            href={`/signup?redirect=${encodeURIComponent(redirect)}`}
-            style={{ color: 'var(--color-accent)', fontWeight: 700, textDecoration: 'none' }}
-          >
-            新規登録
-          </Link>
-        </div>
-      </DesktopAuthShell>
-
-      <div className="relative mx-auto flex min-h-screen w-full max-w-[480px] flex-col bg-[#f3f0e9] pt-3 font-[var(--font-body)] [background-image:radial-gradient(rgba(26,26,26,0.045)_1px,transparent_1px)] [background-size:22px_22px] lg:hidden">
-      <div className="px-[14px] pt-1">
+      <div className="relative mx-auto flex min-h-screen w-full max-w-[480px] flex-col bg-[#f3f0e9] pt-3 font-[var(--font-body)] [background-image:radial-gradient(rgba(26,26,26,0.045)_1px,transparent_1px)] [background-size:22px_22px] lg:min-h-0 lg:flex-1 lg:overflow-y-auto">
+      <div className="lg:mx-auto lg:w-full lg:max-w-md lg:pt-16">
+      <div className="px-[14px] pt-1 lg:hidden">
         <Link
           href="/"
           className="flex h-[38px] w-[38px] items-center justify-center rounded-[19px] border-2 border-[var(--solid-ink)] bg-white text-[var(--solid-ink)] transition-all duration-100 active:translate-x-px active:translate-y-px"
@@ -212,7 +144,7 @@ function LoginForm() {
 
       <div className="flex-1" />
       </div>
-    </>
+      </div>
   );
 }
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,7 +5,7 @@ import Image from 'next/image';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { Icon } from '@/components/ui/Icon';
-import { DesktopHomeView } from '@/components/desktop/DesktopHome';
+import { DesktopStudySidebar } from '@/components/desktop/DesktopStudySidebar';
 import { SolidEmpty, SolidPanel } from '@/components/redesign/SolidPage';
 import { ScanCaptureModal } from '@/components/home/ScanCaptureModal';
 import { LpDemoSection } from '@/components/home/LpDemoSection';
@@ -34,6 +34,7 @@ import {
   consumeHomeGeneratingWordbook,
   type HomeGeneratingWordbookPayload,
 } from '@/lib/home/home-session-storage';
+import { useIsDesktop } from '@/hooks/use-is-desktop';
 import { getDailyStats, getStreakDays } from '@/lib/utils';
 import { isBillingEnabled } from '@/lib/billing/feature';
 import type { Project, SubscriptionStatus, Word } from '@/types';
@@ -309,11 +310,13 @@ export default function HomePage() {
   const router = useRouter();
   const { user, subscription, isPro, loading: authLoading } = useAuth();
   useOnboarding();
+  const isDesktop = useIsDesktop();
   const [projects, setProjects] = useState<HomeProjectStats[]>([]);
   const [stats, setStats] = useState<HomeStats>(EMPTY_STATS);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [pendingScans, setPendingScans] = useState<HomePendingScan[]>([]);
+  const [homeQuery, setHomeQuery] = useState('');
   const [recentScanJobs, setRecentScanJobs] = useState<RecentScanJob[]>([]);
   const [pendingGeneratingWordbook, setPendingGeneratingWordbook] = useState<HomeGeneratingWordbookPayload | null>(null);
 
@@ -528,189 +531,235 @@ export default function HomePage() {
     return <GuestHomePage />;
   }
 
+  const homeQ = homeQuery.trim().toLowerCase();
+  const filteredProjects = homeQ
+    ? projects.filter((p) => p.title.toLowerCase().includes(homeQ))
+    : projects;
+  const shownProjects = isDesktop ? filteredProjects : filteredProjects.slice(0, HOME_MY_BOOKS_VISIBLE_LIMIT);
+
   return (
     <>
-      <DesktopHomeView
-        projects={projects}
-        stats={stats}
-        loading={loading}
-        error={error}
-        pendingScans={displayedPendingScans}
-        onStartScan={() => router.push('/scan')}
-      />
-      <div className="relative min-h-screen bg-[var(--color-background)] pb-[110px] pt-3 font-[var(--font-body)] lg:hidden">
-      <div className="flex items-center justify-between px-[18px] pb-4 pt-2 lg:hidden">
-        <div className="font-display text-[26px] font-black leading-none tracking-[0.1em] text-[var(--solid-ink)]">
-          MERKEN
-          <span className="ml-1 inline-block h-[5px] w-[5px] -translate-y-2 bg-[var(--color-accent)]" />
+      {/* Desktop topbar */}
+      <div className="hidden items-center gap-4 border-b border-[var(--color-border)] bg-[rgba(246,245,241,0.86)] px-8 py-[18px] backdrop-blur-sm lg:flex">
+        <div className="min-w-0 flex-1">
+          <div className="font-mono text-[11px] tracking-[0.06em] text-[var(--color-muted)]">HOME / ライブラリ</div>
+          <h1 className="font-display text-2xl font-extrabold text-[var(--solid-ink)]">マイ単語帳</h1>
         </div>
-        <div className="flex items-center gap-2">
-          <div className="flex items-center gap-[5px] rounded-full border-2 border-[var(--solid-ink)] bg-[var(--color-surface)] px-2.5 py-1.5">
-            <span className="inline-flex text-[var(--color-warning)]">
-              <Icon name="local_fire_department" size={13} filled />
-            </span>
-            <span className="font-mono text-xs font-bold text-[var(--solid-ink)]">{streakDays}</span>
-            <span className="text-[10px] font-semibold text-[var(--color-muted)]">日連続</span>
-          </div>
-        </div>
+        <label className="flex min-w-[230px] items-center gap-2 rounded-[10px] border-[1.5px] border-[var(--solid-ink)] bg-white px-3.5 py-2 text-[var(--color-muted)]">
+          <Icon name="search" size={18} />
+          <input
+            type="search"
+            value={homeQuery}
+            onChange={(e) => setHomeQuery(e.target.value)}
+            placeholder="単語帳を検索"
+            className="min-w-0 flex-1 bg-transparent text-[13.5px] text-[var(--color-foreground)] outline-none placeholder:text-[var(--color-muted)]"
+          />
+        </label>
+        <button
+          type="button"
+          onClick={() => setVocabScanOpen(true)}
+          className="inline-flex items-center gap-2 rounded-[var(--solid-radius-sm)] border-[1.5px] border-[var(--color-accent-ink)] bg-[var(--color-accent)] px-[18px] py-2.5 font-display text-sm font-bold text-white shadow-[2px_3px_0_var(--color-accent-ink)] transition-all hover:translate-x-px hover:translate-y-px hover:shadow-[1px_2px_0_var(--color-accent-ink)]"
+        >
+          <Icon name="add" size={18} />
+          新規作成
+        </button>
       </div>
 
-      {error && (
-        <div className="px-[18px] pb-3">
-          <SolidPanel className="!rounded-[12px] border-[var(--color-error)]" faceClassName="!p-3 text-xs font-bold text-[var(--color-error)]">
-            {error}
-          </SolidPanel>
-        </div>
-      )}
+      {/* Main content area */}
+      <div className="relative min-h-screen bg-[var(--color-background)] pb-[110px] pt-3 font-[var(--font-body)] lg:min-h-0 lg:flex-1 lg:overflow-y-auto lg:pb-10 lg:pt-0">
+        <div className="lg:grid lg:grid-cols-[1fr_300px] lg:items-start lg:gap-6 lg:px-8 lg:pt-7">
+          <div>
+            {/* Mobile header */}
+            <div className="flex items-center justify-between px-[18px] pb-4 pt-2 lg:hidden">
+              <div className="font-display text-[26px] font-black leading-none tracking-[0.1em] text-[var(--solid-ink)]">
+                MERKEN
+                <span className="ml-1 inline-block h-[5px] w-[5px] -translate-y-2 bg-[var(--color-accent)]" />
+              </div>
+              <div className="flex items-center gap-2">
+                <div className="flex items-center gap-[5px] rounded-full border-2 border-[var(--solid-ink)] bg-[var(--color-surface)] px-2.5 py-1.5">
+                  <span className="inline-flex text-[var(--color-warning)]">
+                    <Icon name="local_fire_department" size={13} filled />
+                  </span>
+                  <span className="font-mono text-xs font-bold text-[var(--solid-ink)]">{streakDays}</span>
+                  <span className="text-[10px] font-semibold text-[var(--color-muted)]">日連続</span>
+                </div>
+              </div>
+            </div>
 
-      <PwaInstallBanner />
+            {error && (
+              <div className="px-[18px] pb-3 lg:px-0">
+                <SolidPanel className="!rounded-[12px] border-[var(--color-error)]" faceClassName="!p-3 text-xs font-bold text-[var(--color-error)]">
+                  {error}
+                </SolidPanel>
+              </div>
+            )}
 
-      <div className="grid grid-cols-2 gap-2.5 px-[18px] pb-3.5">
-        {goalState === 'empty' ? (
-          <button type="button" onClick={() => setVocabScanOpen(true)} className="block text-left">
-            <SolidPanel className="!rounded-2xl" faceClassName="!p-3 min-h-[120px]">
-              <div className="font-mono text-[10px] font-semibold uppercase tracking-[0.02em] text-[var(--color-muted)]">
-                TODAY&apos;S GOAL
-              </div>
-              <div className="mt-2 flex items-center gap-1.5">
-                <span className="inline-flex text-[var(--solid-ink)]">
-                  <Icon name="photo_camera" size={26} />
-                </span>
-                <span className="font-display text-[18px] font-extrabold leading-tight text-[var(--solid-ink)]">
-                  最初のスキャン
-                </span>
-              </div>
-              <div className="mt-3.5 flex items-center gap-[3px] text-[var(--solid-ink)]">
-                <span className="text-[13px] font-bold">スキャンを開始</span>
-                <span className="inline-flex text-[var(--color-accent)]">
-                  <Icon name="chevron_right" size={12} />
-                </span>
-              </div>
-            </SolidPanel>
-          </button>
-        ) : goalState === 'learn' ? (
-          <Link href="/quiz/all?learn=1&from=/" className="block">
-            <SolidPanel className="!rounded-2xl" faceClassName="!p-3 min-h-[120px]">
-              <div className="font-mono text-[10px] font-semibold uppercase tracking-[0.02em] text-[var(--color-muted)]">
-                TODAY&apos;S GOAL
-              </div>
-              <div className="mt-2 flex items-baseline gap-1">
-                <span className="font-display text-[30px] font-extrabold tabular-nums leading-none text-[var(--solid-ink)]">
-                  {unmasteredCount}
-                </span>
-                <span className="text-sm font-bold text-[var(--solid-ink)]">語</span>
-              </div>
-              <div className="mt-0.5 text-[11px] tabular-nums text-[var(--color-muted)]">
-                未習得 ・ 本日 {completedToday} 語学習
-              </div>
-              <div className="mt-2.5 h-[5px] overflow-hidden rounded-full bg-[rgba(26,26,26,0.08)]">
-                <div className="h-full bg-[var(--color-accent)]" style={{ width: `${learnProgress}%` }} />
-              </div>
-              <div className="mt-3 flex items-center gap-[3px] text-[var(--solid-ink)]">
-                <span className="text-[13px] font-bold">学習を始める</span>
-                <span className="inline-flex text-[var(--color-accent)]">
-                  <Icon name="chevron_right" size={12} />
-                </span>
-              </div>
-            </SolidPanel>
-          </Link>
-        ) : (
-          <Link href="/quiz/all?review=1&from=/" className="block">
-            <SolidPanel className="!rounded-2xl" faceClassName="!p-3 min-h-[120px]">
-              <div className="font-mono text-[10px] font-semibold uppercase tracking-[0.02em] text-[var(--color-muted)]">
-                TODAY&apos;S GOAL
-              </div>
-              <div className="mt-2 flex items-baseline gap-1">
-                <span className="font-display text-[30px] font-extrabold tabular-nums leading-none text-[var(--solid-ink)]">
-                  {dueCount}
-                </span>
-                <span className="text-sm font-bold text-[var(--solid-ink)]">語</span>
-              </div>
-              <div className="mt-0.5 text-[11px] tabular-nums text-[var(--color-muted)]">
-                {completedToday} / {goalTotal} 完了
-              </div>
-              <div className="mt-2.5 h-[5px] overflow-hidden rounded-full bg-[rgba(26,26,26,0.08)]">
-                <div className="h-full bg-[var(--color-accent)]" style={{ width: `${goalProgress}%` }} />
-              </div>
-              <div className="mt-3 flex items-center gap-[3px] text-[var(--solid-ink)]">
-                <span className="text-[13px] font-bold">復習を始める</span>
-                <span className="inline-flex text-[var(--color-accent)]">
-                  <Icon name="chevron_right" size={12} />
-                </span>
-              </div>
-            </SolidPanel>
-          </Link>
-        )}
+            <PwaInstallBanner />
 
-        <SolidPanel className="!rounded-2xl" faceClassName="!p-3 min-h-[120px]">
-          <div className="font-mono text-[10px] font-semibold uppercase tracking-[0.02em] text-[var(--color-muted)]">
-            MASTERY
-          </div>
-          <div className="mt-1.5 flex items-center gap-2.5">
-            <MiniDonut mastered={mastered} review={review} total={totalWords} />
-            <div className="flex flex-1 flex-col gap-[5px]">
-              <LegendItem color="var(--color-success)" label="習得" count={mastered} />
-              <LegendItem color="var(--color-warning)" label="学習中" count={review} />
-              <LegendItem color="rgba(26,26,26,0.15)" label="未学習" count={newW} />
+            {/* Goal + Mastery cards */}
+            <div className="grid grid-cols-2 gap-2.5 px-[18px] pb-3.5 lg:gap-4 lg:px-0">
+              {goalState === 'empty' ? (
+                <button type="button" onClick={() => setVocabScanOpen(true)} className="block text-left">
+                  <SolidPanel className="!rounded-2xl" faceClassName="!p-3 min-h-[120px] lg:!p-5">
+                    <div className="font-mono text-[10px] font-semibold uppercase tracking-[0.02em] text-[var(--color-muted)]">
+                      TODAY&apos;S GOAL
+                    </div>
+                    <div className="mt-2 flex items-center gap-1.5">
+                      <span className="inline-flex text-[var(--solid-ink)]">
+                        <Icon name="photo_camera" size={26} />
+                      </span>
+                      <span className="font-display text-[18px] font-extrabold leading-tight text-[var(--solid-ink)]">
+                        最初のスキャン
+                      </span>
+                    </div>
+                    <div className="mt-3.5 flex items-center gap-[3px] text-[var(--solid-ink)]">
+                      <span className="text-[13px] font-bold">スキャンを開始</span>
+                      <span className="inline-flex text-[var(--color-accent)]">
+                        <Icon name="chevron_right" size={12} />
+                      </span>
+                    </div>
+                  </SolidPanel>
+                </button>
+              ) : goalState === 'learn' ? (
+                <Link href="/quiz/all?learn=1&from=/" className="block">
+                  <SolidPanel className="!rounded-2xl" faceClassName="!p-3 min-h-[120px] lg:!p-5">
+                    <div className="font-mono text-[10px] font-semibold uppercase tracking-[0.02em] text-[var(--color-muted)]">
+                      TODAY&apos;S GOAL
+                    </div>
+                    <div className="mt-2 flex items-baseline gap-1">
+                      <span className="font-display text-[30px] font-extrabold tabular-nums leading-none text-[var(--solid-ink)] lg:text-[36px]">
+                        {unmasteredCount}
+                      </span>
+                      <span className="text-sm font-bold text-[var(--solid-ink)]">語</span>
+                    </div>
+                    <div className="mt-0.5 text-[11px] tabular-nums text-[var(--color-muted)]">
+                      未習得 ・ 本日 {completedToday} 語学習
+                    </div>
+                    <div className="mt-2.5 h-[5px] overflow-hidden rounded-full bg-[rgba(26,26,26,0.08)] lg:h-[7px]">
+                      <div className="h-full bg-[var(--color-accent)]" style={{ width: `${learnProgress}%` }} />
+                    </div>
+                    <div className="mt-3 flex items-center gap-[3px] text-[var(--solid-ink)]">
+                      <span className="text-[13px] font-bold">学習を始める</span>
+                      <span className="inline-flex text-[var(--color-accent)]">
+                        <Icon name="chevron_right" size={12} />
+                      </span>
+                    </div>
+                  </SolidPanel>
+                </Link>
+              ) : (
+                <Link href="/quiz/all?review=1&from=/" className="block">
+                  <SolidPanel className="!rounded-2xl" faceClassName="!p-3 min-h-[120px] lg:!p-5">
+                    <div className="font-mono text-[10px] font-semibold uppercase tracking-[0.02em] text-[var(--color-muted)]">
+                      TODAY&apos;S GOAL
+                    </div>
+                    <div className="mt-2 flex items-baseline gap-1">
+                      <span className="font-display text-[30px] font-extrabold tabular-nums leading-none text-[var(--solid-ink)] lg:text-[36px]">
+                        {dueCount}
+                      </span>
+                      <span className="text-sm font-bold text-[var(--solid-ink)]">語</span>
+                    </div>
+                    <div className="mt-0.5 text-[11px] tabular-nums text-[var(--color-muted)]">
+                      {completedToday} / {goalTotal} 完了
+                    </div>
+                    <div className="mt-2.5 h-[5px] overflow-hidden rounded-full bg-[rgba(26,26,26,0.08)] lg:h-[7px]">
+                      <div className="h-full bg-[var(--color-accent)]" style={{ width: `${goalProgress}%` }} />
+                    </div>
+                    <div className="mt-3 flex items-center gap-[3px] text-[var(--solid-ink)]">
+                      <span className="text-[13px] font-bold">復習を始める</span>
+                      <span className="inline-flex text-[var(--color-accent)]">
+                        <Icon name="chevron_right" size={12} />
+                      </span>
+                    </div>
+                  </SolidPanel>
+                </Link>
+              )}
+
+              <SolidPanel className="!rounded-2xl" faceClassName="!p-3 min-h-[120px] lg:!p-5">
+                <div className="font-mono text-[10px] font-semibold uppercase tracking-[0.02em] text-[var(--color-muted)]">
+                  MASTERY
+                </div>
+                <div className="mt-1.5 flex items-center gap-2.5">
+                  <MiniDonut mastered={mastered} review={review} total={totalWords} />
+                  <div className="flex flex-1 flex-col gap-[5px]">
+                    <LegendItem color="var(--color-success)" label="習得" count={mastered} />
+                    <LegendItem color="var(--color-warning)" label="学習中" count={review} />
+                    <LegendItem color="rgba(26,26,26,0.15)" label="未学習" count={newW} />
+                  </div>
+                </div>
+              </SolidPanel>
+            </div>
+
+            {/* My Books section */}
+            <div className="flex items-baseline justify-between px-5 pb-2.5 pt-3 lg:px-0 lg:pt-5">
+              <div>
+                <div className="font-mono text-[10px] font-semibold tracking-[0.06em] text-[var(--color-muted)]">
+                  MY BOOKS
+                </div>
+                <h2 className="font-display text-[19px] font-extrabold tracking-[-0.01em] text-[var(--solid-ink)] lg:text-xl">
+                  マイ単語帳
+                </h2>
+              </div>
+              <div className="flex items-center gap-3">
+                <span className="hidden font-mono text-xs text-[var(--color-muted)] lg:inline">
+                  {projects.length} 冊 · {totalWords} 語
+                </span>
+                <Link href="/projects" className="flex items-center gap-[3px] text-[13px] font-semibold text-[var(--color-accent)]">
+                  すべて見る
+                  <Icon name="chevron_right" size={11} />
+                </Link>
+              </div>
+            </div>
+
+            {/* Project list */}
+            <div className="flex flex-col gap-2.5 px-[18px] pb-4 lg:grid lg:grid-cols-2 lg:gap-3 lg:px-0 lg:pb-8 xl:grid-cols-3">
+              {displayedPendingScans.map((job) => (
+                <GeneratingProjectCard
+                  key={job.id}
+                  title={job.project_title}
+                  iconDataUrl={job.iconDataUrl}
+                />
+              ))}
+              {loading && shownProjects.length === 0 ? (
+                <div className="flex items-center justify-center py-10 text-[var(--color-muted)] lg:col-span-full">
+                  <Icon name="progress_activity" size={20} className="animate-spin" />
+                  <span className="ml-2 text-sm">読み込み中...</span>
+                </div>
+              ) : shownProjects.length === 0 ? (
+                <div className="lg:col-span-full">
+                  <SolidEmpty
+                    icon="menu_book"
+                    title={homeQ ? '一致する単語帳がありません' : '単語帳はまだありません'}
+                    description={homeQ ? '検索語を変えてもう一度探してください。' : 'スキャンまたは手入力で最初の単語帳を作成しましょう。'}
+                    action={
+                      <Link href="/scan" className="solid-link-primary">
+                        <Icon name="add_a_photo" size={16} />
+                        新規スキャン
+                      </Link>
+                    }
+                  />
+                </div>
+              ) : (
+                shownProjects.map((project) => <ProjectRow key={project.id} project={project} />)
+              )}
             </div>
           </div>
-        </SolidPanel>
-      </div>
 
-      <div className="flex items-baseline justify-between px-5 pb-2.5 pt-3">
-        <div>
-          <div className="font-mono text-[10px] font-semibold tracking-[0.06em] text-[var(--color-muted)]">
-            MY BOOKS
+          {/* Desktop study sidebar */}
+          <div className="hidden lg:block">
+            <DesktopStudySidebar
+              stats={stats}
+              reviewHref={totalWords > 0 ? '/quiz/all?review=1&from=/' : '/projects'}
+            />
           </div>
-          <h2 className="font-display text-[19px] font-extrabold tracking-[-0.01em] text-[var(--solid-ink)]">
-            マイ単語帳
-          </h2>
         </div>
-        <Link href="/projects" className="flex items-center gap-[3px] text-[13px] font-semibold text-[var(--color-accent)]">
-          すべて見る
-          <Icon name="chevron_right" size={11} />
-        </Link>
       </div>
 
-      <div className="flex flex-col gap-2.5 px-[18px] pb-4">
-        {displayedPendingScans.map((job) => (
-          <GeneratingProjectCard
-            key={job.id}
-            title={job.project_title}
-            iconDataUrl={job.iconDataUrl}
-          />
-        ))}
-        {loading && visibleProjects.length === 0 ? (
-          <div className="flex items-center justify-center py-10 text-[var(--color-muted)]">
-            <Icon name="progress_activity" size={20} className="animate-spin" />
-            <span className="ml-2 text-sm">読み込み中...</span>
-          </div>
-        ) : visibleProjects.length === 0 ? (
-          <SolidEmpty
-            icon="menu_book"
-            title="単語帳はまだありません"
-            description="スキャンまたは手入力で最初の単語帳を作成しましょう。"
-            action={
-              <Link href="/scan" className="solid-link-primary">
-                <Icon name="add_a_photo" size={16} />
-                新規スキャン
-              </Link>
-            }
-          />
-        ) : (
-          visibleProjects.map((project) => <ProjectRow key={project.id} project={project} />)
-        )}
-      </div>
-
-      </div>
       <ScanCaptureModal
         isOpen={vocabScanOpen}
         onClose={() => setVocabScanOpen(false)}
         defaultMode="vocab"
         onBackgroundScanStarted={showHomeGeneratingWordbook}
       />
-
-
     </>
   );
 }

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -1,38 +1,17 @@
 'use client';
 
 import { useRouter } from 'next/navigation';
-import { DesktopLegalDocView } from '@/components/desktop/DesktopSupport';
 import { Icon } from '@/components/ui/Icon';
 
-const PRIVACY_ARTICLES = [
-  { h: '収集する情報', p: ['本サービスの提供にあたり、以下の情報を取得します。'], list: ['アカウント情報（メールアドレス、パスワード〈暗号化済み〉）', '学習データ（作成した単語帳、クイズの回答履歴、学習進捗）', 'アップロード画像（単語抽出のために送信された画像。処理後、サーバーには保存しません）', '決済情報（有料プラン利用時。Stripeが処理し、本サービスではカード情報等を保持しません）'] },
-  { h: '利用目的', p: ['取得した情報は、以下の目的のために利用します。'], list: ['サービスの提供・運営・改善', 'ユーザーの学習データの保存・同期', 'お問い合わせへの対応', '利用規約違反への対応', '統計データの作成（個人を特定できない形に加工）'] },
-  { h: '第三者サービス', p: ['本サービスでは、認証・データベース・AI抽出・決済・ホスティングのため第三者サービスを利用します。各サービスのプライバシーポリシーについては、各社のサイトをご確認ください。'], list: ['Supabase — 認証・データベース', 'Google (Gemini 2.5 Flash) — 画像OCR・単語抽出', 'OpenAI — クイズ生成・例文生成', 'Stripe — 決済処理', 'Vercel — ホスティング'] },
-  { h: '画像データの取り扱い', p: ['ユーザーがアップロードした画像は、単語抽出処理のためにGoogle Gemini APIに送信されます。処理完了後、画像データは本サービスのサーバーには保存されません。'] },
-  { h: 'データの保存', list: ['無料プラン: データはユーザーのブラウザ（IndexedDB）にローカル保存されます。サーバーには送信されません。', 'Proプラン: データはSupabase（クラウド）に保存され、デバイス間で同期されます。'] },
-  { h: 'Cookie・類似技術', p: ['本サービスでは、ログイン状態の維持や利用状況の分析のためCookieおよびローカルストレージを使用します。ブラウザの設定によりこれらを無効化できますが、一部機能が利用できなくなる場合があります。'] },
-  { h: 'データの削除', p: ['ユーザーはいつでも自身のデータを削除できます。アカウント削除をご希望の場合は、お問い合わせください。アカウント削除時にはすべての関連データを削除します。'] },
-  { h: 'セキュリティ', p: ['本サービスは、個人情報の漏洩・紛失を防ぐために適切なセキュリティ対策を講じています。通信はすべてSSL/TLSにより暗号化されています。'] },
-  { h: 'ポリシーの変更', p: ['本ポリシーは必要に応じて改定することがあります。重要な変更がある場合は、サービス内で通知します。'] },
-  { h: 'お問い合わせ', p: ['本ポリシーに関するお問い合わせは support@merken.jp までご連絡ください。'] },
-];
 
 export default function PrivacyPage() {
   const router = useRouter();
 
   return (
-    <>
-      <DesktopLegalDocView
-        title="プライバシーポリシー"
-        updated="2026年2月24日"
-        intro="MERKEN（以下「本サービス」）は、ユーザーのプライバシーを尊重し、個人情報の保護に努めます。本ポリシーは、本サービスにおける個人情報の取り扱いについて定めます。"
-        toc={PRIVACY_ARTICLES.map((article) => article.h)}
-        articles={PRIVACY_ARTICLES}
-        onBack={() => router.back()}
-      />
-      <div className="relative min-h-screen bg-[var(--color-background)] pt-3 font-[var(--font-body)] lg:hidden">
+      <div className="relative min-h-screen bg-[var(--color-background)] pt-3 font-[var(--font-body)] lg:min-h-0 lg:flex-1 lg:overflow-y-auto lg:pb-10">
+      <div className="lg:mx-auto lg:max-w-3xl lg:px-8 lg:pt-7">
       {/* Header */}
-      <div className="px-[18px] pb-3.5 pt-1">
+      <div className="px-[18px] pb-3.5 pt-1 lg:px-0">
         <div className="mb-0.5 flex items-center gap-2">
           <button
             type="button"
@@ -48,7 +27,7 @@ export default function PrivacyPage() {
       </div>
 
       {/* Intro */}
-      <div className="px-[18px] pb-3.5">
+      <div className="px-[18px] pb-3.5 lg:px-0">
         <div className="rounded-xl border-2 border-[var(--solid-ink)] bg-[#faf7f1] p-[12px_14px]">
           <p className="m-0 text-[11px] leading-[1.75] text-[var(--solid-ink)]">
             MERKEN（以下「本サービス」）は、ユーザーのプライバシーを尊重し、個人情報の保護に努めます。本ポリシーは、本サービスにおける個人情報の取り扱いについて定めます。
@@ -123,13 +102,13 @@ export default function PrivacyPage() {
 
       <Footer updated="2026年2月24日" />
       </div>
-    </>
+      </div>
   );
 }
 
 function Section({ num, label, children }: { num: string; label: string; children: React.ReactNode }) {
   return (
-    <div className="px-[18px] pb-3">
+    <div className="px-[18px] pb-3 lg:px-0">
       <div className="flex items-baseline gap-1.5 pb-1.5 pl-1 font-mono text-[9px] font-bold uppercase tracking-[0.08em] text-[var(--color-muted)]">
         <span className="text-[var(--solid-ink)]">§{num}</span>
         <span>{label}</span>
@@ -157,7 +136,7 @@ function OL({ items }: { items: string[] }) {
 
 function Footer({ updated }: { updated: string }) {
   return (
-    <div className="px-[18px] pb-[110px] pt-1">
+    <div className="px-[18px] pb-[110px] pt-1 lg:px-0">
       <div className="text-center font-mono text-[9px] tracking-[0.04em] text-[var(--color-muted)]">
         最終更新 {updated} · MERKEN
       </div>

--- a/src/app/project/[id]/page.tsx
+++ b/src/app/project/[id]/page.tsx
@@ -3,7 +3,6 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useParams, useRouter } from 'next/navigation';
 import Link from 'next/link';
-import { DesktopProjectDetailView } from '@/components/desktop/DesktopProjectDetail';
 import { Icon } from '@/components/ui/Icon';
 import { useToast } from '@/components/ui/toast';
 import { WordLimitModal } from '@/components/limits';
@@ -935,35 +934,40 @@ export default function ProjectPage() {
 
   return (
     <>
-      <DesktopProjectDetailView
-        project={project}
-        projectId={projectId}
-        words={words}
-        filteredWords={filteredWords}
-        wordsLoaded={wordsLoaded}
-        counts={counts}
-        query={query}
-        onQueryChange={setQuery}
-        filterActive={wordFilterActive}
-        sortActive={wordSortOrder !== 'createdAsc'}
-        selectMode={selectMode}
-        selectedWordIds={selectedWordIds}
-        onOpenFilterSheet={() => setWordShowFilterSheet(true)}
-        onOpenSortSheet={() => setWordShowSortSheet(true)}
-        onToggleSelectMode={() => {
-          if (selectMode) handleExitSelectMode();
-          else { setSelectMode(true); setSelectedWordIds(new Set()); }
-        }}
-        onToggleSelectWordGroup={handleToggleSelectWordGroup}
-        onRename={handleOpenRename}
-        onToggleFavorite={(word) => void handleToggleFavorite(word)}
-        onCycleVocabularyType={(word) => void handleCycleVocabularyType(word)}
-        onDeleteWord={handleOpenDeleteWord}
-        onBulkDelete={() => setBulkDeleteModalOpen(true)}
-        onScan={() => setShowScanCaptureModal(true)}
-        onManualAdd={() => setShowManualWordModal(true)}
-      />
-      <div className="relative flex min-h-screen flex-col bg-[var(--color-background)] font-[var(--font-body)] lg:hidden">
+      <div className="relative flex min-h-screen flex-col bg-[var(--color-background)] font-[var(--font-body)] lg:min-h-0 lg:flex-1 lg:overflow-y-auto lg:pb-10 lg:pt-0">
+
+      {/* Desktop topbar */}
+      <div className="hidden lg:flex items-center gap-4 border-b border-[var(--color-border)] bg-[var(--color-background)] px-8 py-4">
+        <button type="button" onClick={() => router.replace('/')} className="flex h-[38px] w-[38px] items-center justify-center rounded-[19px] border-2 border-[var(--solid-ink)] bg-white text-[var(--solid-ink)] transition-all duration-100 active:translate-x-px active:translate-y-px">
+          <Icon name="chevron_left" size={18} />
+        </button>
+        <div className="min-w-0 flex-1">
+          <div className="font-mono text-[10px] font-bold tracking-[0.08em] text-[var(--color-muted)]">BOOK</div>
+          <h1 className="truncate font-display text-lg font-extrabold text-[var(--solid-ink)]">{project.title}</h1>
+        </div>
+        <div className="flex items-center gap-2">
+          <HeaderBtn aria-label="共有" onClick={handleOpenShareSheet}>
+            <Icon name="ios_share" size={16} />
+          </HeaderBtn>
+          <div className="relative">
+            <HeaderBtn aria-label="メニュー" onClick={() => setMenuOpen((open) => !open)}>
+              <Icon name="more_horiz" size={16} />
+            </HeaderBtn>
+            {menuOpen && (
+              <>
+                <button type="button" className="fixed inset-0 z-20 cursor-default bg-transparent" aria-label="メニューを閉じる" onClick={() => setMenuOpen(false)} />
+                <div className="absolute right-0 top-11 z-30 w-[170px] overflow-hidden rounded-[14px] border-2 border-[var(--solid-ink)] bg-white">
+                  <MenuButton icon="edit" label="名称変更" onClick={handleOpenRename} />
+                  <MenuButton icon="image" label="画像設定" onClick={handleOpenImagePicker} />
+                  <MenuButton icon="delete" label="削除" destructive onClick={() => { setMenuOpen(false); setDeleteModalOpen(true); }} />
+                </div>
+              </>
+            )}
+          </div>
+        </div>
+      </div>
+
+      {/* Mobile header */}
       <div className="sticky top-0 z-10 flex items-center justify-between bg-[var(--color-background)] px-4 pb-2 pt-3 lg:hidden">
         <HeaderBtn onClick={() => router.replace('/')} aria-label="ホームへ戻る">
           <Icon name="chevron_left" size={16} />
@@ -998,7 +1002,7 @@ export default function ProjectPage() {
         </div>
       </div>
 
-      <div className="flex items-start gap-3.5 px-5 pb-2.5 pt-[18px] lg:pt-8">
+      <div className="flex items-start gap-3.5 px-5 pb-2.5 pt-[18px] lg:px-8 lg:pt-8">
         <div
           className="flex h-16 w-16 shrink-0 items-center justify-center rounded-[13px] border-2 bg-center bg-cover font-display text-[28px] font-extrabold text-white"
           style={{
@@ -1022,11 +1026,11 @@ export default function ProjectPage() {
         </div>
       </div>
 
-      <div className="px-5 pb-3.5">
+      <div className="px-5 pb-3.5 lg:px-8">
         <StackedBar total={counts.total} m={counts.mastered} a={counts.active} l={counts.learning} n={counts.newCount} />
       </div>
 
-      <div className="flex items-center gap-2 px-[18px] pb-4">
+      <div className="flex items-center gap-2 px-[18px] pb-4 lg:px-8">
         <div className="relative flex-1">
           <div className="pointer-events-none absolute inset-0 rounded-[10px] bg-[var(--color-accent)]" style={{ transform: 'translate(2px, 2px)' }} />
           <Link
@@ -1093,7 +1097,7 @@ export default function ProjectPage() {
         </div>
       </div>
 
-      <div className="flex items-center gap-2 px-5 pb-2">
+      <div className="flex items-center gap-2 px-5 pb-2 lg:px-8">
         <label
           htmlFor="project-word-search"
           className="flex min-w-0 flex-1 items-center gap-1.5 rounded-full border-2 border-[var(--solid-ink)] bg-white px-3 py-[7px] text-[var(--color-muted)]"
@@ -1152,7 +1156,7 @@ export default function ProjectPage() {
         </button>
       </div>
 
-      <div className={`flex flex-col px-4 ${selectMode ? 'pb-[160px]' : 'pb-[max(24px,env(safe-area-inset-bottom))]'}`}>
+      <div className={`flex flex-col px-4 lg:px-8 ${selectMode ? 'pb-[160px]' : 'pb-[max(24px,env(safe-area-inset-bottom))]'}`}>
         {!wordsLoaded ? (
           <div className="flex items-center justify-center py-12 text-[var(--color-muted)]">
             <Icon name="progress_activity" size={20} className="animate-spin" />

--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import Link from 'next/link';
-import { DesktopProjectsView } from '@/components/desktop/DesktopProjects';
+import { DesktopStudySidebar } from '@/components/desktop/DesktopStudySidebar';
 import { Icon } from '@/components/ui/Icon';
 import { SolidEmpty, SolidPanel } from '@/components/redesign/SolidPage';
 import { useAuth } from '@/hooks/use-auth';
@@ -156,21 +156,56 @@ export default function ProjectListPage() {
     });
   }, [projects, query, sort]);
 
+  const reviewHref = summaryStats.totalWords > 0 ? '/quiz/all?review=1&from=/projects' : '/projects';
+
   return (
-    <>
-      <DesktopProjectsView
-        projects={filtered}
-        loading={loading}
-        error={error}
-        query={query}
-        sort={sort}
-        summaryStats={summaryStats}
-        reviewHref={summaryStats.totalWords > 0 ? '/quiz/all?review=1&from=/projects' : '/projects'}
-        onQueryChange={setQuery}
-        onSortChange={setSort}
-      />
-      <div className="relative min-h-screen bg-[var(--color-background)] pb-[150px] pt-3 font-[var(--font-body)] lg:hidden">
-      <div className="px-5 pb-3.5 pt-2.5">
+    <div className="relative min-h-screen bg-[var(--color-background)] pb-[150px] pt-3 font-[var(--font-body)] lg:min-h-0 lg:flex-1 lg:overflow-y-auto lg:pb-10 lg:pt-0">
+      {/* Desktop topbar */}
+      <div className="hidden items-center gap-4 border-b border-[var(--color-border)] bg-[rgba(246,245,241,0.86)] px-8 py-[18px] backdrop-blur-sm lg:flex">
+        <div className="flex-1">
+          <div className="font-mono text-[10px] font-semibold uppercase tracking-[0.06em] text-[var(--color-muted)]">
+            ライブラリ / 管理
+          </div>
+          <h1 className="mt-0.5 font-display text-[20px] font-extrabold leading-[1.1] tracking-[-0.02em] text-[var(--solid-ink)]">
+            単語帳
+          </h1>
+        </div>
+        <label className="flex items-center gap-2 rounded-full border-2 border-[var(--color-border)] bg-[var(--color-surface)] px-3.5 py-2 text-[var(--color-muted)]">
+          <Icon name="search" size={15} />
+          <input
+            type="search"
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            placeholder="単語帳を検索"
+            className="min-w-0 bg-transparent text-[13px] text-[var(--solid-ink)] outline-none placeholder:text-[var(--color-muted)]"
+          />
+        </label>
+        {SORTS.map((s) => (
+          <button
+            key={s.k}
+            type="button"
+            onClick={() => setSort(s.k)}
+            className={`inline-flex shrink-0 items-center gap-[5px] whitespace-nowrap rounded-full px-3 py-1.5 text-[11px] font-semibold transition-colors ${
+              sort === s.k
+                ? 'border-2 border-[var(--solid-ink)] bg-[var(--solid-ink)] text-white'
+                : 'border-2 border-[var(--color-border)] bg-[var(--color-surface)] text-[var(--color-foreground)]'
+            }`}
+          >
+            <Icon name={s.icon} size={12} />
+            {s.label}
+          </button>
+        ))}
+        <Link
+          href="/scan"
+          className="inline-flex items-center gap-1.5 rounded-full bg-[var(--solid-ink)] px-4 py-2 text-[13px] font-bold text-white transition-opacity hover:opacity-90"
+        >
+          <Icon name="add" size={16} />
+          新規作成
+        </Link>
+      </div>
+
+      {/* Mobile header */}
+      <div className="px-5 pb-3.5 pt-2.5 lg:hidden">
         <div className="font-mono text-[10px] font-semibold uppercase tracking-[0.06em] text-[var(--color-muted)]">
           MY BOOKS
         </div>
@@ -179,7 +214,8 @@ export default function ProjectListPage() {
         </h1>
       </div>
 
-      <div className="px-[18px] pb-2.5 pt-1">
+      {/* Mobile search */}
+      <div className="px-[18px] pb-2.5 pt-1 lg:hidden">
         <label className="flex items-center gap-2 rounded-full border-2 border-[var(--color-border)] bg-[var(--color-surface)] px-3.5 py-2 text-[var(--color-muted)]">
           <Icon name="search" size={15} />
           <input
@@ -192,7 +228,8 @@ export default function ProjectListPage() {
         </label>
       </div>
 
-      <div className="flex gap-1.5 overflow-x-auto px-[18px] pb-3.5 pt-1">
+      {/* Mobile sort chips */}
+      <div className="flex gap-1.5 overflow-x-auto px-[18px] pb-3.5 pt-1 lg:hidden">
         {SORTS.map((s) => (
           <button
             key={s.k}
@@ -210,42 +247,52 @@ export default function ProjectListPage() {
         ))}
       </div>
 
-      <div className="flex items-baseline justify-between px-5 pb-2 pt-1">
-        <span className="font-mono text-[11px] uppercase tracking-[0.04em] text-[var(--color-muted)]">すべて</span>
-        <span className="font-mono text-[11px] tabular-nums text-[var(--color-muted)]">{filtered.length} 件</span>
-      </div>
-
-      {error && (
-        <div className="px-[18px] pb-3 text-xs font-bold text-[var(--color-error)]">
-          {error}
-        </div>
-      )}
-
-      <div className="flex flex-col gap-2.5 px-[18px] pb-[150px]">
-        {loading && projects.length === 0 ? (
-          <div className="flex items-center justify-center py-16 text-[var(--color-muted)]">
-            <Icon name="progress_activity" size={20} className="animate-spin" />
-            <span className="ml-2 text-sm">読み込み中...</span>
+      {/* Responsive grid: main content + desktop sidebar */}
+      <div className="lg:grid lg:grid-cols-[1fr_300px] lg:items-start lg:gap-6 lg:px-8 lg:pt-7">
+        <div>
+          <div className="flex items-baseline justify-between px-5 pb-2 pt-1 lg:px-0">
+            <span className="font-mono text-[11px] uppercase tracking-[0.04em] text-[var(--color-muted)]">すべて</span>
+            <span className="font-mono text-[11px] tabular-nums text-[var(--color-muted)]">{filtered.length} 件</span>
           </div>
-        ) : filtered.length === 0 ? (
-          <SolidEmpty
-            icon="menu_book"
-            title={query ? '一致する単語帳がありません' : '単語帳はまだありません'}
-            description={query ? '検索語を変えてもう一度探してください。' : 'スキャンして最初の単語帳を作成しましょう。'}
-            action={
-              <Link href="/scan" className="solid-link-primary">
-                <Icon name="add_a_photo" size={16} />
-                新規スキャン
-              </Link>
-            }
-          />
-        ) : (
-          filtered.map((project) => <BookRow key={project.id} project={project} />)
-        )}
-      </div>
 
+          {error && (
+            <div className="px-[18px] pb-3 text-xs font-bold text-[var(--color-error)] lg:px-0">
+              {error}
+            </div>
+          )}
+
+          <div className="flex flex-col gap-2.5 px-[18px] pb-[150px] lg:grid lg:grid-cols-2 lg:gap-3 lg:px-0 lg:pb-0 xl:grid-cols-3">
+            {loading && projects.length === 0 ? (
+              <div className="flex items-center justify-center py-16 text-[var(--color-muted)] lg:col-span-full">
+                <Icon name="progress_activity" size={20} className="animate-spin" />
+                <span className="ml-2 text-sm">読み込み中...</span>
+              </div>
+            ) : filtered.length === 0 ? (
+              <div className="lg:col-span-full">
+                <SolidEmpty
+                  icon="menu_book"
+                  title={query ? '一致する単語帳がありません' : '単語帳はまだありません'}
+                  description={query ? '検索語を変えてもう一度探してください。' : 'スキャンして最初の単語帳を作成しましょう。'}
+                  action={
+                    <Link href="/scan" className="solid-link-primary">
+                      <Icon name="add_a_photo" size={16} />
+                      新規スキャン
+                    </Link>
+                  }
+                />
+              </div>
+            ) : (
+              filtered.map((project) => <BookRow key={project.id} project={project} />)
+            )}
+          </div>
+        </div>
+
+        {/* Desktop study sidebar */}
+        <div className="hidden lg:block">
+          <DesktopStudySidebar stats={summaryStats} reviewHref={reviewHref} />
+        </div>
       </div>
-    </>
+    </div>
   );
 }
 

--- a/src/app/scan/confirm/page.tsx
+++ b/src/app/scan/confirm/page.tsx
@@ -2,7 +2,6 @@
 
 import { useState, useEffect, useLayoutEffect } from 'react';
 import { useRouter } from 'next/navigation';
-import { DesktopScanConfirmView } from '@/components/desktop/DesktopScan';
 import { Icon } from '@/components/ui/Icon';
 import { TranslationDisplay } from '@/components/word/TranslationDisplay';
 import { useToast } from '@/components/ui/toast';
@@ -347,30 +346,9 @@ export default function ConfirmPage() {
 
   return (
     <>
-      <DesktopScanConfirmView
-        words={words}
-        projectTitle={projectTitle}
-        isAddingToExisting={isAddingToExisting}
-        selectedCount={selectedCount}
-        availableSlots={availableSlots}
-        showLimitWarning={showLimitWarning}
-        excessCount={excessCount}
-        currentWordCount={currentWordCount}
-        saving={saving}
-        isPro={isPro}
-        onProjectTitleChange={setProjectTitle}
-        onToggleWord={handleToggleWord}
-        onEditWord={handleEditWord}
-        onSaveWord={handleSaveWord}
-        onCancelEdit={handleCancelEdit}
-        onDeleteWord={handleDeleteWord}
-        onAddManualWord={handleAddManualWord}
-        onBack={() => router.back()}
-        onSaveProject={() => void handleSaveProject()}
-      />
-      <div className="flex min-h-screen flex-col bg-[var(--color-background)] pt-3 font-[var(--font-body)] lg:hidden">
+      <div className="flex min-h-screen flex-col bg-[var(--color-background)] pt-3 font-[var(--font-body)] lg:min-h-0 lg:flex-1 lg:overflow-y-auto lg:pb-10 lg:pt-0">
       {/* Header */}
-      <div className="flex items-center gap-2.5 px-[14px] pb-2.5 pt-2">
+      <div className="flex items-center gap-2.5 px-[14px] pb-2.5 pt-2 lg:px-8 lg:pt-6">
         <button type="button" onClick={() => router.back()} className="flex h-[38px] w-[38px] items-center justify-center rounded-[19px] border-2 border-[var(--solid-ink)] bg-white text-[var(--solid-ink)] transition-all duration-100 active:translate-x-px active:translate-y-px">
           <Icon name="chevron_left" size={18} />
         </button>
@@ -386,7 +364,7 @@ export default function ConfirmPage() {
       </div>
 
       {/* Scan preview + project name */}
-      <div className="flex items-center gap-2.5 px-[18px] pb-3 pt-0.5">
+      <div className="flex items-center gap-2.5 px-[18px] pb-3 pt-0.5 lg:px-8">
         <div
           className="relative h-[68px] w-[54px] shrink-0 overflow-hidden rounded border-2 border-[var(--solid-ink)]"
           style={{ background: 'linear-gradient(135deg, #d4c9a8, #e8dfc2)' }}
@@ -417,7 +395,7 @@ export default function ConfirmPage() {
       </div>
 
       {/* Stats row */}
-      <div className="flex gap-1.5 px-[18px] pb-3">
+      <div className="flex gap-1.5 px-[18px] pb-3 lg:px-8">
         <StatChip label="抽出" value={words.length} />
         <StatChip label="選択中" value={selectedCount} accent="var(--color-success)" />
         {!isPro && <StatChip label={`残り${availableSlots}語`} value={availableSlots} accent={showLimitWarning ? 'var(--color-warning)' : 'var(--solid-ink)'} />}
@@ -425,7 +403,7 @@ export default function ConfirmPage() {
 
       {/* Limit warning */}
       {showLimitWarning && (
-        <div className="mx-[18px] mb-3 rounded-lg border border-[var(--color-warning)] bg-[rgba(255,165,0,0.06)] px-3 py-2.5">
+        <div className="mx-[18px] mb-3 rounded-lg border border-[var(--color-warning)] bg-[rgba(255,165,0,0.06)] px-3 py-2.5 lg:mx-8">
           <div className="flex items-start gap-2">
             <Icon name="warning" size={16} className="mt-0.5 shrink-0 text-[var(--color-warning)]" />
             <div>
@@ -441,7 +419,7 @@ export default function ConfirmPage() {
 
 
       {/* Word count + add button */}
-      <div className="flex items-center justify-between px-[18px] pb-2.5">
+      <div className="flex items-center justify-between px-[18px] pb-2.5 lg:px-8">
         <div className="font-mono text-[10px] font-bold uppercase tracking-[0.06em] text-[var(--color-muted)]">
           抽出された単語 ({words.length})
         </div>
@@ -451,7 +429,7 @@ export default function ConfirmPage() {
       </div>
 
       {/* Word list */}
-      <div className="flex flex-col gap-[5px] px-[14px] pb-[110px]">
+      <div className="flex flex-col gap-[5px] px-[14px] pb-[110px] lg:grid lg:grid-cols-2 lg:gap-3 lg:px-8 lg:pb-8 xl:grid-cols-3">
         {words.map((w, i) =>
           w.isEditing ? (
             <EditingWordRow key={w.tempId} w={w} onSave={handleSaveWord} onCancel={handleCancelEdit} />
@@ -465,7 +443,7 @@ export default function ConfirmPage() {
       </div>
 
       {/* Bottom action */}
-      <div className="fixed inset-x-0 bottom-0 flex gap-2 bg-gradient-to-t from-[#fafaf7] via-[#fafaf7] to-transparent px-[18px] pb-[30px] pt-3.5">
+      <div className="fixed inset-x-0 bottom-0 flex gap-2 bg-gradient-to-t from-[#fafaf7] via-[#fafaf7] to-transparent px-[18px] pb-[30px] pt-3.5 lg:static lg:px-8 lg:pb-8 lg:pt-4">
         <button
           type="button"
           onClick={() => router.back()}

--- a/src/app/scan/page.tsx
+++ b/src/app/scan/page.tsx
@@ -2,7 +2,6 @@
 
 import { useEffect, useMemo, useState } from 'react';
 import { useRouter } from 'next/navigation';
-import { DesktopScanView } from '@/components/desktop/DesktopScan';
 import { ScanCaptureModal } from '@/components/home/ScanCaptureModal';
 import { useAuth } from '@/hooks/use-auth';
 import { getRepository } from '@/lib/db';
@@ -62,22 +61,13 @@ export default function ScanPage() {
 
   return (
     <>
-      <DesktopScanView
-        projects={projects}
-        loadingProjects={projectsLoading}
-        targetProjectId={targetProjectId}
+      <ScanCaptureModal
+        isOpen
+        onClose={() => router.push('/')}
+        defaultMode="vocab"
+        targetProjectId={targetProjectId ?? undefined}
         targetProjectTitle={targetProject?.title}
-        isPro={isPro}
       />
-      <div className="lg:hidden">
-        <ScanCaptureModal
-          isOpen
-          onClose={() => router.push('/')}
-          defaultMode="vocab"
-          targetProjectId={targetProjectId ?? undefined}
-          targetProjectTitle={targetProject?.title}
-        />
-      </div>
     </>
   );
 }

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -2,7 +2,6 @@
 
 import { useRouter } from 'next/navigation';
 import Link from 'next/link';
-import { DesktopSettingsView } from '@/components/desktop/DesktopAccount';
 import { Icon } from '@/components/ui';
 import { SolidPanel } from '@/components/redesign/SolidPage';
 import { useAuth } from '@/hooks/use-auth';
@@ -33,23 +32,24 @@ export default function SettingsPage() {
   };
 
   return (
-    <>
-      <DesktopSettingsView
-        email={user?.email}
-        username={username}
-        accountId={accountId}
-        isPro={isPro}
-        onSignOut={() => void handleSignOut()}
-      />
-      <div className="relative min-h-screen bg-[var(--color-background)] pb-[110px] pt-3 font-[var(--font-body)] lg:hidden">
-      {/* Header */}
-      <div className="px-[18px] pb-[14px] pt-1">
+      <div className="relative min-h-screen bg-[var(--color-background)] pb-[110px] pt-3 font-[var(--font-body)] lg:min-h-0 lg:flex-1 lg:overflow-y-auto lg:pb-10 lg:pt-0">
+      {/* Desktop topbar */}
+      <div className="hidden items-center gap-4 border-b border-[var(--color-border)] bg-[rgba(246,245,241,0.86)] px-8 py-[18px] backdrop-blur-sm lg:flex">
+        <div className="min-w-0 flex-1">
+          <div className="font-mono text-[11px] tracking-[0.06em] text-[var(--color-muted)]">ACCOUNT</div>
+          <h1 className="font-display text-2xl font-extrabold text-[var(--solid-ink)]">設定</h1>
+        </div>
+      </div>
+
+      <div className="lg:mx-auto lg:max-w-2xl lg:px-8 lg:pt-7">
+      {/* Header (mobile only - desktop has topbar) */}
+      <div className="px-[18px] pb-[14px] pt-1 lg:hidden">
         <div className="font-mono text-[10px] font-bold uppercase tracking-[0.08em] text-[var(--color-muted)]">ACCOUNT</div>
         <div className="mt-0.5 font-display text-[26px] font-extrabold leading-[1.1] tracking-[-0.02em] text-[var(--solid-ink)]">設定</div>
       </div>
 
       {/* Profile card */}
-      <div className="px-[18px] pb-[14px]">
+      <div className="px-[18px] pb-[14px] lg:px-0">
         {authLoading ? (
           <SolidPanel className="!rounded-[14px] !" faceClassName="!p-[14px]">
             <div className="flex h-14 items-center justify-center">
@@ -101,7 +101,7 @@ export default function SettingsPage() {
 
       {/* Upgrade banner (Free only) */}
       {billingEnabled && !isPro && isAuthenticated && (
-        <div className="px-[18px] pb-4">
+        <div className="px-[18px] pb-4 lg:px-0">
           <div>
             <Link href="/subscription" className="flex items-center gap-2.5 rounded-[12px] border-2 border-[var(--solid-ink)] bg-gradient-to-br from-[oklch(0.94_0.06_130)] to-white p-[12px_14px]">
               <div className="flex-1">
@@ -140,7 +140,7 @@ export default function SettingsPage() {
 
       {/* Logout */}
       {isAuthenticated && (
-        <div className="px-[18px] pb-6">
+        <div className="px-[18px] pb-6 lg:px-0">
           <button
             type="button"
             onClick={handleSignOut}
@@ -154,13 +154,13 @@ export default function SettingsPage() {
         </div>
       )}
       </div>
-    </>
+      </div>
   );
 }
 
 function SettingsGroup({ label, children }: { label: string; children: React.ReactNode }) {
   return (
-    <div className="px-[18px] pb-3">
+    <div className="px-[18px] pb-3 lg:px-0">
       <div className="px-1 pb-1.5 font-mono text-[9px] font-bold uppercase tracking-[0.08em] text-[var(--color-muted)]">{label}</div>
       <div className="divide-y divide-[var(--color-border)] overflow-hidden rounded-[12px] border-2 border-[var(--solid-ink)] bg-white">
         {children}

--- a/src/app/share/[shareId]/page.tsx
+++ b/src/app/share/[shareId]/page.tsx
@@ -3,7 +3,6 @@
 import { useEffect, useMemo, useState } from 'react';
 import { useParams, useRouter } from 'next/navigation';
 import Link from 'next/link';
-import { DesktopSharedDetailView } from '@/components/desktop/DesktopSharedDetail';
 import { TranslationDisplay } from '@/components/word/TranslationDisplay';
 import { Icon } from '@/components/ui/Icon';
 import { SolidButton, SolidPanel } from '@/components/redesign/SolidPage';
@@ -424,32 +423,14 @@ export default function SharedDetailPage() {
 
   return (
     <>
-      <DesktopSharedDetailView
-        project={project}
-        words={displayWords}
-        ownerLabel={ownerLabel}
-        selectMode={selectMode}
-        selectedWordIds={selectedWordIds}
-        likeCount={likeCount}
-        liked={liked}
-        importing={importBusy}
-        importedProjectId={importedProjectId}
-        isPreviewLocked={isPreviewLocked}
-        isLoggedIn={!!user}
-        totalWordCount={totalWordCount}
-        previewClearWordCount={SHARE_PREVIEW_CLEAR_WORD_COUNT}
-        lockedCtaHref={loginRedirectHref}
-        onToggleLike={() => void handleToggleLike()}
-        onToggleSelectMode={() => {
-          setSelectMode((current) => !current);
-          setSelectedWordIds(new Set());
-        }}
-        onToggleWord={handleToggleSelect}
-        onImport={() => void handleImport()}
-        onClearSelection={() => setSelectedWordIds(new Set())}
-      />
-      <div className="relative flex min-h-screen flex-col bg-[var(--color-background)] pb-[160px] font-[var(--font-body)] lg:hidden">
-      <div className="flex items-center justify-between px-3.5 pb-2 pt-2">
+      <div className="relative flex min-h-screen flex-col bg-[var(--color-background)] pb-[160px] font-[var(--font-body)] lg:min-h-0 lg:flex-1 lg:overflow-y-auto lg:pb-10 lg:pt-0">
+      <div className="hidden items-center gap-4 border-b border-[var(--color-border)] bg-[rgba(246,245,241,0.86)] px-8 py-[18px] backdrop-blur-sm lg:flex">
+        <div className="min-w-0 flex-1">
+          <div className="font-mono text-[11px] tracking-[0.06em] text-[var(--color-muted)]">SHARED</div>
+          <h1 className="font-display text-2xl font-extrabold text-[var(--solid-ink)]">共有ライブラリ</h1>
+        </div>
+      </div>
+      <div className="flex items-center justify-between px-3.5 pb-2 pt-2 lg:hidden">
         <SharedHeaderBtn onClick={() => router.back()} aria-label="戻る">
           <Icon name="chevron_left" size={16} />
         </SharedHeaderBtn>
@@ -466,7 +447,7 @@ export default function SharedDetailPage() {
         </div>
       </div>
 
-      <div className="px-[18px] pb-3.5 pt-1">
+      <div className="px-[18px] pb-3.5 pt-1 lg:px-8 lg:pt-7">
         <SolidPanel
           className="!rounded-[16px] overflow-hidden"
           faceClassName="!p-4 relative [background:linear-gradient(135deg,oklch(0.94_0.04_14),#fff)]"
@@ -506,13 +487,13 @@ export default function SharedDetailPage() {
         </SolidPanel>
       </div>
 
-      <div className="flex items-center justify-between px-[18px] pb-2.5">
+      <div className="flex items-center justify-between px-[18px] pb-2.5 lg:px-8">
         <div className="font-mono text-[10px] font-bold uppercase tracking-[0.08em] text-[var(--color-muted)]">
           {isPreviewLocked ? `単語プレビュー · ${SHARE_PREVIEW_CLEAR_WORD_COUNT}語まで表示` : `単語プレビュー · 全 ${totalWordCount} 語`}
         </div>
       </div>
 
-      <div className="flex flex-col gap-1 px-3.5 pb-[130px]">
+      <div className="flex flex-col gap-1 px-3.5 pb-[130px] lg:grid lg:grid-cols-2 lg:gap-4 lg:px-8 xl:grid-cols-3">
         {displayWords.map((word, i) => {
           const selected = selectedWordIds.has(word.id);
           const locked = isPreviewLocked && i >= SHARE_PREVIEW_CLEAR_WORD_COUNT;

--- a/src/app/shared/SharedPageClient.tsx
+++ b/src/app/shared/SharedPageClient.tsx
@@ -3,7 +3,6 @@
 import { startTransition, useEffect, useRef, useState, type MouseEvent } from 'react';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
-import { DesktopSharedView } from '@/components/desktop/DesktopShared';
 import { FollowNotificationsButton } from '@/components/notifications/FollowNotificationsButton';
 import { Icon } from '@/components/ui';
 import { useAuth } from '@/hooks/use-auth';
@@ -257,29 +256,20 @@ export default function SharedPageClient({ initialDiscover }: SharedPageClientPr
 
   return (
     <>
-      <DesktopSharedView
-        category={category === 'groups' ? 'all' : category}
-        query={query}
-        payload={discover}
-        loading={loading}
-        loadingMore={loadingMore}
-        error={error}
-        onQueryChange={setQuery}
-        onCategorySelect={handleSelectCategory}
-        onBackToAll={handleBackToAll}
-        onLoadMore={() => void handleLoadMore()}
-        onOpenShareSheet={handleOpenShareSheet}
-        onProjectMissing={handleProjectMissing}
-      />
-
-      <div className="flex min-h-screen flex-col bg-[var(--color-background)] pb-[110px] pt-3 font-[var(--font-body)] lg:hidden">
-        <div className="px-[18px] pb-2 pt-1">
+      <div className="flex min-h-screen flex-col bg-[var(--color-background)] pb-[110px] pt-3 font-[var(--font-body)] lg:min-h-0 lg:flex-1 lg:overflow-y-auto lg:pb-10 lg:pt-0">
+        <div className="hidden items-center gap-4 border-b border-[var(--color-border)] bg-[rgba(246,245,241,0.86)] px-8 py-[18px] backdrop-blur-sm lg:flex">
+          <div className="min-w-0 flex-1">
+            <div className="font-mono text-[11px] tracking-[0.06em] text-[var(--color-muted)]">SHARED</div>
+            <h1 className="font-display text-2xl font-extrabold text-[var(--solid-ink)]">共有ライブラリ</h1>
+          </div>
+        </div>
+        <div className="px-[18px] pb-2 pt-1 lg:px-8 lg:pt-7">
           <div className="flex items-start justify-between gap-3">
             <div className="min-w-0">
-              <div className="font-mono text-[10px] font-bold tracking-[0.08em] text-[var(--color-muted)]">
+              <div className="font-mono text-[10px] font-bold tracking-[0.08em] text-[var(--color-muted)] lg:hidden">
                 COMMUNITY
               </div>
-              <div className="mt-0.5 font-display text-[26px] font-extrabold leading-[1.1] text-[var(--solid-ink)]">
+              <div className="mt-0.5 font-display text-[26px] font-extrabold leading-[1.1] text-[var(--solid-ink)] lg:hidden">
                 共有単語帳
               </div>
             </div>
@@ -298,7 +288,7 @@ export default function SharedPageClient({ initialDiscover }: SharedPageClientPr
         </div>
 
         {category !== 'groups' && category !== 'users' && (
-          <div className="px-[14px] pt-2">
+          <div className="px-[14px] pt-2 lg:px-0">
             <label className="flex min-w-0 items-center gap-2 rounded-[12px] border-2 border-[var(--solid-ink)] bg-white px-3 py-2.5 text-[var(--color-muted)]">
               <Icon name="search" size={16} />
               <span className="sr-only">共有ライブラリを検索</span>
@@ -314,7 +304,7 @@ export default function SharedPageClient({ initialDiscover }: SharedPageClientPr
         )}
 
         {category === 'all' ? (
-          <div className="grid grid-cols-3 gap-2 px-[14px] py-3">
+          <div className="grid grid-cols-3 gap-2 px-[14px] py-3 lg:px-0">
             {(Object.keys(CATEGORY_META) as PageCategory[]).map((key) => (
               <button
                 key={key}
@@ -328,7 +318,7 @@ export default function SharedPageClient({ initialDiscover }: SharedPageClientPr
             ))}
           </div>
         ) : (
-          <div className="flex items-center gap-2 px-[14px] py-3">
+          <div className="flex items-center gap-2 px-[14px] py-3 lg:px-0">
             <button
               type="button"
               onClick={handleBackToAll}
@@ -365,7 +355,7 @@ export default function SharedPageClient({ initialDiscover }: SharedPageClientPr
             onSearch={() => void handleUserSearch()}
           />
         ) : shouldShowResults && (
-          <div className="flex flex-col gap-4 px-[14px]">
+          <div className="flex flex-col gap-4 px-[14px] lg:px-0">
             {error && <ErrorBox message={error} />}
             {loading ? (
               <LoadingBox />
@@ -600,7 +590,7 @@ function ProjectSection({
   return (
     <section>
       <SectionLabel icon="menu_book" label="単語帳" count={projects.length} />
-      <div className="flex flex-col gap-2">
+      <div className="flex flex-col gap-2 lg:grid lg:grid-cols-2 lg:gap-4 xl:grid-cols-3">
         {projects.map((project) => (
           <ProjectCard
             key={project.project.id}

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -4,13 +4,6 @@ import { Suspense, useCallback, useEffect, useRef, useState, type FormEvent, typ
 import Link from 'next/link';
 import { useSearchParams } from 'next/navigation';
 import { OAuthProviderButtons } from '@/components/auth/OAuthProviderButtons';
-import {
-  DesktopAuthError,
-  DesktopAuthField,
-  DesktopAuthOAuth,
-  DesktopAuthPrimaryButton,
-  DesktopAuthShell,
-} from '@/components/desktop/DesktopAuth';
 import { SolidPanel } from '@/components/redesign/SolidPage';
 import { Icon } from '@/components/ui/Icon';
 import { OtpInput } from '@/components/ui/OtpInput';
@@ -226,61 +219,6 @@ function SignupForm() {
   // ── OTP Step ─────────────────────────────────────────────
   if (step === 'otp') {
     return (
-      <>
-        <DesktopAuthShell
-          title="メールを確認"
-          description="届いた6桁の認証コードを入力してください。"
-        >
-          <div className="ds-card" style={{ padding: 20, marginBottom: 18 }}>
-            <div style={{ display: 'flex', alignItems: 'center', gap: 12, marginBottom: 18 }}>
-              <div className="ds-avatar" style={{ width: 42, height: 42, borderRadius: 11 }}>
-                <Icon name="mail" />
-              </div>
-              <div style={{ minWidth: 0 }}>
-                <div style={{ fontWeight: 800, color: 'var(--solid-ink)' }}>認証コードを送信しました</div>
-                <div className="muted" style={{ marginTop: 2, fontSize: 13, overflowWrap: 'anywhere' }}>{email}</div>
-              </div>
-            </div>
-            {error && <DesktopAuthError>{error}</DesktopAuthError>}
-            <OtpInput
-              length={SIGNUP_OTP_LENGTH}
-              value={otpCode}
-              onChange={setOtpCode}
-              disabled={loading}
-            />
-            <DesktopAuthPrimaryButton
-              type="button"
-              variant="accent"
-              disabled={loading || !isSignupOtpComplete(otpCode)}
-              onClick={handleVerifyOtp}
-            >
-              {loading ? '確認中...' : '登録を完了する'}
-            </DesktopAuthPrimaryButton>
-          </div>
-          <div style={{ display: 'flex', justifyContent: 'space-between', gap: 14, fontSize: 12.5 }}>
-            <button
-              type="button"
-              onClick={() => {
-                setStep('form');
-                setOtpCode('');
-                setError(null);
-              }}
-              style={{ color: 'var(--color-muted)', fontWeight: 700 }}
-            >
-              メールアドレスを変更
-            </button>
-            <button
-              type="button"
-              onClick={handleResendOtp}
-              disabled={loading || resendCooldown > 0}
-              style={{ color: resendCooldown > 0 ? 'var(--color-muted)' : 'var(--color-accent)', fontWeight: 700 }}
-            >
-              {resendCooldown > 0 ? `再送信 ${resendCooldown}秒` : 'コードを再送信'}
-            </button>
-          </div>
-        </DesktopAuthShell>
-
-        <div className="lg:hidden">
           <SignupShell
             stepIndex={stepIndex}
             totalSteps={totalSteps}
@@ -347,96 +285,12 @@ function SignupForm() {
               </div>
             </SolidPanel>
           </SignupShell>
-        </div>
-      </>
     );
   }
 
   // ── Form Step (email + password) ─────────────────────────
   if (step === 'form') {
     return (
-      <>
-        <DesktopAuthShell
-          title="アカウントを作成"
-          description="無料で始められます。クレジットカード不要。"
-        >
-          <form onSubmit={handleFormSubmit}>
-            {error && <DesktopAuthError>{error}</DesktopAuthError>}
-            <DesktopAuthField
-              label="メールアドレス"
-              placeholder="you@example.com"
-              type="email"
-              value={email}
-              onChange={setEmail}
-              autoComplete="email"
-              disabled={loading}
-            />
-            <DesktopAuthField
-              label="パスワード"
-              placeholder="8文字以上"
-              type={showPassword ? 'text' : 'password'}
-              value={password}
-              onChange={setPassword}
-              autoComplete="new-password"
-              disabled={loading}
-              trailing={
-                <button
-                  type="button"
-                  onClick={() => setShowPassword((value) => !value)}
-                  style={{ fontFamily: 'var(--font-mono)', fontSize: 10, fontWeight: 800, color: 'var(--color-muted)' }}
-                  aria-label={showPassword ? 'パスワードを隠す' : 'パスワードを表示'}
-                >
-                  {showPassword ? '非表示' : '表示'}
-                </button>
-              }
-            />
-            <DesktopAuthField
-              label="パスワード（確認）"
-              placeholder="もう一度入力"
-              type={showPassword ? 'text' : 'password'}
-              value={confirmPassword}
-              onChange={setConfirmPassword}
-              autoComplete="new-password"
-              disabled={loading}
-            />
-            <DesktopAuthPrimaryButton
-              variant="accent"
-              disabled={
-                loading ||
-                email.trim().length === 0 ||
-                password.length === 0 ||
-                confirmPassword.length === 0
-              }
-            >
-              {loading ? '送信中...' : '認証コードを送信'}
-            </DesktopAuthPrimaryButton>
-          </form>
-
-          <DesktopAuthOAuth
-            redirectPath={redirect}
-            disabled={loading}
-            onError={(message) => setError(message || null)}
-          />
-
-          <div className="muted" style={{ fontSize: 12, textAlign: 'center', marginTop: 18, lineHeight: 1.6 }}>
-            登録すると
-            <Link href="/terms" style={{ color: 'var(--color-accent)', textDecoration: 'none' }}>利用規約</Link>
-            と
-            <Link href="/privacy" style={{ color: 'var(--color-accent)', textDecoration: 'none' }}>プライバシーポリシー</Link>
-            に同意したものとみなされます。
-          </div>
-          <div className="muted" style={{ fontSize: 13.5, textAlign: 'center', marginTop: 16 }}>
-            すでにアカウントをお持ちの方は{' '}
-            <Link
-              href={`/login?redirect=${encodeURIComponent(redirect)}`}
-              style={{ color: 'var(--color-accent)', fontWeight: 700, textDecoration: 'none' }}
-            >
-              ログイン
-            </Link>
-          </div>
-        </DesktopAuthShell>
-
-        <div className="lg:hidden">
           <SignupShell
             stepIndex={stepIndex}
             totalSteps={totalSteps}
@@ -529,65 +383,12 @@ function SignupForm() {
               </Link>
             </div>
           </SignupShell>
-        </div>
-      </>
     );
   }
 
   // ── Level Step ───────────────────────────────────────────
   if (step === 'level') {
     return (
-      <>
-        <DesktopAuthShell
-          title="受検何級に合格したいですか？"
-          description="目標の級を選択してください。"
-        >
-          {error && <DesktopAuthError>{error}</DesktopAuthError>}
-          <div className="ds-field">
-            <label>合格したい級</label>
-            <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8, marginTop: 4 }}>
-              <button
-                type="button"
-                onClick={() => setEikenLevel(null)}
-                className={`ds-chip ${eikenLevel === null ? 'active' : ''}`}
-              >
-                未定
-              </button>
-              {EIKEN_LEVELS.map((level) => (
-                <button
-                  key={level.value}
-                  type="button"
-                  onClick={() => setEikenLevel(level.value)}
-                  className={`ds-chip ${eikenLevel === level.value ? 'active' : ''}`}
-                >
-                  {level.label}
-                </button>
-              ))}
-            </div>
-            <div style={{ fontSize: 11, color: 'var(--color-muted)', marginTop: 8 }}>
-              あとから設定画面で変更できます。
-            </div>
-          </div>
-          <DesktopAuthPrimaryButton
-            type="button"
-            variant="accent"
-            onClick={handleLevelSubmit}
-          >
-            アカウント情報へ
-          </DesktopAuthPrimaryButton>
-          <button
-            type="button"
-            onClick={() => {
-              setStep('profile');
-              setError(null);
-            }}
-            style={{ display: 'block', margin: '14px auto 0', color: 'var(--color-muted)', fontSize: 12.5, fontWeight: 700 }}
-          >
-            ユーザー名とIDを修正
-          </button>
-        </DesktopAuthShell>
-
-        <div className="lg:hidden">
           <SignupShell
             stepIndex={stepIndex}
             totalSteps={totalSteps}
@@ -637,8 +438,6 @@ function SignupForm() {
               </PrimaryAction>
             </div>
           </SignupShell>
-        </div>
-      </>
     );
   }
 
@@ -649,68 +448,6 @@ function SignupForm() {
     handleAvailable !== false;
 
   return (
-    <>
-      {/* Desktop */}
-      <DesktopAuthShell
-        title="プロフィール設定"
-        description="ユーザー名とユーザーIDを設定してください。"
-      >
-        {error && <DesktopAuthError>{error}</DesktopAuthError>}
-        <DesktopAuthField
-          label="ユーザー名"
-          placeholder="山田太郎"
-          type="text"
-          value={displayName}
-          onChange={setDisplayName}
-          autoComplete="name"
-          disabled={loading}
-        />
-        <div className="ds-field">
-          <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 12, marginBottom: 7 }}>
-            <label style={{ marginBottom: 0 }}>ユーザーID</label>
-            {userHandle.length >= 3 && (
-              <span style={{ fontSize: 11, fontWeight: 700, color: handleChecking ? 'var(--color-muted)' : handleAvailable ? 'var(--color-accent)' : handleAvailable === false ? 'var(--color-error)' : 'var(--color-muted)' }}>
-                {handleChecking ? '確認中...' : handleAvailable ? '利用可能' : handleAvailable === false ? '使用済み' : ''}
-              </span>
-            )}
-          </div>
-          <div style={{ position: 'relative' }}>
-            <input
-              className="ds-input"
-              type="text"
-              value={userHandle}
-              onChange={(e) => handleUserHandleChange(e.target.value)}
-              placeholder="kenta_123"
-              autoComplete="username"
-              style={{ paddingLeft: 30 }}
-            />
-            <span style={{ position: 'absolute', left: 12, top: '50%', transform: 'translateY(-50%)', fontSize: 14, fontWeight: 700, color: 'var(--color-muted)' }}>@</span>
-          </div>
-          <div style={{ fontSize: 11, color: 'var(--color-muted)', marginTop: 5 }}>
-            半角英小文字・数字・アンダースコア（3〜20文字）
-          </div>
-        </div>
-        <DesktopAuthPrimaryButton
-          type="button"
-          variant="accent"
-          disabled={!onboardingValid}
-          onClick={handleProfileSubmit}
-        >
-          次へ進む
-        </DesktopAuthPrimaryButton>
-        <div className="muted" style={{ fontSize: 13.5, textAlign: 'center', marginTop: 16 }}>
-          すでにアカウントをお持ちの方は{' '}
-          <Link
-            href={`/login?redirect=${encodeURIComponent(redirect)}`}
-            style={{ color: 'var(--color-accent)', fontWeight: 700, textDecoration: 'none' }}
-          >
-            ログイン
-          </Link>
-        </div>
-      </DesktopAuthShell>
-
-      {/* Mobile */}
-      <div className="lg:hidden">
         <SignupShell
           stepIndex={stepIndex}
           totalSteps={totalSteps}
@@ -784,8 +521,6 @@ function SignupForm() {
             </Link>
           </div>
         </SignupShell>
-      </div>
-    </>
   );
 }
 
@@ -809,8 +544,9 @@ function SignupShell({
   const backClassName = 'flex h-[38px] w-[38px] items-center justify-center rounded-[19px] border-2 border-[var(--solid-ink)] bg-white text-[var(--solid-ink)] transition-all duration-100 active:translate-x-px active:translate-y-px';
 
   return (
-    <div className="relative mx-auto flex min-h-screen w-full max-w-[480px] flex-col bg-[#f3f0e9] pt-3 font-[var(--font-body)] [background-image:radial-gradient(rgba(26,26,26,0.045)_1px,transparent_1px)] [background-size:22px_22px]">
-      <div className="flex items-center gap-2 px-[14px] pt-1">
+    <div className="relative mx-auto flex min-h-screen w-full max-w-[480px] flex-col bg-[#f3f0e9] pt-3 font-[var(--font-body)] [background-image:radial-gradient(rgba(26,26,26,0.045)_1px,transparent_1px)] [background-size:22px_22px] lg:min-h-0 lg:flex-1 lg:overflow-y-auto">
+      <div className="lg:mx-auto lg:w-full lg:max-w-md lg:pt-16">
+      <div className="flex items-center gap-2 px-[14px] pt-1 lg:hidden">
         {backHref ? (
           <Link href={backHref} className={backClassName} aria-label="戻る">
             <Icon name="chevron_left" size={16} />
@@ -864,6 +600,7 @@ function SignupShell({
       {children}
 
       <div className="flex-1" />
+      </div>
     </div>
   );
 }

--- a/src/app/stats/page.tsx
+++ b/src/app/stats/page.tsx
@@ -3,7 +3,6 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import Link from 'next/link';
 import { AnimatePresence, motion } from 'framer-motion';
-import { DesktopStatsView } from '@/components/desktop/DesktopStats';
 import { Icon } from '@/components/ui/Icon';
 import { SolidPanel } from '@/components/redesign/SolidPage';
 import { useAuth } from '@/hooks/use-auth';
@@ -146,9 +145,14 @@ export default function StatsPage() {
 
   return (
     <>
-      <DesktopStatsView stats={stats} loading={statsLoading} />
-      <div className="relative min-h-screen bg-[var(--color-background)] pb-[110px] font-[var(--font-body)] lg:hidden">
-        <div className="flex items-center gap-3 px-[18px] pb-2 pt-4">
+      <div className="relative min-h-screen bg-[var(--color-background)] pb-[110px] font-[var(--font-body)] lg:min-h-0 lg:flex-1 lg:overflow-y-auto lg:pb-10 lg:pt-0">
+        <div className="hidden items-center gap-4 border-b border-[var(--color-border)] bg-[rgba(246,245,241,0.86)] px-8 py-[18px] backdrop-blur-sm lg:flex">
+          <div className="min-w-0 flex-1">
+            <div className="font-mono text-[11px] tracking-[0.06em] text-[var(--color-muted)]">STATS</div>
+            <h1 className="font-display text-2xl font-extrabold text-[var(--solid-ink)]">統計</h1>
+          </div>
+        </div>
+        <div className="flex items-center gap-3 px-[18px] pb-2 pt-4 lg:px-8 lg:pt-7">
           <button
             type="button"
             onClick={() => setShowStats((v) => !v)}
@@ -187,21 +191,21 @@ export default function StatsPage() {
                   <span className="ml-2 text-sm">読み込み中...</span>
                 </div>
               ) : !stats ? (
-                <div className="px-[18px] pb-3">
+                <div className="px-[18px] pb-3 lg:px-0">
                   <SolidPanel className="!rounded-[14px]" faceClassName="!p-6 text-center text-sm text-[var(--color-muted)]">
                     統計を読み込めませんでした
                   </SolidPanel>
                 </div>
               ) : (
-                <div className="pb-2">
-                  <div className="grid grid-cols-2 gap-2 px-[18px] pb-3">
+                <div className="pb-2 lg:px-8 lg:pt-7">
+                  <div className="grid grid-cols-2 gap-2 px-[18px] pb-3 lg:grid-cols-4 lg:px-0">
                     <KPI label="連続日数" value={stats.quizStats.streakDays} suffix="日" accent icon="local_fire_department" />
                     <KPI label="累計学習日" value={totalDays} suffix="日" />
                     <KPI label="今週の復習" value={weekTotal} suffix="語" />
                     <KPI label="1日平均" value={avgPerDay} suffix="語" />
                   </div>
 
-                  <div className="px-[18px] pb-3">
+                  <div className="px-[18px] pb-3 lg:px-0">
                     <SolidPanel className="!rounded-[14px]" faceClassName="!p-3.5">
                       <div className="mb-3 flex items-baseline justify-between">
                         <div>
@@ -240,7 +244,7 @@ export default function StatsPage() {
                     </SolidPanel>
                   </div>
 
-                  <div className="px-[18px] pb-3">
+                  <div className="px-[18px] pb-3 lg:px-0">
                     <SolidPanel className="!rounded-[14px]" faceClassName="!p-3.5">
                       <div className="mb-2.5 flex items-baseline justify-between">
                         <div>
@@ -271,7 +275,7 @@ export default function StatsPage() {
                     </SolidPanel>
                   </div>
 
-                  <div className="px-[18px] pb-3">
+                  <div className="px-[18px] pb-3 lg:px-0">
                     <SolidPanel className="!rounded-[14px]" faceClassName="!p-3.5">
                       <div className="mb-2 font-mono text-[10px] font-bold tracking-[0.06em] text-[var(--color-muted)]">BREAKDOWN</div>
                       <div className="flex items-baseline gap-1">
@@ -302,7 +306,7 @@ export default function StatsPage() {
             <Icon name="progress_activity" size={20} className="animate-spin" />
           </div>
         ) : sessions.length === 0 ? (
-          <div className="px-[18px] py-16 text-center text-[13px] font-bold text-[var(--color-muted)]">
+          <div className="px-[18px] py-16 text-center text-[13px] font-bold text-[var(--color-muted)] lg:px-8">
             まだ活動がありません
           </div>
         ) : (
@@ -331,7 +335,7 @@ function TimelineItem({
 }) {
   return (
     <article className="border-b border-[var(--color-border)] transition-colors hover:bg-[var(--color-surface-secondary)]">
-      <div className="flex items-start gap-3.5 px-[18px] py-4">
+      <div className="flex items-start gap-3.5 px-[18px] py-4 lg:px-8">
         <FeedAvatar profile={session.profile} />
         <div className="min-w-0 flex-1">
           <p className="text-[15px] font-bold leading-snug text-[var(--solid-ink)]">
@@ -359,7 +363,7 @@ function TimelineItem({
         </button>
       </div>
       {expanded && (
-        <div className="border-t border-[var(--color-border)] bg-[var(--color-surface-secondary)] px-[18px] py-4">
+        <div className="border-t border-[var(--color-border)] bg-[var(--color-surface-secondary)] px-[18px] py-4 lg:px-8">
           <div className="pl-[52px]">
             {session.words.length > 0 ? (
               <div className="flex flex-col gap-2">

--- a/src/app/subscription/page.tsx
+++ b/src/app/subscription/page.tsx
@@ -3,7 +3,6 @@
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import Link from 'next/link';
-import { DesktopSubscriptionView } from '@/components/desktop/DesktopAccount';
 import { Icon } from '@/components/ui/Icon';
 import { useAuth } from '@/hooks/use-auth';
 import { STRIPE_CONFIG } from '@/lib/stripe/config';
@@ -58,16 +57,14 @@ export default function SubscriptionPage() {
 
   return (
     <>
-      <DesktopSubscriptionView
-        price={plan.price}
-        processing={processing}
-        error={error}
-        isPro={isPro}
-        userSignedIn={Boolean(user)}
-        onSubscribe={() => void handleSubscribe()}
-      />
-      <div className="relative min-h-screen bg-[var(--color-background)] pt-3 font-[var(--font-body)] lg:hidden">
-      <div className="flex items-center gap-2 px-[14px] pb-2 pt-1">
+      <div className="hidden items-center gap-4 border-b border-[var(--color-border)] bg-[rgba(246,245,241,0.86)] px-8 py-[18px] backdrop-blur-sm lg:flex">
+        <div className="min-w-0 flex-1">
+          <div className="font-mono text-[11px] tracking-[0.06em] text-[var(--color-muted)]">SUBSCRIPTION</div>
+          <h1 className="font-display text-2xl font-extrabold text-[var(--solid-ink)]">サブスクリプション</h1>
+        </div>
+      </div>
+      <div className="relative min-h-screen bg-[var(--color-background)] pt-3 font-[var(--font-body)] lg:min-h-0 lg:flex-1 lg:overflow-y-auto lg:pb-10 lg:pt-0">
+      <div className="flex items-center gap-2 px-[14px] pb-2 pt-1 lg:hidden">
         <button
           type="button"
           onClick={() => router.back()}
@@ -82,7 +79,8 @@ export default function SubscriptionPage() {
         </span>
       </div>
 
-      <div className="px-[18px] pb-[18px]">
+      <div className="lg:mx-auto lg:max-w-2xl lg:px-8 lg:pt-7">
+      <div className="px-[18px] pb-[18px] lg:px-0">
         <div className="relative">
           <div className="absolute inset-0 rounded-[18px] bg-[var(--solid-ink)]" style={{ transform: 'translate(3px, 3px)' }} />
           <div
@@ -104,7 +102,7 @@ export default function SubscriptionPage() {
         </div>
       </div>
 
-      <div className="px-[18px] pb-4">
+      <div className="px-[18px] pb-4 lg:px-0">
         <div className="mb-2 pl-1 font-mono text-[10px] font-bold tracking-[0.08em] text-[var(--color-muted)]">
           PLAN
         </div>
@@ -126,7 +124,7 @@ export default function SubscriptionPage() {
         </div>
       </div>
 
-      <div className="px-[18px] pb-4">
+      <div className="px-[18px] pb-4 lg:px-0">
         <div className="mb-2 pl-1 font-mono text-[10px] font-bold tracking-[0.08em] text-[var(--color-muted)]">
           COMPARE
         </div>
@@ -156,7 +154,7 @@ export default function SubscriptionPage() {
         </div>
       </div>
 
-      <div className="px-[18px] pb-4">
+      <div className="px-[18px] pb-4 lg:px-0">
         {error && (
           <div className="mb-3 rounded-[10px] border border-[var(--color-error)] bg-white px-3 py-2 text-xs font-bold text-[var(--color-error)]">
             {error}
@@ -184,6 +182,7 @@ export default function SubscriptionPage() {
       </div>
 
       <div className="h-[100px]" />
+      </div>
       </div>
     </>
   );

--- a/src/app/terms/page.tsx
+++ b/src/app/terms/page.tsx
@@ -1,38 +1,17 @@
 'use client';
 
 import { useRouter } from 'next/navigation';
-import { DesktopLegalDocView } from '@/components/desktop/DesktopSupport';
 import { Icon } from '@/components/ui/Icon';
 
-const TERMS_ARTICLES = [
-  { h: '適用', p: ['本規約は、本サービスの利用に関わる一切の関係に適用されます。運営者はサービス内において本規約のほか個別の規定を定めることがあり、両者が異なる場合は個別規定が優先します。'] },
-  { h: 'サービス内容', p: ['本サービスは、画像から英単語を抽出し、日本語訳とクイズを自動生成する学習支援サービスです。AI技術を利用しているため、抽出結果や翻訳の正確性を完全に保証するものではありません。'] },
-  { h: 'アカウント登録', p: ['本サービスの一部機能はアカウント登録が必要です。利用者は、登録時に正確な情報を提供するものとします。'], list: ['ユーザーは正確な情報を登録するものとします。', 'アカウントの管理はユーザーの責任とします。', 'アカウントの第三者への譲渡・貸与は禁止します。'] },
-  { h: '禁止事項', p: ['利用者は、本サービスの利用にあたり以下の行為をしてはなりません。'], list: ['法令または公序良俗に違反する行為', 'サービスの運営を妨害する行為（リバースエンジニアリング、過度なリクエストを含む）', '不正アクセスまたはそれを試みる行為', '本サービスを商業目的で無断利用する行為', '虚偽の情報を登録する行為'] },
-  { h: '有料プラン (Pro)', p: ['Proプランは月額課金制です。支払いはStripeを通じて処理されます。解約はいつでも可能で、解約後も契約期間終了日まではご利用いただけます。返金は原則として行いません。'] },
-  { h: '知的財産権', p: ['本サービスに関する知的財産権は運営者に帰属します。ユーザーが登録した単語・例文等のコンテンツの権利はユーザーに帰属しますが、本サービスの提供・改善のため必要な範囲で利用する権利を許諾するものとします。'] },
-  { h: '免責事項', list: ['AIによる抽出・翻訳結果の正確性は保証しません。', 'サービスの中断・停止による損害について責任を負いません。', 'ユーザー間または第三者とのトラブルについて責任を負いません。'] },
-  { h: 'サービスの変更・終了', p: ['運営者は、事前の通知なくサービス内容の変更または終了を行うことがあります。これにより利用者に生じた損害について、運営者は責任を負いません。'] },
-  { h: '準拠法・管轄', p: ['本規約は日本法に準拠します。本サービスに関して紛争が生じた場合、福岡地方裁判所を第一審の専属的合意管轄裁判所とします。'] },
-  { h: 'お問い合わせ', p: ['本規約に関するお問い合わせは support@merken.jp までご連絡ください。'] },
-];
 
 export default function TermsPage() {
   const router = useRouter();
 
   return (
-    <>
-      <DesktopLegalDocView
-        title="利用規約"
-        updated="2026年2月24日"
-        intro="本規約は、MERKEN（以下「本サービス」）の利用に関する条件を定めるものです。ユーザーは本規約に同意の上、本サービスを利用するものとします。"
-        toc={TERMS_ARTICLES.map((article) => article.h)}
-        articles={TERMS_ARTICLES}
-        onBack={() => router.back()}
-      />
-      <div className="relative min-h-screen bg-[var(--color-background)] pt-3 font-[var(--font-body)] lg:hidden">
+      <div className="relative min-h-screen bg-[var(--color-background)] pt-3 font-[var(--font-body)] lg:min-h-0 lg:flex-1 lg:overflow-y-auto lg:pb-10">
+      <div className="lg:mx-auto lg:max-w-3xl lg:px-8 lg:pt-7">
       {/* Header */}
-      <div className="px-[18px] pb-3.5 pt-1">
+      <div className="px-[18px] pb-3.5 pt-1 lg:px-0">
         <div className="mb-0.5 flex items-center gap-2">
           <button
             type="button"
@@ -48,7 +27,7 @@ export default function TermsPage() {
       </div>
 
       {/* Intro */}
-      <div className="px-[18px] pb-3.5">
+      <div className="px-[18px] pb-3.5 lg:px-0">
         <div className="rounded-xl border-2 border-[var(--solid-ink)] bg-[#faf7f1] p-[12px_14px]">
           <p className="m-0 text-[11px] leading-[1.75] text-[var(--solid-ink)]">
             本規約は、MERKEN（以下「本サービス」）の利用に関する条件を定めるものです。ユーザーは本規約に同意の上、本サービスを利用するものとします。
@@ -117,13 +96,13 @@ export default function TermsPage() {
 
       <Footer updated="2026年2月24日" />
       </div>
-    </>
+      </div>
   );
 }
 
 function Section({ num, label, children }: { num: string; label: string; children: React.ReactNode }) {
   return (
-    <div className="px-[18px] pb-3">
+    <div className="px-[18px] pb-3 lg:px-0">
       <div className="flex items-baseline gap-1.5 pb-1.5 pl-1 font-mono text-[9px] font-bold uppercase tracking-[0.08em] text-[var(--color-muted)]">
         <span className="text-[var(--solid-ink)]">§{num}</span>
         <span>{label}</span>
@@ -151,7 +130,7 @@ function OL({ items }: { items: string[] }) {
 
 function Footer({ updated }: { updated: string }) {
   return (
-    <div className="px-[18px] pb-[110px] pt-1">
+    <div className="px-[18px] pb-[110px] pt-1 lg:px-0">
       <div className="text-center font-mono text-[9px] tracking-[0.04em] text-[var(--color-muted)]">
         最終更新 {updated} · MERKEN
       </div>

--- a/src/app/tokusho/page.tsx
+++ b/src/app/tokusho/page.tsx
@@ -2,10 +2,14 @@
 
 import { type ReactNode } from 'react';
 import { useRouter } from 'next/navigation';
-import { DesktopTokushoView, type TokushoSection } from '@/components/desktop/DesktopSupport';
 import { Icon } from '@/components/ui/Icon';
 
 const TOKUSHO_UPDATED = '2026年4月13日';
+
+type TokushoSection = {
+  label: string;
+  rows: { label: string; value: ReactNode }[];
+};
 
 const TOKUSHO_SECTIONS: TokushoSection[] = [
   {
@@ -69,11 +73,10 @@ export default function TokushoPage() {
   const router = useRouter();
 
   return (
-    <>
-      <DesktopTokushoView onBack={() => router.back()} sections={TOKUSHO_SECTIONS} updated={TOKUSHO_UPDATED} />
-      <div className="relative min-h-screen bg-[var(--color-background)] pt-3 font-[var(--font-body)] lg:hidden">
+      <div className="relative min-h-screen bg-[var(--color-background)] pt-3 font-[var(--font-body)] lg:min-h-0 lg:flex-1 lg:overflow-y-auto lg:pb-10">
+      <div className="lg:mx-auto lg:max-w-3xl lg:px-8 lg:pt-7">
       {/* Header */}
-      <div className="px-[18px] pb-3.5 pt-1">
+      <div className="px-[18px] pb-3.5 pt-1 lg:px-0">
         <div className="mb-0.5 flex items-center gap-2">
           <button
             type="button"
@@ -91,7 +94,7 @@ export default function TokushoPage() {
       </div>
 
       {/* Intro */}
-      <div className="px-[18px] pb-3.5">
+      <div className="px-[18px] pb-3.5 lg:px-0">
         <div className="rounded-xl border-2 border-[var(--solid-ink)] bg-[#faf7f1] p-[12px_14px]">
           <p className="m-0 text-[11px] leading-[1.75] text-[var(--solid-ink)]">
             特定商取引法第11条に基づき、Pro 購読サービスの提供に関する事項を以下の通り表示します。
@@ -111,13 +114,13 @@ export default function TokushoPage() {
 
       <Footer updated={TOKUSHO_UPDATED} />
       </div>
-    </>
+      </div>
   );
 }
 
 function Section({ label, children }: { label: string; children: ReactNode }) {
   return (
-    <div className="px-[18px] pb-3">
+    <div className="px-[18px] pb-3 lg:px-0">
       <div className="pb-1.5 pl-1 font-mono text-[9px] font-bold uppercase tracking-[0.08em] text-[var(--color-muted)]">
         {label}
       </div>
@@ -142,7 +145,7 @@ function DefRow({ label, children, last }: { label: string; children: ReactNode;
 
 function Footer({ updated }: { updated: string }) {
   return (
-    <div className="px-[18px] pb-[110px] pt-1">
+    <div className="px-[18px] pb-[110px] pt-1 lg:px-0">
       <div className="text-center font-mono text-[9px] tracking-[0.04em] text-[var(--color-muted)]">
         最終更新 {updated} · MERKEN
       </div>

--- a/src/hooks/use-is-desktop.ts
+++ b/src/hooks/use-is-desktop.ts
@@ -1,0 +1,17 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+const DESKTOP_BREAKPOINT = 1024;
+
+export function useIsDesktop() {
+  const [isDesktop, setIsDesktop] = useState(false);
+  useEffect(() => {
+    const mql = window.matchMedia(`(min-width: ${DESKTOP_BREAKPOINT}px)`);
+    setIsDesktop(mql.matches);
+    const handler = (e: MediaQueryListEvent) => setIsDesktop(e.matches);
+    mql.addEventListener('change', handler);
+    return () => mql.removeEventListener('change', handler);
+  }, []);
+  return isDesktop;
+}


### PR DESCRIPTION
## Summary

- **Remove all Desktop*View component imports and renders** from 18 page files, eliminating the parallel desktop component tree that duplicated mobile functionality
- **Make mobile components responsive** using Tailwind `lg:` breakpoint classes so a single component tree serves both mobile and desktop
- **Net reduction of ~316 lines** (836 removed, 520 added) while maintaining full desktop functionality

## Changes by page category

### Core pages (home, projects, project detail)
- Home page: replaced `DesktopHomeView` with responsive grid layout + `DesktopStudySidebar` in right column
- Projects page: replaced `DesktopProjectsView` with desktop topbar + responsive grid + sidebar
- Project detail page: replaced 819-line `DesktopProjectDetailView` with desktop topbar including menu/share controls, responsive padding on all content sections

### Scan flow
- Scan page: removed `DesktopScanView`, `ScanCaptureModal` now renders on all screen sizes
- Scan confirm page: removed `DesktopScanConfirmView`, word list becomes responsive grid on desktop, bottom action bar becomes static on desktop

### Auth pages
- Login/Signup: removed `DesktopAuthShell` and all desktop auth field components, mobile forms centered with `lg:mx-auto lg:max-w-md` on desktop

### Content pages
- Settings, Stats, Subscription, Favorites, Friends: each got desktop topbar + centered/padded content
- Legal pages (Terms, Privacy, Tokusho, Contact): centered with `lg:mx-auto lg:max-w-3xl`
- Shared/Share detail: desktop topbar + responsive grid for project/word lists

### New utility
- `src/hooks/use-is-desktop.ts`: `useIsDesktop()` hook using `matchMedia` at 1024px breakpoint for JS-level structural differences

## Responsive pattern applied

1. Remove Desktop*View import and render block
2. Replace `lg:hidden` wrapper with `lg:min-h-0 lg:flex-1 lg:overflow-y-auto lg:pb-10 lg:pt-0`
3. Add `hidden lg:flex` desktop topbar with page title and controls
4. Add `lg:px-8` to content sections, `lg:px-0` where mobile padding should be overridden
5. Word/project lists become `lg:grid lg:grid-cols-2 lg:gap-3 xl:grid-cols-3`

## Test plan

- [ ] Verify all pages render correctly on mobile (< 1024px)
- [ ] Verify all pages render correctly on desktop (>= 1024px)
- [ ] Test home page: study sidebar visible on desktop, project grid layout
- [ ] Test project detail: menu, share, rename, delete, word list, select mode, bulk actions
- [ ] Test scan flow: capture modal and confirm page on both sizes
- [ ] Test auth flow: login and signup forms centered on desktop
- [ ] Test resize behavior: smooth transition at 1024px breakpoint
- [ ] Verify `npm run build` passes (confirmed locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AytsXSEYMmwf9SJzMzeWFv

---
_Generated by [Claude Code](https://claude.ai/code/session_01AytsXSEYMmwf9SJzMzeWFv)_