### PR TITLE
[codex] Support multiple default official wordbooks

### DIFF
--- a/src/app/api/auth/otp.contract.test.ts
+++ b/src/app/api/auth/otp.contract.test.ts
@@ -583,11 +583,11 @@ test('signup-verify valid OTP saves onboarding profile and imports default offic
         assert.equal(client, adminClient);
         assert.equal(userId, 'created-user-1');
         assert.equal(eikenLevel, 'pre2');
-        return {
+        return [{
           officialWordbookId: 'official-pre2',
           projectId: 'project-pre2',
           wordCount: 20,
-        };
+        }];
       },
     },
   );

--- a/src/lib/official-wordbooks/import-default.test.ts
+++ b/src/lib/official-wordbooks/import-default.test.ts
@@ -73,8 +73,10 @@ class FakeOfficialWordbookClient {
 
   constructor(
     private readonly fixtures: {
+      officialWordbooks?: Array<Record<string, unknown>> | null;
       officialWordbook?: Record<string, unknown> | null;
       officialWords?: Array<Record<string, unknown>>;
+      officialWordsByWordbookId?: Record<string, Array<Record<string, unknown>>>;
     } = {},
   ) {}
 
@@ -108,19 +110,16 @@ class FakeOfficialWordbookClient {
   }
 
   async resolveMaybeSingle<T>(operation: QueryOperation): Promise<{ data: T | null; error: null }> {
-    if (operation.table === 'official_wordbooks' && operation.action === 'select') {
-      return {
-        data: (this.fixtures.officialWordbook ?? null) as T | null,
-        error: null,
-      };
-    }
     throw new Error(`Unexpected maybeSingle operation: ${operation.table}.${operation.action}`);
   }
 
   async resolveSingle<T>(operation: QueryOperation): Promise<{ data: T | null; error: null }> {
     if (operation.table === 'projects' && operation.action === 'insert') {
+      const projectIndex = this.operations
+        .filter((item) => item.table === 'projects' && item.action === 'insert')
+        .indexOf(operation) + 1;
       return {
-        data: { id: 'project-1' } as T,
+        data: { id: `project-${projectIndex}` } as T,
         error: null,
       };
     }
@@ -128,7 +127,24 @@ class FakeOfficialWordbookClient {
   }
 
   async resolveQuery(operation: QueryOperation): Promise<{ data: unknown; error: null }> {
+    if (operation.table === 'official_wordbooks' && operation.action === 'select') {
+      const data = this.fixtures.officialWordbooks
+        ?? (this.fixtures.officialWordbook ? [this.fixtures.officialWordbook] : []);
+      return { data, error: null };
+    }
+
     if (operation.table === 'official_wordbook_words' && operation.action === 'select') {
+      const officialWordbookId = operation.filters.find((filter) =>
+        filter.field === 'official_wordbook_id'
+      )?.value;
+      if (typeof officialWordbookId === 'string') {
+        return {
+          data: this.fixtures.officialWordsByWordbookId?.[officialWordbookId]
+            ?? this.fixtures.officialWords
+            ?? [],
+          error: null,
+        };
+      }
       return {
         data: this.fixtures.officialWords ?? [],
         error: null,
@@ -159,6 +175,10 @@ function findOperation(client: FakeOfficialWordbookClient, table: string, action
   const operation = client.operations.find((item) => item.table === table && item.action === action);
   assert.ok(operation, `expected ${table}.${action} operation`);
   return operation;
+}
+
+function findOperations(client: FakeOfficialWordbookClient, table: string, action: QueryAction): QueryOperation[] {
+  return client.operations.filter((item) => item.table === table && item.action === action);
 }
 
 test('default official wordbook import skips null eiken levels', async () => {
@@ -209,11 +229,11 @@ test('default official wordbook import copies official words into a user project
 
   const result = await importDefaultOfficialWordbook(client as never, 'user-1', 'pre2');
 
-  assert.deepEqual(result, {
+  assert.deepEqual(result, [{
     officialWordbookId: 'official-pre2',
     projectId: 'project-1',
     wordCount: 1,
-  });
+  }]);
 
   const projectInsert = findOperation(client, 'projects', 'insert');
   assert.deepEqual(projectInsert.payload, {
@@ -260,4 +280,78 @@ test('default official wordbook import copies official words into a user project
     position: 0,
     is_primary: true,
   }]);
+});
+
+test('default official wordbook import copies every active default wordbook for a level', async () => {
+  const client = new FakeOfficialWordbookClient({
+    officialWordbooks: [
+      {
+        id: 'official-pre1-1',
+        title: '英検準一級単語集1',
+        is_default: true,
+        source_labels: ['official', 'eiken:pre1'],
+      },
+      {
+        id: 'official-pre1-2',
+        title: '英検準一級単語集2',
+        is_default: true,
+        source_labels: ['official', 'eiken:pre1'],
+      },
+      {
+        id: 'official-pre1-extra',
+        title: '英検準一級 補助単語集',
+        is_default: false,
+        source_labels: ['official', 'eiken:pre1'],
+      },
+    ],
+    officialWordsByWordbookId: {
+      'official-pre1-1': [
+        {
+          id: 'official-word-1',
+          english: 'notion',
+          japanese: '概念',
+          translations: [{ translationJa: '概念', normalizedTranslationJa: '概念', source: 'user' }],
+        },
+      ],
+      'official-pre1-2': [
+        {
+          id: 'official-word-2',
+          english: 'obscure',
+          japanese: '曖昧な',
+          translations: [{ translationJa: '曖昧な', normalizedTranslationJa: '曖昧な', source: 'user' }],
+        },
+      ],
+    },
+  });
+
+  const result = await importDefaultOfficialWordbook(client as never, 'user-1', 'pre1');
+
+  assert.deepEqual(result, [
+    {
+      officialWordbookId: 'official-pre1-1',
+      projectId: 'project-1',
+      wordCount: 1,
+    },
+    {
+      officialWordbookId: 'official-pre1-2',
+      projectId: 'project-2',
+      wordCount: 1,
+    },
+  ]);
+
+  const projectInserts = findOperations(client, 'projects', 'insert');
+  assert.deepEqual(projectInserts.map((operation) =>
+    (operation.payload as { title: string }).title
+  ), [
+    '英検準一級単語集1',
+    '英検準一級単語集2',
+  ]);
+
+  const wordbookWordSelects = findOperations(client, 'official_wordbook_words', 'select');
+  assert.deepEqual(wordbookWordSelects.map((operation) =>
+    operation.filters.find((filter) => filter.field === 'official_wordbook_id')?.value
+  ), [
+    'official-pre1-1',
+    'official-pre1-2',
+  ]);
 });

--- a/src/lib/official-wordbooks/import-default.test.ts
+++ b/src/lib/official-wordbooks/import-default.test.ts
@@ -23,7 +23,6 @@ interface QueryOperation {
   columns?: string;
   filters: QueryFilter[];
   orders: QueryOrder[];
-  limitCount?: number;
 }
 
 class FakeOfficialWordbookQuery {
@@ -37,23 +36,19 @@ class FakeOfficialWordbookQuery {
     return this;
   }
 
-  order(column: string, options: unknown) {
-    this.operation.orders.push({ column, options });
+  in(field: string, values: unknown[]) {
+    this.operation.filters.push({ field, value: values });
     return this;
   }
 
-  limit(count: number) {
-    this.operation.limitCount = count;
+  order(column: string, options: unknown) {
+    this.operation.orders.push({ column, options });
     return this;
   }
 
   select(columns = '*') {
     this.operation.columns = columns;
     return this;
-  }
-
-  async maybeSingle<T = unknown>(): Promise<{ data: T | null; error: null }> {
-    return this.client.resolveMaybeSingle<T>(this.operation);
   }
 
   async single<T = unknown>(): Promise<{ data: T | null; error: null }> {
@@ -73,10 +68,9 @@ class FakeOfficialWordbookClient {
 
   constructor(
     private readonly fixtures: {
-      officialWordbooks?: Array<Record<string, unknown>> | null;
-      officialWordbook?: Record<string, unknown> | null;
-      officialWords?: Array<Record<string, unknown>>;
-      officialWordsByWordbookId?: Record<string, Array<Record<string, unknown>>>;
+      officialProjects?: Array<Record<string, unknown>>;
+      wordsByProjectId?: Record<string, Array<Record<string, unknown>>>;
+      translationsByWordId?: Record<string, Array<Record<string, unknown>>>;
     } = {},
   ) {}
 
@@ -109,10 +103,6 @@ class FakeOfficialWordbookClient {
     return new FakeOfficialWordbookQuery(this, operation);
   }
 
-  async resolveMaybeSingle<T>(operation: QueryOperation): Promise<{ data: T | null; error: null }> {
-    throw new Error(`Unexpected maybeSingle operation: ${operation.table}.${operation.action}`);
-  }
-
   async resolveSingle<T>(operation: QueryOperation): Promise<{ data: T | null; error: null }> {
     if (operation.table === 'projects' && operation.action === 'insert') {
       const projectIndex = this.operations
@@ -127,28 +117,27 @@ class FakeOfficialWordbookClient {
   }
 
   async resolveQuery(operation: QueryOperation): Promise<{ data: unknown; error: null }> {
-    if (operation.table === 'official_wordbooks' && operation.action === 'select') {
-      const data = this.fixtures.officialWordbooks
-        ?? (this.fixtures.officialWordbook ? [this.fixtures.officialWordbook] : []);
-      return { data, error: null };
-    }
-
-    if (operation.table === 'official_wordbook_words' && operation.action === 'select') {
-      const officialWordbookId = operation.filters.find((filter) =>
-        filter.field === 'official_wordbook_id'
-      )?.value;
-      if (typeof officialWordbookId === 'string') {
-        return {
-          data: this.fixtures.officialWordsByWordbookId?.[officialWordbookId]
-            ?? this.fixtures.officialWords
-            ?? [],
-          error: null,
-        };
-      }
+    if (operation.table === 'projects' && operation.action === 'select') {
       return {
-        data: this.fixtures.officialWords ?? [],
+        data: this.fixtures.officialProjects ?? [],
         error: null,
       };
+    }
+
+    if (operation.table === 'words' && operation.action === 'select') {
+      const projectId = operation.filters.find((filter) => filter.field === 'project_id')?.value;
+      return {
+        data: typeof projectId === 'string' ? this.fixtures.wordsByProjectId?.[projectId] ?? [] : [],
+        error: null,
+      };
+    }
+
+    if (operation.table === 'word_translations' && operation.action === 'select') {
+      const wordIds = operation.filters.find((filter) => filter.field === 'word_id')?.value;
+      const rows = Array.isArray(wordIds)
+        ? wordIds.flatMap((wordId) => this.fixtures.translationsByWordId?.[String(wordId)] ?? [])
+        : [];
+      return { data: rows, error: null };
     }
 
     if (operation.table === 'words' && operation.action === 'insert') {
@@ -190,47 +179,63 @@ test('default official wordbook import skips null eiken levels', async () => {
   assert.equal(client.operations.length, 0);
 });
 
-test('default official wordbook import returns null when the level has no official data', async () => {
-  const client = new FakeOfficialWordbookClient({ officialWordbook: null });
+test('default official wordbook import returns null when the level has no official projects', async () => {
+  const client = new FakeOfficialWordbookClient({ officialProjects: [] });
 
   const result = await importDefaultOfficialWordbook(client as never, 'user-1', '3');
 
   assert.equal(result, null);
 
-  const wordbookSelect = findOperation(client, 'official_wordbooks', 'select');
-  assert.deepEqual(wordbookSelect.filters, [
-    { field: 'eiken_level', value: '3' },
-    { field: 'is_active', value: true },
+  const projectSelect = findOperation(client, 'projects', 'select');
+  assert.deepEqual(projectSelect.filters, [
+    { field: 'official_eiken_level', value: '3' },
+    { field: 'official_is_active', value: true },
   ]);
 });
 
-test('default official wordbook import copies official words into a user project', async () => {
+test('default official wordbook import copies a normal project into a user project', async () => {
   const client = new FakeOfficialWordbookClient({
-    officialWordbook: {
-      id: 'official-pre2',
-      title: '英検準2級 公式単語帳',
-      source_labels: ['official', 'eiken:pre2'],
-      icon_image: 'icon.png',
-    },
-    officialWords: [
+    officialProjects: [
       {
-        id: 'official-word-1',
-        english: 'improve',
-        japanese: '改善する',
-        translations: [{ translationJa: '改善する', normalizedTranslationJa: '改善する', source: 'user' }],
-        distractors: ['悪化する', '維持する'],
-        vocabulary_type: 'active',
-        japanese_source: 'scan',
-        part_of_speech_tags: ['verb'],
-        custom_sections: [{ id: 'memo', title: 'Memo', content: 'Core verb' }],
+        id: 'official-project-pre2',
+        title: 'Source Project Title',
+        official_title: '英検準2級 公式単語帳',
+        icon_image: 'icon.png',
+        official_is_default: true,
       },
     ],
+    wordsByProjectId: {
+      'official-project-pre2': [
+        {
+          id: 'source-word-1',
+          english: 'improve',
+          japanese: '改善する',
+          distractors: ['悪化する', '維持する'],
+          vocabulary_type: 'active',
+          japanese_source: 'scan',
+          part_of_speech_tags: ['verb'],
+          custom_sections: [{ id: 'memo', title: 'Memo', content: 'Core verb' }],
+        },
+      ],
+    },
+    translationsByWordId: {
+      'source-word-1': [
+        {
+          word_id: 'source-word-1',
+          translation_ja: '改善する',
+          normalized_translation_ja: '改善する',
+          source: 'user',
+          meaning_rank: 1,
+          position: 0,
+        },
+      ],
+    },
   });
 
   const result = await importDefaultOfficialWordbook(client as never, 'user-1', 'pre2');
 
   assert.deepEqual(result, [{
-    officialWordbookId: 'official-pre2',
+    officialWordbookId: 'official-project-pre2',
     projectId: 'project-1',
     wordCount: 1,
   }]);
@@ -243,7 +248,12 @@ test('default official wordbook import copies official words into a user project
     icon_image: 'icon.png',
   });
 
-  const wordsInsert = findOperation(client, 'words', 'insert');
+  const sourceWordsSelect = findOperation(client, 'words', 'select');
+  assert.deepEqual(sourceWordsSelect.filters, [
+    { field: 'project_id', value: 'official-project-pre2' },
+  ]);
+
+  const wordsInsert = findOperations(client, 'words', 'insert')[0];
   assert.deepEqual(wordsInsert.payload, [{
     project_id: 'project-1',
     english: 'improve',
@@ -282,43 +292,40 @@ test('default official wordbook import copies official words into a user project
   }]);
 });
 
-test('default official wordbook import copies every active default wordbook for a level', async () => {
+test('default official wordbook import copies every active default project for a level', async () => {
   const client = new FakeOfficialWordbookClient({
-    officialWordbooks: [
+    officialProjects: [
       {
         id: 'official-pre1-1',
-        title: '英検準一級単語集1',
-        is_default: true,
-        source_labels: ['official', 'eiken:pre1'],
+        title: 'ターゲット section16',
+        official_title: '英検準一級単語集1',
+        official_is_default: true,
       },
       {
         id: 'official-pre1-2',
-        title: '英検準一級単語集2',
-        is_default: true,
-        source_labels: ['official', 'eiken:pre1'],
+        title: 'ターゲット section17',
+        official_title: '英検準一級単語集2',
+        official_is_default: true,
       },
       {
         id: 'official-pre1-extra',
         title: '英検準一級 補助単語集',
-        is_default: false,
-        source_labels: ['official', 'eiken:pre1'],
+        official_is_default: false,
       },
     ],
-    officialWordsByWordbookId: {
+    wordsByProjectId: {
       'official-pre1-1': [
         {
-          id: 'official-word-1',
+          id: 'source-word-1',
           english: 'notion',
           japanese: '概念',
-          translations: [{ translationJa: '概念', normalizedTranslationJa: '概念', source: 'user' }],
         },
       ],
       'official-pre1-2': [
         {
-          id: 'official-word-2',
+          id: 'source-word-2',
           english: 'obscure',
           japanese: '曖昧な',
-          translations: [{ translationJa: '曖昧な', normalizedTranslationJa: '曖昧な', source: 'user' }],
         },
       ],
     },
@@ -347,9 +354,9 @@ test('default official wordbook import copies every active default wordbook for 
     '英検準一級単語集2',
   ]);
 
-  const wordbookWordSelects = findOperations(client, 'official_wordbook_words', 'select');
-  assert.deepEqual(wordbookWordSelects.map((operation) =>
-    operation.filters.find((filter) => filter.field === 'official_wordbook_id')?.value
+  const sourceWordSelects = findOperations(client, 'words', 'select');
+  assert.deepEqual(sourceWordSelects.map((operation) =>
+    operation.filters.find((filter) => filter.field === 'project_id')?.value
   ), [
     'official-pre1-1',
     'official-pre1-2',

--- a/src/lib/official-wordbooks/import-default.ts
+++ b/src/lib/official-wordbooks/import-default.ts
@@ -12,6 +12,7 @@ type OfficialWordbookRow = {
   title: string;
   source_labels?: unknown;
   icon_image?: string | null;
+  is_default?: boolean | null;
 };
 
 type OfficialWordbookWordRow = {
@@ -42,11 +43,13 @@ type CreatedWordRow = {
   id: string;
 };
 
-export type DefaultOfficialWordbookImportResult = {
+export type DefaultOfficialWordbookImportItem = {
   officialWordbookId: string;
   projectId: string;
   wordCount: number;
-} | null;
+};
+
+export type DefaultOfficialWordbookImportResult = DefaultOfficialWordbookImportItem[] | null;
 
 function isOfficialWordbookSchemaError(error: PostgrestError | null): boolean {
   if (!error) return false;
@@ -105,152 +108,159 @@ export async function importDefaultOfficialWordbook(
 ): Promise<DefaultOfficialWordbookImportResult> {
   if (!eikenLevel) return null;
 
-  const { data: officialWordbook, error: wordbookError } = await supabase
+  const { data: officialWordbooks, error: wordbookError } = await supabase
     .from('official_wordbooks')
-    .select('id,title,source_labels,icon_image')
+    .select('id,title,source_labels,icon_image,is_default')
     .eq('eiken_level', eikenLevel)
     .eq('is_active', true)
     .order('is_default', { ascending: false })
-    .order('sort_order', { ascending: true })
-    .limit(1)
-    .maybeSingle<OfficialWordbookRow>();
+    .order('sort_order', { ascending: true });
 
   if (wordbookError) {
     if (isOfficialWordbookSchemaError(wordbookError)) return null;
     throw new Error(`Failed to fetch official wordbook: ${wordbookError.message}`);
   }
 
-  if (!officialWordbook) return null;
+  const activeWordbooks = (officialWordbooks ?? []) as unknown as OfficialWordbookRow[];
+  if (activeWordbooks.length === 0) return null;
 
-  const { data: officialWords, error: wordsError } = await supabase
-    .from('official_wordbook_words')
-    .select([
-      'id',
-      'english',
-      'japanese',
-      'translations',
-      'distractors',
-      'vocabulary_type',
-      'japanese_source',
-      'lexicon_entry_id',
-      'lexicon_sense_id',
-      'example_sentence',
-      'example_sentence_ja',
-      'pronunciation',
-      'part_of_speech_tags',
-      'related_words',
-      'usage_patterns',
-      'word_order_quiz',
-      'custom_sections',
-    ].join(','))
-    .eq('official_wordbook_id', officialWordbook.id)
-    .order('sort_order', { ascending: true })
-    .order('created_at', { ascending: true });
+  const defaultWordbooks = activeWordbooks.filter((wordbook) => wordbook.is_default);
+  const wordbooksToImport = defaultWordbooks.length > 0 ? defaultWordbooks : activeWordbooks.slice(0, 1);
+  const createdProjectIds: string[] = [];
+  const imported: DefaultOfficialWordbookImportItem[] = [];
 
-  if (wordsError) {
-    if (isOfficialWordbookSchemaError(wordsError)) return null;
-    throw new Error(`Failed to fetch official wordbook words: ${wordsError.message}`);
-  }
-
-  const sourceWords = (officialWords ?? []) as unknown as OfficialWordbookWordRow[];
-  if (sourceWords.length === 0) return null;
-
-  let projectId: string | null = null;
   try {
-    const sourceLabels = normalizeStringArray(officialWordbook.source_labels);
-    const { data: project, error: projectError } = await supabase
-      .from('projects')
-      .insert({
-        user_id: userId,
-        title: officialWordbook.title,
-        source_labels: sourceLabels.length > 0 ? sourceLabels : ['official', `eiken:${eikenLevel}`],
-        ...(officialWordbook.icon_image ? { icon_image: officialWordbook.icon_image } : {}),
-      })
-      .select('id')
-      .single<CreatedProjectRow>();
+    for (const officialWordbook of wordbooksToImport) {
+      const { data: officialWords, error: wordsError } = await supabase
+        .from('official_wordbook_words')
+        .select([
+          'id',
+          'english',
+          'japanese',
+          'translations',
+          'distractors',
+          'vocabulary_type',
+          'japanese_source',
+          'lexicon_entry_id',
+          'lexicon_sense_id',
+          'example_sentence',
+          'example_sentence_ja',
+          'pronunciation',
+          'part_of_speech_tags',
+          'related_words',
+          'usage_patterns',
+          'word_order_quiz',
+          'custom_sections',
+        ].join(','))
+        .eq('official_wordbook_id', officialWordbook.id)
+        .order('sort_order', { ascending: true })
+        .order('created_at', { ascending: true });
 
-    if (projectError || !project) {
-      throw new Error(`Failed to create imported official wordbook: ${projectError?.message ?? 'missing project row'}`);
-    }
-    projectId = project.id;
-
-    const defaultSR = getDefaultSpacedRepetitionFields();
-    const normalizedWords = sourceWords.map((word) => normalizeWordForTranslationPersistence({
-      projectId: project.id,
-      english: word.english,
-      japanese: word.japanese ?? '',
-      translations: word.translations ?? undefined,
-      distractors: normalizeStringArray(word.distractors, 10),
-      vocabularyType: normalizeVocabularyType(word.vocabulary_type),
-      japaneseSource: normalizeJapaneseSource(word.japanese_source),
-      lexiconEntryId: word.lexicon_entry_id ?? undefined,
-      lexiconSenseId: word.lexicon_sense_id ?? undefined,
-      exampleSentence: word.example_sentence ?? undefined,
-      exampleSentenceJa: word.example_sentence_ja ?? undefined,
-      pronunciation: word.pronunciation ?? undefined,
-      partOfSpeechTags: normalizeStringArray(word.part_of_speech_tags, 10),
-      relatedWords: normalizeNullableJson(word.related_words),
-      usagePatterns: normalizeNullableJson(word.usage_patterns),
-      wordOrderQuiz: normalizeNullableJson(word.word_order_quiz),
-      customSections: normalizeJsonArray(word.custom_sections),
-    }));
-
-    const wordRows = normalizedWords.map((word, index) => ({
-      project_id: project.id,
-      english: word.english,
-      japanese: word.japanese,
-      japanese_source: word.japaneseSource ?? normalizeJapaneseSource(sourceWords[index]?.japanese_source) ?? null,
-      vocabulary_type: word.vocabularyType ?? null,
-      lexicon_entry_id: word.lexiconEntryId ?? null,
-      lexicon_sense_id: word.lexiconSenseId ?? null,
-      distractors: word.distractors,
-      example_sentence: word.exampleSentence ?? null,
-      example_sentence_ja: word.exampleSentenceJa ?? null,
-      pronunciation: word.pronunciation ?? null,
-      part_of_speech_tags: word.partOfSpeechTags.length > 0 ? word.partOfSpeechTags : null,
-      related_words: word.relatedWords ?? null,
-      usage_patterns: word.usagePatterns ?? null,
-      word_order_quiz: word.wordOrderQuiz ?? null,
-      custom_sections: word.customSections ?? [],
-      status: 'new',
-      ease_factor: defaultSR.easeFactor,
-      interval_days: defaultSR.intervalDays,
-      repetition: defaultSR.repetition,
-      is_favorite: false,
-    }));
-
-    const { data: createdWords, error: createWordsError } = await supabase
-      .from('words')
-      .insert(wordRows)
-      .select('id');
-
-    if (createWordsError) {
-      throw new Error(`Failed to create official wordbook words: ${createWordsError.message}`);
-    }
-
-    const createdWordRows = (createdWords ?? []) as CreatedWordRow[];
-    const translationRows = buildWordTranslationInsertRows(
-      normalizedWords,
-      createdWordRows.map((word) => word.id),
-    );
-
-    if (translationRows.length > 0) {
-      const { error: translationError } = await supabase
-        .from('word_translations')
-        .upsert(translationRows, { onConflict: 'word_id,normalized_translation_ja' });
-
-      if (translationError) {
-        throw new Error(`Failed to create official wordbook translations: ${translationError.message}`);
+      if (wordsError) {
+        if (isOfficialWordbookSchemaError(wordsError)) return imported.length > 0 ? imported : null;
+        throw new Error(`Failed to fetch official wordbook words: ${wordsError.message}`);
       }
+
+      const sourceWords = (officialWords ?? []) as unknown as OfficialWordbookWordRow[];
+      if (sourceWords.length === 0) continue;
+
+      const sourceLabels = normalizeStringArray(officialWordbook.source_labels);
+      const { data: project, error: projectError } = await supabase
+        .from('projects')
+        .insert({
+          user_id: userId,
+          title: officialWordbook.title,
+          source_labels: sourceLabels.length > 0 ? sourceLabels : ['official', `eiken:${eikenLevel}`],
+          ...(officialWordbook.icon_image ? { icon_image: officialWordbook.icon_image } : {}),
+        })
+        .select('id')
+        .single<CreatedProjectRow>();
+
+      if (projectError || !project) {
+        throw new Error(`Failed to create imported official wordbook: ${projectError?.message ?? 'missing project row'}`);
+      }
+      createdProjectIds.push(project.id);
+
+      const defaultSR = getDefaultSpacedRepetitionFields();
+      const normalizedWords = sourceWords.map((word) => normalizeWordForTranslationPersistence({
+        projectId: project.id,
+        english: word.english,
+        japanese: word.japanese ?? '',
+        translations: word.translations ?? undefined,
+        distractors: normalizeStringArray(word.distractors, 10),
+        vocabularyType: normalizeVocabularyType(word.vocabulary_type),
+        japaneseSource: normalizeJapaneseSource(word.japanese_source),
+        lexiconEntryId: word.lexicon_entry_id ?? undefined,
+        lexiconSenseId: word.lexicon_sense_id ?? undefined,
+        exampleSentence: word.example_sentence ?? undefined,
+        exampleSentenceJa: word.example_sentence_ja ?? undefined,
+        pronunciation: word.pronunciation ?? undefined,
+        partOfSpeechTags: normalizeStringArray(word.part_of_speech_tags, 10),
+        relatedWords: normalizeNullableJson(word.related_words),
+        usagePatterns: normalizeNullableJson(word.usage_patterns),
+        wordOrderQuiz: normalizeNullableJson(word.word_order_quiz),
+        customSections: normalizeJsonArray(word.custom_sections),
+      }));
+
+      const wordRows = normalizedWords.map((word, index) => ({
+        project_id: project.id,
+        english: word.english,
+        japanese: word.japanese,
+        japanese_source: word.japaneseSource ?? normalizeJapaneseSource(sourceWords[index]?.japanese_source) ?? null,
+        vocabulary_type: word.vocabularyType ?? null,
+        lexicon_entry_id: word.lexiconEntryId ?? null,
+        lexicon_sense_id: word.lexiconSenseId ?? null,
+        distractors: word.distractors,
+        example_sentence: word.exampleSentence ?? null,
+        example_sentence_ja: word.exampleSentenceJa ?? null,
+        pronunciation: word.pronunciation ?? null,
+        part_of_speech_tags: word.partOfSpeechTags.length > 0 ? word.partOfSpeechTags : null,
+        related_words: word.relatedWords ?? null,
+        usage_patterns: word.usagePatterns ?? null,
+        word_order_quiz: word.wordOrderQuiz ?? null,
+        custom_sections: word.customSections ?? [],
+        status: 'new',
+        ease_factor: defaultSR.easeFactor,
+        interval_days: defaultSR.intervalDays,
+        repetition: defaultSR.repetition,
+        is_favorite: false,
+      }));
+
+      const { data: createdWords, error: createWordsError } = await supabase
+        .from('words')
+        .insert(wordRows)
+        .select('id');
+
+      if (createWordsError) {
+        throw new Error(`Failed to create official wordbook words: ${createWordsError.message}`);
+      }
+
+      const createdWordRows = (createdWords ?? []) as CreatedWordRow[];
+      const translationRows = buildWordTranslationInsertRows(
+        normalizedWords,
+        createdWordRows.map((word) => word.id),
+      );
+
+      if (translationRows.length > 0) {
+        const { error: translationError } = await supabase
+          .from('word_translations')
+          .upsert(translationRows, { onConflict: 'word_id,normalized_translation_ja' });
+
+        if (translationError) {
+          throw new Error(`Failed to create official wordbook translations: ${translationError.message}`);
+        }
+      }
+
+      imported.push({
+        officialWordbookId: officialWordbook.id,
+        projectId: project.id,
+        wordCount: createdWordRows.length,
+      });
     }
 
-    return {
-      officialWordbookId: officialWordbook.id,
-      projectId: project.id,
-      wordCount: createdWordRows.length,
-    };
+    return imported.length > 0 ? imported : null;
   } catch (error) {
-    if (projectId) {
+    for (const projectId of createdProjectIds) {
       await supabase.from('projects').delete().eq('id', projectId);
     }
     throw error;

--- a/src/lib/official-wordbooks/import-default.ts
+++ b/src/lib/official-wordbooks/import-default.ts
@@ -7,19 +7,18 @@ import {
 
 export type OfficialWordbookEikenLevel = '5' | '4' | '3' | 'pre2' | '2' | 'pre1' | '1';
 
-type OfficialWordbookRow = {
+type OfficialProjectRow = {
   id: string;
   title: string;
-  source_labels?: unknown;
+  official_title?: string | null;
   icon_image?: string | null;
-  is_default?: boolean | null;
+  official_is_default?: boolean | null;
 };
 
-type OfficialWordbookWordRow = {
+type SourceWordRow = {
   id: string;
   english: string;
   japanese?: string | null;
-  translations?: unknown;
   distractors?: unknown;
   vocabulary_type?: string | null;
   japanese_source?: string | null;
@@ -33,6 +32,16 @@ type OfficialWordbookWordRow = {
   usage_patterns?: unknown;
   word_order_quiz?: unknown;
   custom_sections?: unknown;
+};
+
+type SourceWordTranslationRow = {
+  word_id: string;
+  translation_ja: string;
+  normalized_translation_ja?: string | null;
+  source?: 'scan' | 'ai' | 'user' | null;
+  lexicon_sense_id?: string | null;
+  meaning_rank?: number | null;
+  position?: number | null;
 };
 
 type CreatedProjectRow = {
@@ -51,7 +60,7 @@ export type DefaultOfficialWordbookImportItem = {
 
 export type DefaultOfficialWordbookImportResult = DefaultOfficialWordbookImportItem[] | null;
 
-function isOfficialWordbookSchemaError(error: PostgrestError | null): boolean {
+function isOfficialProjectSchemaError(error: PostgrestError | null): boolean {
   if (!error) return false;
   const text = `${error.code ?? ''} ${error.message ?? ''} ${error.details ?? ''} ${error.hint ?? ''}`.toLowerCase();
   return (
@@ -60,8 +69,26 @@ function isOfficialWordbookSchemaError(error: PostgrestError | null): boolean {
     || error.code === 'PGRST200'
     || error.code === 'PGRST204'
   ) && (
-    text.includes('official_wordbooks')
-    || text.includes('official_wordbook_words')
+    text.includes('projects')
+    || text.includes('words')
+    || text.includes('word_translations')
+    || text.includes('official_')
+    || text.includes('schema cache')
+    || text.includes('could not find')
+    || text.includes('does not exist')
+  );
+}
+
+function isWordTranslationsSchemaError(error: PostgrestError | null): boolean {
+  if (!error) return false;
+  const text = `${error.code ?? ''} ${error.message ?? ''} ${error.details ?? ''} ${error.hint ?? ''}`.toLowerCase();
+  return (
+    error.code === '42P01'
+    || error.code === '42703'
+    || error.code === 'PGRST200'
+    || error.code === 'PGRST204'
+  ) && (
+    text.includes('word_translations')
     || text.includes('schema cache')
     || text.includes('could not find')
     || text.includes('does not exist')
@@ -101,6 +128,199 @@ function normalizeJapaneseSource(value: string | null | undefined): 'scan' | 'ai
   return value === 'scan' || value === 'ai' ? value : undefined;
 }
 
+function getOfficialProjectTitle(project: OfficialProjectRow): string {
+  const officialTitle = project.official_title?.trim();
+  return officialTitle || project.title;
+}
+
+function buildSourceTranslationPayload(translations: readonly SourceWordTranslationRow[]): unknown[] {
+  return translations.map((translation) => ({
+    translationJa: translation.translation_ja,
+    normalizedTranslationJa: translation.normalized_translation_ja ?? translation.translation_ja,
+    source: translation.source ?? undefined,
+    lexiconSenseId: translation.lexicon_sense_id ?? undefined,
+    meaningRank: translation.meaning_rank ?? undefined,
+  }));
+}
+
+async function fetchSourceTranslations(
+  supabase: SupabaseClient,
+  wordIds: readonly string[],
+): Promise<Map<string, SourceWordTranslationRow[]>> {
+  const translationsByWordId = new Map<string, SourceWordTranslationRow[]>();
+  if (wordIds.length === 0) return translationsByWordId;
+
+  const { data, error } = await supabase
+    .from('word_translations')
+    .select([
+      'word_id',
+      'translation_ja',
+      'normalized_translation_ja',
+      'source',
+      'lexicon_sense_id',
+      'meaning_rank',
+      'position',
+    ].join(','))
+    .in('word_id', wordIds)
+    .order('position', { ascending: true })
+    .order('meaning_rank', { ascending: true })
+    .order('created_at', { ascending: true });
+
+  if (error) {
+    if (isWordTranslationsSchemaError(error)) return translationsByWordId;
+    throw new Error(`Failed to fetch official project translations: ${error.message}`);
+  }
+
+  for (const translation of (data ?? []) as unknown as SourceWordTranslationRow[]) {
+    const list = translationsByWordId.get(translation.word_id) ?? [];
+    list.push(translation);
+    translationsByWordId.set(translation.word_id, list);
+  }
+
+  return translationsByWordId;
+}
+
+async function importOfficialProject(
+  supabase: SupabaseClient,
+  userId: string,
+  eikenLevel: OfficialWordbookEikenLevel,
+  officialProject: OfficialProjectRow,
+): Promise<DefaultOfficialWordbookImportItem | null> {
+  const { data: sourceRows, error: wordsError } = await supabase
+    .from('words')
+    .select([
+      'id',
+      'english',
+      'japanese',
+      'distractors',
+      'vocabulary_type',
+      'japanese_source',
+      'lexicon_entry_id',
+      'lexicon_sense_id',
+      'example_sentence',
+      'example_sentence_ja',
+      'pronunciation',
+      'part_of_speech_tags',
+      'related_words',
+      'usage_patterns',
+      'word_order_quiz',
+      'custom_sections',
+      'created_at',
+    ].join(','))
+    .eq('project_id', officialProject.id)
+    .order('created_at', { ascending: true })
+    .order('id', { ascending: true });
+
+  if (wordsError) {
+    if (isOfficialProjectSchemaError(wordsError)) return null;
+    throw new Error(`Failed to fetch official project words: ${wordsError.message}`);
+  }
+
+  const sourceWords = (sourceRows ?? []) as unknown as SourceWordRow[];
+  if (sourceWords.length === 0) return null;
+
+  const translationsByWordId = await fetchSourceTranslations(
+    supabase,
+    sourceWords.map((word) => word.id),
+  );
+
+  const { data: project, error: projectError } = await supabase
+    .from('projects')
+    .insert({
+      user_id: userId,
+      title: getOfficialProjectTitle(officialProject),
+      source_labels: ['official', `eiken:${eikenLevel}`],
+      ...(officialProject.icon_image ? { icon_image: officialProject.icon_image } : {}),
+    })
+    .select('id')
+    .single<CreatedProjectRow>();
+
+  if (projectError || !project) {
+    throw new Error(`Failed to create imported official wordbook: ${projectError?.message ?? 'missing project row'}`);
+  }
+
+  try {
+    const defaultSR = getDefaultSpacedRepetitionFields();
+    const normalizedWords = sourceWords.map((word) => normalizeWordForTranslationPersistence({
+      projectId: project.id,
+      english: word.english,
+      japanese: word.japanese ?? '',
+      translations: buildSourceTranslationPayload(translationsByWordId.get(word.id) ?? []),
+      distractors: normalizeStringArray(word.distractors, 10),
+      vocabularyType: normalizeVocabularyType(word.vocabulary_type),
+      japaneseSource: normalizeJapaneseSource(word.japanese_source),
+      lexiconEntryId: word.lexicon_entry_id ?? undefined,
+      lexiconSenseId: word.lexicon_sense_id ?? undefined,
+      exampleSentence: word.example_sentence ?? undefined,
+      exampleSentenceJa: word.example_sentence_ja ?? undefined,
+      pronunciation: word.pronunciation ?? undefined,
+      partOfSpeechTags: normalizeStringArray(word.part_of_speech_tags, 10),
+      relatedWords: normalizeNullableJson(word.related_words),
+      usagePatterns: normalizeNullableJson(word.usage_patterns),
+      wordOrderQuiz: normalizeNullableJson(word.word_order_quiz),
+      customSections: normalizeJsonArray(word.custom_sections),
+    }));
+
+    const wordRows = normalizedWords.map((word, index) => ({
+      project_id: project.id,
+      english: word.english,
+      japanese: word.japanese,
+      japanese_source: word.japaneseSource ?? normalizeJapaneseSource(sourceWords[index]?.japanese_source) ?? null,
+      vocabulary_type: word.vocabularyType ?? null,
+      lexicon_entry_id: word.lexiconEntryId ?? null,
+      lexicon_sense_id: word.lexiconSenseId ?? null,
+      distractors: word.distractors,
+      example_sentence: word.exampleSentence ?? null,
+      example_sentence_ja: word.exampleSentenceJa ?? null,
+      pronunciation: word.pronunciation ?? null,
+      part_of_speech_tags: word.partOfSpeechTags.length > 0 ? word.partOfSpeechTags : null,
+      related_words: word.relatedWords ?? null,
+      usage_patterns: word.usagePatterns ?? null,
+      word_order_quiz: word.wordOrderQuiz ?? null,
+      custom_sections: word.customSections ?? [],
+      status: 'new',
+      ease_factor: defaultSR.easeFactor,
+      interval_days: defaultSR.intervalDays,
+      repetition: defaultSR.repetition,
+      is_favorite: false,
+    }));
+
+    const { data: createdWords, error: createWordsError } = await supabase
+      .from('words')
+      .insert(wordRows)
+      .select('id');
+
+    if (createWordsError) {
+      throw new Error(`Failed to create official wordbook words: ${createWordsError.message}`);
+    }
+
+    const createdWordRows = (createdWords ?? []) as CreatedWordRow[];
+    const translationRows = buildWordTranslationInsertRows(
+      normalizedWords,
+      createdWordRows.map((word) => word.id),
+    );
+
+    if (translationRows.length > 0) {
+      const { error: translationError } = await supabase
+        .from('word_translations')
+        .upsert(translationRows, { onConflict: 'word_id,normalized_translation_ja' });
+
+      if (translationError) {
+        throw new Error(`Failed to create official wordbook translations: ${translationError.message}`);
+      }
+    }
+
+    return {
+      officialWordbookId: officialProject.id,
+      projectId: project.id,
+      wordCount: createdWordRows.length,
+    };
+  } catch (error) {
+    await supabase.from('projects').delete().eq('id', project.id);
+    throw error;
+  }
+}
+
 export async function importDefaultOfficialWordbook(
   supabase: SupabaseClient,
   userId: string,
@@ -108,161 +328,31 @@ export async function importDefaultOfficialWordbook(
 ): Promise<DefaultOfficialWordbookImportResult> {
   if (!eikenLevel) return null;
 
-  const { data: officialWordbooks, error: wordbookError } = await supabase
-    .from('official_wordbooks')
-    .select('id,title,source_labels,icon_image,is_default')
-    .eq('eiken_level', eikenLevel)
-    .eq('is_active', true)
-    .order('is_default', { ascending: false })
-    .order('sort_order', { ascending: true });
+  const { data: officialProjects, error: projectError } = await supabase
+    .from('projects')
+    .select('id,title,official_title,icon_image,official_is_default')
+    .eq('official_eiken_level', eikenLevel)
+    .eq('official_is_active', true)
+    .order('official_is_default', { ascending: false })
+    .order('official_sort_order', { ascending: true })
+    .order('created_at', { ascending: true });
 
-  if (wordbookError) {
-    if (isOfficialWordbookSchemaError(wordbookError)) return null;
-    throw new Error(`Failed to fetch official wordbook: ${wordbookError.message}`);
+  if (projectError) {
+    if (isOfficialProjectSchemaError(projectError)) return null;
+    throw new Error(`Failed to fetch official projects: ${projectError.message}`);
   }
 
-  const activeWordbooks = (officialWordbooks ?? []) as unknown as OfficialWordbookRow[];
-  if (activeWordbooks.length === 0) return null;
+  const activeProjects = (officialProjects ?? []) as unknown as OfficialProjectRow[];
+  if (activeProjects.length === 0) return null;
 
-  const defaultWordbooks = activeWordbooks.filter((wordbook) => wordbook.is_default);
-  const wordbooksToImport = defaultWordbooks.length > 0 ? defaultWordbooks : activeWordbooks.slice(0, 1);
-  const createdProjectIds: string[] = [];
+  const defaultProjects = activeProjects.filter((project) => project.official_is_default);
+  const projectsToImport = defaultProjects.length > 0 ? defaultProjects : activeProjects.slice(0, 1);
   const imported: DefaultOfficialWordbookImportItem[] = [];
 
-  try {
-    for (const officialWordbook of wordbooksToImport) {
-      const { data: officialWords, error: wordsError } = await supabase
-        .from('official_wordbook_words')
-        .select([
-          'id',
-          'english',
-          'japanese',
-          'translations',
-          'distractors',
-          'vocabulary_type',
-          'japanese_source',
-          'lexicon_entry_id',
-          'lexicon_sense_id',
-          'example_sentence',
-          'example_sentence_ja',
-          'pronunciation',
-          'part_of_speech_tags',
-          'related_words',
-          'usage_patterns',
-          'word_order_quiz',
-          'custom_sections',
-        ].join(','))
-        .eq('official_wordbook_id', officialWordbook.id)
-        .order('sort_order', { ascending: true })
-        .order('created_at', { ascending: true });
-
-      if (wordsError) {
-        if (isOfficialWordbookSchemaError(wordsError)) return imported.length > 0 ? imported : null;
-        throw new Error(`Failed to fetch official wordbook words: ${wordsError.message}`);
-      }
-
-      const sourceWords = (officialWords ?? []) as unknown as OfficialWordbookWordRow[];
-      if (sourceWords.length === 0) continue;
-
-      const sourceLabels = normalizeStringArray(officialWordbook.source_labels);
-      const { data: project, error: projectError } = await supabase
-        .from('projects')
-        .insert({
-          user_id: userId,
-          title: officialWordbook.title,
-          source_labels: sourceLabels.length > 0 ? sourceLabels : ['official', `eiken:${eikenLevel}`],
-          ...(officialWordbook.icon_image ? { icon_image: officialWordbook.icon_image } : {}),
-        })
-        .select('id')
-        .single<CreatedProjectRow>();
-
-      if (projectError || !project) {
-        throw new Error(`Failed to create imported official wordbook: ${projectError?.message ?? 'missing project row'}`);
-      }
-      createdProjectIds.push(project.id);
-
-      const defaultSR = getDefaultSpacedRepetitionFields();
-      const normalizedWords = sourceWords.map((word) => normalizeWordForTranslationPersistence({
-        projectId: project.id,
-        english: word.english,
-        japanese: word.japanese ?? '',
-        translations: word.translations ?? undefined,
-        distractors: normalizeStringArray(word.distractors, 10),
-        vocabularyType: normalizeVocabularyType(word.vocabulary_type),
-        japaneseSource: normalizeJapaneseSource(word.japanese_source),
-        lexiconEntryId: word.lexicon_entry_id ?? undefined,
-        lexiconSenseId: word.lexicon_sense_id ?? undefined,
-        exampleSentence: word.example_sentence ?? undefined,
-        exampleSentenceJa: word.example_sentence_ja ?? undefined,
-        pronunciation: word.pronunciation ?? undefined,
-        partOfSpeechTags: normalizeStringArray(word.part_of_speech_tags, 10),
-        relatedWords: normalizeNullableJson(word.related_words),
-        usagePatterns: normalizeNullableJson(word.usage_patterns),
-        wordOrderQuiz: normalizeNullableJson(word.word_order_quiz),
-        customSections: normalizeJsonArray(word.custom_sections),
-      }));
-
-      const wordRows = normalizedWords.map((word, index) => ({
-        project_id: project.id,
-        english: word.english,
-        japanese: word.japanese,
-        japanese_source: word.japaneseSource ?? normalizeJapaneseSource(sourceWords[index]?.japanese_source) ?? null,
-        vocabulary_type: word.vocabularyType ?? null,
-        lexicon_entry_id: word.lexiconEntryId ?? null,
-        lexicon_sense_id: word.lexiconSenseId ?? null,
-        distractors: word.distractors,
-        example_sentence: word.exampleSentence ?? null,
-        example_sentence_ja: word.exampleSentenceJa ?? null,
-        pronunciation: word.pronunciation ?? null,
-        part_of_speech_tags: word.partOfSpeechTags.length > 0 ? word.partOfSpeechTags : null,
-        related_words: word.relatedWords ?? null,
-        usage_patterns: word.usagePatterns ?? null,
-        word_order_quiz: word.wordOrderQuiz ?? null,
-        custom_sections: word.customSections ?? [],
-        status: 'new',
-        ease_factor: defaultSR.easeFactor,
-        interval_days: defaultSR.intervalDays,
-        repetition: defaultSR.repetition,
-        is_favorite: false,
-      }));
-
-      const { data: createdWords, error: createWordsError } = await supabase
-        .from('words')
-        .insert(wordRows)
-        .select('id');
-
-      if (createWordsError) {
-        throw new Error(`Failed to create official wordbook words: ${createWordsError.message}`);
-      }
-
-      const createdWordRows = (createdWords ?? []) as CreatedWordRow[];
-      const translationRows = buildWordTranslationInsertRows(
-        normalizedWords,
-        createdWordRows.map((word) => word.id),
-      );
-
-      if (translationRows.length > 0) {
-        const { error: translationError } = await supabase
-          .from('word_translations')
-          .upsert(translationRows, { onConflict: 'word_id,normalized_translation_ja' });
-
-        if (translationError) {
-          throw new Error(`Failed to create official wordbook translations: ${translationError.message}`);
-        }
-      }
-
-      imported.push({
-        officialWordbookId: officialWordbook.id,
-        projectId: project.id,
-        wordCount: createdWordRows.length,
-      });
-    }
-
-    return imported.length > 0 ? imported : null;
-  } catch (error) {
-    for (const projectId of createdProjectIds) {
-      await supabase.from('projects').delete().eq('id', projectId);
-    }
-    throw error;
+  for (const officialProject of projectsToImport) {
+    const result = await importOfficialProject(supabase, userId, eikenLevel, officialProject);
+    if (result) imported.push(result);
   }
+
+  return imported.length > 0 ? imported : null;
 }

--- a/supabase/migrations/20260629082705_allow_multiple_default_official_wordbooks.sql
+++ b/supabase/migrations/20260629082705_allow_multiple_default_official_wordbooks.sql
@@ -1,0 +1,5 @@
+-- Allow one target level to seed multiple official default wordbooks.
+-- The onboarding importer now imports every active default wordbook for the
+-- selected Eiken level, ordered by sort_order.
+
+DROP INDEX IF EXISTS public.idx_official_wordbooks_one_default_per_level;

--- a/supabase/migrations/20260629082705_allow_multiple_default_official_wordbooks.sql
+++ b/supabase/migrations/20260629082705_allow_multiple_default_official_wordbooks.sql
@@ -1,5 +1,83 @@
--- Allow one target level to seed multiple official default wordbooks.
--- The onboarding importer now imports every active default wordbook for the
--- selected Eiken level, ordered by sort_order.
+-- Store official wordbook sources as normal projects.
+-- projects / words / word_translations remain the single source shape; the
+-- official_* columns only mark which projects should seed onboarding copies.
 
-DROP INDEX IF EXISTS public.idx_official_wordbooks_one_default_per_level;
+DROP TABLE IF EXISTS public.official_wordbook_words;
+DROP TABLE IF EXISTS public.official_wordbooks;
+
+ALTER TABLE public.projects
+  ADD COLUMN IF NOT EXISTS official_slug text NULL,
+  ADD COLUMN IF NOT EXISTS official_title text NULL,
+  ADD COLUMN IF NOT EXISTS official_description text NULL,
+  ADD COLUMN IF NOT EXISTS official_eiken_level text NULL,
+  ADD COLUMN IF NOT EXISTS official_is_default boolean NOT NULL DEFAULT false,
+  ADD COLUMN IF NOT EXISTS official_is_active boolean NOT NULL DEFAULT false,
+  ADD COLUMN IF NOT EXISTS official_sort_order integer NOT NULL DEFAULT 0;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'projects_official_slug_format'
+      AND conrelid = 'public.projects'::regclass
+  ) THEN
+    ALTER TABLE public.projects
+      ADD CONSTRAINT projects_official_slug_format
+      CHECK (official_slug IS NULL OR official_slug ~ '^[a-z0-9][a-z0-9_-]{1,80}$');
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'projects_official_eiken_level_check'
+      AND conrelid = 'public.projects'::regclass
+  ) THEN
+    ALTER TABLE public.projects
+      ADD CONSTRAINT projects_official_eiken_level_check
+      CHECK (
+        official_eiken_level IS NULL
+        OR official_eiken_level IN ('5', '4', '3', 'pre2', '2', 'pre1', '1')
+      );
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'projects_official_title_non_empty'
+      AND conrelid = 'public.projects'::regclass
+  ) THEN
+    ALTER TABLE public.projects
+      ADD CONSTRAINT projects_official_title_non_empty
+      CHECK (official_title IS NULL OR btrim(official_title) <> '');
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'projects_official_metadata_consistent'
+      AND conrelid = 'public.projects'::regclass
+  ) THEN
+    ALTER TABLE public.projects
+      ADD CONSTRAINT projects_official_metadata_consistent
+      CHECK (
+        NOT official_is_active
+        OR (
+          official_slug IS NOT NULL
+          AND official_title IS NOT NULL
+          AND official_eiken_level IS NOT NULL
+        )
+      );
+  END IF;
+END
+$$;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_projects_official_slug
+  ON public.projects (official_slug)
+  WHERE official_slug IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_projects_official_level_default
+  ON public.projects (official_eiken_level, official_is_default DESC, official_sort_order, created_at)
+  WHERE official_is_active AND official_eiken_level IS NOT NULL;
+
+NOTIFY pgrst, 'reload schema';

--- a/supabase/migrations/20260629083721_seed_pre1_official_wordbooks.sql
+++ b/supabase/migrations/20260629083721_seed_pre1_official_wordbooks.sql
@@ -1,0 +1,169 @@
+-- Seed the four pre-1 official wordbooks from the author's existing projects.
+-- Re-running this migration logic by hand is safe: official rows are upserted
+-- by slug and their copied word rows are recreated from the source projects.
+
+WITH seed(project_id, title, slug, sort_order) AS (
+  VALUES
+    ('bb12e258-7731-4a06-ba31-b277bd256b03'::uuid, '英検準一級単語集1', 'eiken-pre1-default-1', 1),
+    ('bed17fdf-168c-4f3f-8aff-0e612bb2d161'::uuid, '英検準一級単語集2', 'eiken-pre1-default-2', 2),
+    ('59affa0b-65af-4051-a1ca-7a6f22a21ddc'::uuid, '英検準一級単語集3', 'eiken-pre1-default-3', 3),
+    ('880ac7f4-0af5-4965-a45b-10bf6d3cedb7'::uuid, '英検準一級単語集4', 'eiken-pre1-default-4', 4)
+),
+upserted AS (
+  INSERT INTO public.official_wordbooks (
+    slug,
+    title,
+    description,
+    eiken_level,
+    is_default,
+    is_active,
+    source_labels,
+    icon_image,
+    sort_order
+  )
+  SELECT
+    seed.slug,
+    seed.title,
+    '英検準一級向けの公式単語帳です。',
+    'pre1',
+    true,
+    true,
+    ARRAY['official', 'eiken:pre1']::text[],
+    projects.icon_image,
+    seed.sort_order
+  FROM seed
+  JOIN public.projects ON projects.id = seed.project_id
+  ON CONFLICT (slug) DO UPDATE
+  SET
+    title = EXCLUDED.title,
+    description = EXCLUDED.description,
+    eiken_level = EXCLUDED.eiken_level,
+    is_default = EXCLUDED.is_default,
+    is_active = EXCLUDED.is_active,
+    source_labels = EXCLUDED.source_labels,
+    icon_image = EXCLUDED.icon_image,
+    sort_order = EXCLUDED.sort_order,
+    updated_at = now()
+  RETURNING id, slug
+),
+deleted_words AS (
+  DELETE FROM public.official_wordbook_words words
+  USING upserted
+  WHERE words.official_wordbook_id = upserted.id
+  RETURNING words.id
+)
+INSERT INTO public.official_wordbook_words (
+  official_wordbook_id,
+  english,
+  japanese,
+  translations,
+  distractors,
+  vocabulary_type,
+  japanese_source,
+  lexicon_entry_id,
+  lexicon_sense_id,
+  example_sentence,
+  example_sentence_ja,
+  pronunciation,
+  part_of_speech_tags,
+  related_words,
+  usage_patterns,
+  word_order_quiz,
+  custom_sections,
+  sort_order,
+  created_at,
+  updated_at
+)
+SELECT
+  upserted.id,
+  words.english,
+  NULLIF(btrim(words.japanese), ''),
+  COALESCE(
+    translations.translations,
+    CASE
+      WHEN NULLIF(btrim(words.japanese), '') IS NULL THEN '[]'::jsonb
+      ELSE jsonb_build_array(jsonb_strip_nulls(jsonb_build_object(
+        'translationJa', btrim(words.japanese),
+        'normalizedTranslationJa', NULLIF(lower(regexp_replace(btrim(words.japanese), '\s+', ' ', 'g')), ''),
+        'source', words.japanese_source,
+        'lexiconSenseId', words.lexicon_sense_id,
+        'meaningRank', 1
+      )))
+    END
+  ),
+  COALESCE(words.distractors, '[]'::jsonb),
+  words.vocabulary_type,
+  words.japanese_source,
+  words.lexicon_entry_id,
+  words.lexicon_sense_id,
+  words.example_sentence,
+  words.example_sentence_ja,
+  words.pronunciation,
+  CASE
+    WHEN jsonb_typeof(words.part_of_speech_tags) = 'array' THEN ARRAY(
+      SELECT jsonb_array_elements_text(words.part_of_speech_tags)
+    )
+    ELSE NULL
+  END,
+  CASE
+    WHEN jsonb_typeof(words.related_words) = 'array' THEN words.related_words
+    ELSE NULL
+  END,
+  CASE
+    WHEN jsonb_typeof(words.usage_patterns) = 'array' THEN words.usage_patterns
+    ELSE NULL
+  END,
+  words.word_order_quiz,
+  CASE
+    WHEN jsonb_typeof(words.custom_sections) = 'array' THEN words.custom_sections
+    ELSE '[]'::jsonb
+  END,
+  (row_number() OVER (
+    PARTITION BY upserted.id
+    ORDER BY words.created_at, words.id
+  ) - 1)::integer,
+  words.created_at,
+  words.updated_at
+FROM seed
+JOIN upserted ON upserted.slug = seed.slug
+JOIN public.words ON words.project_id = seed.project_id
+LEFT JOIN LATERAL (
+  SELECT jsonb_agg(
+    jsonb_strip_nulls(jsonb_build_object(
+      'translationJa', word_translations.translation_ja,
+      'normalizedTranslationJa', word_translations.normalized_translation_ja,
+      'source', word_translations.source,
+      'lexiconSenseId', word_translations.lexicon_sense_id,
+      'meaningRank', word_translations.meaning_rank
+    ))
+    ORDER BY word_translations.position, word_translations.meaning_rank, word_translations.created_at
+  ) FILTER (WHERE NULLIF(btrim(word_translations.translation_ja), '') IS NOT NULL) AS translations
+  FROM public.word_translations
+  WHERE word_translations.word_id = words.id
+) translations ON true
+ORDER BY seed.sort_order, words.created_at, words.id;
+
+DO $$
+DECLARE
+  empty_wordbooks integer;
+BEGIN
+  SELECT count(*)
+  INTO empty_wordbooks
+  FROM public.official_wordbooks wordbooks
+  WHERE wordbooks.slug IN (
+    'eiken-pre1-default-1',
+    'eiken-pre1-default-2',
+    'eiken-pre1-default-3',
+    'eiken-pre1-default-4'
+  )
+    AND NOT EXISTS (
+      SELECT 1
+      FROM public.official_wordbook_words words
+      WHERE words.official_wordbook_id = wordbooks.id
+    );
+
+  IF empty_wordbooks > 0 THEN
+    RAISE EXCEPTION 'pre1 official wordbook seed produced % empty wordbook(s)', empty_wordbooks;
+  END IF;
+END
+$$;

--- a/supabase/migrations/20260629083721_seed_pre1_official_wordbooks.sql
+++ b/supabase/migrations/20260629083721_seed_pre1_official_wordbooks.sql
@@ -1,156 +1,53 @@
--- Seed the four pre-1 official wordbooks from the author's existing projects.
--- Re-running this migration logic by hand is safe: official rows are upserted
--- by slug and their copied word rows are recreated from the source projects.
+-- Mark the four existing pre-1 projects as official onboarding sources.
+-- The source content stays in the normal projects / words / word_translations
+-- tables, so official wordbooks have the same shape as every other wordbook.
 
-WITH seed(project_id, title, slug, sort_order) AS (
+WITH seed(project_id, official_title, official_slug, official_sort_order) AS (
   VALUES
     ('bb12e258-7731-4a06-ba31-b277bd256b03'::uuid, '英検準一級単語集1', 'eiken-pre1-default-1', 1),
     ('bed17fdf-168c-4f3f-8aff-0e612bb2d161'::uuid, '英検準一級単語集2', 'eiken-pre1-default-2', 2),
     ('59affa0b-65af-4051-a1ca-7a6f22a21ddc'::uuid, '英検準一級単語集3', 'eiken-pre1-default-3', 3),
     ('880ac7f4-0af5-4965-a45b-10bf6d3cedb7'::uuid, '英検準一級単語集4', 'eiken-pre1-default-4', 4)
-),
-upserted AS (
-  INSERT INTO public.official_wordbooks (
-    slug,
-    title,
-    description,
-    eiken_level,
-    is_default,
-    is_active,
-    source_labels,
-    icon_image,
-    sort_order
-  )
-  SELECT
-    seed.slug,
-    seed.title,
-    '英検準一級向けの公式単語帳です。',
-    'pre1',
-    true,
-    true,
-    ARRAY['official', 'eiken:pre1']::text[],
-    projects.icon_image,
-    seed.sort_order
-  FROM seed
-  JOIN public.projects ON projects.id = seed.project_id
-  ON CONFLICT (slug) DO UPDATE
-  SET
-    title = EXCLUDED.title,
-    description = EXCLUDED.description,
-    eiken_level = EXCLUDED.eiken_level,
-    is_default = EXCLUDED.is_default,
-    is_active = EXCLUDED.is_active,
-    source_labels = EXCLUDED.source_labels,
-    icon_image = EXCLUDED.icon_image,
-    sort_order = EXCLUDED.sort_order,
-    updated_at = now()
-  RETURNING id, slug
-),
-deleted_words AS (
-  DELETE FROM public.official_wordbook_words words
-  USING upserted
-  WHERE words.official_wordbook_id = upserted.id
-  RETURNING words.id
 )
-INSERT INTO public.official_wordbook_words (
-  official_wordbook_id,
-  english,
-  japanese,
-  translations,
-  distractors,
-  vocabulary_type,
-  japanese_source,
-  lexicon_entry_id,
-  lexicon_sense_id,
-  example_sentence,
-  example_sentence_ja,
-  pronunciation,
-  part_of_speech_tags,
-  related_words,
-  usage_patterns,
-  word_order_quiz,
-  custom_sections,
-  sort_order,
-  created_at,
-  updated_at
-)
-SELECT
-  upserted.id,
-  words.english,
-  NULLIF(btrim(words.japanese), ''),
-  COALESCE(
-    translations.translations,
-    CASE
-      WHEN NULLIF(btrim(words.japanese), '') IS NULL THEN '[]'::jsonb
-      ELSE jsonb_build_array(jsonb_strip_nulls(jsonb_build_object(
-        'translationJa', btrim(words.japanese),
-        'normalizedTranslationJa', NULLIF(lower(regexp_replace(btrim(words.japanese), '\s+', ' ', 'g')), ''),
-        'source', words.japanese_source,
-        'lexiconSenseId', words.lexicon_sense_id,
-        'meaningRank', 1
-      )))
-    END
-  ),
-  COALESCE(words.distractors, '[]'::jsonb),
-  words.vocabulary_type,
-  words.japanese_source,
-  words.lexicon_entry_id,
-  words.lexicon_sense_id,
-  words.example_sentence,
-  words.example_sentence_ja,
-  words.pronunciation,
-  CASE
-    WHEN jsonb_typeof(words.part_of_speech_tags) = 'array' THEN ARRAY(
-      SELECT jsonb_array_elements_text(words.part_of_speech_tags)
-    )
-    ELSE NULL
-  END,
-  CASE
-    WHEN jsonb_typeof(words.related_words) = 'array' THEN words.related_words
-    ELSE NULL
-  END,
-  CASE
-    WHEN jsonb_typeof(words.usage_patterns) = 'array' THEN words.usage_patterns
-    ELSE NULL
-  END,
-  words.word_order_quiz,
-  CASE
-    WHEN jsonb_typeof(words.custom_sections) = 'array' THEN words.custom_sections
-    ELSE '[]'::jsonb
-  END,
-  (row_number() OVER (
-    PARTITION BY upserted.id
-    ORDER BY words.created_at, words.id
-  ) - 1)::integer,
-  words.created_at,
-  words.updated_at
+UPDATE public.projects projects
+SET
+  official_slug = seed.official_slug,
+  official_title = seed.official_title,
+  official_description = '英検準一級向けの公式単語帳です。',
+  official_eiken_level = 'pre1',
+  official_is_default = true,
+  official_is_active = true,
+  official_sort_order = seed.official_sort_order,
+  updated_at = now()
 FROM seed
-JOIN upserted ON upserted.slug = seed.slug
-JOIN public.words ON words.project_id = seed.project_id
-LEFT JOIN LATERAL (
-  SELECT jsonb_agg(
-    jsonb_strip_nulls(jsonb_build_object(
-      'translationJa', word_translations.translation_ja,
-      'normalizedTranslationJa', word_translations.normalized_translation_ja,
-      'source', word_translations.source,
-      'lexiconSenseId', word_translations.lexicon_sense_id,
-      'meaningRank', word_translations.meaning_rank
-    ))
-    ORDER BY word_translations.position, word_translations.meaning_rank, word_translations.created_at
-  ) FILTER (WHERE NULLIF(btrim(word_translations.translation_ja), '') IS NOT NULL) AS translations
-  FROM public.word_translations
-  WHERE word_translations.word_id = words.id
-) translations ON true
-ORDER BY seed.sort_order, words.created_at, words.id;
+WHERE projects.id = seed.project_id;
 
 DO $$
 DECLARE
-  empty_wordbooks integer;
+  marked_projects integer;
+  empty_projects integer;
 BEGIN
   SELECT count(*)
-  INTO empty_wordbooks
-  FROM public.official_wordbooks wordbooks
-  WHERE wordbooks.slug IN (
+  INTO marked_projects
+  FROM public.projects
+  WHERE official_slug IN (
+    'eiken-pre1-default-1',
+    'eiken-pre1-default-2',
+    'eiken-pre1-default-3',
+    'eiken-pre1-default-4'
+  )
+    AND official_eiken_level = 'pre1'
+    AND official_is_default
+    AND official_is_active;
+
+  IF marked_projects <> 4 THEN
+    RAISE EXCEPTION 'pre1 official seed marked % project(s), expected 4', marked_projects;
+  END IF;
+
+  SELECT count(*)
+  INTO empty_projects
+  FROM public.projects projects
+  WHERE projects.official_slug IN (
     'eiken-pre1-default-1',
     'eiken-pre1-default-2',
     'eiken-pre1-default-3',
@@ -158,12 +55,14 @@ BEGIN
   )
     AND NOT EXISTS (
       SELECT 1
-      FROM public.official_wordbook_words words
-      WHERE words.official_wordbook_id = wordbooks.id
+      FROM public.words words
+      WHERE words.project_id = projects.id
     );
 
-  IF empty_wordbooks > 0 THEN
-    RAISE EXCEPTION 'pre1 official wordbook seed produced % empty wordbook(s)', empty_wordbooks;
+  IF empty_projects > 0 THEN
+    RAISE EXCEPTION 'pre1 official seed found % empty source project(s)', empty_projects;
   END IF;
 END
 $$;
+
+NOTIFY pgrst, 'reload schema';


### PR DESCRIPTION
## Summary
- Use normal `projects` / `words` / `word_translations` as the official wordbook source shape.
- Remove the separate official word rows table from the effective schema and add official metadata columns to `projects`.
- Import every active default official project during signup instead of only the first one.
- Mark the four existing pre1 projects as official onboarding sources.
- Track copied official wordbooks with `projects.official_source_project_id` so backfills can be idempotent.

## Seeded pre1 source projects
- `eiken-pre1-default-1`: `bb12e258-7731-4a06-ba31-b277bd256b03`
- `eiken-pre1-default-2`: `bed17fdf-168c-4f3f-8aff-0e612bb2d161`
- `eiken-pre1-default-3`: `59affa0b-65af-4051-a1ca-7a6f22a21ddc`
- `eiken-pre1-default-4`: `880ac7f4-0af5-4965-a45b-10bf6d3cedb7`

## Production DB
- Applied with `SUPABASE_TELEMETRY_DISABLED=1 supabase db push --linked --yes` to linked project `ryoyvpayoacgeqgoehgk`.
- Applied migrations:
  - `20260628090000_add_active_word_status.sql`
  - `20260628224834_create_official_wordbooks.sql`
  - `20260629082705_allow_multiple_default_official_wordbooks.sql`
  - `20260629083721_seed_pre1_official_wordbooks.sql`
- Verified the effective schema drops `official_wordbooks` and `official_wordbook_words`.
- Verified the four pre1 source projects are active/default official sources with word counts `111`, `100`, `100`, `92`.
- Ran the existing-user backfill idempotently. Result: `0` copied projects, `0` copied words, `0` copied translations. Existing `profiles.eiken_level` data currently has one user at `1` and no `pre1` users, so there was no matching pre1 backfill target. Pending matching copies: `0`.

## Notes
- The previous 834 count was a bad verification query: it counted `words` after joining `word_translations`, so multi-translation words were counted more than once.
- Rechecked with `count(distinct words.id)`: the four projects contain 403 word rows total.

## Validation
- `./node_modules/.bin/tsx --test src/lib/official-wordbooks/import-default.test.ts src/app/api/auth/otp.contract.test.ts src/lib/auth/signup-flow.test.ts`
- `./node_modules/.bin/tsc --noEmit --pretty false`
- `./node_modules/.bin/eslint src/app/api/auth/otp.contract.test.ts src/app/api/auth/signup-verify/route.ts src/app/signup/page.tsx src/lib/auth/signup-flow.ts src/lib/auth/signup-flow.test.ts src/lib/official-wordbooks/import-default.ts src/lib/official-wordbooks/import-default.test.ts`
- `SUPABASE_TELEMETRY_DISABLED=1 supabase db push --linked --dry-run`
- `SUPABASE_TELEMETRY_DISABLED=1 supabase db push --linked --yes`
- `git diff --check`
