### PR TITLE
Add Pro plan upgrade email notification via Resend

### DIFF
--- a/src/app/api/subscription/notify-pro/route.ts
+++ b/src/app/api/subscription/notify-pro/route.ts
@@ -1,0 +1,34 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { sendProUpgradeEmail } from '@/lib/resend/client';
+
+export async function POST(request: NextRequest) {
+  const adminSecret = process.env.ADMIN_SECRET;
+  if (!adminSecret) {
+    return NextResponse.json({ error: 'Server configuration error' }, { status: 500 });
+  }
+
+  const authHeader = request.headers.get('authorization');
+  if (authHeader !== `Bearer ${adminSecret}`) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  let body: { email?: string };
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 });
+  }
+
+  const { email } = body;
+  if (!email || typeof email !== 'string') {
+    return NextResponse.json({ error: 'email is required' }, { status: 400 });
+  }
+
+  const result = await sendProUpgradeEmail({ to: email });
+
+  if (result.error) {
+    return NextResponse.json({ error: result.error }, { status: 500 });
+  }
+
+  return NextResponse.json({ success: true, messageId: result.messageId });
+}

--- a/src/lib/resend/client.ts
+++ b/src/lib/resend/client.ts
@@ -84,6 +84,108 @@ export async function sendOtpEmail({ to, otpCode }: SendOtpEmailParams): Promise
   }
 }
 
+interface SendProUpgradeEmailParams {
+  to: string;
+}
+
+export async function sendProUpgradeEmail({ to }: SendProUpgradeEmailParams): Promise<ResendResponse> {
+  const apiKey = process.env.RESEND_API_KEY;
+
+  if (!apiKey) {
+    console.error('RESEND_API_KEY is not set');
+    return { error: 'メール送信の設定エラーです' };
+  }
+
+  try {
+    const response = await fetch(RESEND_API_URL, {
+      method: 'POST',
+      headers: {
+        'Authorization': `Bearer ${apiKey}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        from: 'Merken <noreply@merken.jp>',
+        to: [to],
+        subject: '【Merken】Proプランへのアップグレード完了',
+        html: `
+          <!DOCTYPE html>
+          <html>
+          <head>
+            <meta charset="utf-8">
+            <style>
+              body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; color: #1a1a1a; }
+              .container { max-width: 480px; margin: 0 auto; padding: 40px 20px; }
+              .badge {
+                display: inline-block;
+                background: linear-gradient(135deg, #6366f1, #8b5cf6);
+                color: #fff;
+                font-weight: bold;
+                font-size: 14px;
+                padding: 6px 16px;
+                border-radius: 20px;
+                margin-bottom: 16px;
+              }
+              .features {
+                background: #f9fafb;
+                border-radius: 12px;
+                padding: 20px 24px;
+                margin: 24px 0;
+              }
+              .features ul { margin: 0; padding-left: 20px; }
+              .features li { margin-bottom: 8px; line-height: 1.6; }
+              .cta {
+                display: inline-block;
+                background: #6366f1;
+                color: #fff !important;
+                text-decoration: none;
+                font-weight: bold;
+                padding: 12px 32px;
+                border-radius: 8px;
+                margin: 16px 0;
+              }
+              .footer { color: #6b7280; font-size: 14px; margin-top: 32px; }
+            </style>
+          </head>
+          <body>
+            <div class="container">
+              <div class="badge">PRO</div>
+              <h2>Proプランへようこそ！</h2>
+              <p>Merken Proプランへのアップグレードが完了しました。以下の機能がご利用いただけます。</p>
+              <div class="features">
+                <ul>
+                  <li><strong>無制限スキャン</strong> — 1日の制限なし</li>
+                  <li><strong>無制限単語登録</strong> — 100語の制限なし</li>
+                  <li><strong>クラウド同期</strong> — 複数デバイスで学習</li>
+                  <li><strong>高度なスキャンモード</strong> — 丸囲み・マーカー・英検・熟語・間違い抽出</li>
+                </ul>
+              </div>
+              <a href="https://www.merken.jp" class="cta">Merkenを開く</a>
+              <div class="footer">
+                <p>ご不明な点がございましたら、お気軽にお問い合わせください。</p>
+                <p>Merken - 単語学習アプリ</p>
+              </div>
+            </div>
+          </body>
+          </html>
+        `,
+        text: `Proプランへようこそ！\n\nMerken Proプランへのアップグレードが完了しました。\n\n以下の機能がご利用いただけます：\n- 無制限スキャン（1日の制限なし）\n- 無制限単語登録（100語の制限なし）\n- クラウド同期（複数デバイスで学習）\n- 高度なスキャンモード（丸囲み・マーカー・英検・熟語・間違い抽出）\n\nhttps://www.merken.jp\n\nMerken - 単語学習アプリ`,
+      }),
+    });
+
+    if (!response.ok) {
+      const errorData = await response.json().catch(() => ({}));
+      console.error('Resend API error:', response.status, errorData);
+      return { error: 'メール送信に失敗しました' };
+    }
+
+    const data = await response.json();
+    return { messageId: data.id };
+  } catch (error) {
+    console.error('Resend API request failed:', error);
+    return { error: 'メール送信に失敗しました' };
+  }
+}
+
 // 6桁のOTPコードを生成
 export function generateOtpCode(): string {
   return Math.floor(100000 + Math.random() * 900000).toString();

--- a/src/lib/subscription/billing-activation.ts
+++ b/src/lib/subscription/billing-activation.ts
@@ -1,5 +1,6 @@
 import { SupabaseClient } from '@supabase/supabase-js';
 import { getCheckoutSession, STRIPE_CONFIG } from '@/lib/stripe';
+import { sendProUpgradeEmail } from '@/lib/resend/client';
 import type Stripe from 'stripe';
 
 type ActivationContext = 'webhook' | 'reconcile';
@@ -363,6 +364,19 @@ export async function activateBillingFromSession(
     sessionId: params.sessionId,
     reusedSession: Boolean(session.used_at),
   });
+
+  if (!session.used_at) {
+    supabaseAdmin.auth.admin.getUserById(params.userId).then(({ data }: { data: { user: { email?: string } | null } }) => {
+      const email = data?.user?.email;
+      if (email) {
+        sendProUpgradeEmail({ to: email }).catch((err) => {
+          console.error('[BillingActivation] failed to send Pro upgrade email', err);
+        });
+      }
+    }).catch((err) => {
+      console.error('[BillingActivation] failed to look up user email', err);
+    });
+  }
 
   return {
     activated: true,


### PR DESCRIPTION
## Summary\n\n- Add `sendProUpgradeEmail()` to `src/lib/resend/client.ts` — styled HTML/text email notifying users their plan is now Pro, listing unlocked features\n- Auto-send the email during billing activation (`billing-activation.ts`) on first-time upgrades (fire-and-forget, won't block the activation flow)\n- Add `POST /api/subscription/notify-pro` API route for manually sending the notification to a specific email (requires `ADMIN_SECRET` bearer auth)\n\n## Test plan\n\n- [ ] Verify `sendProUpgradeEmail` sends correctly via Resend (use Resend dashboard or test key)\n- [ ] Trigger a Stripe checkout completion and confirm the Pro upgrade email is sent automatically\n- [ ] Test `/api/subscription/notify-pro` with valid `ADMIN_SECRET` and email → expect 200 + messageId\n- [ ] Test `/api/subscription/notify-pro` without auth → expect 401\n- [ ] Test `/api/subscription/notify-pro` without email body → expect 400\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)\n\nhttps://claude.ai/code/session_01AkEEtkVhheWvZY8p6wBzKc

---
_Generated by [Claude Code](https://claude.ai/code/session_01AkEEtkVhheWvZY8p6wBzKc)_