### PR TITLE
リール: 既読リサイクルで無限フィード化 + ボトムナビ常時表示

### DIFF
--- a/src/app/api/reels/shared.ts
+++ b/src/app/api/reels/shared.ts
@@ -11,7 +11,7 @@ import type {
 } from '@/lib/reels/types';
 import { decodeReelCursor, encodeReelCursor } from '@/lib/reels/cursor';
 import { eikenLevelsAround } from '@/lib/reels/eiken-cefr';
-import { rankReelCandidates } from '@/lib/reels/ranking';
+import { selectReelCandidates } from '@/lib/reels/ranking';
 import { createSharedSearchEmbedding } from '@/lib/shared-projects/tag-embeddings';
 
 type SupabaseAdminClient = ReturnType<typeof getSupabaseAdmin>;
@@ -312,11 +312,15 @@ async function fetchRankingInputs(admin: SupabaseAdminClient, userId: string): P
   return { eikenLevel, interestTags: Array.from(interestTags) };
 }
 
-async function fetchSeenKeys(admin: SupabaseAdminClient, userId: string): Promise<Set<string>> {
+/** item_key -> seen_at for words seen within the freshness window. */
+async function fetchSeenAtByKey(
+  admin: SupabaseAdminClient,
+  userId: string,
+): Promise<Record<string, string>> {
   const since = new Date(Date.now() - SEEN_WINDOW_DAYS * 86_400_000).toISOString();
   const { data, error } = await admin
     .from('reel_seen_words')
-    .select('item_key')
+    .select('item_key,seen_at')
     .eq('user_id', userId)
     .gte('seen_at', since)
     .order('seen_at', { ascending: false })
@@ -324,9 +328,13 @@ async function fetchSeenKeys(admin: SupabaseAdminClient, userId: string): Promis
 
   if (error) {
     // Dedup is best-effort; an error here must not break the feed.
-    return new Set();
+    return {};
   }
-  return new Set((data ?? []).map((row) => row.item_key as string));
+  const result: Record<string, string> = {};
+  for (const row of (data ?? []) as { item_key: string; seen_at: string }[]) {
+    result[row.item_key] = row.seen_at;
+  }
+  return result;
 }
 
 type UserFeedbackSummary = {
@@ -520,22 +528,25 @@ export async function buildReelFeedPage(options: {
   const page = cursor?.page ?? 0;
 
   const rankingInputs = await fetchRankingInputs(admin, options.userId);
-  const [sharedCandidates, officialCandidates, seenKeys, feedback, tagSimilarityByBookId] =
+  const [sharedCandidates, officialCandidates, seenAtByKey, feedback, tagSimilarityByBookId] =
     await Promise.all([
       fetchSharedCandidates(admin),
       fetchOfficialCandidates(admin, rankingInputs.eikenLevel),
-      fetchSeenKeys(admin, options.userId),
+      fetchSeenAtByKey(admin, options.userId),
       fetchUserFeedback(admin, options.userId),
       fetchTagSimilarity(admin, rankingInputs.interestTags),
     ]);
 
-  const unseen = [...sharedCandidates, ...officialCandidates].filter(
-    (candidate) => !seenKeys.has(candidate.id) && !feedback.excludedKeys.has(candidate.id),
+  // Only not-interested words are excluded outright; seen words stay in
+  // the pool and get recycled as review cards when the unseen pool runs dry.
+  const candidates = [...sharedCandidates, ...officialCandidates].filter(
+    (candidate) => !feedback.excludedKeys.has(candidate.id),
   );
 
   const rankSeed = (seed ^ Math.imul(page + 1, 0x9e3779b1)) >>> 0;
-  const picked = rankReelCandidates(
-    unseen,
+  const selections = selectReelCandidates(
+    candidates,
+    seenAtByKey,
     {
       eikenLevel: rankingInputs.eikenLevel,
       interestTags: rankingInputs.interestTags,
@@ -551,34 +562,41 @@ export async function buildReelFeedPage(options: {
   // Count the page against the daily limit (batch; must run as the user).
   const { data: usageData, error: usageError } = await options.userClient.rpc(
     'check_and_increment_reel_views',
-    { p_requested: picked.length },
+    { p_requested: selections.length },
   );
   if (usageError || !usageData) {
     throw new Error(usageError?.message || 'reel_usage_rpc_failed');
   }
   const usage = usageData as ReelUsageRpcResult;
 
-  const granted = Math.max(0, Math.min(picked.length, usage.granted));
-  const grantedCandidates = picked.slice(0, granted);
+  const granted = Math.max(0, Math.min(selections.length, usage.granted));
+  const grantedSelections = selections.slice(0, granted);
 
-  if (grantedCandidates.length > 0) {
+  if (grantedSelections.length > 0) {
+    // Refresh seen_at on every serve so recycled words rotate to the back
+    // of the LRU queue instead of repeating immediately.
     await admin.from('reel_seen_words').upsert(
-      grantedCandidates.map((candidate) => ({
+      grantedSelections.map((selection) => ({
         user_id: options.userId,
-        item_key: candidate.id,
+        item_key: selection.candidate.id,
+        seen_at: new Date().toISOString(),
       })),
-      { onConflict: 'user_id,item_key', ignoreDuplicates: true },
+      { onConflict: 'user_id,item_key' },
     );
   }
 
-  const items = await enrichItems(admin, options.userId, grantedCandidates);
+  const recycledByKey = new Map(
+    grantedSelections.map((selection) => [selection.candidate.id, selection.recycled]),
+  );
+  const items = (
+    await enrichItems(admin, options.userId, grantedSelections.map((s) => s.candidate))
+  ).map((item) => ({ ...item, isRecycled: recycledByKey.get(item.id) ?? false }));
 
   const limitReached = usage.limit !== null && usage.current_count >= usage.limit;
-  const poolExhausted = picked.length < limit && unseen.length <= picked.length;
+  // The feed never runs dry (seen words recycle); nextCursor is null only
+  // at the free daily limit or when the platform has no content at all.
   const nextCursor =
-    limitReached || poolExhausted || items.length === 0
-      ? null
-      : encodeReelCursor({ seed, page: page + 1 });
+    limitReached || items.length === 0 ? null : encodeReelCursor({ seed, page: page + 1 });
 
   return {
     items,

--- a/src/app/reels/page.tsx
+++ b/src/app/reels/page.tsx
@@ -236,11 +236,9 @@ export default function ReelsPage() {
         </div>
       </div>
 
-      {/* Feed area: full-bleed on mobile, centered column on desktop */}
-      <div
-        className="min-h-0 flex-1 lg:flex lg:justify-center"
-        style={{ paddingBottom: 'max(8px, env(safe-area-inset-bottom))' }}
-      >
+      {/* Feed area: full-bleed on mobile, centered column on desktop.
+          Mobile bottom padding clears the always-visible floating bottom nav. */}
+      <div className="min-h-0 flex-1 pb-[max(96px,calc(env(safe-area-inset-bottom)+84px))] lg:flex lg:justify-center lg:pb-2">
         <div className="h-full w-full lg:max-w-[420px] lg:rounded-[var(--solid-radius)] lg:border-2 lg:border-[var(--solid-ink)] lg:bg-[var(--color-surface)] lg:overflow-hidden">
           {status === 'loading' && items.length === 0 ? (
             <ReelSkeleton />

--- a/src/app/reels/page.tsx
+++ b/src/app/reels/page.tsx
@@ -8,7 +8,6 @@ import { getRepository } from '@/lib/db';
 import { invalidateHomeCache } from '@/lib/home-cache';
 import { triggerHaptic } from '@/lib/haptics';
 import { useToast } from '@/components/ui';
-import { Icon } from '@/components/ui/Icon';
 import type { ReelBook, ReelFeedback, ReelItem } from '@/lib/reels/types';
 import { generateWordShareImage } from '@/lib/reels/share-image';
 import type { VocabularyType } from '@/types';
@@ -218,14 +217,8 @@ export default function ReelsPage() {
         className="flex flex-shrink-0 items-center justify-between px-3 pb-2"
         style={{ paddingTop: 'max(8px, calc(env(safe-area-inset-top) + 8px))' }}
       >
-        <button
-          type="button"
-          aria-label="戻る"
-          onClick={() => router.back()}
-          className="flex h-10 w-10 items-center justify-center rounded-full text-[var(--color-foreground)] transition-colors hover:bg-[var(--color-surface-secondary)]"
-        >
-          <Icon name="arrow_back_ios_new" size={20} />
-        </button>
+        {/* Spacer keeps the title centered (bottom nav handles navigation) */}
+        <div className="h-10 w-10" />
         <h1 className="font-display text-base font-bold text-[var(--color-foreground)]">リール</h1>
         <div className="flex h-10 min-w-10 items-center justify-end">
           {remainingLabel && (

--- a/src/components/reel/ReelActionRail.tsx
+++ b/src/components/reel/ReelActionRail.tsx
@@ -8,6 +8,7 @@ type ReelActionRailProps = {
   item: ReelItem;
   onLike: () => void;
   onSpeak: () => void;
+  onComment: () => void;
   onShare: () => void;
   onMore: () => void;
 };
@@ -58,7 +59,7 @@ function RailButton({
 }
 
 /** SNS-style vertical action rail on the right edge of a reel card. */
-export function ReelActionRail({ item, onLike, onSpeak, onShare, onMore }: ReelActionRailProps) {
+export function ReelActionRail({ item, onLike, onSpeak, onComment, onShare, onMore }: ReelActionRailProps) {
   return (
     <div className="flex flex-col items-center gap-4">
       <RailButton
@@ -69,13 +70,18 @@ export function ReelActionRail({ item, onLike, onSpeak, onShare, onMore }: ReelA
         onClick={onLike}
         ariaLabel={item.likedByMe ? 'いいねを取り消す' : 'いいねする'}
       />
+      <RailButton
+        icon="chat_bubble"
+        label={item.commentCount > 0 ? String(item.commentCount) : undefined}
+        onClick={onComment}
+        ariaLabel="コメントを見る・書く"
+      />
       <RailButton icon="volume_up" onClick={onSpeak} ariaLabel="発音を再生" />
       <RailButton icon="send" onClick={onShare} ariaLabel="この単語を共有" />
       <RailButton
         icon="more_horiz"
-        label={item.commentCount > 0 ? String(item.commentCount) : undefined}
         onClick={onMore}
-        ariaLabel="その他のメニュー（コメント・興味あり/なし）"
+        ariaLabel="その他のメニュー（興味あり/なし）"
       />
     </div>
   );

--- a/src/components/reel/ReelCard.tsx
+++ b/src/components/reel/ReelCard.tsx
@@ -152,8 +152,13 @@ export function ReelCard({
         >
           {/* Front: English + IPA only */}
           <div className="flex h-full w-1/2 flex-col items-center justify-center gap-4 px-8 text-center">
-            {item.partOfSpeechTags.length > 0 && (
+            {(item.partOfSpeechTags.length > 0 || item.isRecycled) && (
               <div className="flex flex-wrap justify-center gap-1.5">
+                {item.isRecycled && (
+                  <span className="rounded-full border border-[var(--color-accent)] bg-[var(--color-accent-light)] px-2.5 py-0.5 text-xs font-bold text-[var(--color-accent-ink)]">
+                    復習
+                  </span>
+                )}
                 {item.partOfSpeechTags.slice(0, 3).map((tag) => (
                   <span
                     key={tag}

--- a/src/components/reel/ReelCard.tsx
+++ b/src/components/reel/ReelCard.tsx
@@ -191,6 +191,7 @@ export function ReelCard({
             item={item}
             onLike={onLike}
             onSpeak={() => speak(item.english)}
+            onComment={() => setCommentsOpen(true)}
             onShare={onShare}
             onMore={() => setMoreOpen(true)}
           />
@@ -202,15 +203,11 @@ export function ReelCard({
         <ReelBookCard book={item.book} importing={importing} onImport={onImport} />
       </div>
 
-      {/* "..." menu: comments + interested / not-interested */}
+      {/* "..." menu: interested / not-interested feedback */}
       <ReelMoreSheet
         item={item}
         isOpen={moreOpen}
         onClose={() => setMoreOpen(false)}
-        onOpenComments={() => {
-          setMoreOpen(false);
-          setCommentsOpen(true);
-        }}
         onFeedback={(feedback) => {
           setMoreOpen(false);
           onFeedback(feedback);

--- a/src/components/reel/ReelFeed.tsx
+++ b/src/components/reel/ReelFeed.tsx
@@ -2,11 +2,12 @@
 
 import { useCallback, useEffect, useRef, useState } from 'react';
 import type { ReelBook, ReelFeedback, ReelItem } from '@/lib/reels/types';
+import type { ReelFeedItem } from '@/hooks/use-reel-feed';
 import { ReelCard } from './ReelCard';
-import { ReelEndCard, ReelLimitCard } from './ReelStatusCards';
+import { ReelLimitCard } from './ReelStatusCards';
 
 type ReelFeedProps = {
-  items: ReelItem[];
+  items: ReelFeedItem[];
   hasMore: boolean;
   limitReached: boolean;
   usageLimit: number | null;
@@ -88,7 +89,7 @@ export function ReelFeed({
     >
       {items.map((item, index) => (
         <div
-          key={item.id}
+          key={item.feedKey}
           ref={observeCard}
           data-reel-index={index}
           className="h-full w-full snap-start"
@@ -110,11 +111,6 @@ export function ReelFeed({
       {limitReached && (
         <div className="h-full w-full snap-start">
           <ReelLimitCard limit={usageLimit} />
-        </div>
-      )}
-      {!limitReached && !hasMore && items.length > 0 && (
-        <div className="h-full w-full snap-start">
-          <ReelEndCard />
         </div>
       )}
     </div>

--- a/src/components/reel/ReelMoreSheet.tsx
+++ b/src/components/reel/ReelMoreSheet.tsx
@@ -8,7 +8,6 @@ type ReelMoreSheetProps = {
   item: ReelItem;
   isOpen: boolean;
   onClose: () => void;
-  onOpenComments: () => void;
   onFeedback: (feedback: ReelFeedback) => void;
 };
 
@@ -41,26 +40,14 @@ function SheetRow({
   );
 }
 
-/** "..." menu: comments entry + interested / not-interested feedback. */
-export function ReelMoreSheet({
-  item,
-  isOpen,
-  onClose,
-  onOpenComments,
-  onFeedback,
-}: ReelMoreSheetProps) {
+/** "..." menu: interested / not-interested feedback. */
+export function ReelMoreSheet({ item, isOpen, onClose, onFeedback }: ReelMoreSheetProps) {
   return (
     <Modal isOpen={isOpen} onClose={onClose} variant="sheet">
       <div className="px-4 pb-6 pt-5">
         <p className="mb-3 truncate px-3 font-display text-sm font-bold text-[var(--color-secondary-text)]">
           {item.english}
         </p>
-        <SheetRow
-          icon="chat_bubble"
-          label="コメント"
-          sub={item.commentCount > 0 ? `${item.commentCount}件のコメント` : 'コメントを見る・書く'}
-          onClick={onOpenComments}
-        />
         <SheetRow
           icon="thumb_up"
           label="興味あり"

--- a/src/components/reel/ReelStatusCards.tsx
+++ b/src/components/reel/ReelStatusCards.tsx
@@ -40,21 +40,6 @@ export function ReelLimitCard({ limit }: { limit: number | null }) {
   );
 }
 
-/** Shown when the candidate pool is exhausted. */
-export function ReelEndCard() {
-  return (
-    <StatusShell>
-      <Icon name="celebration" size={40} className="text-[var(--color-accent)]" />
-      <h2 className="mt-3 font-display text-lg font-bold text-[var(--color-foreground)]">
-        今日のリールは以上です
-      </h2>
-      <p className="mt-2 text-sm leading-relaxed text-[var(--color-secondary-text)]">
-        新しい単語帳が公開されると、ここに新しい単語が流れてきます。
-      </p>
-    </StatusShell>
-  );
-}
-
 /** Shown when there are no candidates at all. */
 export function ReelEmptyState() {
   return (

--- a/src/components/ui/PersistentAppShell.tsx
+++ b/src/components/ui/PersistentAppShell.tsx
@@ -18,7 +18,7 @@ const HIDE_BOTTOM_NAV_PATHS = [
   '/project/', '/share/', '/quiz/', '/quiz2/', '/flashcard/',
   '/quick-response/', '/scan/confirm', '/shared/share-wordbook',
   '/subscription', '/collections/new', '/word/', '/favorites', '/profile', '/follows',
-  '/groups/', '/reels',
+  '/groups/',
 ];
 
 function shouldHideShell(pathname: string): boolean {

--- a/src/hooks/use-reel-feed.ts
+++ b/src/hooks/use-reel-feed.ts
@@ -5,16 +5,21 @@ import type { ReelFeedPage, ReelFeedUsage, ReelItem } from '@/lib/reels/types';
 
 export type ReelFeedStatus = 'loading' | 'ready' | 'error';
 
+/** Feed entry with a client-unique key — the same word may legitimately
+ * reappear later in a session once the pool recycles. */
+export type ReelFeedItem = ReelItem & { feedKey: string };
+
 type FeedResponse = ReelFeedPage & { success: boolean; error?: string };
 
 export function useReelFeed() {
-  const [items, setItems] = useState<ReelItem[]>([]);
+  const [items, setItems] = useState<ReelFeedItem[]>([]);
   const [status, setStatus] = useState<ReelFeedStatus>('loading');
   const [usage, setUsage] = useState<ReelFeedUsage | null>(null);
   const [limitReached, setLimitReached] = useState(false);
   const nextCursorRef = useRef<string | null>(null);
   const [hasMore, setHasMore] = useState(true);
   const fetchingRef = useRef(false);
+  const feedSequenceRef = useRef(0);
 
   const fetchPage = useCallback(async (cursor: string | null, replace: boolean) => {
     if (fetchingRef.current) return;
@@ -30,11 +35,11 @@ export function useReelFeed() {
       if (!payload.success) {
         throw new Error(payload.error || 'feed_failed');
       }
-      setItems((prev) => {
-        if (replace) return payload.items;
-        const seen = new Set(prev.map((item) => item.id));
-        return [...prev, ...payload.items.filter((item) => !seen.has(item.id))];
+      const keyed: ReelFeedItem[] = payload.items.map((item) => {
+        feedSequenceRef.current += 1;
+        return { ...item, feedKey: `${item.id}#${feedSequenceRef.current}` };
       });
+      setItems((prev) => (replace ? keyed : [...prev, ...keyed]));
       setUsage(payload.usage);
       setLimitReached(payload.limitReached);
       nextCursorRef.current = payload.nextCursor;

--- a/src/lib/reels/ranking.test.ts
+++ b/src/lib/reels/ranking.test.ts
@@ -2,7 +2,7 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 
 import type { ReelBook, ReelCandidate, ReelRankingContext } from './types';
-import { rankReelCandidates, scoreReelCandidate } from './ranking';
+import { rankReelCandidates, scoreReelCandidate, selectReelCandidates } from './ranking';
 
 const NOW = '2026-07-03T00:00:00.000Z';
 
@@ -168,4 +168,70 @@ test('interested feedback boosts the book, not-interested penalizes it', () => {
   const neutral = scoreReelCandidate(candidate, neutralCtx, 9);
   assert.ok(scoreReelCandidate(candidate, interestedCtx, 9) > neutral);
   assert.ok(scoreReelCandidate(candidate, notInterestedCtx, 9) < neutral);
+});
+
+// ---------- selectReelCandidates (infinite feed / seen recycling) ----------
+
+test('selectReelCandidates returns unseen-only when the pool is sufficient', () => {
+  const ctx = makeContext();
+  const candidates = Array.from({ length: 20 }, (_, i) =>
+    makeCandidate(`c${i}`, { book: makeBook({ id: `book-${i % 5}` }) }),
+  );
+  const selections = selectReelCandidates(candidates, {}, ctx, 42, 8);
+  assert.equal(selections.length, 8);
+  assert.ok(selections.every((s) => s.recycled === false));
+  const ranked = rankReelCandidates(candidates, ctx, 42, 8).map((c) => c.id);
+  assert.deepEqual(selections.map((s) => s.candidate.id), ranked);
+});
+
+test('selectReelCandidates fills the shortfall with least-recently-seen words', () => {
+  const ctx = makeContext();
+  const candidates = Array.from({ length: 6 }, (_, i) =>
+    makeCandidate(`c${i}`, { book: makeBook({ id: `book-${i}` }) }),
+  );
+  // c0..c3 already seen; c2 is the oldest, c1 the freshest.
+  const seenAtByKey = {
+    c0: '2026-07-02T00:00:00.000Z',
+    c1: '2026-07-03T00:00:00.000Z',
+    c2: '2026-07-01T00:00:00.000Z',
+    c3: '2026-07-02T12:00:00.000Z',
+  };
+  const selections = selectReelCandidates(candidates, seenAtByKey, ctx, 7, 4);
+  assert.equal(selections.length, 4);
+  const unseenPart = selections.filter((s) => !s.recycled).map((s) => s.candidate.id).sort();
+  assert.deepEqual(unseenPart, ['c4', 'c5']);
+  const recycledPart = selections.filter((s) => s.recycled).map((s) => s.candidate.id);
+  assert.equal(recycledPart.length, 2);
+  // The freshest-seen word (c1) must not be recycled while older ones exist
+  // (needed*3 = 6 covers all four seen words, ranked among the oldest first).
+  assert.ok(recycledPart.includes('c2'), 'oldest seen word should be in the recycle pool');
+});
+
+test('selectReelCandidates never returns empty when everything was seen', () => {
+  const ctx = makeContext();
+  const candidates = Array.from({ length: 30 }, (_, i) =>
+    makeCandidate(`c${i}`, { book: makeBook({ id: `book-${i % 6}` }) }),
+  );
+  const seenAtByKey = Object.fromEntries(
+    candidates.map((c, i) => [c.id, `2026-07-0${(i % 3) + 1}T00:00:00.000Z`]),
+  );
+  const selections = selectReelCandidates(candidates, seenAtByKey, ctx, 5, 8);
+  assert.equal(selections.length, 8);
+  assert.ok(selections.every((s) => s.recycled === true));
+});
+
+test('selectReelCandidates is deterministic for a fixed seed', () => {
+  const ctx = makeContext();
+  const candidates = Array.from({ length: 25 }, (_, i) =>
+    makeCandidate(`c${i}`, { book: makeBook({ id: `book-${i % 5}` }) }),
+  );
+  const seenAtByKey = Object.fromEntries(
+    candidates.slice(0, 20).map((c, i) => [c.id, `2026-06-${String(10 + i).padStart(2, '0')}T00:00:00.000Z`]),
+  );
+  const first = selectReelCandidates(candidates, seenAtByKey, ctx, 99, 8);
+  const second = selectReelCandidates(candidates, seenAtByKey, ctx, 99, 8);
+  assert.deepEqual(
+    first.map((s) => [s.candidate.id, s.recycled]),
+    second.map((s) => [s.candidate.id, s.recycled]),
+  );
 });

--- a/src/lib/reels/ranking.ts
+++ b/src/lib/reels/ranking.ts
@@ -167,3 +167,45 @@ export function rankReelCandidates(
 
   return picked;
 }
+
+export type ReelSelection = { candidate: ReelCandidate; recycled: boolean };
+
+/**
+ * Select up to `limit` candidates for a feed page, never running dry:
+ * unseen candidates are ranked first; any shortfall is filled by
+ * recycling seen candidates as review cards, least-recently-seen first.
+ * Pure and deterministic for a given (candidates, seenAtByKey, ctx, seed).
+ */
+export function selectReelCandidates(
+  candidates: ReelCandidate[],
+  seenAtByKey: Record<string, string>,
+  ctx: ReelRankingContext,
+  seed: number,
+  limit: number,
+): ReelSelection[] {
+  if (limit <= 0 || candidates.length === 0) return [];
+
+  const unseen = candidates.filter((candidate) => seenAtByKey[candidate.id] === undefined);
+  const picked: ReelSelection[] = rankReelCandidates(unseen, ctx, seed, limit).map(
+    (candidate) => ({ candidate, recycled: false }),
+  );
+
+  const needed = limit - picked.length;
+  if (needed <= 0) return picked;
+
+  // LRU recycle pool: seen candidates, oldest seen_at first. Ties broken
+  // by id so the order stays deterministic.
+  const recyclePool = candidates
+    .filter((candidate) => seenAtByKey[candidate.id] !== undefined)
+    .sort(
+      (a, b) =>
+        seenAtByKey[a.id].localeCompare(seenAtByKey[b.id]) || a.id.localeCompare(b.id),
+    )
+    .slice(0, needed * 3);
+
+  for (const candidate of rankReelCandidates(recyclePool, ctx, seed, needed)) {
+    picked.push({ candidate, recycled: true });
+  }
+
+  return picked;
+}

--- a/src/lib/reels/types.ts
+++ b/src/lib/reels/types.ts
@@ -41,6 +41,8 @@ export type ReelItem = {
   likeCount: number;
   likedByMe: boolean;
   commentCount: number;
+  /** true when re-served as a review card after the unseen pool ran out */
+  isRecycled?: boolean;
   book: ReelBook;
 };
 
@@ -70,7 +72,7 @@ export type ReelFeedPage = {
 };
 
 /** Candidate fed into the ranking function (before like/imported enrichment). */
-export type ReelCandidate = Omit<ReelItem, 'likeCount' | 'likedByMe' | 'commentCount'>;
+export type ReelCandidate = Omit<ReelItem, 'likeCount' | 'likedByMe' | 'commentCount' | 'isRecycled'>;
 
 /** Personalization context for ranking. */
 export type ReelRankingContext = {


### PR DESCRIPTION
## 概要

PR #329（マージ済み）のリール機能へのフォローアップ2件です。

### 1. フィード枯渇の廃止（無限フィード化）

「見尽くしてもまだリールがありません」の状態を無くします。未読候補がページを満たせないときは、**既読単語を「最も昔に見たもの（LRU）から」復習カードとして再供給**します。単語学習アプリなので再表示は間隔反復として合理的です。

- 新純関数 `selectReelCandidates`（`src/lib/reels/ranking.ts`）: 未読を従来ランキングで選抜 → 不足分をLRU既読プール（不足数×3件）から同じスコアリング・多様性ルールで補充。決定的でテスト可能
- 配信時に `reel_seen_words.seen_at` を**更新**する方式に変更（従来は `ignoreDuplicates`）→ リサイクルされた単語がLRUの最後尾に回り、すぐに再登場しない
- リサイクルカードには小さな**「復習」チップ**（アクセント色）を表示
- 「今日のリールは以上です」終端カード（ReelEndCard）を削除。`nextCursor: null` になるのは無料上限到達時と、公開コンテンツが皆無の時のみ
- フィードentryにクライアント一意の `feedKey` を導入（同一単語がセッション内で正当に再登場し得るため）
- **不変**: 「興味なし」単語の恒久除外、無料50枚/日制限、7日窓のセマンティクス（7日超の既読は従来通り未読プールに自然復帰）
- **DBマイグレーション不要**

### 2. リールページでもボトムナビを常時表示

- `HIDE_BOTTOM_NAV_PATHS` から `/reels` を削除（`src/components/ui/PersistentAppShell.tsx`）
- フィード下部の単語帳カードが浮遊ナビに隠れないよう、モバイル時のフィード下パディングを `max(96px, safe-area+84px)` に拡大（デスクトップは変更なし）。ナビ(z-40)はページ(z-30)の上、シート類(z-100)はさらに上で整合

## テスト

`selectReelCandidates` のユニットテスト4件を追加（未読十分時は従来と同一 / LRU優先の補充 / **全既読でも空にならない** / 固定seedで決定的）。

## 検証結果

- `npm run lint`: 変更ファイルにエラー0
- `npm test`: 697件中696件パス（唯一の失敗 `words/create/route.test.ts` はmainでも再現する既存の失敗で本PRと無関係）
- `npm run build`: 成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018JwjuhBcpDeykSMCQ4LjKe

---
_Generated by [Claude Code](https://claude.ai/code/session_018JwjuhBcpDeykSMCQ4LjKe)_