### PR TITLE
リール: ボトムナビを再び非表示にし戻るボタンを復活

### DIFF
--- a/src/app/reels/page.tsx
+++ b/src/app/reels/page.tsx
@@ -8,6 +8,7 @@ import { getRepository } from '@/lib/db';
 import { invalidateHomeCache } from '@/lib/home-cache';
 import { triggerHaptic } from '@/lib/haptics';
 import { useToast } from '@/components/ui';
+import { Icon } from '@/components/ui/Icon';
 import type { ReelBook, ReelFeedback, ReelItem } from '@/lib/reels/types';
 import { generateWordShareImage } from '@/lib/reels/share-image';
 import type { VocabularyType } from '@/types';
@@ -217,8 +218,14 @@ export default function ReelsPage() {
         className="flex flex-shrink-0 items-center justify-between px-3 pb-2"
         style={{ paddingTop: 'max(8px, calc(env(safe-area-inset-top) + 8px))' }}
       >
-        {/* Spacer keeps the title centered (bottom nav handles navigation) */}
-        <div className="h-10 w-10" />
+        <button
+          type="button"
+          aria-label="戻る"
+          onClick={() => router.back()}
+          className="flex h-10 w-10 items-center justify-center rounded-full text-[var(--color-foreground)] transition-colors hover:bg-[var(--color-surface-secondary)]"
+        >
+          <Icon name="arrow_back_ios_new" size={20} />
+        </button>
         <h1 className="font-display text-base font-bold text-[var(--color-foreground)]">リール</h1>
         <div className="flex h-10 min-w-10 items-center justify-end">
           {remainingLabel && (
@@ -229,9 +236,11 @@ export default function ReelsPage() {
         </div>
       </div>
 
-      {/* Feed area: full-bleed on mobile, centered column on desktop.
-          Mobile bottom padding clears the always-visible floating bottom nav. */}
-      <div className="min-h-0 flex-1 pb-[max(96px,calc(env(safe-area-inset-bottom)+84px))] lg:flex lg:justify-center lg:pb-2">
+      {/* Feed area: full-bleed on mobile, centered column on desktop */}
+      <div
+        className="min-h-0 flex-1 lg:flex lg:justify-center"
+        style={{ paddingBottom: 'max(8px, env(safe-area-inset-bottom))' }}
+      >
         <div className="h-full w-full lg:max-w-[420px] lg:rounded-[var(--solid-radius)] lg:border-2 lg:border-[var(--solid-ink)] lg:bg-[var(--color-surface)] lg:overflow-hidden">
           {status === 'loading' && items.length === 0 ? (
             <ReelSkeleton />

--- a/src/components/ui/PersistentAppShell.tsx
+++ b/src/components/ui/PersistentAppShell.tsx
@@ -18,7 +18,7 @@ const HIDE_BOTTOM_NAV_PATHS = [
   '/project/', '/share/', '/quiz/', '/quiz2/', '/flashcard/',
   '/quick-response/', '/scan/confirm', '/shared/share-wordbook',
   '/subscription', '/collections/new', '/word/', '/favorites', '/profile', '/follows',
-  '/groups/',
+  '/groups/', '/reels',
 ];
 
 function shouldHideShell(pathname: string): boolean {


### PR DESCRIPTION
## 概要

直前のナビゲーション変更を元に戻し、リールを没入表示に戻します。

- `/reels` を `HIDE_BOTTOM_NAV_PATHS` に再追加 → リール閲覧中はボトムナビ非表示
- 上部バー左端の**戻るボタン**（`router.back()`）を復活（スペーサーから差し替え）
- ナビが消えるためフィード下部のパディングを元の safe-area インセットに戻す

無限フィード化・コメントのレール展開・共有サムネ生成などの機能はそのまま維持しています。

## 検証

- `npm run lint`: エラー0
- `npm run build`: 成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018JwjuhBcpDeykSMCQ4LjKe

---
_Generated by [Claude Code](https://claude.ai/code/session_018JwjuhBcpDeykSMCQ4LjKe)_