### PR TITLE
Allow joining public study groups without an invite code

### DIFF
--- a/src/app/api/shared-projects/groups/join/route.test.ts
+++ b/src/app/api/shared-projects/groups/join/route.test.ts
@@ -3,6 +3,7 @@ import test from 'node:test';
 import { NextRequest } from 'next/server';
 
 import { handleStudyGroupJoinPost } from './route';
+import { StudyGroupAccessError } from '../shared';
 
 function jsonRequest(body: unknown) {
   return new NextRequest('http://localhost/api/shared-projects/groups/join', {
@@ -48,4 +49,60 @@ test('study group join returns the joined group', async () => {
   const payload = await res.json();
   assert.equal(payload.success, true);
   assert.equal(payload.group.role, 'member');
+});
+
+test('study group join by groupId joins a public group without a code', async () => {
+  let receivedGroupId = '';
+  const res = await handleStudyGroupJoinPost(jsonRequest({ groupId: 'group-2' }), {
+    requireAuthenticatedUser: async () => ({
+      ok: true as const,
+      user: { id: 'user-1' } as never,
+    }),
+    joinPublicStudyGroupById: async (_userId, groupId) => {
+      receivedGroupId = groupId;
+      return {
+        id: groupId,
+        name: 'Public Class',
+        inviteCode: 'abcd-1234',
+        role: 'member',
+        visibility: 'public',
+        memberCount: 3,
+        projectCount: 2,
+        createdAt: '2026-06-14T00:00:00.000Z',
+      };
+    },
+  });
+
+  assert.equal(res.status, 200);
+  assert.equal(receivedGroupId, 'group-2');
+  const payload = await res.json();
+  assert.equal(payload.success, true);
+  assert.equal(payload.group.visibility, 'public');
+});
+
+test('study group join by groupId returns 403 for a private group', async () => {
+  const res = await handleStudyGroupJoinPost(jsonRequest({ groupId: 'group-3' }), {
+    requireAuthenticatedUser: async () => ({
+      ok: true as const,
+      user: { id: 'user-1' } as never,
+    }),
+    joinPublicStudyGroupById: async () => {
+      throw new StudyGroupAccessError('not_public');
+    },
+  });
+
+  assert.equal(res.status, 403);
+  const payload = await res.json();
+  assert.equal(payload.success, false);
+});
+
+test('study group join rejects a request with neither inviteCode nor groupId', async () => {
+  const res = await handleStudyGroupJoinPost(jsonRequest({}), {
+    requireAuthenticatedUser: async () => ({
+      ok: true as const,
+      user: { id: 'user-1' } as never,
+    }),
+  });
+
+  assert.equal(res.status, 400);
 });

--- a/src/app/api/shared-projects/groups/join/route.ts
+++ b/src/app/api/shared-projects/groups/join/route.ts
@@ -2,15 +2,20 @@ import { NextRequest, NextResponse } from 'next/server';
 import { z } from 'zod';
 import { parseJsonWithSchema } from '@/lib/api/validation';
 import { requireAuthenticatedUser } from '../../shared';
-import { joinStudyGroupByInviteCode } from '../shared';
+import { joinPublicStudyGroupById, joinStudyGroupByInviteCode, StudyGroupAccessError } from '../shared';
 
 const joinStudyGroupSchema = z.object({
-  inviteCode: z.string().trim().min(1).max(120),
-}).strict();
+  inviteCode: z.string().trim().min(1).max(120).optional(),
+  groupId: z.string().trim().min(1).optional(),
+}).strict().refine(
+  (data) => Boolean(data.inviteCode) || Boolean(data.groupId),
+  { message: '招待コードまたはグループIDを指定してください。' },
+);
 
 type StudyGroupJoinPostDeps = {
   requireAuthenticatedUser?: typeof requireAuthenticatedUser;
   joinStudyGroupByInviteCode?: typeof joinStudyGroupByInviteCode;
+  joinPublicStudyGroupById?: typeof joinPublicStudyGroupById;
 };
 
 export async function handleStudyGroupJoinPost(
@@ -18,7 +23,8 @@ export async function handleStudyGroupJoinPost(
   deps: StudyGroupJoinPostDeps = {},
 ) {
   const requireAuthenticated = deps.requireAuthenticatedUser ?? requireAuthenticatedUser;
-  const joinGroup = deps.joinStudyGroupByInviteCode ?? joinStudyGroupByInviteCode;
+  const joinByInviteCode = deps.joinStudyGroupByInviteCode ?? joinStudyGroupByInviteCode;
+  const joinPublicById = deps.joinPublicStudyGroupById ?? joinPublicStudyGroupById;
 
   try {
     const auth = await requireAuthenticated(request);
@@ -29,13 +35,25 @@ export async function handleStudyGroupJoinPost(
     });
     if (!parsed.ok) return parsed.response;
 
-    const group = await joinGroup(auth.user.id, parsed.data.inviteCode);
+    // Joining by groupId is only valid for public groups — re-checked inside
+    // joinPublicStudyGroupById regardless of how the client got the id.
+    const group = parsed.data.groupId
+      ? await joinPublicById(auth.user.id, parsed.data.groupId)
+      : await joinByInviteCode(auth.user.id, parsed.data.inviteCode!);
+
     if (!group) {
       return NextResponse.json({ success: false, error: 'グループが見つかりません。' }, { status: 404 });
     }
 
     return NextResponse.json({ success: true, group });
   } catch (error) {
+    if (error instanceof StudyGroupAccessError && error.code === 'not_public') {
+      return NextResponse.json(
+        { success: false, error: 'このグループは非公開です。招待コードが必要です。' },
+        { status: 403 },
+      );
+    }
+
     console.error('study-group join error:', error);
     return NextResponse.json({ success: false, error: 'グループへの参加に失敗しました。' }, { status: 500 });
   }

--- a/src/app/api/shared-projects/groups/shared.ts
+++ b/src/app/api/shared-projects/groups/shared.ts
@@ -293,6 +293,27 @@ export async function getPublicStudyGroupPreview(
   };
 }
 
+async function upsertStudyGroupMembership(
+  group: Pick<StudyGroupRow, 'id' | 'owner_user_id'>,
+  userId: string,
+  admin: SupabaseAdminClient,
+): Promise<void> {
+  const { error: memberError } = await admin
+    .from('study_group_members')
+    .upsert(
+      [{
+        group_id: group.id,
+        user_id: userId,
+        role: group.owner_user_id === userId ? 'owner' : 'member',
+      }],
+      { onConflict: 'group_id,user_id', ignoreDuplicates: true },
+    );
+
+  if (memberError) {
+    throw new Error(memberError.message || 'study_group_join_failed');
+  }
+}
+
 export async function joinStudyGroupByInviteCode(
   userId: string,
   inviteCodeInput: string,
@@ -312,20 +333,38 @@ export async function joinStudyGroupByInviteCode(
   }
   if (!group) return null;
 
-  const { error: memberError } = await admin
-    .from('study_group_members')
-    .upsert(
-      [{
-        group_id: group.id,
-        user_id: userId,
-        role: group.owner_user_id === userId ? 'owner' : 'member',
-      }],
-      { onConflict: 'group_id,user_id', ignoreDuplicates: true },
-    );
+  await upsertStudyGroupMembership(group, userId, admin);
 
-  if (memberError) {
-    throw new Error(memberError.message || 'study_group_join_failed');
+  return getStudyGroupSummaryForUser(group.id, userId, admin);
+}
+
+/**
+ * Joins a group by id without an invite code. Only permitted when the group's
+ * `visibility` is `public` — re-checked server-side regardless of what the
+ * client believes, since the preview payload is not itself an authorization
+ * grant. Throws `StudyGroupAccessError('not_public')` for a private group so
+ * the API can return a distinct "invite code required" error.
+ */
+export async function joinPublicStudyGroupById(
+  userId: string,
+  groupId: string,
+  admin: SupabaseAdminClient = getSupabaseAdmin(),
+): Promise<StudyGroupSummary | null> {
+  const { data: group, error: groupError } = await admin
+    .from('study_groups')
+    .select(STUDY_GROUP_SELECT_COLUMNS)
+    .eq('id', groupId)
+    .maybeSingle<StudyGroupRow>();
+
+  if (groupError) {
+    throw new Error(groupError.message || 'study_group_lookup_failed');
   }
+  if (!group) return null;
+  if (normalizeStudyGroupVisibility(group.visibility) !== 'public') {
+    throw new StudyGroupAccessError('not_public');
+  }
+
+  await upsertStudyGroupMembership(group, userId, admin);
 
   return getStudyGroupSummaryForUser(group.id, userId, admin);
 }
@@ -984,7 +1023,7 @@ export class StudyGroupProjectAccessError extends Error {
 }
 
 export class StudyGroupAccessError extends Error {
-  constructor(readonly code: 'owner_required' | 'cannot_remove_owner' | 'invalid_name') {
+  constructor(readonly code: 'owner_required' | 'cannot_remove_owner' | 'invalid_name' | 'not_public') {
     super(code);
     this.name = 'StudyGroupAccessError';
   }

--- a/src/app/groups/[groupId]/join/page.tsx
+++ b/src/app/groups/[groupId]/join/page.tsx
@@ -78,16 +78,15 @@ export default function GroupJoinPage() {
     };
   }, [authLoading, isAuthenticated, groupId, router]);
 
-  const handleJoin = useCallback(async () => {
-    const trimmed = inviteCode.trim();
-    if (!trimmed || joining) return;
+  const submitJoin = useCallback(async (body: { inviteCode: string } | { groupId: string }) => {
+    if (joining) return;
     triggerHaptic();
     setJoining(true);
     try {
       const response = await fetch('/api/shared-projects/groups/join', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ inviteCode: trimmed }),
+        body: JSON.stringify(body),
       });
       const payload = await response.json().catch(() => null) as JoinResponse | null;
       if (response.status === 404) {
@@ -105,7 +104,18 @@ export default function GroupJoinPage() {
     } finally {
       setJoining(false);
     }
-  }, [inviteCode, joining, router, showToast]);
+  }, [joining, router, showToast]);
+
+  const handleJoin = useCallback(() => {
+    const trimmed = inviteCode.trim();
+    if (!trimmed) return;
+    return submitJoin({ inviteCode: trimmed });
+  }, [inviteCode, submitJoin]);
+
+  const handleJoinById = useCallback(() => {
+    if (!groupId) return;
+    return submitJoin({ groupId });
+  }, [groupId, submitJoin]);
 
   return (
     <div
@@ -173,43 +183,67 @@ export default function GroupJoinPage() {
             </div>
           </section>
 
-          <section className="rounded-[18px] border-2 border-[var(--solid-ink)] bg-white p-4">
-            <div className="flex items-center gap-2.5">
-              <span className="inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-[10px] border-2 border-[var(--solid-ink)] bg-[var(--color-accent)] text-white">
-                <Icon name="key" size={18} />
-              </span>
-              <div>
-                <h2 className="font-display text-[16px] font-extrabold leading-tight text-[var(--solid-ink)]">招待コードで参加</h2>
-                <div className="text-[11px] font-bold text-[var(--color-muted)]">グループのオーナーから招待コードを受け取ってください</div>
+          {preview?.visibility === 'public' ? (
+            <section className="rounded-[18px] border-2 border-[var(--solid-ink)] bg-white p-4">
+              <div className="flex items-center gap-2.5">
+                <span className="inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-[10px] border-2 border-[var(--solid-ink)] bg-[var(--color-accent)] text-white">
+                  <Icon name="public" size={18} />
+                </span>
+                <div>
+                  <h2 className="font-display text-[16px] font-extrabold leading-tight text-[var(--solid-ink)]">誰でも参加できます</h2>
+                  <div className="text-[11px] font-bold text-[var(--color-muted)]">公開グループなので招待コードは不要です</div>
+                </div>
               </div>
-            </div>
 
-            <form
-              onSubmit={(event) => { event.preventDefault(); void handleJoin(); }}
-              className="mt-4 flex flex-col gap-3"
-            >
-              <label className="flex min-w-0 items-center gap-2 rounded-[12px] border-2 border-[var(--solid-ink)] bg-white px-3 py-3">
-                <Icon name="vpn_key" size={16} className="shrink-0 text-[var(--color-muted)]" />
-                <span className="sr-only">招待コード</span>
-                <input
-                  value={inviteCode}
-                  onChange={(event) => setInviteCode(event.target.value)}
-                  placeholder="招待コードを入力"
-                  autoComplete="off"
-                  autoCapitalize="none"
-                  className="min-w-0 flex-1 bg-transparent font-mono text-[15px] font-extrabold text-[var(--solid-ink)] outline-none placeholder:font-semibold placeholder:text-[var(--color-muted)]"
-                />
-              </label>
               <button
-                type="submit"
-                disabled={joining || !inviteCode.trim()}
-                className="flex w-full items-center justify-center gap-2 rounded-[12px] border-2 border-[var(--solid-ink)] bg-[var(--solid-ink)] px-4 py-3 font-display text-[14px] font-extrabold text-white shadow-[3px_3px_0_var(--solid-ink)] transition-all duration-100 active:translate-x-[3px] active:translate-y-[3px] active:shadow-none disabled:opacity-50 disabled:shadow-none"
+                type="button"
+                onClick={() => void handleJoinById()}
+                disabled={joining}
+                className="mt-4 flex w-full items-center justify-center gap-2 rounded-[12px] border-2 border-[var(--solid-ink)] bg-[var(--solid-ink)] px-4 py-3 font-display text-[14px] font-extrabold text-white shadow-[3px_3px_0_var(--solid-ink)] transition-all duration-100 active:translate-x-[3px] active:translate-y-[3px] active:shadow-none disabled:opacity-50 disabled:shadow-none"
               >
                 <Icon name={joining ? 'progress_activity' : 'login'} size={18} className={joining ? 'animate-spin' : undefined} />
                 {joining ? '参加中...' : 'グループに参加'}
               </button>
-            </form>
-          </section>
+            </section>
+          ) : (
+            <section className="rounded-[18px] border-2 border-[var(--solid-ink)] bg-white p-4">
+              <div className="flex items-center gap-2.5">
+                <span className="inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-[10px] border-2 border-[var(--solid-ink)] bg-[var(--color-accent)] text-white">
+                  <Icon name="key" size={18} />
+                </span>
+                <div>
+                  <h2 className="font-display text-[16px] font-extrabold leading-tight text-[var(--solid-ink)]">招待コードで参加</h2>
+                  <div className="text-[11px] font-bold text-[var(--color-muted)]">グループのオーナーから招待コードを受け取ってください</div>
+                </div>
+              </div>
+
+              <form
+                onSubmit={(event) => { event.preventDefault(); void handleJoin(); }}
+                className="mt-4 flex flex-col gap-3"
+              >
+                <label className="flex min-w-0 items-center gap-2 rounded-[12px] border-2 border-[var(--solid-ink)] bg-white px-3 py-3">
+                  <Icon name="vpn_key" size={16} className="shrink-0 text-[var(--color-muted)]" />
+                  <span className="sr-only">招待コード</span>
+                  <input
+                    value={inviteCode}
+                    onChange={(event) => setInviteCode(event.target.value)}
+                    placeholder="招待コードを入力"
+                    autoComplete="off"
+                    autoCapitalize="none"
+                    className="min-w-0 flex-1 bg-transparent font-mono text-[15px] font-extrabold text-[var(--solid-ink)] outline-none placeholder:font-semibold placeholder:text-[var(--color-muted)]"
+                  />
+                </label>
+                <button
+                  type="submit"
+                  disabled={joining || !inviteCode.trim()}
+                  className="flex w-full items-center justify-center gap-2 rounded-[12px] border-2 border-[var(--solid-ink)] bg-[var(--solid-ink)] px-4 py-3 font-display text-[14px] font-extrabold text-white shadow-[3px_3px_0_var(--solid-ink)] transition-all duration-100 active:translate-x-[3px] active:translate-y-[3px] active:shadow-none disabled:opacity-50 disabled:shadow-none"
+                >
+                  <Icon name={joining ? 'progress_activity' : 'login'} size={18} className={joining ? 'animate-spin' : undefined} />
+                  {joining ? '参加中...' : 'グループに参加'}
+                </button>
+              </form>
+            </section>
+          )}
         </div>
       )}
     </div>


### PR DESCRIPTION
## Summary

- The `visibility` toggle on study groups (added in #327) only affected the discovery listing and display labels — the join endpoint always required an invite code regardless of visibility, so setting a group to "public" still prompted every visitor for a code.
- Added `joinPublicStudyGroupById` (`src/app/api/shared-projects/groups/shared.ts`), which looks up the group by id and re-checks `visibility === 'public'` server-side before allowing the join (never trusts the client).
- Extended `POST /api/shared-projects/groups/join` to accept either `inviteCode` or `groupId`; a private group joined by id now returns 403 with "このグループは非公開です。招待コードが必要です。".
- `src/app/groups/[groupId]/join/page.tsx` now shows a single "グループに参加" button (no code field) for public groups, and falls back to the existing invite-code form for private/unknown groups.

## Test plan

- [x] `npm run lint` — no new errors/warnings introduced
- [x] `npm test` — 712/713 passing; the 1 failure (`words/create` route test) pre-exists on `main`, unrelated to this change
- [x] `npm run build` — succeeds
- [x] Added route tests: joining a public group by `groupId` succeeds, joining a private group by `groupId` returns 403, and a request with neither `inviteCode` nor `groupId` is rejected
- [ ] Manual verification in a running app (create a public group, join from another account without a code; confirm private groups still require the code) — not yet performed in this session

---
_Generated by [Claude Code](https://claude.ai/code/session_01HXUpqwvwLhy6QxpJsbRVby)_