### PR TITLE
共有単語帳: 公開後もタグを追加・削除・編集できるようにする

### DIFF
--- a/src/app/api/shared-projects/share-wordbook/[id]/tags/route.ts
+++ b/src/app/api/shared-projects/share-wordbook/[id]/tags/route.ts
@@ -1,0 +1,42 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { parseJsonWithSchema } from '@/lib/api/validation';
+import { requireAuthenticatedUser } from '../../../shared';
+import {
+  updateSharedWordbookTags,
+  SharedWordbookError,
+} from '../../../shared-wordbooks';
+
+type Params = { params: Promise<{ id: string }> };
+
+const tagsSchema = z.object({
+  sharedTags: z.array(z.string().trim().min(1).max(64)).max(8),
+}).strict();
+
+function errorStatus(error: SharedWordbookError): number {
+  if (error.code === 'not_found') return 404;
+  if (error.code === 'forbidden') return 403;
+  return 400;
+}
+
+export async function PATCH(request: NextRequest, { params }: Params) {
+  try {
+    const auth = await requireAuthenticatedUser(request);
+    if (!auth.ok) return auth.response;
+
+    const { id } = await params;
+    const parsed = await parseJsonWithSchema(request, tagsSchema, {
+      invalidMessage: 'タグを確認してください。',
+    });
+    if (!parsed.ok) return parsed.response;
+
+    const wordbook = await updateSharedWordbookTags(auth.user.id, id, parsed.data.sharedTags);
+    return NextResponse.json({ success: true, wordbook, sharedTags: wordbook.project.sharedTags ?? [] });
+  } catch (error) {
+    if (error instanceof SharedWordbookError) {
+      return NextResponse.json({ success: false, error: '共有単語帳を更新できませんでした。' }, { status: errorStatus(error) });
+    }
+    console.error('share-wordbook tags update error:', error);
+    return NextResponse.json({ success: false, error: 'タグの保存に失敗しました。' }, { status: 500 });
+  }
+}

--- a/src/app/api/shared-projects/shared-wordbooks.test.ts
+++ b/src/app/api/shared-projects/shared-wordbooks.test.ts
@@ -10,6 +10,7 @@ import {
   setSharedWordbookLike,
   SharedWordbookError,
   unpublishSharedWordbook,
+  updateSharedWordbookTags,
 } from './shared-wordbooks';
 
 type Row = Record<string, unknown>;
@@ -277,6 +278,27 @@ test('rename and unpublish enforce ownership', async () => {
 
   await unpublishSharedWordbook('u1', 'sw1', asAdmin(admin));
   assert.equal(store.shared_wordbooks.length, 0);
+});
+
+test('updateSharedWordbookTags enforces ownership and normalizes tags', async () => {
+  const store = makeStore({
+    shared_wordbooks: [
+      { id: 'sw1', share_id: 'abc', source_project_id: 'p1', user_id: 'u1', title: 'A', shared_tags: ['old'], word_count: 0, like_count: 0, created_at: '2026-02-01T00:00:00Z' },
+    ],
+  });
+  const admin = new FakeAdmin(store);
+
+  await assert.rejects(
+    () => updateSharedWordbookTags('intruder', 'sw1', ['#new'], asAdmin(admin)),
+    (error: unknown) => error instanceof SharedWordbookError && error.code === 'forbidden',
+  );
+
+  const updated = await updateSharedWordbookTags('u1', 'sw1', ['#TOEIC', '#TOEIC', '#熟語'], asAdmin(admin));
+  assert.deepEqual(updated.project.sharedTags, ['TOEIC', '熟語']);
+  assert.deepEqual(store.shared_wordbooks[0].shared_tags, ['TOEIC', '熟語']);
+
+  const cleared = await updateSharedWordbookTags('u1', 'sw1', [], asAdmin(admin));
+  assert.deepEqual(cleared.project.sharedTags, []);
 });
 
 test('setSharedWordbookLike updates the denormalized like_count', async () => {

--- a/src/app/api/shared-projects/shared-wordbooks.ts
+++ b/src/app/api/shared-projects/shared-wordbooks.ts
@@ -619,6 +619,60 @@ export async function renameSharedWordbook(
   return mapSharedWordbookCard(updated, 'owner', profileByUserId);
 }
 
+export async function updateSharedWordbookTags(
+  userId: string,
+  sharedWordbookId: string,
+  sharedTags: readonly string[],
+  admin: SupabaseAdminClient = getSupabaseAdmin(),
+): Promise<SharedProjectCard> {
+  const { data: row, error } = await admin
+    .from('shared_wordbooks')
+    .select('id,user_id')
+    .eq('id', sharedWordbookId)
+    .maybeSingle<{ id: string; user_id: string }>();
+
+  if (error) {
+    throw new Error(error.message || 'shared_wordbook_tags_lookup_failed');
+  }
+  if (!row) {
+    throw new SharedWordbookError('not_found', 'shared_wordbook_not_found');
+  }
+  if (row.user_id !== userId) {
+    throw new SharedWordbookError('forbidden', 'shared_wordbook_not_owned');
+  }
+
+  const tags = normalizeSharedTags(sharedTags);
+
+  let tagsEmbedding: number[] | null = null;
+  try {
+    tagsEmbedding = await createSharedTagsEmbedding(tags);
+  } catch (embeddingError) {
+    console.warn('[shared-wordbooks] tag embedding skipped:', embeddingError);
+  }
+
+  const payload: Record<string, unknown> = {
+    shared_tags: tags,
+    updated_at: new Date().toISOString(),
+  };
+  if (tagsEmbedding) {
+    payload.shared_tags_embedding = tagsEmbedding;
+  }
+
+  const { data: updated, error: updateError } = await admin
+    .from('shared_wordbooks')
+    .update(payload)
+    .eq('id', sharedWordbookId)
+    .select(SHARED_WORDBOOK_SELECT)
+    .single<SharedWordbookRow>();
+
+  if (updateError || !updated) {
+    throw new Error(updateError?.message || 'shared_wordbook_tags_update_failed');
+  }
+
+  const profileByUserId = await getProfilesByUserIds(admin, [userId]);
+  return mapSharedWordbookCard(updated, 'owner', profileByUserId);
+}
+
 export async function unpublishSharedWordbook(
   userId: string,
   sharedWordbookId: string,

--- a/src/app/share/[shareId]/page.tsx
+++ b/src/app/share/[shareId]/page.tsx
@@ -14,8 +14,10 @@ import { isBillingEnabled } from '@/lib/billing/feature';
 import { getRepository } from '@/lib/db';
 import { invalidateHomeCache } from '@/lib/home-cache';
 import { getPartOfSpeechLabel } from '@/lib/part-of-speech-labels';
+import { saveSharedWordbookTags } from '@/lib/shared-projects/client';
 import type { SharedProjectPreviewPayload } from '@/lib/shared-projects/types';
 import type { Project, Word } from '@/types';
+import { formatSharedTag, parseSharedTagsInput } from '../../../../shared/shared-tags';
 
 const SHARE_PREVIEW_CLEAR_WORD_COUNT = 5;
 
@@ -137,6 +139,9 @@ export default function SharedDetailPage() {
   const [renameOpen, setRenameOpen] = useState(false);
   const [renameDraft, setRenameDraft] = useState('');
   const [ownerActionBusy, setOwnerActionBusy] = useState(false);
+  const [tagsOpen, setTagsOpen] = useState(false);
+  const [tagsDraft, setTagsDraft] = useState('');
+  const [tagsSaving, setTagsSaving] = useState(false);
 
   const subscriptionStatus = subscription?.status || 'free';
   const wasPro = subscription?.plan === 'pro' && subscriptionStatus !== 'active';
@@ -386,6 +391,28 @@ export default function SharedDetailPage() {
     }
   };
 
+  const handleOpenTags = () => {
+    setTagsDraft((project?.sharedTags ?? []).map(formatSharedTag).join(', '));
+    setTagsOpen(true);
+  };
+
+  const handleSaveTags = async () => {
+    if (!project || tagsSaving) return;
+    setTagsSaving(true);
+    try {
+      const nextTags = parseSharedTagsInput(tagsDraft);
+      const savedTags = await saveSharedWordbookTags(project.id, nextTags);
+      setProject((current) => (current ? { ...current, sharedTags: savedTags } : current));
+      setTagsOpen(false);
+      showToast({ message: 'タグを保存しました', type: 'success' });
+    } catch (tagsError) {
+      console.error('Failed to update shared wordbook tags:', tagsError);
+      showToast({ message: 'タグの保存に失敗しました', type: 'error' });
+    } finally {
+      setTagsSaving(false);
+    }
+  };
+
   const handleUnpublish = async () => {
     if (!project || ownerActionBusy) return;
     if (typeof window !== 'undefined' && !window.confirm('この単語帳の公開を停止しますか？共有ページから削除されます。')) {
@@ -500,6 +527,29 @@ export default function SharedDetailPage() {
 
           {project.description && (
             <p className="mt-2.5 text-xs leading-[1.55] text-[var(--color-muted)]">{project.description}</p>
+          )}
+
+          {((project.sharedTags?.length ?? 0) > 0 || isOwner) && (
+            <div className="mt-2.5 flex flex-wrap items-center gap-1.5">
+              {(project.sharedTags ?? []).map((tag) => (
+                <span
+                  key={tag}
+                  className="inline-flex items-center rounded-full border border-[var(--color-border)] bg-white px-2 py-0.5 font-mono text-[10px] font-bold text-[var(--color-muted)]"
+                >
+                  {formatSharedTag(tag)}
+                </span>
+              ))}
+              {isOwner && (
+                <button
+                  type="button"
+                  onClick={handleOpenTags}
+                  className="inline-flex items-center gap-0.5 rounded-full border border-dashed border-[var(--color-border)] bg-white px-2 py-0.5 font-mono text-[10px] font-bold text-[var(--color-muted)]"
+                >
+                  <Icon name="edit" size={11} />
+                  {(project.sharedTags?.length ?? 0) > 0 ? 'タグを編集' : 'タグを追加'}
+                </button>
+              )}
+            </div>
           )}
 
           <div className="mt-3 flex gap-2.5 border-t border-dashed border-[var(--color-border)] pt-3">
@@ -662,6 +712,56 @@ export default function SharedDetailPage() {
                 className="inline-flex h-[44px] flex-1 items-center justify-center gap-1.5 rounded-[10px] border-2 border-[var(--solid-ink)] bg-[var(--solid-ink)] text-[13px] font-extrabold text-white disabled:opacity-45"
               >
                 <Icon name={ownerActionBusy ? 'progress_activity' : 'check'} size={15} className={ownerActionBusy ? 'animate-spin' : undefined} />
+                保存
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {tagsOpen && (
+        <div className="fixed inset-0 z-[120] flex items-center justify-center px-6" style={{ fontFamily: 'var(--font-body)' }}>
+          <button
+            type="button"
+            className="absolute inset-0 cursor-default"
+            aria-label="閉じる"
+            onClick={() => setTagsOpen(false)}
+            style={{ background: 'rgba(26,26,26,0.45)', backdropFilter: 'blur(3px)' }}
+          />
+          <div
+            className="relative w-full animate-fade-in-up"
+            style={{
+              maxWidth: 360,
+              background: '#faf7f1',
+              border: '2px solid var(--solid-ink)',
+              borderRadius: 18,
+              padding: '18px',
+              boxShadow: '0 12px 32px rgba(26,26,26,0.22)',
+            }}
+          >
+            <div className="mb-3 font-display text-[17px] font-extrabold text-[var(--solid-ink)]">タグを編集</div>
+            <input
+              value={tagsDraft}
+              onChange={(event) => setTagsDraft(event.target.value)}
+              placeholder="例: #TOEIC, #熟語, #高校英語"
+              autoFocus
+              className="mb-3 w-full rounded-[10px] border-2 border-[var(--solid-ink)] bg-white px-3 py-2.5 text-[14px] font-bold text-[var(--solid-ink)] outline-none"
+            />
+            <div className="flex gap-2">
+              <button
+                type="button"
+                onClick={() => setTagsOpen(false)}
+                className="inline-flex h-[44px] flex-1 items-center justify-center rounded-[10px] border-2 border-[var(--solid-ink)] bg-white text-[13px] font-extrabold text-[var(--solid-ink)]"
+              >
+                キャンセル
+              </button>
+              <button
+                type="button"
+                onClick={() => void handleSaveTags()}
+                disabled={tagsSaving}
+                className="inline-flex h-[44px] flex-1 items-center justify-center gap-1.5 rounded-[10px] border-2 border-[var(--solid-ink)] bg-[var(--solid-ink)] text-[13px] font-extrabold text-white disabled:opacity-45"
+              >
+                <Icon name={tagsSaving ? 'progress_activity' : 'check'} size={15} className={tagsSaving ? 'animate-spin' : undefined} />
                 保存
               </button>
             </div>

--- a/src/lib/shared-projects/client.ts
+++ b/src/lib/shared-projects/client.ts
@@ -22,3 +22,20 @@ export async function saveProjectSharedTags(projectId: string, sharedTags: reado
 
   return normalizeSharedTags(payload.sharedTags);
 }
+
+export async function saveSharedWordbookTags(sharedWordbookId: string, sharedTags: readonly string[]): Promise<string[]> {
+  const response = await fetch(`/api/shared-projects/share-wordbook/${encodeURIComponent(sharedWordbookId)}/tags`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      sharedTags: sharedTags.map(formatSharedTag).filter(Boolean),
+    }),
+  });
+
+  const payload = await response.json().catch(() => null) as SharedTagsPatchResponse | null;
+  if (!response.ok || !payload?.success) {
+    throw new Error(payload?.error || 'shared_tags_update_failed');
+  }
+
+  return normalizeSharedTags(payload.sharedTags);
+}


### PR DESCRIPTION
## Summary
- これまで共有単語帳（`shared_wordbooks`）のタグは公開時にしか設定できず、公開後は「共有停止」と「名称変更」しか導線がなかった
- `shared_wordbooks.shared_tags` を更新する `updateSharedWordbookTags()` を追加し、所有者チェック・タグ正規化・埋め込み再生成（失敗時はベストエフォートでスキップ）を行う
- `PATCH /api/shared-projects/share-wordbook/[id]/tags` を新設し、既存の `[projectId]/shared-tags` エンドポイントと同じバリデーションパターンで `shared_wordbooks` 側を更新する
- クライアントヘルパー `saveSharedWordbookTags()` を追加
- 所有者向け管理画面 `/share/[shareId]` にタグ表示＋編集モーダルを追加（既存の名前変更モーダルと同じUIパターン）

## Test plan
- [x] `npx tsx --test src/app/api/shared-projects/shared-wordbooks.test.ts` — 所有者チェック・正規化・タグクリアの新規テストを含めて全件パス
- [x] `npx tsx --test src/app/api/shared-projects/shared-tags.route.test.ts src/app/shared/shared-page-utils.test.ts` — 既存タグ関連テストにリグレッションなし
- [x] `npx tsc --noEmit` — エラーなし
- [x] `npm run lint` — 変更ファイルに新規のエラー・警告なし（既存の無関係な警告のみ）
- [x] `npm run build` — 成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01EjcNfkC5hZ9aKmR9HSf1CY)_