### PR TITLE
お問い合わせフォームにahoperson@merken.jpをCC追加

### DIFF
--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -51,7 +51,7 @@ export default function ContactPage() {
       <div className="px-[18px] pb-3">
         <div className="pb-1.5 pl-1 font-mono text-[9px] font-bold uppercase tracking-[0.08em] text-[var(--color-muted)]">連絡先</div>
         <a
-          href="mailto:support@merken.jp"
+          href="mailto:support@merken.jp?cc=ahoperson@merken.jp"
           className="flex items-center gap-3 rounded-xl border-2 border-[var(--solid-ink)] bg-white p-[12px_14px] transition-all duration-100 active:translate-x-px active:translate-y-px"
         >
           <span className="inline-flex h-[30px] w-[30px] shrink-0 items-center justify-center rounded-[8px] bg-[rgba(26,26,26,0.05)] text-[var(--solid-ink)]">

--- a/src/components/desktop/DesktopSupport.tsx
+++ b/src/components/desktop/DesktopSupport.tsx
@@ -92,7 +92,7 @@ export function DesktopContactView({ onBack }: { onBack: () => void }) {
                 <input className="ds-input" type="email" placeholder="you@example.com" />
               </div>
               <div style={{ display: 'flex', alignItems: 'center', gap: 12, marginTop: 6 }}>
-                <a className="ds-btn accent" href={`mailto:support@merken.jp?subject=${encodeURIComponent(kind)}`}>
+                <a className="ds-btn accent" href={`mailto:support@merken.jp?cc=ahoperson@merken.jp&subject=${encodeURIComponent(kind)}`}>
                   <Icon name="send" />
                   送信する
                 </a>
@@ -102,7 +102,7 @@ export function DesktopContactView({ onBack }: { onBack: () => void }) {
           </div>
 
           <div style={{ display: 'flex', flexDirection: 'column', gap: 16, position: 'sticky', top: 0 }}>
-            <a href="mailto:support@merken.jp" className="ds-card ds-contact-method" style={{ color: 'inherit', textDecoration: 'none' }}>
+            <a href="mailto:support@merken.jp?cc=ahoperson@merken.jp" className="ds-card ds-contact-method" style={{ color: 'inherit', textDecoration: 'none' }}>
               <div className="ic"><Icon name="mail" style={{ color: 'var(--color-accent)' }} /></div>
               <div style={{ flex: 1 }}>
                 <div style={{ fontSize: 13.5, fontWeight: 600 }}>メールで直接</div>


### PR DESCRIPTION
## Summary
- お問い合わせフォームの送信先メールアドレス（`mailto:` リンク）に `ahoperson@merken.jp` を CC として追加しました
- 対象: モバイル向け `src/app/contact/page.tsx` およびデスクトップ向け `src/components/desktop/DesktopSupport.tsx`（フォーム送信ボタン・連絡先カードの両方）
- 本アプリのお問い合わせフォームはサーバーサイド送信ではなく、ユーザーのメールクライアントを開く `mailto:` リンクのため、`cc` パラメータとして追加する方式としました

## Test plan
- [ ] `npm run build` が通ることを確認
- [ ] `/contact` ページ（モバイル・デスクトップ双方）でリンクをクリックし、メールクライアントの宛先(To: support@merken.jp)とCC(ahoperson@merken.jp)が正しく設定されることを確認


---
_Generated by [Claude Code](https://claude.ai/code/session_018V1zNb5XFRyaENHCoHvSpc)_