### PR TITLE
単語帳が無い時の新規スキャンボタンを下部バーと同じ作成シートに統一

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -8,6 +8,7 @@ import { Icon } from '@/components/ui/Icon';
 import { DesktopHomeView } from '@/components/desktop/DesktopHome';
 import { SolidEmpty, SolidPanel } from '@/components/redesign/SolidPage';
 import { ScanCaptureModal } from '@/components/home/ScanCaptureModal';
+import { CreateWordbookSheet } from '@/components/home/CreateWordbookSheet';
 import { LpDemoSection } from '@/components/home/LpDemoSection';
 import { GeneratingProjectCard } from '@/components/project/GeneratingProjectCard';
 import { PwaInstallBanner } from '@/components/home/PwaInstallBanner';
@@ -318,6 +319,7 @@ export default function HomePage() {
   const [pendingGeneratingWordbook, setPendingGeneratingWordbook] = useState<HomeGeneratingWordbookPayload | null>(null);
 
   const [vocabScanOpen, setVocabScanOpen] = useState(false);
+  const [createSheetOpen, setCreateSheetOpen] = useState(false);
   const loadHomeRef = useRef<() => Promise<void>>(() => Promise.resolve());
 
   const subscriptionStatus: SubscriptionStatus = subscription?.status || 'free';
@@ -691,10 +693,10 @@ export default function HomePage() {
             title="単語帳はまだありません"
             description="スキャンまたは手入力で最初の単語帳を作成しましょう。"
             action={
-              <Link href="/scan" className="solid-link-primary">
+              <button type="button" onClick={() => setCreateSheetOpen(true)} className="solid-link-primary">
                 <Icon name="add_a_photo" size={16} />
                 新規スキャン
-              </Link>
+              </button>
             }
           />
         ) : (
@@ -708,6 +710,10 @@ export default function HomePage() {
         onClose={() => setVocabScanOpen(false)}
         defaultMode="vocab"
         onBackgroundScanStarted={showHomeGeneratingWordbook}
+      />
+      <CreateWordbookSheet
+        isOpen={createSheetOpen}
+        onClose={() => setCreateSheetOpen(false)}
       />
 
 

--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link';
 import { DesktopProjectsView } from '@/components/desktop/DesktopProjects';
 import { Icon } from '@/components/ui/Icon';
 import { SolidEmpty, SolidPanel } from '@/components/redesign/SolidPage';
+import { CreateWordbookSheet } from '@/components/home/CreateWordbookSheet';
 import { useAuth } from '@/hooks/use-auth';
 import { getRepository } from '@/lib/db';
 import { localRepository } from '@/lib/db/local-repository';
@@ -76,6 +77,7 @@ export default function ProjectListPage() {
   const [sort, setSort] = useState<SortKey>('newest');
   const [error, setError] = useState<string | null>(null);
   const [summaryStats, setSummaryStats] = useState<DesktopStudySummaryStats>(EMPTY_DESKTOP_STUDY_SUMMARY);
+  const [createSheetOpen, setCreateSheetOpen] = useState(false);
 
   const subscriptionStatus: SubscriptionStatus = subscription?.status || 'free';
   const wasPro = subscription?.plan === 'pro' && subscriptionStatus !== 'active';
@@ -233,10 +235,10 @@ export default function ProjectListPage() {
             title={query ? '一致する単語帳がありません' : '単語帳はまだありません'}
             description={query ? '検索語を変えてもう一度探してください。' : 'スキャンして最初の単語帳を作成しましょう。'}
             action={
-              <Link href="/scan" className="solid-link-primary">
+              <button type="button" onClick={() => setCreateSheetOpen(true)} className="solid-link-primary">
                 <Icon name="add_a_photo" size={16} />
                 新規スキャン
-              </Link>
+              </button>
             }
           />
         ) : (
@@ -245,6 +247,10 @@ export default function ProjectListPage() {
       </div>
 
       </div>
+      <CreateWordbookSheet
+        isOpen={createSheetOpen}
+        onClose={() => setCreateSheetOpen(false)}
+      />
     </>
   );
 }


### PR DESCRIPTION
## 概要

単語帳がまだ無い時に表示される空状態の「新規スキャン」ボタンが `/scan` へ直接ページ遷移していたのを、下部バー中央の「作成」ボタンをタップした時と同じ UI（`CreateWordbookSheet`：写真でスキャン / 共有ライブラリから / 空の単語帳を作成 を選ぶボトムシート）を開くように統一しました。

## 変更内容

- `src/app/page.tsx`（ホーム）: 空状態の「新規スキャン」の `Link href="/scan"` を、`CreateWordbookSheet` を開くボタンに変更
- `src/app/projects/page.tsx`（マイ単語帳）: 同様に空状態の「新規スキャン」を `CreateWordbookSheet` を開くボタンに変更

見た目（`solid-link-primary` のスタイル、アイコン、ラベル）は従来のまま、タップ時の挙動のみ変更しています。

## 確認

- `npx eslint` 対象2ファイル: エラーなし（既存の未使用変数 warning のみ）
- `npm run build`: 成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015r6B5xWyCb7hHeNmrQXm4V

---
_Generated by [Claude Code](https://claude.ai/code/session_015r6B5xWyCb7hHeNmrQXm4V)_