### PR TITLE
英検フィルタをホワイトリスト方式に変更(lexicon未登録語も除外)

### DIFF
--- a/scripts/import-words-cefr-dataset.ts
+++ b/scripts/import-words-cefr-dataset.ts
@@ -11,9 +11,10 @@ import {
 // https://github.com/Maximax67/Words-CEFR-Dataset
 //
 // インポート方針:
-// - レベルは小数(外挿値)なので四捨五入して A1-C1 のみ取り込む。
-//   C2 バケットは「稀語のデフォルト値」として全体の約7割を占めるノイズであり、
-//   英検フィルタでは lexicon 未登録語を「難しい側」として扱うため取り込む価値がない。
+// - レベルは小数(外挿値)なので四捨五入して A1-C2 を取り込む。
+//   C2 バケットは「稀語のデフォルト値」を多く含むが、英検フィルタが lexicon 未登録語を
+//   除外する(ホワイトリスト方式)ため、本物の難語を lexicon に載せておく必要がある。
+//   C2 はどの英検級のしきい値も通過するので、レベルの精度は問題にならない。
 // - 固有名詞 (Penn: NNP/NNPS) はスキップする。
 // - 既存行のうち OLP (CEFR-J / Octanove) 由来の cefr_level は人手キュレーション値なので
 //   上書きしない。それ以外(cefr_level が NULL、または runtime/AI 経由で作られた行)は
@@ -189,7 +190,6 @@ async function fetchSeeds(): Promise<Map<string, ImportSeed>> {
 
   const merged = new Map<string, ImportSeed>();
   let skippedProperNouns = 0;
-  let skippedC2 = 0;
 
   for (const row of wordPosRows) {
     const word = wordById.get(row.word_id?.trim() ?? '');
@@ -206,10 +206,6 @@ async function fetchSeeds(): Promise<Map<string, ImportSeed>> {
     const level = Number.parseFloat(row.level ?? '');
     if (!Number.isFinite(level)) continue;
     const bucket = Math.min(6, Math.max(1, Math.round(level)));
-    if (bucket >= 6) {
-      skippedC2 += 1;
-      continue;
-    }
     const cefrLevel = CEFR_BY_BUCKET[bucket];
 
     const normalized_headword = normalizeHeadword(word);
@@ -235,7 +231,7 @@ async function fetchSeeds(): Promise<Map<string, ImportSeed>> {
   }
 
   console.log(
-    `Prepared ${merged.size} seeds (skipped ${skippedProperNouns} proper-noun rows, ${skippedC2} extrapolated-C2 rows)`,
+    `Prepared ${merged.size} seeds (skipped ${skippedProperNouns} proper-noun rows)`,
   );
   return merged;
 }

--- a/src/lib/lexicon/eiken-cefr-filter.test.ts
+++ b/src/lib/lexicon/eiken-cefr-filter.test.ts
@@ -19,7 +19,7 @@ test('getEikenCefrThreshold maps EIKEN grades to the easiest CEFR level of their
   assert.equal(getEikenCefrThreshold(null), null);
 });
 
-test('filterWordsByLexiconCefrLevel removes words the lexicon marks below the EIKEN level', async () => {
+test('filterWordsByLexiconCefrLevel removes below-level words and lexicon-unknown words', async () => {
   const levels = new Map<string, CefrLevel>([
     ['pen', 'A1'],
     ['consider', 'B1'],
@@ -39,9 +39,10 @@ test('filterWordsByLexiconCefrLevel removes words the lexicon marks below the EI
     lookupCefrLevels: async () => levels,
   });
 
+  // pen/consider はレベル未満、zymurgy はlexicon未登録(ゴミ文字列扱い)として除外
   assert.deepEqual(
     result.words.map((word) => word.english),
-    ['abolish', 'hypothesis', 'zymurgy'],
+    ['abolish', 'hypothesis'],
   );
   assert.equal(result.removedCount, 2);
   assert.equal(result.unknownCount, 1);

--- a/src/lib/lexicon/eiken-cefr-filter.ts
+++ b/src/lib/lexicon/eiken-cefr-filter.ts
@@ -82,9 +82,10 @@ export async function lookupLexiconCefrLevels(
 /**
  * 抽出済み単語を lexicon の CEFR レベルで決定的にフィルタする。
  * - lexicon 上のレベルが指定英検級のしきい値未満 -> 除外
- * - lexicon に無い/レベル不明な単語 -> 残す(誤除外を避ける。未知語は稀語・固有名詞が中心で
- *   「簡単すぎる単語の混入」の原因にならないため、判定はAI側の抽出結果に委ねる)
- * - ルックアップ失敗時はフィルタなしで返す(fail-open)
+ * - lexicon に無い/レベル不明な単語 -> 除外(unknownCount にカウント)。
+ *   OCR誤読やゴミ文字列の混入を防ぐため、lexicon をホワイトリストとして扱う。
+ *   本物の難語が誤除外されないよう、インポートスクリプトはC2バケットまで取り込むこと。
+ * - ルックアップ自体の失敗(DB障害など)時はフィルタなしで返す(fail-open)
  */
 export async function filterWordsByLexiconCefrLevel<T extends { english: string }>(
   words: T[],
@@ -114,7 +115,7 @@ export async function filterWordsByLexiconCefrLevel<T extends { english: string 
     const level = levels.get(normalizeHeadword(word.english));
     if (!level) {
       unknownCount += 1;
-      return true;
+      return false;
     }
     if (cefrIndex(level) < thresholdIndex) {
       removedCount += 1;


### PR DESCRIPTION
## 概要

#344 / #345 のフォローアップ。英検フィルタの未知語の扱いを「残す」から「除外」に変更(ホワイトリスト方式)。

## 変更内容

### 1. `eiken-cefr-filter.ts`: lexicon未登録語を除外

- これまで: lexiconにCEFRレベルが無い単語は「難しい側」とみなして残していた
- これから: **除外**する。lexiconをホワイトリストとして扱い、OCR誤読やゴミ文字列が未知語としてすり抜けるのを防ぐ
- DB障害などルックアップ自体の失敗時のfail-open(フィルタなしで返す)は維持

### 2. インポートスクリプト: C2バケットも取り込む

未知語を除外する前提では、本物の難語(C2級)がlexicon未登録のせいで誤除外される。これを防ぐため、これまでスキップしていた外挿C2バケットも取り込むよう変更。

- 取り込み規模: 約66,800行 → **約174,800行**(ユニーク見出し語 約114,500語。内訳 A1: 5,695 / A2: 9,123 / B1: 10,259 / B2: 11,741 / C1: 4,294 / C2: 73,362)
- C2ラベルは外挿デフォルト値を多く含むが、どの英検級のしきい値も通過するため精度は結果に影響しない(「実在する単語か」のホワイトリストとして機能すればよい)
- 上書きルール(OLPキュレーション値の保持)・固有名詞スキップは従来どおり

## ⚠️ マージ後に必要な作業

**インポートスクリプトの再実行が必須**です:

```bash
npx tsx --env-file=.env.local scripts/import-words-cefr-dataset.ts
```

再実行しないままフィルタだけデプロイされると、C2相当の難語が「未登録=除外」で消えます(既存の約6.7万行分は引き続き機能するため、影響は難語の取りこぼしのみ)。スクリプトは冪等なので再実行安全です。

## テスト

- `eiken-cefr-filter.test.ts` を新挙動(未知語除外)に更新
- `npm test`: 737/738 pass(失敗1件 `words/create` は main でも再現する既存の問題)、`tsc --noEmit` クリーン

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FY8wNYizpbRp4wWDP3bEfk

---
_Generated by [Claude Code](https://claude.ai/code/session_01FY8wNYizpbRp4wWDP3bEfk)_