### PR TITLE
グループ機能にデスクトップ版の導線とページを追加

### DIFF
--- a/src/app/groups/[groupId]/bookshelf/GroupBookshelfClient.tsx
+++ b/src/app/groups/[groupId]/bookshelf/GroupBookshelfClient.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useState } from 'react';
 import Link from 'next/link';
 import { useParams } from 'next/navigation';
+import { DesktopButton } from '@/components/desktop/DesktopChrome';
 import { Icon } from '@/components/ui';
 import { useAuth } from '@/hooks/use-auth';
 import { useToast } from '@/components/ui/toast';
@@ -88,62 +89,104 @@ export default function GroupBookshelfClient() {
     }
   }, [groupId, removingProjectId, showToast]);
 
+  const stateView = authLoading || loading ? (
+    <LoadingState />
+  ) : !isAuthenticated ? (
+    <CenteredCard icon="lock" title="ログインが必要です">
+      <Link href="/login?redirect=/shared" className="mt-4 inline-flex rounded-[10px] border-2 border-[var(--solid-ink)] bg-[var(--solid-ink)] px-5 py-3 font-display text-sm font-bold text-white">
+        ログイン
+      </Link>
+    </CenteredCard>
+  ) : error || !group ? (
+    <CenteredCard icon="error" title={error ?? 'グループが見つかりません'}>
+      <button type="button" onClick={() => void load()} className="mt-4 inline-flex rounded-[10px] border-2 border-[var(--solid-ink)] bg-white px-5 py-3 font-display text-sm font-bold text-[var(--solid-ink)]">
+        再読み込み
+      </button>
+    </CenteredCard>
+  ) : null;
+
+  const emptyShelf = (
+    <div className="rounded-[16px] border-2 border-dashed border-[var(--color-border)] bg-white px-4 py-10 text-center">
+      <Icon name="auto_stories" size={34} className="mx-auto text-[var(--color-muted)]" />
+      <div className="mt-2 text-[13px] font-extrabold text-[var(--solid-ink)]">本棚はまだ空っぽ</div>
+      <div className="mt-1 text-[12px] font-bold text-[var(--color-muted)]">最初の1冊を共有して本棚を作ろう！</div>
+    </div>
+  );
+
+  const renderBooks = () => projects.map((card) => (
+    <BookCard
+      key={card.project.id}
+      card={card}
+      removing={removingProjectId === card.project.id}
+      removeDisabled={removingProjectId !== null}
+      onRemove={() => void handleRemoveProject(card)}
+    />
+  ));
+
   return (
-    <div
-      className="relative mx-auto min-h-screen w-full max-w-[560px] bg-[var(--color-background)] font-[var(--font-body)]"
-      style={{
-        paddingTop: 0,
-        paddingBottom: 'max(2rem, env(safe-area-inset-bottom))',
-      }}
-    >
-      {authLoading || loading ? (
-        <LoadingState />
-      ) : !isAuthenticated ? (
-        <CenteredCard icon="lock" title="ログインが必要です">
-          <Link href="/login?redirect=/shared" className="mt-4 inline-flex rounded-[10px] border-2 border-[var(--solid-ink)] bg-[var(--solid-ink)] px-5 py-3 font-display text-sm font-bold text-white">
-            ログイン
-          </Link>
-        </CenteredCard>
-      ) : error || !group ? (
-        <CenteredCard icon="error" title={error ?? 'グループが見つかりません'}>
-          <button type="button" onClick={() => void load()} className="mt-4 inline-flex rounded-[10px] border-2 border-[var(--solid-ink)] bg-white px-5 py-3 font-display text-sm font-bold text-[var(--solid-ink)]">
-            再読み込み
-          </button>
-        </CenteredCard>
-      ) : (
-        <div className="flex flex-col gap-4 px-[14px]">
-          <BookshelfHeader groupId={groupId} groupName={group.name} bookCount={projects.length} />
-
-          {projects.length === 0 ? (
-            <div className="rounded-[16px] border-2 border-dashed border-[var(--color-border)] bg-white px-4 py-10 text-center">
-              <Icon name="auto_stories" size={34} className="mx-auto text-[var(--color-muted)]" />
-              <div className="mt-2 text-[13px] font-extrabold text-[var(--solid-ink)]">本棚はまだ空っぽ</div>
-              <div className="mt-1 text-[12px] font-bold text-[var(--color-muted)]">最初の1冊を共有して本棚を作ろう！</div>
+    <>
+      {/* Desktop */}
+      <div className="hidden h-full min-h-0 flex-col lg:flex">
+        <div className="ds-top">
+          <div style={{ flex: 1, minWidth: 0 }}>
+            <div className="crumb">
+              {group ? `共有ライブラリ / ${group.name}` : '共有ライブラリ / グループ'}
             </div>
-          ) : (
-            <div className="grid grid-cols-2 gap-3">
-              {projects.map((card) => (
-                <BookCard
-                  key={card.project.id}
-                  card={card}
-                  removing={removingProjectId === card.project.id}
-                  removeDisabled={removingProjectId !== null}
-                  onRemove={() => void handleRemoveProject(card)}
-                />
-              ))}
-            </div>
-          )}
-
-          <button
-            type="button"
-            onClick={() => { triggerHaptic(); setShareSheetOpen(true); }}
-            className="flex w-full items-center justify-center gap-2 rounded-[12px] border-2 border-[var(--solid-ink)] bg-[var(--solid-ink)] px-4 py-3 font-display text-[14px] font-extrabold text-white shadow-[3px_3px_0_var(--solid-ink)] transition-all duration-100 active:translate-x-[3px] active:translate-y-[3px] active:shadow-none"
+            <h1>本棚{group ? `・${projects.length}冊` : ''}</h1>
+          </div>
+          <DesktopButton
+            href={`/groups/${encodeURIComponent(groupId)}`}
+            icon="arrow_back"
+            variant="ghost"
           >
-            <Icon name="library_add" size={18} />
-            単語帳を共有
-          </button>
+            グループへ戻る
+          </DesktopButton>
+          {group && (
+            <DesktopButton variant="dark" icon="library_add" onClick={() => setShareSheetOpen(true)}>
+              単語帳を共有
+            </DesktopButton>
+          )}
         </div>
-      )}
+        <div className="ds-scroll">
+          {stateView ?? (group && (
+            projects.length === 0 ? emptyShelf : (
+              <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(200px, 1fr))', gap: 18 }}>
+                {renderBooks()}
+              </div>
+            )
+          ))}
+        </div>
+      </div>
+
+      {/* Mobile */}
+      <div
+        className="relative mx-auto min-h-screen w-full max-w-[560px] bg-[var(--color-background)] font-[var(--font-body)] lg:hidden"
+        style={{
+          paddingTop: 0,
+          paddingBottom: 'max(2rem, env(safe-area-inset-bottom))',
+        }}
+      >
+        {stateView ?? (group && (
+          <div className="flex flex-col gap-4 px-[14px]">
+            <BookshelfHeader groupId={groupId} groupName={group.name} bookCount={projects.length} />
+
+            {projects.length === 0 ? emptyShelf : (
+              <div className="grid grid-cols-2 gap-3">
+                {renderBooks()}
+              </div>
+            )}
+
+            <button
+              type="button"
+              onClick={() => { triggerHaptic(); setShareSheetOpen(true); }}
+              className="flex w-full items-center justify-center gap-2 rounded-[12px] border-2 border-[var(--solid-ink)] bg-[var(--solid-ink)] px-4 py-3 font-display text-[14px] font-extrabold text-white shadow-[3px_3px_0_var(--solid-ink)] transition-all duration-100 active:translate-x-[3px] active:translate-y-[3px] active:shadow-none"
+            >
+              <Icon name="library_add" size={18} />
+              単語帳を共有
+            </button>
+          </div>
+        ))}
+      </div>
 
       <ShareToGroupSheet
         open={shareSheetOpen}
@@ -155,7 +198,7 @@ export default function GroupBookshelfClient() {
         onClose={() => setShareSheetOpen(false)}
         onShared={() => { setShareSheetOpen(false); void load(); }}
       />
-    </div>
+    </>
   );
 }
 

--- a/src/app/groups/[groupId]/join/page.tsx
+++ b/src/app/groups/[groupId]/join/page.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useState } from 'react';
 import Link from 'next/link';
 import { useParams, useRouter } from 'next/navigation';
+import { DesktopButton } from '@/components/desktop/DesktopChrome';
 import { Icon } from '@/components/ui';
 import { useAuth } from '@/hooks/use-auth';
 import { useToast } from '@/components/ui/toast';
@@ -117,43 +118,24 @@ export default function GroupJoinPage() {
     return submitJoin({ groupId });
   }, [groupId, submitJoin]);
 
-  return (
-    <div
-      className="relative mx-auto min-h-screen w-full max-w-[560px] bg-[var(--color-background)] font-[var(--font-body)]"
-      style={{
-        paddingTop: 'max(0.75rem, env(safe-area-inset-top))',
-        paddingBottom: 'max(2rem, env(safe-area-inset-bottom))',
-      }}
-    >
-      <div className="flex items-center gap-2 px-[14px] pt-1">
-        <Link
-          href="/shared"
-          aria-label="共有に戻る"
-          className="inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-full border-2 border-[var(--solid-ink)] bg-white text-[var(--solid-ink)] transition-all duration-100 active:translate-x-px active:translate-y-px"
-        >
-          <Icon name="arrow_back" size={16} />
-        </Link>
-        <div className="font-mono text-[10px] font-bold tracking-[0.08em] text-[var(--color-muted)]">
-          JOIN GROUP
-        </div>
-      </div>
+  const stateView = authLoading || checking ? (
+    <div className="flex items-center justify-center py-24 text-[var(--color-muted)]">
+      <Icon name="progress_activity" className="animate-spin" size={22} />
+      <span className="ml-2 text-sm font-bold">読み込み中...</span>
+    </div>
+  ) : !isAuthenticated ? (
+    <CenteredCard icon="lock" title="ログインが必要です">
+      <Link
+        href={`/login?redirect=/groups/${groupId}/join`}
+        className="mt-4 inline-flex rounded-[10px] border-2 border-[var(--solid-ink)] bg-[var(--solid-ink)] px-5 py-3 font-display text-sm font-bold text-white"
+      >
+        ログイン
+      </Link>
+    </CenteredCard>
+  ) : null;
 
-      {authLoading || checking ? (
-        <div className="flex items-center justify-center py-24 text-[var(--color-muted)]">
-          <Icon name="progress_activity" className="animate-spin" size={22} />
-          <span className="ml-2 text-sm font-bold">読み込み中...</span>
-        </div>
-      ) : !isAuthenticated ? (
-        <CenteredCard icon="lock" title="ログインが必要です">
-          <Link
-            href={`/login?redirect=/groups/${groupId}/join`}
-            className="mt-4 inline-flex rounded-[10px] border-2 border-[var(--solid-ink)] bg-[var(--solid-ink)] px-5 py-3 font-display text-sm font-bold text-white"
-          >
-            ログイン
-          </Link>
-        </CenteredCard>
-      ) : (
-        <div className="flex flex-col gap-4 px-[14px] pt-4">
+  const joinContent = stateView === null ? (
+    <div className="flex flex-col gap-4">
           <section
             className="relative overflow-hidden rounded-[18px] border-2 border-[var(--solid-ink)] p-4 text-white"
             style={{ background: `linear-gradient(135deg, ${thumbColor(preview?.id ?? groupId)} 0%, var(--solid-ink) 160%)` }}
@@ -244,9 +226,57 @@ export default function GroupJoinPage() {
               </form>
             </section>
           )}
-        </div>
-      )}
     </div>
+  ) : null;
+
+  return (
+    <>
+      {/* Desktop */}
+      <div className="hidden h-full min-h-0 flex-col lg:flex">
+        <div className="ds-top">
+          <div style={{ flex: 1, minWidth: 0 }}>
+            <div className="crumb">共有ライブラリ / グループ</div>
+            <h1 style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+              {preview?.name ? `${preview.name}に参加` : 'グループに参加'}
+            </h1>
+          </div>
+          <DesktopButton href="/shared" icon="arrow_back" variant="ghost">共有ライブラリ</DesktopButton>
+        </div>
+        <div className="ds-scroll">
+          <div style={{ maxWidth: 560 }}>
+            {stateView ?? joinContent}
+          </div>
+        </div>
+      </div>
+
+      {/* Mobile */}
+      <div
+        className="relative mx-auto min-h-screen w-full max-w-[560px] bg-[var(--color-background)] font-[var(--font-body)] lg:hidden"
+        style={{
+          paddingTop: 'max(0.75rem, env(safe-area-inset-top))',
+          paddingBottom: 'max(2rem, env(safe-area-inset-bottom))',
+        }}
+      >
+        <div className="flex items-center gap-2 px-[14px] pt-1">
+          <Link
+            href="/shared"
+            aria-label="共有に戻る"
+            className="inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-full border-2 border-[var(--solid-ink)] bg-white text-[var(--solid-ink)] transition-all duration-100 active:translate-x-px active:translate-y-px"
+          >
+            <Icon name="arrow_back" size={16} />
+          </Link>
+          <div className="font-mono text-[10px] font-bold tracking-[0.08em] text-[var(--color-muted)]">
+            JOIN GROUP
+          </div>
+        </div>
+
+        {stateView ?? (
+          <div className="px-[14px] pt-4">
+            {joinContent}
+          </div>
+        )}
+      </div>
+    </>
   );
 }
 

--- a/src/app/groups/[groupId]/page.tsx
+++ b/src/app/groups/[groupId]/page.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import Link from 'next/link';
 import { useParams } from 'next/navigation';
+import { DesktopButton } from '@/components/desktop/DesktopChrome';
 import { Icon } from '@/components/ui';
 import { useAuth } from '@/hooks/use-auth';
 import { useToast } from '@/components/ui/toast';
@@ -97,49 +98,103 @@ export default function GroupPage() {
     [leaderboard],
   );
 
+  const settingsHref = `/groups/${encodeURIComponent(groupId)}/settings`;
+
+  const stateView = authLoading || loading ? (
+    <LoadingState />
+  ) : !isAuthenticated ? (
+    <CenteredCard icon="lock" title="ログインが必要です">
+      <Link href="/login?redirect=/shared" className="mt-4 inline-flex rounded-[10px] border-2 border-[var(--solid-ink)] bg-[var(--solid-ink)] px-5 py-3 font-display text-sm font-bold text-white">
+        ログイン
+      </Link>
+    </CenteredCard>
+  ) : error || !group ? (
+    <CenteredCard icon="error" title={error ?? 'グループが見つかりません'}>
+      <button type="button" onClick={() => void load()} className="mt-4 inline-flex rounded-[10px] border-2 border-[var(--solid-ink)] bg-white px-5 py-3 font-display text-sm font-bold text-[var(--solid-ink)]">
+        再読み込み
+      </button>
+    </CenteredCard>
+  ) : null;
+
   return (
-    <div
-      className="relative mx-auto min-h-screen w-full max-w-[560px] bg-[var(--color-background)] font-[var(--font-body)]"
-      style={{
-        // The <body> already pads by env(safe-area-inset-top) (globals.css), so
-        // the header sits just below the notch with no extra gap. Adding more
-        // padding here would double-count the inset and leave a dead band.
-        paddingTop: 0,
-        paddingBottom: 'max(2rem, env(safe-area-inset-bottom))',
-      }}
-    >
-      {authLoading || loading ? (
-        <LoadingState />
-      ) : !isAuthenticated ? (
-        <CenteredCard icon="lock" title="ログインが必要です">
-          <Link href="/login?redirect=/shared" className="mt-4 inline-flex rounded-[10px] border-2 border-[var(--solid-ink)] bg-[var(--solid-ink)] px-5 py-3 font-display text-sm font-bold text-white">
-            ログイン
-          </Link>
-        </CenteredCard>
-      ) : error || !group ? (
-        <CenteredCard icon="error" title={error ?? 'グループが見つかりません'}>
-          <button type="button" onClick={() => void load()} className="mt-4 inline-flex rounded-[10px] border-2 border-[var(--solid-ink)] bg-white px-5 py-3 font-display text-sm font-bold text-[var(--solid-ink)]">
-            再読み込み
-          </button>
-        </CenteredCard>
-      ) : (
-        <div className="flex flex-col gap-4 px-[14px]">
-          <GroupHeader
-            group={group}
-            totalQuiz={totalQuiz}
-            onCopyInvite={() => void copyInvite()}
-            onShare={() => { triggerHaptic(); setInviteShareOpen(true); }}
-            settingsHref={`/groups/${encodeURIComponent(groupId)}/settings`}
-          />
-          <BookshelfSection groupId={groupId} projects={projects} />
-          <LeaderboardSection leaderboard={leaderboard} />
-          <MissedWordsSection
-            groupId={groupId}
-            missedWords={missedWords}
-            totalCount={missedWordsTotalCount}
-          />
+    <>
+      {/* Desktop */}
+      <div className="hidden h-full min-h-0 flex-col lg:flex">
+        <div className="ds-top">
+          <div style={{ flex: 1, minWidth: 0 }}>
+            <div className="crumb">共有ライブラリ / グループ</div>
+            <h1 style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+              {group?.name ?? 'グループ'}
+            </h1>
+          </div>
+          <DesktopButton href="/shared" icon="arrow_back" variant="ghost">共有ライブラリ</DesktopButton>
+          {group && (
+            <>
+              <button type="button" className="ds-btn" onClick={() => void copyInvite()} title="招待コードをコピー">
+                <Icon name="content_copy" />
+                <span className="mono">{group.inviteCode}</span>
+              </button>
+              <DesktopButton variant="dark" icon="ios_share" onClick={() => setInviteShareOpen(true)}>
+                シェア
+              </DesktopButton>
+              <DesktopButton href={settingsHref} icon="settings" variant="ghost" title="グループ設定">{''}</DesktopButton>
+            </>
+          )}
         </div>
-      )}
+        <div className="ds-scroll">
+          {stateView ?? (group && (
+            <>
+              <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3, minmax(0, 1fr))', gap: 16, marginBottom: 20 }}>
+                <DesktopGroupStat icon="group" label="メンバー" value={group.memberCount} unit="人" />
+                <DesktopGroupStat icon="menu_book" label="共有単語帳" value={group.projectCount} unit="冊" />
+                <DesktopGroupStat icon="bolt" label="今週の解答" value={totalQuiz} unit="問" />
+              </div>
+              <div style={{ display: 'grid', gridTemplateColumns: 'minmax(0, 1.55fr) minmax(320px, 1fr)', gap: 20, alignItems: 'start' }}>
+                <div className="flex flex-col gap-5">
+                  <BookshelfSection groupId={groupId} projects={projects} />
+                  <MissedWordsSection
+                    groupId={groupId}
+                    missedWords={missedWords}
+                    totalCount={missedWordsTotalCount}
+                  />
+                </div>
+                <LeaderboardSection leaderboard={leaderboard} />
+              </div>
+            </>
+          ))}
+        </div>
+      </div>
+
+      {/* Mobile */}
+      <div
+        className="relative mx-auto min-h-screen w-full max-w-[560px] bg-[var(--color-background)] font-[var(--font-body)] lg:hidden"
+        style={{
+          // The <body> already pads by env(safe-area-inset-top) (globals.css), so
+          // the header sits just below the notch with no extra gap. Adding more
+          // padding here would double-count the inset and leave a dead band.
+          paddingTop: 0,
+          paddingBottom: 'max(2rem, env(safe-area-inset-bottom))',
+        }}
+      >
+        {stateView ?? (group && (
+          <div className="flex flex-col gap-4 px-[14px]">
+            <GroupHeader
+              group={group}
+              totalQuiz={totalQuiz}
+              onCopyInvite={() => void copyInvite()}
+              onShare={() => { triggerHaptic(); setInviteShareOpen(true); }}
+              settingsHref={settingsHref}
+            />
+            <BookshelfSection groupId={groupId} projects={projects} />
+            <LeaderboardSection leaderboard={leaderboard} />
+            <MissedWordsSection
+              groupId={groupId}
+              missedWords={missedWords}
+              totalCount={missedWordsTotalCount}
+            />
+          </div>
+        ))}
+      </div>
 
       {group && (
         <GroupInviteShareSheet
@@ -148,6 +203,37 @@ export default function GroupPage() {
           onClose={() => setInviteShareOpen(false)}
         />
       )}
+    </>
+  );
+}
+
+function DesktopGroupStat({ icon, label, value, unit }: { icon: string; label: string; value: number; unit: string }) {
+  return (
+    <div className="ds-card flat" style={{ padding: 16, display: 'flex', alignItems: 'center', gap: 12 }}>
+      <span
+        style={{
+          width: 38,
+          height: 38,
+          borderRadius: 10,
+          border: '2px solid var(--solid-ink)',
+          background: 'var(--color-surface-secondary)',
+          display: 'inline-flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          flexShrink: 0,
+        }}
+      >
+        <Icon name={icon} size={18} />
+      </span>
+      <div style={{ minWidth: 0 }}>
+        <div className="mono muted" style={{ fontSize: 10, fontWeight: 700, textTransform: 'uppercase', letterSpacing: '0.06em' }}>
+          {label}
+        </div>
+        <div style={{ fontFamily: 'var(--font-display)', fontWeight: 800, fontSize: 20, lineHeight: 1.2 }}>
+          {value}
+          <span style={{ fontSize: 12, color: 'var(--color-secondary-text)', fontWeight: 700 }}> {unit}</span>
+        </div>
+      </div>
     </div>
   );
 }

--- a/src/app/groups/[groupId]/settings/page.tsx
+++ b/src/app/groups/[groupId]/settings/page.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useState } from 'react';
 import Link from 'next/link';
 import { useParams, useRouter } from 'next/navigation';
+import { DesktopButton } from '@/components/desktop/DesktopChrome';
 import { Icon } from '@/components/ui';
 import { useAuth } from '@/hooks/use-auth';
 import { useToast } from '@/components/ui/toast';
@@ -200,48 +201,24 @@ export default function GroupSettingsPage() {
 
   const backHref = `/groups/${encodeURIComponent(groupId)}`;
 
-  return (
-    <div
-      className="relative mx-auto min-h-screen w-full max-w-[560px] bg-[var(--color-background)] font-[var(--font-body)]"
-      style={{
-        // The <body> already pads by env(safe-area-inset-top) (globals.css), so
-        // the header sits just below the notch with no extra gap. Adding more
-        // padding here would double-count the inset and leave a dead band.
-        paddingTop: 0,
-        paddingBottom: 'max(2rem, env(safe-area-inset-bottom))',
-      }}
-    >
-      <header className="flex items-center gap-2.5 px-[14px] pb-1 pt-2">
-        <Link
-          href={backHref}
-          aria-label="グループに戻る"
-          onClick={() => triggerHaptic()}
-          className="inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-full border-2 border-[var(--solid-ink)] bg-white text-[var(--solid-ink)] transition-all duration-100 active:translate-x-px active:translate-y-px"
-        >
-          <Icon name="arrow_back" size={16} />
-        </Link>
-        <div className="min-w-0">
-          <div className="font-mono text-[10px] font-bold uppercase tracking-[0.08em] text-[var(--color-muted)]">GROUP SETTINGS</div>
-          <h1 className="truncate font-display text-[18px] font-extrabold text-[var(--solid-ink)]">グループ設定</h1>
-        </div>
-      </header>
+  const stateView = authLoading || loading ? (
+    <LoadingState />
+  ) : !isAuthenticated ? (
+    <CenteredCard icon="lock" title="ログインが必要です">
+      <Link href="/login?redirect=/shared" className="mt-4 inline-flex rounded-[10px] border-2 border-[var(--solid-ink)] bg-[var(--solid-ink)] px-5 py-3 font-display text-sm font-bold text-white">
+        ログイン
+      </Link>
+    </CenteredCard>
+  ) : error || !group ? (
+    <CenteredCard icon="error" title={error ?? 'グループが見つかりません'}>
+      <button type="button" onClick={() => void load()} className="mt-4 inline-flex rounded-[10px] border-2 border-[var(--solid-ink)] bg-white px-5 py-3 font-display text-sm font-bold text-[var(--solid-ink)]">
+        再読み込み
+      </button>
+    </CenteredCard>
+  ) : null;
 
-      {authLoading || loading ? (
-        <LoadingState />
-      ) : !isAuthenticated ? (
-        <CenteredCard icon="lock" title="ログインが必要です">
-          <Link href="/login?redirect=/shared" className="mt-4 inline-flex rounded-[10px] border-2 border-[var(--solid-ink)] bg-[var(--solid-ink)] px-5 py-3 font-display text-sm font-bold text-white">
-            ログイン
-          </Link>
-        </CenteredCard>
-      ) : error || !group ? (
-        <CenteredCard icon="error" title={error ?? 'グループが見つかりません'}>
-          <button type="button" onClick={() => void load()} className="mt-4 inline-flex rounded-[10px] border-2 border-[var(--solid-ink)] bg-white px-5 py-3 font-display text-sm font-bold text-[var(--solid-ink)]">
-            再読み込み
-          </button>
-        </CenteredCard>
-      ) : (
-        <div className="flex flex-col gap-4 px-[14px] pt-3">
+  const sections = group ? (
+    <div className="flex flex-col gap-4">
           {/* Group name */}
           <SectionCard icon="badge" title="グループ名" accent="#137FEC">
             {isOwner ? (
@@ -433,14 +410,69 @@ export default function GroupSettingsPage() {
             </SectionCard>
           )}
 
-          {!isOwner && (
-            <p className="px-1 pb-2 text-[11px] font-bold leading-relaxed text-[var(--color-muted)]">
-              グループ名の変更・メンバーや単語帳の削除はオーナーのみ可能です。
-            </p>
-          )}
-        </div>
+      {!isOwner && (
+        <p className="px-1 pb-2 text-[11px] font-bold leading-relaxed text-[var(--color-muted)]">
+          グループ名の変更・メンバーや単語帳の削除はオーナーのみ可能です。
+        </p>
       )}
     </div>
+  ) : null;
+
+  return (
+    <>
+      {/* Desktop */}
+      <div className="hidden h-full min-h-0 flex-col lg:flex">
+        <div className="ds-top">
+          <div style={{ flex: 1, minWidth: 0 }}>
+            <div className="crumb">
+              {group ? `共有ライブラリ / ${group.name}` : '共有ライブラリ / グループ'}
+            </div>
+            <h1>グループ設定</h1>
+          </div>
+          <DesktopButton href={backHref} icon="arrow_back" variant="ghost">
+            グループへ戻る
+          </DesktopButton>
+        </div>
+        <div className="ds-scroll">
+          <div style={{ maxWidth: 720 }}>
+            {stateView ?? sections}
+          </div>
+        </div>
+      </div>
+
+      {/* Mobile */}
+      <div
+        className="relative mx-auto min-h-screen w-full max-w-[560px] bg-[var(--color-background)] font-[var(--font-body)] lg:hidden"
+        style={{
+          // The <body> already pads by env(safe-area-inset-top) (globals.css), so
+          // the header sits just below the notch with no extra gap. Adding more
+          // padding here would double-count the inset and leave a dead band.
+          paddingTop: 0,
+          paddingBottom: 'max(2rem, env(safe-area-inset-bottom))',
+        }}
+      >
+        <header className="flex items-center gap-2.5 px-[14px] pb-1 pt-2">
+          <Link
+            href={backHref}
+            aria-label="グループに戻る"
+            onClick={() => triggerHaptic()}
+            className="inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-full border-2 border-[var(--solid-ink)] bg-white text-[var(--solid-ink)] transition-all duration-100 active:translate-x-px active:translate-y-px"
+          >
+            <Icon name="arrow_back" size={16} />
+          </Link>
+          <div className="min-w-0">
+            <div className="font-mono text-[10px] font-bold uppercase tracking-[0.08em] text-[var(--color-muted)]">GROUP SETTINGS</div>
+            <h1 className="truncate font-display text-[18px] font-extrabold text-[var(--solid-ink)]">グループ設定</h1>
+          </div>
+        </header>
+
+        {stateView ?? (
+          <div className="px-[14px] pt-3">
+            {sections}
+          </div>
+        )}
+      </div>
+    </>
   );
 }
 

--- a/src/app/groups/[groupId]/struggling/GroupStrugglingClient.tsx
+++ b/src/app/groups/[groupId]/struggling/GroupStrugglingClient.tsx
@@ -1,8 +1,9 @@
 'use client';
 
-import { useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import Link from 'next/link';
 import { useParams } from 'next/navigation';
+import { DesktopButton } from '@/components/desktop/DesktopChrome';
 import { Icon } from '@/components/ui';
 import type { StudyGroupStrugglingWord, StudyGroupSummary } from '@/lib/shared-projects/types';
 
@@ -33,92 +34,113 @@ export default function GroupStrugglingClient() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
-  useEffect(() => {
+  const load = useCallback(async () => {
     if (!groupId) return;
-
-    let cancelled = false;
     setLoading(true);
     setError(null);
-
-    fetch(`/api/shared-projects/groups/${encodeURIComponent(groupId)}/struggling-words?all=1`, { cache: 'no-store' })
-      .then(async (response) => {
-        const payload = await response.json().catch(() => null) as GroupStrugglingResponse | null;
-        if (!response.ok || !payload?.success) throw new Error(payload?.error || 'group_struggling_failed');
-        if (cancelled) return;
-        setGroup(payload.group ?? null);
-        setWords(payload.words ?? []);
-        setTotalCount(payload.totalCount ?? payload.words?.length ?? 0);
-      })
-      .catch((loadError) => {
-        if (cancelled) return;
-        console.error('Failed to load group struggling words:', loadError);
-        setError(loadError instanceof Error ? loadError.message : '苦戦中の単語を読み込めませんでした。');
-      })
-      .finally(() => {
-        if (!cancelled) setLoading(false);
-      });
-
-    return () => {
-      cancelled = true;
-    };
+    try {
+      const response = await fetch(`/api/shared-projects/groups/${encodeURIComponent(groupId)}/struggling-words?all=1`, { cache: 'no-store' });
+      const payload = await response.json().catch(() => null) as GroupStrugglingResponse | null;
+      if (!response.ok || !payload?.success) throw new Error(payload?.error || 'group_struggling_failed');
+      setGroup(payload.group ?? null);
+      setWords(payload.words ?? []);
+      setTotalCount(payload.totalCount ?? payload.words?.length ?? 0);
+    } catch (loadError) {
+      console.error('Failed to load group struggling words:', loadError);
+      setError(loadError instanceof Error ? loadError.message : '苦戦中の単語を読み込めませんでした。');
+    } finally {
+      setLoading(false);
+    }
   }, [groupId]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
 
   const lowestMissCount = useMemo(
     () => words.length > 0 ? words[words.length - 1]!.wrongCount : 0,
     [words],
   );
 
+  const listCard = (
+    <section className="rounded-[14px] border-2 border-[var(--solid-ink)] bg-white p-4 shadow-[4px_4px_0_var(--solid-ink)]">
+      {loading ? (
+        <div className="flex items-center justify-center gap-2 py-10 text-sm font-bold text-[var(--color-muted)]">
+          <Icon name="progress_activity" className="animate-spin" size={18} />
+          読み込み中...
+        </div>
+      ) : error ? (
+        <div className="py-8 text-center text-sm font-bold text-[var(--color-error)]">{error}</div>
+      ) : words.length === 0 ? (
+        <div className="py-8 text-center text-sm font-bold text-[var(--color-muted)]">2人以上が間違えた単語がまだありません</div>
+      ) : (
+        <div className="divide-y divide-[var(--color-border)]">
+          {words.map((word, index) => (
+            <div key={word.key} className="grid grid-cols-[42px_minmax(0,1fr)_auto] items-center gap-3 py-3">
+              <div className="font-mono text-xs font-black text-[var(--color-muted)]">#{index + 1}</div>
+              <div className="min-w-0">
+                <div className="truncate text-base font-black">{word.english}</div>
+                <div className="mt-0.5 truncate text-xs font-bold text-[var(--color-muted)]">{word.japanese}</div>
+              </div>
+              <div className="flex flex-col items-end gap-1">
+                <span className="rounded-[9px] border-2 border-[var(--solid-ink)] bg-[var(--color-error)] px-2 py-1 text-xs font-black text-white">
+                  {word.wrongCount}回
+                </span>
+                <span className="text-[11px] font-bold text-[var(--color-muted)]">
+                  {word.learnerCount}人・{formatDate(word.lastWrongAt)}
+                </span>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </section>
+  );
+
+  const summaryLabel = `間違い回数が多い順に全${totalCount}件を表示${lowestMissCount > 0 ? `・最低${lowestMissCount}回まで` : ''}`;
+
   return (
-    <main className="min-h-screen bg-[var(--color-background)] pb-24 pt-5 text-[var(--solid-ink)]">
-      <div className="mx-auto flex w-full max-w-4xl flex-col gap-5 px-4">
-        <Link href={`/groups/${encodeURIComponent(groupId)}`} className="inline-flex w-fit items-center gap-1 text-[13px] font-bold text-[var(--color-accent)]">
-          <Icon name="arrow_back" size={15} />
-          グループへ戻る
-        </Link>
-
-        <section className="rounded-[14px] border-2 border-[var(--solid-ink)] bg-white p-4 shadow-[4px_4px_0_var(--solid-ink)]">
-          <div className="flex flex-col gap-1">
-            <div className="text-xs font-black text-[var(--color-muted)]">みんなが苦戦中の単語</div>
-            <h1 className="font-display text-2xl font-black">{group?.name ?? 'グループ'}</h1>
-            <p className="text-xs font-bold text-[var(--color-muted)]">
-              間違い回数が多い順に全{totalCount}件を表示{lowestMissCount > 0 ? `・最低${lowestMissCount}回まで` : ''}
-            </p>
+    <>
+      {/* Desktop */}
+      <div className="hidden h-full min-h-0 flex-col lg:flex">
+        <div className="ds-top">
+          <div style={{ flex: 1, minWidth: 0 }}>
+            <div className="crumb">
+              {group ? `共有ライブラリ / ${group.name}` : '共有ライブラリ / グループ'}
+            </div>
+            <h1>みんなが苦戦中の単語</h1>
           </div>
-        </section>
-
-        <section className="rounded-[14px] border-2 border-[var(--solid-ink)] bg-white p-4 shadow-[4px_4px_0_var(--solid-ink)]">
-          {loading ? (
-            <div className="flex items-center justify-center gap-2 py-10 text-sm font-bold text-[var(--color-muted)]">
-              <Icon name="progress_activity" className="animate-spin" size={18} />
-              読み込み中...
-            </div>
-          ) : error ? (
-            <div className="py-8 text-center text-sm font-bold text-[var(--color-error)]">{error}</div>
-          ) : words.length === 0 ? (
-            <div className="py-8 text-center text-sm font-bold text-[var(--color-muted)]">2人以上が間違えた単語がまだありません</div>
-          ) : (
-            <div className="divide-y divide-[var(--color-border)]">
-              {words.map((word, index) => (
-                <div key={word.key} className="grid grid-cols-[42px_minmax(0,1fr)_auto] items-center gap-3 py-3">
-                  <div className="font-mono text-xs font-black text-[var(--color-muted)]">#{index + 1}</div>
-                  <div className="min-w-0">
-                    <div className="truncate text-base font-black">{word.english}</div>
-                    <div className="mt-0.5 truncate text-xs font-bold text-[var(--color-muted)]">{word.japanese}</div>
-                  </div>
-                  <div className="flex flex-col items-end gap-1">
-                    <span className="rounded-[9px] border-2 border-[var(--solid-ink)] bg-[var(--color-error)] px-2 py-1 text-xs font-black text-white">
-                      {word.wrongCount}回
-                    </span>
-                    <span className="text-[11px] font-bold text-[var(--color-muted)]">
-                      {word.learnerCount}人・{formatDate(word.lastWrongAt)}
-                    </span>
-                  </div>
-                </div>
-              ))}
-            </div>
-          )}
-        </section>
+          <DesktopButton href={`/groups/${encodeURIComponent(groupId)}`} icon="arrow_back" variant="ghost">
+            グループへ戻る
+          </DesktopButton>
+        </div>
+        <div className="ds-scroll">
+          <div style={{ maxWidth: 860 }}>
+            <div className="muted" style={{ fontSize: 13, marginBottom: 14 }}>{summaryLabel}</div>
+            {listCard}
+          </div>
+        </div>
       </div>
-    </main>
+
+      {/* Mobile */}
+      <main className="min-h-screen bg-[var(--color-background)] pb-24 pt-5 text-[var(--solid-ink)] lg:hidden">
+        <div className="mx-auto flex w-full max-w-4xl flex-col gap-5 px-4">
+          <Link href={`/groups/${encodeURIComponent(groupId)}`} className="inline-flex w-fit items-center gap-1 text-[13px] font-bold text-[var(--color-accent)]">
+            <Icon name="arrow_back" size={15} />
+            グループへ戻る
+          </Link>
+
+          <section className="rounded-[14px] border-2 border-[var(--solid-ink)] bg-white p-4 shadow-[4px_4px_0_var(--solid-ink)]">
+            <div className="flex flex-col gap-1">
+              <div className="text-xs font-black text-[var(--color-muted)]">みんなが苦戦中の単語</div>
+              <h1 className="font-display text-2xl font-black">{group?.name ?? 'グループ'}</h1>
+              <p className="text-xs font-bold text-[var(--color-muted)]">{summaryLabel}</p>
+            </div>
+          </section>
+
+          {listCard}
+        </div>
+      </main>
+    </>
   );
 }

--- a/src/app/shared/SharedPageClient.tsx
+++ b/src/app/shared/SharedPageClient.tsx
@@ -125,7 +125,7 @@ function isDiscoverPayload(payload: DiscoverResponse | null): payload is SharedD
 
 export default function SharedPageClient({ initialDiscover }: SharedPageClientProps) {
   const router = useRouter();
-  const { user } = useAuth();
+  const { user, isAuthenticated, loading: authLoading } = useAuth();
   const { showToast } = useToast();
 
   const [category, setCategory] = useState<SharedDiscoverCategory | 'groups'>('all');
@@ -137,6 +137,7 @@ export default function SharedPageClient({ initialDiscover }: SharedPageClientPr
   const [groupResults, setGroupResults] = useState<PublicStudyGroupSummary[]>([]);
   const [groupLoading, setGroupLoading] = useState(false);
   const [groupError, setGroupError] = useState<string | null>(null);
+  const [myGroups, setMyGroups] = useState<StudyGroupSummary[]>([]);
 
   const [userQuery, setUserQuery] = useState('');
   const [userResults, setUserResults] = useState<FollowSearchResult[]>([]);
@@ -149,6 +150,30 @@ export default function SharedPageClient({ initialDiscover }: SharedPageClientPr
 
   const [chooserOpen, setChooserOpen] = useState(false);
   const [selectedGenre, setSelectedGenre] = useState<WordbookGenre | null>(null);
+
+  // Joined groups feed both the mobile 参加中のグループ section and the desktop
+  // view (which also uses them to hide already-joined groups from search).
+  useEffect(() => {
+    if (authLoading || !isAuthenticated) {
+      setMyGroups([]);
+      return;
+    }
+
+    let cancelled = false;
+    fetch('/api/shared-projects/groups', { cache: 'no-store' })
+      .then(async (response) => {
+        const payload = await response.json().catch(() => null) as MyGroupsApiResponse | null;
+        if (!response.ok || !payload?.success) throw new Error(payload?.error || 'my_groups_failed');
+        if (!cancelled) setMyGroups(payload.groups ?? []);
+      })
+      .catch((error) => {
+        if (!cancelled) console.warn('Failed to load joined groups:', error);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [authLoading, isAuthenticated]);
 
   useEffect(() => {
     if (category === 'groups') return;
@@ -279,12 +304,19 @@ export default function SharedPageClient({ initialDiscover }: SharedPageClientPr
   return (
     <>
       <DesktopSharedView
-        category={category === 'groups' ? 'all' : category}
+        category={category}
         query={query}
         payload={discover}
         loading={loading}
         loadingMore={loadingMore}
         error={error}
+        joinedGroups={myGroups}
+        groupQuery={groupQuery}
+        groupResults={groupResults}
+        groupLoading={groupLoading}
+        groupError={groupError}
+        onGroupQueryChange={setGroupQuery}
+        onGroupSearch={() => void handleGroupSearch()}
         onQueryChange={setQuery}
         onCategorySelect={handleSelectCategory}
         onBackToAll={handleBackToAll}
@@ -357,7 +389,7 @@ export default function SharedPageClient({ initialDiscover }: SharedPageClientPr
           </div>
         )}
 
-        {category === 'all' && <JoinedGroupsSection />}
+        {category === 'all' && <JoinedGroupsSection groups={myGroups} />}
 
         {category === 'groups' ? (
           <GroupSearchSection
@@ -365,6 +397,7 @@ export default function SharedPageClient({ initialDiscover }: SharedPageClientPr
             groupResults={groupResults}
             groupLoading={groupLoading}
             groupError={groupError}
+            joinedGroups={myGroups}
             onQueryChange={setGroupQuery}
             onSearch={() => void handleGroupSearch()}
           />
@@ -1035,30 +1068,8 @@ function UserSearchSection({
   );
 }
 
-function JoinedGroupsSection() {
-  const { isAuthenticated, loading: authLoading } = useAuth();
-  const [groups, setGroups] = useState<StudyGroupSummary[]>([]);
-
-  useEffect(() => {
-    if (authLoading || !isAuthenticated) return;
-
-    let cancelled = false;
-    fetch('/api/shared-projects/groups', { cache: 'no-store' })
-      .then(async (response) => {
-        const payload = await response.json().catch(() => null) as MyGroupsApiResponse | null;
-        if (!response.ok || !payload?.success) throw new Error(payload?.error || 'my_groups_failed');
-        if (!cancelled) setGroups(payload.groups ?? []);
-      })
-      .catch((error) => {
-        if (!cancelled) console.warn('Failed to load joined groups:', error);
-      });
-
-    return () => {
-      cancelled = true;
-    };
-  }, [authLoading, isAuthenticated]);
-
-  if (!isAuthenticated || groups.length === 0) return null;
+function JoinedGroupsSection({ groups }: { groups: StudyGroupSummary[] }) {
+  if (groups.length === 0) return null;
 
   return (
     <div className="px-[14px] pb-1 pt-3">
@@ -1127,6 +1138,7 @@ function GroupSearchSection({
   groupResults,
   groupLoading,
   groupError,
+  joinedGroups,
   onQueryChange,
   onSearch,
 }: {
@@ -1134,11 +1146,10 @@ function GroupSearchSection({
   groupResults: PublicStudyGroupSummary[];
   groupLoading: boolean;
   groupError: string | null;
+  joinedGroups: StudyGroupSummary[];
   onQueryChange: (value: string) => void;
   onSearch: () => void;
 }) {
-  const { isAuthenticated, loading: authLoading } = useAuth();
-  const [joinedIds, setJoinedIds] = useState<Set<string>>(new Set());
   const searchedInitiallyRef = useRef(false);
 
   useEffect(() => {
@@ -1147,27 +1158,9 @@ function GroupSearchSection({
     onSearch();
   }, [onSearch]);
 
-  useEffect(() => {
-    if (authLoading || !isAuthenticated) return;
-
-    let cancelled = false;
-    fetch('/api/shared-projects/groups', { cache: 'no-store' })
-      .then(async (response) => {
-        const payload = await response.json().catch(() => null) as MyGroupsApiResponse | null;
-        if (!response.ok || !payload?.success) throw new Error(payload?.error || 'my_groups_failed');
-        if (!cancelled) setJoinedIds(new Set((payload.groups ?? []).map((group) => group.id)));
-      })
-      .catch((error) => {
-        if (!cancelled) console.warn('Failed to load joined groups for search filtering:', error);
-      });
-
-    return () => {
-      cancelled = true;
-    };
-  }, [authLoading, isAuthenticated]);
-
   // Hide groups the viewer already belongs to — those live in the
   // "参加中のグループ" section and don't need a join entry point here.
+  const joinedIds = new Set(joinedGroups.map((group) => group.id));
   const visibleGroups = groupResults.filter((group) => !joinedIds.has(group.id));
 
   return (

--- a/src/components/desktop/DesktopChrome.tsx
+++ b/src/components/desktop/DesktopChrome.tsx
@@ -27,7 +27,7 @@ function activeKeyForPath(pathname: string): NavKey {
   if (pathname === '/stats') return 'stats';
   if (pathname === '/reels') return 'reels';
   if (pathname === '/friends') return 'friends';
-  if (pathname === '/shared' || pathname.startsWith('/share/')) return 'shared';
+  if (pathname === '/shared' || pathname.startsWith('/share/') || pathname.startsWith('/groups/')) return 'shared';
   if (pathname === '/favorites' || pathname.startsWith('/collections')) return 'fav';
   if (pathname.startsWith('/scan')) return 'scan';
   if (pathname === '/settings' || pathname.startsWith('/subscription')) return 'settings';

--- a/src/components/desktop/DesktopShared.tsx
+++ b/src/components/desktop/DesktopShared.tsx
@@ -9,15 +9,20 @@ import { desktopThumbColor } from '@/components/desktop/desktop-data';
 import { Icon } from '@/components/ui/Icon';
 import { formatSharedTag } from '../../../shared/shared-tags';
 import type {
+  PublicStudyGroupSummary,
   SharedDiscoverCategory,
   SharedDiscoverPayload,
   SharedProjectCard,
   SharedUserSummary,
+  StudyGroupSummary,
 } from '@/lib/shared-projects/types';
 
-const CATEGORY_META: Record<Exclude<SharedDiscoverCategory, 'all'>, { label: string; icon: string; description: string }> = {
+type DesktopSharedCategory = Exclude<SharedDiscoverCategory, 'all'> | 'groups';
+
+const CATEGORY_META: Record<DesktopSharedCategory, { label: string; icon: string; description: string }> = {
   users: { label: 'ユーザー', icon: 'person', description: '学習者アカウント' },
   projects: { label: '単語帳', icon: 'menu_book', description: 'みんなが公開している単語帳' },
+  groups: { label: 'グループ検索', icon: 'groups', description: '公開グループを探して参加' },
 };
 
 export function DesktopSharedView({
@@ -27,6 +32,13 @@ export function DesktopSharedView({
   loading,
   loadingMore,
   error,
+  joinedGroups,
+  groupQuery,
+  groupResults,
+  groupLoading,
+  groupError,
+  onGroupQueryChange,
+  onGroupSearch,
   onQueryChange,
   onCategorySelect,
   onBackToAll,
@@ -34,23 +46,31 @@ export function DesktopSharedView({
   onOpenShareSheet,
   onProjectMissing,
 }: {
-  category: SharedDiscoverCategory;
+  category: SharedDiscoverCategory | 'groups';
   query: string;
   payload: SharedDiscoverPayload;
   loading: boolean;
   loadingMore: boolean;
   error: string | null;
+  joinedGroups: StudyGroupSummary[];
+  groupQuery: string;
+  groupResults: PublicStudyGroupSummary[];
+  groupLoading: boolean;
+  groupError: string | null;
+  onGroupQueryChange: (value: string) => void;
+  onGroupSearch: () => void;
   onQueryChange: (value: string) => void;
-  onCategorySelect: (category: Exclude<SharedDiscoverCategory, 'all'>) => void;
+  onCategorySelect: (category: DesktopSharedCategory) => void;
   onBackToAll: () => void;
   onLoadMore: () => void;
   onOpenShareSheet: () => void;
   onProjectMissing: (projectId: string) => void;
 }) {
   const isCategory = category !== 'all';
+  const isGroups = category === 'groups';
   const activeMeta = isCategory ? CATEGORY_META[category] : null;
   const hasQuery = query.trim().length > 0;
-  const shouldShowResults = isCategory || hasQuery || loading || Boolean(error);
+  const shouldShowResults = !isGroups && (isCategory || hasQuery || loading || Boolean(error));
 
   return (
     <div className="hidden h-full min-h-0 flex-col lg:flex">
@@ -66,12 +86,29 @@ export function DesktopSharedView({
           <div className="crumb">{isCategory ? `共有ライブラリ / ${activeMeta!.label}` : 'コレクション / 探す'}</div>
           <h1>{isCategory ? activeMeta!.label : '共有ライブラリ'}</h1>
         </div>
-        <DesktopSearchBox
-          placeholder={isCategory ? `${activeMeta!.label}を検索` : 'ユーザー・単語帳を検索'}
-          value={query}
-          onChange={(event) => onQueryChange(event.target.value)}
-          style={{ width: '100%', minWidth: 0 }}
-        />
+        {isGroups ? (
+          <form
+            onSubmit={(event) => { event.preventDefault(); onGroupSearch(); }}
+            style={{ display: 'flex', gap: 8, minWidth: 0 }}
+          >
+            <DesktopSearchBox
+              placeholder="グループ名で検索"
+              value={groupQuery}
+              onChange={(event) => onGroupQueryChange(event.target.value)}
+              style={{ width: '100%', minWidth: 0 }}
+            />
+            <button type="submit" className="ds-btn dark" disabled={groupLoading} aria-label="グループを検索">
+              <Icon name={groupLoading ? 'progress_activity' : 'arrow_forward'} className={groupLoading ? 'animate-spin' : undefined} />
+            </button>
+          </form>
+        ) : (
+          <DesktopSearchBox
+            placeholder={isCategory ? `${activeMeta!.label}を検索` : 'ユーザー・単語帳を検索'}
+            value={query}
+            onChange={(event) => onQueryChange(event.target.value)}
+            style={{ width: '100%', minWidth: 0 }}
+          />
+        )}
         <div style={{ justifySelf: 'end', display: 'flex', alignItems: 'center', gap: 8 }}>
           <FollowNotificationsButton variant="desktop" />
           <DesktopButton variant="dark" icon="add" onClick={onOpenShareSheet}>
@@ -92,8 +129,8 @@ export function DesktopSharedView({
             </div>
           </div>
         ) : (
-          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(2, minmax(0, 1fr))', gap: 16, marginBottom: 24 }}>
-            {(Object.keys(CATEGORY_META) as Array<Exclude<SharedDiscoverCategory, 'all'>>).map((key) => (
+          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3, minmax(0, 1fr))', gap: 16, marginBottom: 24 }}>
+            {(Object.keys(CATEGORY_META) as DesktopSharedCategory[]).map((key) => (
               <button
                 key={key}
                 type="button"
@@ -128,6 +165,19 @@ export function DesktopSharedView({
           </div>
         )}
 
+        {category === 'all' && !hasQuery && !loading && (
+          <JoinedGroupGrid groups={joinedGroups} />
+        )}
+
+        {isGroups && (
+          <GroupSearchResults
+            joinedGroups={joinedGroups}
+            groupResults={groupResults}
+            groupLoading={groupLoading}
+            groupError={groupError}
+          />
+        )}
+
         {shouldShowResults && (
           <>
             {error && (
@@ -158,6 +208,123 @@ export function DesktopSharedView({
           </>
         )}
       </div>
+    </div>
+  );
+}
+
+// Joined study groups shown on the discover top view — the desktop entry
+// point into each group's page (mirrors the mobile 参加中のグループ section).
+function JoinedGroupGrid({ groups }: { groups: StudyGroupSummary[] }) {
+  if (groups.length === 0) return null;
+  return (
+    <section style={{ marginBottom: 26 }}>
+      <SectionTitle count={groups.length}>参加中のグループ</SectionTitle>
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3, minmax(0, 1fr))', gap: 16 }}>
+        {groups.map((group) => (
+          <Link
+            key={group.id}
+            href={`/groups/${encodeURIComponent(group.id)}`}
+            className="ds-card"
+            style={{ padding: 18, display: 'flex', alignItems: 'center', gap: 14, color: 'inherit', textDecoration: 'none' }}
+          >
+            <div
+              className="ds-project-icon ds-project-icon--lg"
+              style={{ background: desktopThumbColor(group.id) }}
+            >
+              {group.name.charAt(0)}
+            </div>
+            <div style={{ flex: 1, minWidth: 0 }}>
+              <div style={{ display: 'flex', alignItems: 'center', gap: 6, minWidth: 0 }}>
+                <span style={{ fontFamily: 'var(--font-display)', fontWeight: 700, fontSize: 15, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                  {group.name}
+                </span>
+                {group.role === 'owner' && <span className="ds-tag plain">owner</span>}
+              </div>
+              <div className="muted" style={{ marginTop: 4, fontSize: 12, display: 'flex', alignItems: 'center', gap: 10 }}>
+                <span style={{ display: 'inline-flex', alignItems: 'center', gap: 3 }}>
+                  <Icon name="group" style={{ fontSize: 14 }} />{group.memberCount}人
+                </span>
+                <span style={{ display: 'inline-flex', alignItems: 'center', gap: 3 }}>
+                  <Icon name="menu_book" style={{ fontSize: 14 }} />{group.projectCount}冊
+                </span>
+              </div>
+            </div>
+            <Icon name="chevron_right" style={{ fontSize: 20, color: 'var(--color-muted)', flexShrink: 0 }} />
+          </Link>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function GroupSearchResults({
+  joinedGroups,
+  groupResults,
+  groupLoading,
+  groupError,
+}: {
+  joinedGroups: StudyGroupSummary[];
+  groupResults: PublicStudyGroupSummary[];
+  groupLoading: boolean;
+  groupError: string | null;
+}) {
+  // Groups the viewer already belongs to live in 参加中のグループ — no join entry needed.
+  const joinedIds = new Set(joinedGroups.map((group) => group.id));
+  const visibleGroups = groupResults.filter((group) => !joinedIds.has(group.id));
+
+  if (groupError) {
+    return (
+      <div className="ds-card" style={{ padding: 14, color: 'var(--color-error)', borderColor: 'var(--color-error)' }}>
+        {groupError}
+      </div>
+    );
+  }
+  if (groupLoading && visibleGroups.length === 0) {
+    return (
+      <div className="ds-card" style={{ padding: 34, color: 'var(--color-muted)', display: 'flex', gap: 8, alignItems: 'center' }}>
+        <Icon name="progress_activity" className="animate-spin" />
+        検索中...
+      </div>
+    );
+  }
+  if (visibleGroups.length === 0) {
+    return <EmptyCard label="グループがありません" />;
+  }
+
+  return (
+    <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3, minmax(0, 1fr))', gap: 16 }}>
+      {visibleGroups.map((group) => (
+        <Link
+          key={group.id}
+          href={`/groups/${encodeURIComponent(group.id)}/join`}
+          className="ds-card"
+          style={{ padding: 18, display: 'flex', alignItems: 'center', gap: 14, color: 'inherit', textDecoration: 'none' }}
+        >
+          <div
+            className="ds-project-icon ds-project-icon--lg"
+            style={{ background: desktopThumbColor(group.id) }}
+          >
+            {group.name.charAt(0)}
+          </div>
+          <div style={{ flex: 1, minWidth: 0 }}>
+            <div style={{ fontFamily: 'var(--font-display)', fontWeight: 700, fontSize: 15, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+              {group.name}
+            </div>
+            <div className="muted" style={{ marginTop: 4, fontSize: 12, display: 'flex', alignItems: 'center', gap: 10, minWidth: 0 }}>
+              <span style={{ display: 'inline-flex', alignItems: 'center', gap: 3 }}>
+                <Icon name="group" style={{ fontSize: 14 }} />{group.memberCount}人
+              </span>
+              <span style={{ display: 'inline-flex', alignItems: 'center', gap: 3 }}>
+                <Icon name="menu_book" style={{ fontSize: 14 }} />{group.projectCount}冊
+              </span>
+              {group.ownerUsername && (
+                <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>@{group.ownerUsername}</span>
+              )}
+            </div>
+          </div>
+          <Icon name="chevron_right" style={{ fontSize: 20, color: 'var(--color-muted)', flexShrink: 0 }} />
+        </Link>
+      ))}
     </div>
   );
 }


### PR DESCRIPTION
## 概要

グループ機能はこれまでモバイル専用レイアウトのみで、デスクトップ(lg以上)では導線が存在せず、ページ自体も `ds-live-main`(`overflow: hidden`)内でスクロール不能でした。本PRでデスクトップ版の導線とページ一式を追加します。

## 導線

- **共有ライブラリ(`/shared`)のデスクトップビュー**
  - トップ画面に「参加中のグループ」セクションを追加(カードクリックでグループページへ)
  - カテゴリタイルに「グループ検索」を追加(公開グループの検索と参加導線、参加済みグループは非表示)
  - グループ検索カテゴリ選択時はトップバーの検索ボックスがグループ名検索に切り替わる
- **サイドバー**: `/groups` 配下のページで「共有ライブラリ」がアクティブ表示されるように修正

## ページ(デスクトップレイアウト)

各ページに `ds-top`(パンくず+タイトル+アクション)+ `ds-scroll` のデスクトップツリーを追加し、既存のモバイルツリーは `lg:hidden` で維持:

| ページ | デスクトップ構成 |
|---|---|
| `/groups/[id]` | 統計タイル(メンバー/単語帳/今週の解答)+ 2カラムグリッド(本棚・苦戦中単語 / 週間ランキング)。トップバーに招待コードコピー・シェア・設定 |
| `/groups/[id]/bookshelf` | 本のグリッド(auto-fill)+ 単語帳共有ボタン |
| `/groups/[id]/settings` | 設定セクションを最大幅720pxのカラムで表示 |
| `/groups/[id]/join` | 参加カードをスクロール領域内に表示 |
| `/groups/[id]/struggling` | 苦戦中単語リストを最大幅860pxで表示 |

## リファクタリング

- 参加中グループの取得を `SharedPageClient` に集約し、モバイル(参加中セクション・検索フィルタ)とデスクトップで共用 — 同一APIへの重複フェッチを解消
- `GroupStrugglingClient` の effect 内同期 `setState` を兄弟ページと同じ `load` コールバックパターンに変更(リポジトリ唯一の既存 lint エラーを解消)

## 検証

- `npx tsc --noEmit` クリーン
- `npx eslint`(変更ファイル)クリーン(既存エラー1件も解消)
- `npm test`: 737 pass / 1 fail — 失敗は `words/create` の既存の失敗(mainでも再現、本変更と無関係)
- `npm run build` 成功
- dev サーバー + Playwright(1440×900)で `/shared`・グループ各ページのデスクトップ描画、グループ検索カテゴリのクリック動作、未ログイン状態カードの表示を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013up66SdsCeiF6L1VFX6DN9

---
_Generated by [Claude Code](https://claude.ai/code/session_013up66SdsCeiF6L1VFX6DN9)_