### PR TITLE
ホームに保存済み単語の導線を復活 & リールから単語を保存済みに追加

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -147,6 +147,7 @@ type HomeStats = {
   activeW: number;
   review: number;
   newW: number;
+  favoriteCount: number;
 };
 
 type HomeProjectStats = ProjectWithStats & {
@@ -217,6 +218,7 @@ function buildHomeStats(allWords: Word[]): HomeStats {
     activeW: statusCounts.activeTotal,
     review: statusCounts.learningTotal,
     newW: statusCounts.unlearnedTotal,
+    favoriteCount: allWords.filter((word) => word.isFavorite).length,
   };
 }
 
@@ -304,6 +306,7 @@ const EMPTY_STATS: HomeStats = {
   activeW: 0,
   review: 0,
   newW: 0,
+  favoriteCount: 0,
 };
 
 export default function HomePage() {
@@ -492,7 +495,7 @@ export default function HomePage() {
     }
   }, [pendingGeneratingWordbook?.linkedJobId, recentScanJobs]);
 
-  const { dueCount, completedToday, streakDays, totalWords, mastered, review, newW } = stats;
+  const { dueCount, completedToday, streakDays, totalWords, mastered, review, newW, favoriteCount } = stats;
   const unmasteredCount = newW + review;
   const goalTotal = dueCount + completedToday;
   const goalProgress = goalTotal > 0 ? Math.round((completedToday / goalTotal) * 100) : 0;
@@ -657,6 +660,33 @@ export default function HomePage() {
             </div>
           </div>
         </SolidPanel>
+      </div>
+
+      <div className="px-[18px] pb-3.5">
+        <Link href="/favorites" className="block">
+          <SolidPanel className="!rounded-2xl" faceClassName="!p-3">
+            <div className="flex items-center gap-2.5">
+              <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full border-2 border-[var(--solid-ink)] bg-[var(--color-accent)] text-white">
+                <Icon name="bookmark" size={17} filled />
+              </span>
+              <div className="min-w-0 flex-1">
+                <div className="font-mono text-[10px] font-semibold uppercase tracking-[0.02em] text-[var(--color-muted)]">
+                  SAVED WORDS
+                </div>
+                <div className="text-sm font-bold text-[var(--solid-ink)]">保存済み単語</div>
+              </div>
+              <div className="flex items-baseline gap-0.5">
+                <span className="font-display text-lg font-extrabold tabular-nums text-[var(--solid-ink)]">
+                  {favoriteCount}
+                </span>
+                <span className="text-[11px] font-bold text-[var(--color-muted)]">語</span>
+              </div>
+              <span className="inline-flex text-[var(--color-accent)]">
+                <Icon name="chevron_right" size={14} />
+              </span>
+            </div>
+          </SolidPanel>
+        </Link>
       </div>
 
       <div className="flex items-baseline justify-between px-5 pb-2.5 pt-3">

--- a/src/app/reels/page.tsx
+++ b/src/app/reels/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useMemo, useRef, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { useAuth } from '@/hooks';
 import { useReelFeed } from '@/hooks/use-reel-feed';
@@ -34,6 +34,9 @@ function normalizeVocabularyType(value: string | undefined): VocabularyType | un
   return value === 'active' || value === 'passive' ? value : undefined;
 }
 
+/** Wordbook that collects words saved one-by-one from the reel feed. */
+const REEL_SAVED_PROJECT_TITLE = 'リールで保存した単語';
+
 export default function ReelsPage() {
   const router = useRouter();
   const { user, subscription, loading: authLoading } = useAuth();
@@ -48,9 +51,11 @@ export default function ReelsPage() {
     retry,
     likeItem,
     markBookImported,
+    markWordSaved,
     bumpCommentCount,
   } = useReelFeed();
   const [importingBookId, setImportingBookId] = useState<string | null>(null);
+  const savingWordIdsRef = useRef<Set<string>>(new Set());
 
   const subscriptionStatus = subscription?.status || 'free';
   const wasPro = subscription?.plan === 'pro' && subscriptionStatus !== 'active';
@@ -137,6 +142,72 @@ export default function ReelsPage() {
       }
     },
     [user, wasPro, importingBookId, repository, router, showToast, markBookImported],
+  );
+
+  const handleSaveWord = useCallback(
+    async (item: ReelItem) => {
+      if (!user) {
+        router.push('/login?redirect=/reels');
+        return;
+      }
+      // Downgraded (ex-Pro) accounts get the read-only remote repository, so
+      // writes would fail — guide them back to Pro instead.
+      if (wasPro) {
+        showToast({ message: '解約後は読み取り専用のため、保存にはProプランへの再登録が必要です。', type: 'warning' });
+        router.push('/subscription');
+        return;
+      }
+      if (item.savedByMe || savingWordIdsRef.current.has(item.id)) return;
+
+      savingWordIdsRef.current.add(item.id);
+      try {
+        const projects = await repository.getProjects(user.id);
+        const savedProject =
+          projects.find((project) => project.title === REEL_SAVED_PROJECT_TITLE)
+          ?? (await repository.createProject({
+            userId: user.id,
+            title: REEL_SAVED_PROJECT_TITLE,
+          }));
+
+        const existingWords = await repository.getWords(savedProject.id);
+        const existing = existingWords.find(
+          (word) => word.english.toLowerCase() === item.english.toLowerCase(),
+        );
+        if (existing) {
+          if (!existing.isFavorite) {
+            await repository.updateWord(existing.id, { isFavorite: true });
+          }
+        } else {
+          const [created] = await repository.createWords([
+            {
+              projectId: savedProject.id,
+              english: item.english,
+              japanese: item.japanese,
+              translations: item.translations,
+              distractors: [],
+              pronunciation: item.pronunciation ?? undefined,
+              exampleSentence: item.exampleSentence ?? undefined,
+              exampleSentenceJa: item.exampleSentenceJa ?? undefined,
+              partOfSpeechTags: item.partOfSpeechTags.length > 0 ? item.partOfSpeechTags : undefined,
+            },
+          ]);
+          // createWords always starts words unfavorited; flip it so the word
+          // shows up in 保存済み (/favorites) right away.
+          await repository.updateWord(created.id, { isFavorite: true });
+        }
+
+        invalidateHomeCache();
+        markWordSaved(item.id);
+        triggerHaptic();
+        showToast({ message: `「${item.english}」を保存済みに追加しました`, type: 'success' });
+      } catch (error) {
+        console.error('Failed to save reel word:', error);
+        showToast({ message: '保存に失敗しました', type: 'error' });
+      } finally {
+        savingWordIdsRef.current.delete(item.id);
+      }
+    },
+    [user, wasPro, repository, router, showToast, markWordSaved],
   );
 
   const handleShare = useCallback(
@@ -257,6 +328,7 @@ export default function ReelsPage() {
               importingBookId={null}
               onLoadMore={() => {}}
               onLike={() => {}}
+              onSave={() => {}}
               onImport={() => {}}
               onShare={() => {}}
               onFeedback={() => {}}
@@ -277,6 +349,7 @@ export default function ReelsPage() {
                 triggerHaptic();
                 void likeItem(item);
               }}
+              onSave={(item) => void handleSaveWord(item)}
               onImport={(book) => void handleImport(book)}
               onShare={(item) => void handleShare(item)}
               onFeedback={(item, feedback) => void handleFeedback(item, feedback)}

--- a/src/components/reel/ReelActionRail.tsx
+++ b/src/components/reel/ReelActionRail.tsx
@@ -7,6 +7,7 @@ import type { ReelItem } from '@/lib/reels/types';
 type ReelActionRailProps = {
   item: ReelItem;
   onLike: () => void;
+  onSave: () => void;
   onSpeak: () => void;
   onComment: () => void;
   onShare: () => void;
@@ -18,6 +19,7 @@ function RailButton({
   filled,
   label,
   active,
+  activeVariant = 'like',
   onClick,
   ariaLabel,
 }: {
@@ -25,6 +27,7 @@ function RailButton({
   filled?: boolean;
   label?: string;
   active?: boolean;
+  activeVariant?: 'like' | 'save';
   onClick: () => void;
   ariaLabel: string;
 }) {
@@ -41,14 +44,20 @@ function RailButton({
       <span
         className={cn(
           'flex h-12 w-12 items-center justify-center rounded-full border-2 border-[var(--solid-ink)] bg-[var(--color-surface)] transition-transform duration-100 active:scale-90',
-          active && 'bg-[var(--color-error-light)]',
+          active && (activeVariant === 'save' ? 'bg-[var(--color-accent-light)]' : 'bg-[var(--color-error-light)]'),
         )}
       >
         <Icon
           name={icon}
           filled={filled}
           size={24}
-          className={active ? 'text-[var(--color-error)]' : 'text-[var(--color-foreground)]'}
+          className={
+            active
+              ? activeVariant === 'save'
+                ? 'text-[var(--color-accent)]'
+                : 'text-[var(--color-error)]'
+              : 'text-[var(--color-foreground)]'
+          }
         />
       </span>
       {label !== undefined && (
@@ -59,7 +68,7 @@ function RailButton({
 }
 
 /** SNS-style vertical action rail on the right edge of a reel card. */
-export function ReelActionRail({ item, onLike, onSpeak, onComment, onShare, onMore }: ReelActionRailProps) {
+export function ReelActionRail({ item, onLike, onSave, onSpeak, onComment, onShare, onMore }: ReelActionRailProps) {
   return (
     <div className="flex flex-col items-center gap-4">
       <RailButton
@@ -69,6 +78,15 @@ export function ReelActionRail({ item, onLike, onSpeak, onComment, onShare, onMo
         label={String(item.likeCount)}
         onClick={onLike}
         ariaLabel={item.likedByMe ? 'いいねを取り消す' : 'いいねする'}
+      />
+      <RailButton
+        icon="bookmark"
+        filled={item.savedByMe}
+        active={item.savedByMe}
+        activeVariant="save"
+        label="保存"
+        onClick={onSave}
+        ariaLabel={item.savedByMe ? '保存済みに追加済み' : 'この単語を保存済みに追加'}
       />
       <RailButton
         icon="chat_bubble"

--- a/src/components/reel/ReelCard.tsx
+++ b/src/components/reel/ReelCard.tsx
@@ -15,6 +15,7 @@ type ReelCardProps = {
   active: boolean;
   importing: boolean;
   onLike: () => void;
+  onSave: () => void;
   onImport: () => void;
   onShare: () => void;
   onFeedback: (feedback: ReelFeedback) => void;
@@ -43,6 +44,7 @@ export function ReelCard({
   active,
   importing,
   onLike,
+  onSave,
   onImport,
   onShare,
   onFeedback,
@@ -190,6 +192,7 @@ export function ReelCard({
           <ReelActionRail
             item={item}
             onLike={onLike}
+            onSave={onSave}
             onSpeak={() => speak(item.english)}
             onComment={() => setCommentsOpen(true)}
             onShare={onShare}

--- a/src/components/reel/ReelFeed.tsx
+++ b/src/components/reel/ReelFeed.tsx
@@ -17,6 +17,7 @@ type ReelFeedProps = {
   showAds?: boolean;
   onLoadMore: () => void;
   onLike: (item: ReelItem) => void;
+  onSave: (item: ReelItem) => void;
   onImport: (book: ReelBook) => void;
   onShare: (item: ReelItem) => void;
   onFeedback: (item: ReelItem, feedback: ReelFeedback) => void;
@@ -40,6 +41,7 @@ export function ReelFeed({
   showAds = false,
   onLoadMore,
   onLike,
+  onSave,
   onImport,
   onShare,
   onFeedback,
@@ -110,6 +112,7 @@ export function ReelFeed({
                 active={index === activeIndex}
                 importing={importingBookId === entry.item.book.id}
                 onLike={() => onLike(entry.item)}
+                onSave={() => onSave(entry.item)}
                 onImport={() => onImport(entry.item.book)}
                 onShare={() => onShare(entry.item)}
                 onFeedback={(feedback) => onFeedback(entry.item, feedback)}

--- a/src/hooks/use-reel-feed.ts
+++ b/src/hooks/use-reel-feed.ts
@@ -130,6 +130,14 @@ export function useReelFeed() {
     );
   }, []);
 
+  const markWordSaved = useCallback((itemId: string) => {
+    setItems((prev) =>
+      prev.map((entry) =>
+        entry.id === itemId ? { ...entry, savedByMe: true } : entry,
+      ),
+    );
+  }, []);
+
   const bumpCommentCount = useCallback((itemId: string, delta: number) => {
     setItems((prev) =>
       prev.map((entry) =>
@@ -150,6 +158,7 @@ export function useReelFeed() {
     retry,
     likeItem,
     markBookImported,
+    markWordSaved,
     bumpCommentCount,
   };
 }

--- a/src/lib/reels/types.ts
+++ b/src/lib/reels/types.ts
@@ -41,6 +41,8 @@ export type ReelItem = {
   likeCount: number;
   likedByMe: boolean;
   commentCount: number;
+  /** client-side only: the user added this word to 保存済み this session */
+  savedByMe?: boolean;
   /** true when re-served as a review card after the unseen pool ran out */
   isRecycled?: boolean;
   book: ReelBook;
@@ -72,7 +74,7 @@ export type ReelFeedPage = {
 };
 
 /** Candidate fed into the ranking function (before like/imported enrichment). */
-export type ReelCandidate = Omit<ReelItem, 'likeCount' | 'likedByMe' | 'commentCount' | 'isRecycled'>;
+export type ReelCandidate = Omit<ReelItem, 'likeCount' | 'likedByMe' | 'commentCount' | 'savedByMe' | 'isRecycled'>;
 
 /** Personalization context for ranking. */
 export type ReelRankingContext = {


### PR DESCRIPTION
## 概要

1. **ホーム(モバイル)に保存済み単語への導線を追加**
   - TODAY'S GOAL / MASTERY パネルの下に、保存済み単語カード(`/favorites` へのリンク)を追加
   - 現在の保存済み単語数を表示(`HomeStats` に `favoriteCount` を追加)
   - デスクトップはサイドバーに既存の導線があるためモバイルのみ対応

2. **リールに流れてくる単語を保存済みに追加できるように**
   - リールのアクションレール(いいねの下)にブックマーク「保存」ボタンを追加
   - タップすると「リールで保存した単語」単語帳を find-or-create し、単語を作成して `isFavorite: true` を付与 → `/favorites`(保存済み)にすぐ表示される
   - 同じ英単語が既にその単語帳にある場合は重複作成せず `isFavorite` のみ更新
   - 保存済みの単語はブックマークがアクセント色で塗りつぶし表示(セッション内で `savedByMe` を管理)
   - 未ログインはログインへ、解約後(読み取り専用リポジトリ)の場合は既存のインポート処理と同様に Pro 再登録へ誘導

## 変更ファイル

- `src/app/page.tsx` — 保存済み単語カード + `favoriteCount`
- `src/app/reels/page.tsx` — `handleSaveWord`(find-or-create プロジェクト + 単語作成 + favorite 付与)
- `src/components/reel/ReelActionRail.tsx` — 保存ボタン(`activeVariant` でいいね/保存の色分け)
- `src/components/reel/ReelCard.tsx` / `ReelFeed.tsx` — `onSave` の配線
- `src/hooks/use-reel-feed.ts` — `markWordSaved`
- `src/lib/reels/types.ts` — `ReelItem.savedByMe`(クライアント側のみ)

## 検証

- `npx tsc --noEmit` ✅
- 変更ファイルの ESLint: エラーなし(既存警告1件のみ)
- `npm test`: 752/753 pass — 失敗1件(`words/create route.test.ts`)は変更前の main でも失敗する既存の問題
- `npm run build` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014MtzLSLtnu4k65y7e9oXPA

---
_Generated by [Claude Code](https://claude.ai/code/session_014MtzLSLtnu4k65y7e9oXPA)_