### PR TITLE
無料プランにクラウド同期を解放（サーバ側で異常行動対策）

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,8 +97,8 @@ Data storage abstracted via `WordRepository` interface. Factory in `src/lib/db/i
 getRepository(subscriptionStatus, wasPro)
 // 'active'  -> HybridWordRepository (IndexedDB + Supabase sync)
 // wasPro    -> ReadonlyRemoteRepository (Supabase read-only, writes throw)
-// otherwise -> HybridWordRepository (Free users sync too; 100-word cap enforced
-//              server-side via RLS + enforce_free_word_limit trigger)
+// otherwise -> HybridWordRepository (Free users sync too; 50-wordbook cap enforced
+//              server-side via RLS + enforce_free_project_limit trigger)
 ```
 
 ### Subscription Tiers
@@ -106,12 +106,13 @@ getRepository(subscriptionStatus, wasPro)
 | Feature | Free | Pro (300 JPY/month) |
 |---------|------|---------------------|
 | Scanning | Not available (Pro-only, server-enforced) | Unlimited |
-| Words total | 100 (client + server-enforced) | Unlimited |
+| Wordbooks (単語帳) | 50 (server-enforced) | Unlimited |
+| Words per wordbook | Unlimited | Unlimited |
 | Scan modes | — | all, circled, eiken, idiom |
 | Shared wordbook view/import | Yes (login required) | Yes |
 | Shared wordbook publishing | No (Pro-only) | Yes |
 | Data storage | Cloud (Supabase) + IndexedDB cache (login required) | Cloud (Supabase) + IndexedDB cache |
-| Cross-device sync | Yes (login required; capped at 100 words server-side) | Yes |
+| Cross-device sync | Yes (login required; capped at 50 wordbooks server-side) | Yes |
 
 ### Data Flow
 1. User uploads image -> `/api/extract` -> Gemini 2.5 Flash (or Cloud Run proxy)
@@ -167,7 +168,7 @@ Areas where small changes cause cascading failures. See `docs/boundaries.md` for
    - Correct -> green highlight, Wrong -> red highlight with correct answer shown
    - SM-2 spaced repetition: tracks easeFactor, intervalDays, repetition, nextReviewAt
    - Daily stats recorded: todayCount, correctCount, streakDays
-4. **Free Plan**: scanning is Pro-only (rejected server-side via the `check_and_increment_scan` RPC's `p_require_pro` flag); free users build wordbooks by importing shared wordbooks or adding words manually. Free users get **cloud sync** (cross-device) when logged in — same `HybridWordRepository` as Pro. The 100-word cap is enforced server-side (RLS write policies gate `active Pro OR free plan`; the `enforce_free_word_limit` DB trigger caps free users at 100 words so direct PostgREST calls cannot bypass the client UI). Former-Pro (cancelled) users stay read-only.
+4. **Free Plan**: scanning is Pro-only (rejected server-side via the `check_and_increment_scan` RPC's `p_require_pro` flag); free users build wordbooks by importing shared wordbooks or adding words manually. Free users get **cloud sync** (cross-device) when logged in — same `HybridWordRepository` as Pro. The Free limit is on **wordbook (project) count = 50** (`FREE_WORDBOOK_LIMIT`), not word count — words per wordbook are unlimited. It is enforced server-side (RLS write policies gate `active Pro OR free plan`; the `enforce_free_project_limit` DB trigger caps free users at 50 wordbooks so direct PostgREST calls cannot bypass the client UI). Former-Pro (cancelled) users stay read-only. Default official wordbooks are imported into Supabase server-side at signup (`/api/auth/signup-verify` → `persistDefaultOfficialWordbooksToDb`); the client hydrates them via full sync.
 5. **SSR Compatibility**: Supabase browser client uses lazy initialization. `getDb()` throws on server side.
 6. **Suspense Boundaries**: Pages using `useSearchParams()` wrapped in Suspense for Next.js 16
 7. **Image Processing**: HEIC conversion and compression (max 2MB) to stay under Vercel's 4.5MB limit

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,7 +97,8 @@ Data storage abstracted via `WordRepository` interface. Factory in `src/lib/db/i
 getRepository(subscriptionStatus, wasPro)
 // 'active'  -> HybridWordRepository (IndexedDB + Supabase sync)
 // wasPro    -> ReadonlyRemoteRepository (Supabase read-only, writes throw)
-// otherwise -> LocalWordRepository (IndexedDB only)
+// otherwise -> HybridWordRepository (Free users sync too; 100-word cap enforced
+//              server-side via RLS + enforce_free_word_limit trigger)
 ```
 
 ### Subscription Tiers
@@ -105,12 +106,12 @@ getRepository(subscriptionStatus, wasPro)
 | Feature | Free | Pro (300 JPY/month) |
 |---------|------|---------------------|
 | Scanning | Not available (Pro-only, server-enforced) | Unlimited |
-| Words total | 100 (client-enforced) | Unlimited |
+| Words total | 100 (client + server-enforced) | Unlimited |
 | Scan modes | — | all, circled, eiken, idiom |
 | Shared wordbook view/import | Yes (login required) | Yes |
 | Shared wordbook publishing | No (Pro-only) | Yes |
-| Data storage | IndexedDB (browser-local) | Cloud (Supabase) + IndexedDB cache |
-| Cross-device sync | No | Yes |
+| Data storage | Cloud (Supabase) + IndexedDB cache (login required) | Cloud (Supabase) + IndexedDB cache |
+| Cross-device sync | Yes (login required; capped at 100 words server-side) | Yes |
 
 ### Data Flow
 1. User uploads image -> `/api/extract` -> Gemini 2.5 Flash (or Cloud Run proxy)
@@ -166,7 +167,7 @@ Areas where small changes cause cascading failures. See `docs/boundaries.md` for
    - Correct -> green highlight, Wrong -> red highlight with correct answer shown
    - SM-2 spaced repetition: tracks easeFactor, intervalDays, repetition, nextReviewAt
    - Daily stats recorded: todayCount, correctCount, streakDays
-4. **Free Plan**: scanning is Pro-only (rejected server-side via the `check_and_increment_scan` RPC's `p_require_pro` flag); free users build wordbooks by importing shared wordbooks or adding words manually
+4. **Free Plan**: scanning is Pro-only (rejected server-side via the `check_and_increment_scan` RPC's `p_require_pro` flag); free users build wordbooks by importing shared wordbooks or adding words manually. Free users get **cloud sync** (cross-device) when logged in — same `HybridWordRepository` as Pro. The 100-word cap is enforced server-side (RLS write policies gate `active Pro OR free plan`; the `enforce_free_word_limit` DB trigger caps free users at 100 words so direct PostgREST calls cannot bypass the client UI). Former-Pro (cancelled) users stay read-only.
 5. **SSR Compatibility**: Supabase browser client uses lazy initialization. `getDb()` throws on server side.
 6. **Suspense Boundaries**: Pages using `useSearchParams()` wrapped in Suspense for Next.js 16
 7. **Image Processing**: HEIC conversion and compression (max 2MB) to stay under Vercel's 4.5MB limit

--- a/docs/boundaries.md
+++ b/docs/boundaries.md
@@ -210,7 +210,7 @@ When you change X, you must also check Y.
 
 1. **RLS on newer tables**: Tables added after migration 001 (e.g., `scan_jobs`, `webhook_events`, `subscription_sessions`, `word_embeddings`, `web_push_subscriptions`, `ios_device_tokens`, `collections`, `api_cost_events`, `feature_usage_daily`) -- RLS status is not confirmed for all. Migration `20260209000500_explicit_rls_for_internal_tables.sql` exists and likely addresses some, but a full audit is needed.
 
-2. **Free user word limit (100 words)**: Enforced client-side only at `src/app/scan/confirm/page.tsx`. No server-side enforcement exists at the word creation level. A user calling the API directly could bypass this limit.
+2. **Free user limit (50 wordbooks)**: The Free plan is limited by wordbook (project) count = 50 (`FREE_WORDBOOK_LIMIT`), not word count. Enforced server-side by the `enforce_free_project_limit` DB trigger (migration `20260706100000`), so direct PostgREST calls cannot bypass it; the client also pre-checks in `CreateWordbookSheet`. The former 100-word client-only cap has been removed.
 
 3. **`wasPro` inconsistency**: `use-projects.ts` correctly passes `wasPro` to `getRepository()`, but `scan/confirm/page.tsx` may not pass it in all code paths. This could cause downgraded Pro users to get `localRepository` instead of `readonlyRemoteRepository` during certain operations.
 

--- a/src/app/api/auth/signup-verify/route.ts
+++ b/src/app/api/auth/signup-verify/route.ts
@@ -5,7 +5,10 @@ import { createServerClient } from '@supabase/ssr';
 import { z } from 'zod';
 import { parseJsonWithSchema } from '@/lib/api/validation';
 import { readSingleLineEnv } from '@/lib/env';
-import { fetchDefaultOfficialWordbooksForLocalImport } from '@/lib/official-wordbooks/import-default';
+import {
+  fetchDefaultOfficialWordbooksForLocalImport,
+  persistDefaultOfficialWordbooksToDb,
+} from '@/lib/official-wordbooks/import-default';
 import {
   evaluateAuthOtpCode,
   findAuthUserByNormalizedEmail,
@@ -60,6 +63,7 @@ export type SignupVerifyRouteDeps = {
   getAdminClient?: typeof getAdminClient;
   getServerClient?: typeof getServerClient;
   fetchDefaultOfficialWordbooksForLocalImport?: typeof fetchDefaultOfficialWordbooksForLocalImport;
+  persistDefaultOfficialWordbooksToDb?: typeof persistDefaultOfficialWordbooksToDb;
 };
 
 function buildDefaultAccountId(userId: string): string {
@@ -345,6 +349,23 @@ export async function handleSignupVerifyPost(
         console.error('Failed to fetch default official wordbooks:', defaultImportError);
       }
     }
+
+    // Persist the default wordbooks directly into Supabase (projects + words)
+    // for the new user. The client hydrates its local cache from these rows on
+    // the next full sync, so we no longer hand the payload back for a
+    // browser-only IndexedDB import.
+    if (defaultOfficialWordbooks && defaultOfficialWordbooks.length > 0) {
+      try {
+        await (deps.persistDefaultOfficialWordbooksToDb ?? persistDefaultOfficialWordbooksToDb)(
+          adminClient,
+          userId,
+          defaultOfficialWordbooks,
+        );
+      } catch (persistError) {
+        console.error('Failed to persist default official wordbooks:', persistError);
+      }
+    }
+
     // 使用済みOTPを削除
     await adminClient
       .from('otp_requests')
@@ -357,7 +378,6 @@ export async function handleSignupVerifyPost(
         id: userId,
         email: sessionData.user?.email ?? newUser.user.email,
       },
-      ...(defaultOfficialWordbooks ? { defaultOfficialWordbooks } : {}),
     });
   } catch (error) {
     console.error('Signup verify error:', error);

--- a/src/app/api/words/create/route.ts
+++ b/src/app/api/words/create/route.ts
@@ -236,6 +236,18 @@ export async function handleWordsCreatePost(request: NextRequest, deps?: WordsCr
 
     const { data, error } = await query.select(RESOLVED_WORD_SELECT_COLUMNS);
     if (error) {
+      // The DB enforces the Free-plan 100-word cap via the enforce_free_word_limit
+      // trigger. Surface it as a clean, actionable 403 instead of a raw 500.
+      if (error.message.includes('FREE_WORD_LIMIT_EXCEEDED')) {
+        return NextResponse.json(
+          {
+            success: false,
+            error: '無料プランは100単語までです。Proにアップグレードすると無制限に保存できます。',
+            code: 'FREE_WORD_LIMIT_EXCEEDED',
+          },
+          { status: 403 },
+        );
+      }
       return NextResponse.json({ success: false, error: error.message }, { status: 500 });
     }
 

--- a/src/app/api/words/create/route.ts
+++ b/src/app/api/words/create/route.ts
@@ -236,18 +236,6 @@ export async function handleWordsCreatePost(request: NextRequest, deps?: WordsCr
 
     const { data, error } = await query.select(RESOLVED_WORD_SELECT_COLUMNS);
     if (error) {
-      // The DB enforces the Free-plan 100-word cap via the enforce_free_word_limit
-      // trigger. Surface it as a clean, actionable 403 instead of a raw 500.
-      if (error.message.includes('FREE_WORD_LIMIT_EXCEEDED')) {
-        return NextResponse.json(
-          {
-            success: false,
-            error: '無料プランは100単語までです。Proにアップグレードすると無制限に保存できます。',
-            code: 'FREE_WORD_LIMIT_EXCEEDED',
-          },
-          { status: 403 },
-        );
-      }
       return NextResponse.json({ success: false, error: error.message }, { status: 500 });
     }
 

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -29,8 +29,6 @@ import {
   type SignupStep,
 } from '@/lib/auth/signup-flow';
 import { storePendingOnboarding } from '@/lib/auth/pending-onboarding';
-import { localRepository } from '@/lib/db/local-repository';
-import type { DefaultOfficialWordbookImportItem } from '@/lib/official-wordbooks/import-default';
 import { usePageBackground } from '@/hooks/use-page-background';
 
 const SIGNUP_BG = '#f3f0e9';
@@ -64,75 +62,6 @@ async function readJson(response: Response): Promise<unknown> {
     return await response.json();
   } catch {
     return {};
-  }
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null;
-}
-
-function getSignupUserId(value: unknown): string | null {
-  if (!isRecord(value) || !isRecord(value.user)) return null;
-  return typeof value.user.id === 'string' ? value.user.id : null;
-}
-
-function getDefaultOfficialWordbooks(value: unknown): DefaultOfficialWordbookImportItem[] {
-  if (!isRecord(value) || !Array.isArray(value.defaultOfficialWordbooks)) return [];
-  return value.defaultOfficialWordbooks.filter((wordbook): wordbook is DefaultOfficialWordbookImportItem => (
-    isRecord(wordbook)
-    && typeof wordbook.officialWordbookId === 'string'
-    && (wordbook.officialSlug === undefined || typeof wordbook.officialSlug === 'string')
-    && typeof wordbook.title === 'string'
-    && Array.isArray(wordbook.sourceLabels)
-    && Array.isArray(wordbook.words)
-  ));
-}
-
-async function saveDefaultOfficialWordbooksLocally(
-  userId: string,
-  wordbooks: DefaultOfficialWordbookImportItem[],
-): Promise<void> {
-  const existingProjects = await localRepository.getProjects(userId);
-  const importedOfficialSlugs = new Set(
-    existingProjects
-      .map((project) => project.importedFromOfficialSlug?.trim())
-      .filter((slug): slug is string => Boolean(slug)),
-  );
-
-  for (const wordbook of wordbooks) {
-    const officialSlug = wordbook.officialSlug?.trim();
-    if (officialSlug && importedOfficialSlugs.has(officialSlug)) {
-      continue;
-    }
-
-    const project = await localRepository.createProject({
-      userId,
-      title: wordbook.title,
-      sourceLabels: wordbook.sourceLabels,
-      ...(wordbook.iconImage ? { iconImage: wordbook.iconImage } : {}),
-      ...(officialSlug ? { importedFromOfficialSlug: officialSlug } : {}),
-    });
-    if (officialSlug) importedOfficialSlugs.add(officialSlug);
-
-    await localRepository.createWords(wordbook.words.map((word) => ({
-      projectId: project.id,
-      english: word.english,
-      japanese: word.japanese,
-      translations: word.translations,
-      distractors: word.distractors,
-      vocabularyType: word.vocabularyType ?? undefined,
-      japaneseSource: word.japaneseSource,
-      lexiconEntryId: word.lexiconEntryId,
-      lexiconSenseId: word.lexiconSenseId,
-      exampleSentence: word.exampleSentence,
-      exampleSentenceJa: word.exampleSentenceJa,
-      pronunciation: word.pronunciation,
-      partOfSpeechTags: word.partOfSpeechTags,
-      relatedWords: word.relatedWords,
-      usagePatterns: word.usagePatterns,
-      wordOrderQuiz: word.wordOrderQuiz,
-      customSections: word.customSections,
-    })));
   }
 }
 
@@ -286,16 +215,8 @@ function SignupForm() {
         return;
       }
 
-      const userId = getSignupUserId(data);
-      const defaultOfficialWordbooks = getDefaultOfficialWordbooks(data);
-      if (userId && defaultOfficialWordbooks.length > 0) {
-        try {
-          await saveDefaultOfficialWordbooksLocally(userId, defaultOfficialWordbooks);
-        } catch (localImportError) {
-          console.error('Failed to save default official wordbooks locally:', localImportError);
-        }
-      }
-
+      // Default official wordbooks are now imported into Supabase server-side
+      // by /api/auth/signup-verify; the client hydrates them via full sync.
       window.location.href = redirect;
     } catch {
       setError('通信エラーが発生しました');

--- a/src/components/home/CreateWordbookSheet.tsx
+++ b/src/components/home/CreateWordbookSheet.tsx
@@ -7,7 +7,7 @@ import { SolidButton } from '@/components/redesign/SolidPage';
 import { ScanCapturePanel } from '@/components/home/ScanCapturePanel';
 import { useAuth } from '@/hooks/use-auth';
 import { getRepository } from '@/lib/db';
-import { getGuestUserId } from '@/lib/utils';
+import { getGuestUserId, FREE_WORDBOOK_LIMIT } from '@/lib/utils';
 import type { SubscriptionStatus } from '@/types';
 
 type CreateMethod = 'scan' | 'shared' | 'blank';
@@ -94,6 +94,16 @@ export function CreateWordbookSheet({ isOpen, onClose }: CreateWordbookSheetProp
     setSubmitting(true);
     try {
       const userId = user ? user.id : getGuestUserId();
+      // Free plan is limited to FREE_WORDBOOK_LIMIT wordbooks (server-enforced by
+      // the enforce_free_project_limit trigger). Pre-check for a clean message.
+      if (user && !isPro) {
+        const existing = await repository.getProjects(userId);
+        if (existing.length >= FREE_WORDBOOK_LIMIT) {
+          setErrorMsg(`無料プランは単語帳${FREE_WORDBOOK_LIMIT}冊までです。Proにアップグレードすると無制限に作成できます。`);
+          setSubmitting(false);
+          return;
+        }
+      }
       const project = await repository.createProject({ userId, title: trimmedName });
       onClose();
       router.push(`/project/${project.id}`);

--- a/src/components/pwa/OfflineSyncProvider.tsx
+++ b/src/components/pwa/OfflineSyncProvider.tsx
@@ -4,19 +4,22 @@ import { useEffect, useRef, useCallback } from 'react';
 import { useOnlineStatus } from '@/hooks/use-online-status';
 import { hybridRepository } from '@/lib/db';
 import { useAuth } from '@/hooks/use-auth';
+import { wasProUser } from '@/lib/subscription/status';
 
 const SYNC_INTERVAL = 5 * 60 * 1000; // 5 minutes
 
 export function OfflineSyncProvider({ children }: { children: React.ReactNode }) {
   const isOnline = useOnlineStatus();
   const { user, subscription } = useAuth();
-  const isPro = subscription?.status === 'active';
+  // Cloud sync runs for active Pro AND Free users. Former-Pro (read-only) users
+  // are excluded — they use the readonly repository, not the hybrid sync.
+  const canSync = !wasProUser(subscription);
   const wasOffline = useRef(false);
   const syncIntervalRef = useRef<NodeJS.Timeout | null>(null);
 
   // Background sync function
   const backgroundSync = useCallback(async () => {
-    if (!isOnline || !user || !isPro) return;
+    if (!isOnline || !user || !canSync) return;
 
     try {
       console.log('[OfflineSync] Running background sync');
@@ -24,11 +27,11 @@ export function OfflineSyncProvider({ children }: { children: React.ReactNode })
     } catch (error) {
       console.error('[OfflineSync] Background sync failed:', error);
     }
-  }, [isOnline, user, isPro]);
+  }, [isOnline, user, canSync]);
 
   // Handle online/offline transitions
   useEffect(() => {
-    if (!isPro) return;
+    if (!canSync) return;
 
     if (!isOnline) {
       wasOffline.current = true;
@@ -39,11 +42,11 @@ export function OfflineSyncProvider({ children }: { children: React.ReactNode })
       wasOffline.current = false;
       backgroundSync();
     }
-  }, [isOnline, isPro, backgroundSync]);
+  }, [isOnline, canSync, backgroundSync]);
 
   // Set up periodic sync
   useEffect(() => {
-    if (!isPro || !isOnline) {
+    if (!canSync || !isOnline) {
       if (syncIntervalRef.current) {
         clearInterval(syncIntervalRef.current);
         syncIntervalRef.current = null;
@@ -65,11 +68,11 @@ export function OfflineSyncProvider({ children }: { children: React.ReactNode })
         clearInterval(syncIntervalRef.current);
       }
     };
-  }, [isPro, isOnline, backgroundSync]);
+  }, [canSync, isOnline, backgroundSync]);
 
   // Full sync on first Pro login (if needed)
   useEffect(() => {
-    if (!isPro || !user || !isOnline) return;
+    if (!canSync || !user || !isOnline) return;
 
     const syncedUserId = hybridRepository.getSyncedUserId();
     const lastSync = hybridRepository.getLastSync();
@@ -81,7 +84,7 @@ export function OfflineSyncProvider({ children }: { children: React.ReactNode })
         console.error('[OfflineSync] Full sync failed:', error);
       });
     }
-  }, [isPro, user, isOnline]);
+  }, [canSync, user, isOnline]);
 
   return <>{children}</>;
 }

--- a/src/components/pwa/SyncStatusIndicator.tsx
+++ b/src/components/pwa/SyncStatusIndicator.tsx
@@ -5,13 +5,16 @@ import { Icon } from '@/components/ui/Icon';
 import { useOnlineStatus } from '@/hooks/use-online-status';
 import { hybridRepository, syncQueue } from '@/lib/db';
 import { useAuth } from '@/hooks/use-auth';
+import { wasProUser } from '@/lib/subscription/status';
 
 type SyncStatus = 'synced' | 'syncing' | 'pending' | 'offline';
 
 export function SyncStatusIndicator() {
   const isOnline = useOnlineStatus();
   const { user, subscription } = useAuth();
-  const isPro = subscription?.status === 'active';
+  // Sync status is shown for cloud-synced users (active Pro AND Free);
+  // former-Pro (read-only) users are excluded.
+  const isPro = !wasProUser(subscription);
   
   const [status, setStatus] = useState<SyncStatus>('synced');
   const [pendingCount, setPendingCount] = useState(0);

--- a/src/hooks/use-auth.ts
+++ b/src/hooks/use-auth.ts
@@ -404,14 +404,16 @@ export function useAuth() {
         markAuthenticated();
         logDailyActivity(result.user.id);
         
-        // Trigger initial sync for Pro users (background, non-blocking)
-        if (isActiveProSubscription(result.subscription)) {
+        // Trigger initial sync for cloud-synced users (active Pro OR Free),
+        // background, non-blocking. Former-Pro (read-only) users are excluded —
+        // they use ReadonlyRemoteRepository and must not run the hybrid sync.
+        if (!wasProUser(result.subscription)) {
           const syncedUserId = hybridRepository.getSyncedUserId();
           const lastSync = hybridRepository.getLastSync();
           const needsFullSync = shouldRunFullSync(lastSync, syncedUserId, result.user.id);
           
           if (needsFullSync) {
-            console.log('[Auth] Pro user detected, triggering initial sync');
+            console.log('[Auth] Cloud-synced user detected, triggering initial sync');
             hybridRepository.fullSync(result.user.id).catch((error) => {
               console.error('[Auth] Initial sync failed:', error);
             });

--- a/src/hooks/use-word-count.ts
+++ b/src/hooks/use-word-count.ts
@@ -1,7 +1,6 @@
 'use client';
 
 import { useState, useEffect, useCallback } from 'react';
-import { FREE_WORD_LIMIT } from '@/lib/utils';
 import { getCachedTotalWords, getHasLoaded, subscribeCacheUpdate } from '@/lib/home-cache';
 import { useAuth } from './use-auth';
 
@@ -16,46 +15,46 @@ interface WordCountState {
   loading: boolean;
 }
 
-function deriveState(totalWords: number, isPro: boolean, isLoading: boolean): WordCountState {
-  const limit = isPro ? Infinity : FREE_WORD_LIMIT;
-  const remaining = isPro ? Infinity : Math.max(0, FREE_WORD_LIMIT - totalWords);
-  const percentage = isPro ? 0 : Math.min(100, Math.round((totalWords / FREE_WORD_LIMIT) * 100));
-
+// The Free plan is limited by WORDBOOK count (FREE_WORDBOOK_LIMIT), not word
+// count. This hook now only reports the total word count for display and never
+// blocks adding words. Limit-related flags are inert (kept for compatibility
+// with existing consumers).
+function deriveState(totalWords: number, isLoading: boolean): WordCountState {
   return {
     count: totalWords,
-    limit,
-    remaining,
-    percentage,
-    isNearLimit: !isPro && percentage >= 80,
-    isAlmostFull: !isPro && percentage >= 95,
-    isAtLimit: !isPro && totalWords >= FREE_WORD_LIMIT,
+    limit: Infinity,
+    remaining: Infinity,
+    percentage: 0,
+    isNearLimit: false,
+    isAlmostFull: false,
+    isAtLimit: false,
     loading: isLoading,
   };
 }
 
-// Hook for tracking word count and limit status
+// Hook for tracking word count (for display only — no word cap).
 // Strategy 1: Reads from home-cache instead of making independent DB queries
 export function useWordCount() {
-  const { isPro, loading: authLoading } = useAuth();
+  const { loading: authLoading } = useAuth();
   const cacheReady = getHasLoaded();
 
   const [state, setState] = useState<WordCountState>(() => {
     if (cacheReady) {
-      return deriveState(getCachedTotalWords(), isPro, false);
+      return deriveState(getCachedTotalWords(), false);
     }
-    return deriveState(0, false, true);
+    return deriveState(0, true);
   });
 
   // Subscribe to cache updates from loadProjects
   useEffect(() => {
     const unsubscribe = subscribeCacheUpdate(() => {
-      setState(deriveState(getCachedTotalWords(), isPro, false));
+      setState(deriveState(getCachedTotalWords(), false));
     });
 
     // Also sync when auth finishes and cache is already ready
     if (!authLoading && getHasLoaded()) {
       const timer = window.setTimeout(() => {
-        setState(deriveState(getCachedTotalWords(), isPro, false));
+        setState(deriveState(getCachedTotalWords(), false));
       }, 0);
       return () => {
         window.clearTimeout(timer);
@@ -64,38 +63,26 @@ export function useWordCount() {
     }
 
     return unsubscribe;
-  }, [isPro, authLoading]);
+  }, [authLoading]);
 
   // Refresh function - triggers a re-read from cache
   // The actual data refresh should be done by invalidating + reloading home cache
   const refresh = useCallback(() => {
     if (getHasLoaded()) {
-      setState(deriveState(getCachedTotalWords(), isPro, false));
+      setState(deriveState(getCachedTotalWords(), false));
     }
-  }, [isPro]);
+  }, []);
 
-  // Check if adding new words would exceed limit
-  const canAddWords = useCallback((newWordCount: number): {
+  // Words are never capped now — adding words always succeeds.
+  const canAddWords = useCallback((_newWordCount: number): {
     canAdd: boolean;
     wouldExceed: boolean;
     excessCount: number;
     availableSlots: number;
   } => {
-    if (isPro) {
-      return { canAdd: true, wouldExceed: false, excessCount: 0, availableSlots: Infinity };
-    }
-
-    const availableSlots = Math.max(0, FREE_WORD_LIMIT - state.count);
-    const wouldExceed = state.count + newWordCount > FREE_WORD_LIMIT;
-    const excessCount = Math.max(0, (state.count + newWordCount) - FREE_WORD_LIMIT);
-
-    return {
-      canAdd: !state.isAtLimit,
-      wouldExceed,
-      excessCount,
-      availableSlots,
-    };
-  }, [isPro, state.count, state.isAtLimit]);
+    void _newWordCount;
+    return { canAdd: true, wouldExceed: false, excessCount: 0, availableSlots: Infinity };
+  }, []);
 
   return {
     ...state,

--- a/src/lib/db/index.ts
+++ b/src/lib/db/index.ts
@@ -19,8 +19,8 @@ import { readonlyRemoteRepository } from './readonly-remote-repository';
 
 // Factory function to get the appropriate repository based on subscription
 // Active Pro users: HybridRepository (IndexedDB + Supabase sync)
-// Free users (never Pro): HybridRepository (IndexedDB + Supabase sync, 100-word cap
-//   enforced server-side via RLS + DB triggers)
+// Free users (never Pro): HybridRepository (IndexedDB + Supabase sync, 50-wordbook
+//   cap enforced server-side via RLS + DB triggers)
 // Downgraded Pro users (wasPro=true): ReadonlyRemoteRepository (Supabase read-only)
 export function getRepository(
   subscriptionStatus: SubscriptionStatus = 'free',
@@ -34,8 +34,8 @@ export function getRepository(
     // Downgraded users: Read-only access to Supabase data
     return readonlyRemoteRepository;
   }
-  // Free users: cloud sync is now enabled (cross-device). The Free 100-word cap
-  // is enforced server-side (RLS + enforce_free_word_limit trigger), so the
-  // hybrid repository is safe to use here.
+  // Free users: cloud sync is now enabled (cross-device). The Free 50-wordbook
+  // cap is enforced server-side (RLS + enforce_free_project_limit trigger), so
+  // the hybrid repository is safe to use here.
   return hybridRepository;
 }

--- a/src/lib/db/index.ts
+++ b/src/lib/db/index.ts
@@ -14,14 +14,14 @@ export { ReadonlyRemoteRepository, readonlyRemoteRepository } from './readonly-r
 export { SyncQueue, syncQueue } from './sync-queue';
 
 import type { WordRepository, SubscriptionStatus } from '@/types';
-import { localRepository } from './local-repository';
 import { hybridRepository } from './hybrid-repository';
 import { readonlyRemoteRepository } from './readonly-remote-repository';
 
 // Factory function to get the appropriate repository based on subscription
 // Active Pro users: HybridRepository (IndexedDB + Supabase sync)
+// Free users (never Pro): HybridRepository (IndexedDB + Supabase sync, 100-word cap
+//   enforced server-side via RLS + DB triggers)
 // Downgraded Pro users (wasPro=true): ReadonlyRemoteRepository (Supabase read-only)
-// Free users (never Pro): LocalRepository (IndexedDB only)
 export function getRepository(
   subscriptionStatus: SubscriptionStatus = 'free',
   wasPro: boolean = false,
@@ -34,5 +34,8 @@ export function getRepository(
     // Downgraded users: Read-only access to Supabase data
     return readonlyRemoteRepository;
   }
-  return localRepository;
+  // Free users: cloud sync is now enabled (cross-device). The Free 100-word cap
+  // is enforced server-side (RLS + enforce_free_word_limit trigger), so the
+  // hybrid repository is safe to use here.
+  return hybridRepository;
 }

--- a/src/lib/official-wordbooks/import-default.ts
+++ b/src/lib/official-wordbooks/import-default.ts
@@ -1,9 +1,17 @@
 import type { PostgrestError, SupabaseClient } from '@supabase/supabase-js';
-import { normalizeWordForTranslationPersistence } from '@/lib/words/translation-persistence';
+import {
+  buildWordTranslationInsertRows,
+  isWordTranslationsSchemaError,
+  normalizeWordForTranslationPersistence,
+} from '@/lib/words/translation-persistence';
+import { getDefaultSpacedRepetitionFields } from '@/lib/spaced-repetition';
+import { mapProjectToInsertWithId, mapWordToInsertWithId } from '../../../shared/db';
 import type {
   CustomSection,
+  Project,
   RelatedWord,
   UsagePattern,
+  Word,
   WordOrderQuizCache,
   WordTranslation,
 } from '@/types';
@@ -246,4 +254,113 @@ export async function fetchDefaultOfficialWordbooksForLocalImport(
   }
 
   return imported.length > 0 ? imported : null;
+}
+
+function newId(): string {
+  return globalThis.crypto.randomUUID();
+}
+
+/**
+ * Persist default official wordbooks directly into the user's Supabase rows
+ * (projects + words + word_translations) at signup time, instead of only
+ * writing them to the browser's IndexedDB. This uses the service-role admin
+ * client, so it runs server-side and bypasses RLS; the DB triggers
+ * (set_word_user_id, enforce_free_project_limit) still apply. The client
+ * hydrates its local cache from these rows on the next full sync.
+ *
+ * Existing projects are de-duplicated by imported_from_official_slug so a
+ * re-run (or a mixed local/remote history) never creates duplicate wordbooks.
+ */
+export async function persistDefaultOfficialWordbooksToDb(
+  adminClient: SupabaseClient,
+  userId: string,
+  wordbooks: DefaultOfficialWordbookImportItem[],
+): Promise<void> {
+  if (wordbooks.length === 0) return;
+
+  const { data: existingProjects, error: existingError } = await adminClient
+    .from('projects')
+    .select('imported_from_official_slug')
+    .eq('user_id', userId);
+  if (existingError) {
+    throw new Error(`Failed to read existing projects: ${existingError.message}`);
+  }
+  const importedSlugs = new Set(
+    (existingProjects ?? [])
+      .map((row) => (row as { imported_from_official_slug?: string | null }).imported_from_official_slug?.trim())
+      .filter((slug): slug is string => Boolean(slug)),
+  );
+
+  const nowIso = new Date().toISOString();
+  const srDefaults = getDefaultSpacedRepetitionFields();
+
+  for (const wordbook of wordbooks) {
+    const officialSlug = wordbook.officialSlug?.trim();
+    if (officialSlug && importedSlugs.has(officialSlug)) {
+      continue;
+    }
+
+    const projectId = newId();
+    const project: Project = {
+      id: projectId,
+      userId,
+      title: wordbook.title,
+      sourceLabels: wordbook.sourceLabels,
+      createdAt: nowIso,
+      ...(wordbook.iconImage ? { iconImage: wordbook.iconImage } : {}),
+      ...(officialSlug ? { importedFromOfficialSlug: officialSlug } : {}),
+    };
+
+    const { error: projectError } = await adminClient
+      .from('projects')
+      .insert(mapProjectToInsertWithId(project));
+    if (projectError) {
+      throw new Error(`Failed to insert default wordbook project: ${projectError.message}`);
+    }
+    if (officialSlug) importedSlugs.add(officialSlug);
+
+    if (wordbook.words.length === 0) continue;
+
+    const wordIds = wordbook.words.map(() => newId());
+    const wordRows = wordbook.words.map((word, index) => mapWordToInsertWithId({
+      id: wordIds[index],
+      projectId,
+      english: word.english,
+      japanese: word.japanese,
+      japaneseSource: word.japaneseSource,
+      vocabularyType: word.vocabularyType ?? undefined,
+      lexiconEntryId: word.lexiconEntryId,
+      lexiconSenseId: word.lexiconSenseId,
+      distractors: word.distractors ?? [],
+      exampleSentence: word.exampleSentence,
+      exampleSentenceJa: word.exampleSentenceJa,
+      pronunciation: word.pronunciation,
+      partOfSpeechTags: word.partOfSpeechTags,
+      relatedWords: word.relatedWords,
+      usagePatterns: word.usagePatterns,
+      wordOrderQuiz: word.wordOrderQuiz,
+      customSections: word.customSections,
+      status: 'new',
+      createdAt: nowIso,
+      isFavorite: false,
+      ...srDefaults,
+    } as Word));
+
+    const { error: wordsError } = await adminClient.from('words').insert(wordRows);
+    if (wordsError) {
+      throw new Error(`Failed to insert default wordbook words: ${wordsError.message}`);
+    }
+
+    const translationRows = buildWordTranslationInsertRows(wordbook.words, wordIds);
+    if (translationRows.length > 0) {
+      const { error: translationError } = await adminClient
+        .from('word_translations')
+        .upsert(translationRows, { onConflict: 'word_id,normalized_translation_ja' });
+      // Translations are a non-critical enrichment: never fail the whole signup
+      // import if the child table is unavailable or momentarily out of sync.
+      if (translationError && !isWordTranslationsSchemaError(translationError)) {
+        console.error('[import-default] Failed to insert word translations:', translationError.message);
+      }
+    }
+  }
 }

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -43,6 +43,9 @@ const SCAN_DATE_KEY = 'scanvocab_scan_date';
 // Free plan limits (must match server-side in /api/extract and /api/grammar)
 export const FREE_DAILY_SCAN_LIMIT = 3;
 export const FREE_WORD_LIMIT = 100;
+// Free plan is limited by wordbook (project) count, enforced server-side by the
+// enforce_free_project_limit trigger. Words per wordbook are unlimited for Free.
+export const FREE_WORDBOOK_LIMIT = 50;
 
 export function getDailyScanInfo(): { count: number; remaining: number; canScan: boolean } {
   if (typeof window === 'undefined') {

--- a/supabase/migrations/20260706100000_open_cloud_sync_to_free_with_limits.sql
+++ b/supabase/migrations/20260706100000_open_cloud_sync_to_free_with_limits.sql
@@ -1,0 +1,203 @@
+-- Open personal cloud sync to Free-plan users, with server-enforced abuse limits.
+--
+-- Background: previously only ACTIVE Pro users could read/write their own
+-- projects & words in Supabase (see 005_gate_cloud_sync_to_pro.sql,
+-- 20260209003000_classify_pro_source.sql, 20260322070000_rls_optimize_words_userid.sql).
+-- Free users were IndexedDB-only. This migration:
+--   1. Lets any authenticated user read AND write their OWN projects/words.
+--   2. Keeps former-Pro (cancelled/expired) users READ-ONLY (unchanged invariant):
+--      the write policies allow "active Pro OR free plan" and exclude former-Pro.
+--   3. Enforces the Free-plan 100-word cap AT THE DB LEVEL so it cannot be
+--      bypassed by calling PostgREST directly (the previous cap was client-only).
+--      A generous project-count ceiling guards against empty-project spam.
+--
+-- Active Pro users remain UNLIMITED. Sharing policies (share_id based) are
+-- intentionally left untouched — this migration only changes own-data access.
+
+-- ============================================================
+-- Helpers
+-- ============================================================
+
+-- True when the GIVEN user's subscription is active Pro (source-aware).
+-- Used by the abuse-limit triggers, which run for an arbitrary owner user_id
+-- (not necessarily auth.uid(), e.g. when a service-role job inserts rows).
+CREATE OR REPLACE FUNCTION public.user_is_active_pro(p_user_id UUID)
+RETURNS BOOLEAN
+LANGUAGE SQL
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT EXISTS (
+    SELECT 1 FROM subscriptions s
+    WHERE s.user_id = p_user_id
+      AND public.is_active_pro(
+        s.status, s.plan, s.current_period_end, s.pro_source, s.test_pro_expires_at
+      )
+  );
+$$;
+
+-- True when the CALLER may write cloud data: active Pro OR Free plan.
+-- Former-Pro (plan='pro' but no longer active) is deliberately excluded so
+-- cancelled/expired subscribers stay read-only, matching the app's
+-- ReadonlyRemoteRepository routing.
+CREATE OR REPLACE FUNCTION public.is_caller_cloud_writer()
+RETURNS BOOLEAN
+LANGUAGE SQL
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT EXISTS (
+    SELECT 1 FROM subscriptions s
+    WHERE s.user_id = auth.uid()
+      AND (
+        s.plan = 'free'
+        OR public.is_active_pro(
+          s.status, s.plan, s.current_period_end, s.pro_source, s.test_pro_expires_at
+        )
+      )
+  );
+$$;
+
+-- ============================================================
+-- projects: own-data policies (sharing policies untouched)
+-- ============================================================
+DROP POLICY IF EXISTS "Pro users can view own projects" ON projects;
+DROP POLICY IF EXISTS "Users can view own projects" ON projects;
+DROP POLICY IF EXISTS "Active Pro users can create own projects" ON projects;
+DROP POLICY IF EXISTS "Active Pro users can update own projects" ON projects;
+DROP POLICY IF EXISTS "Active Pro users can delete own projects" ON projects;
+DROP POLICY IF EXISTS "Cloud writers can create own projects" ON projects;
+DROP POLICY IF EXISTS "Cloud writers can update own projects" ON projects;
+DROP POLICY IF EXISTS "Cloud writers can delete own projects" ON projects;
+
+-- READ: any authenticated user can view their own projects (Free + Pro + former-Pro)
+CREATE POLICY "Users can view own projects"
+  ON projects FOR SELECT
+  USING (user_id = auth.uid());
+
+-- WRITE: active Pro or Free plan (former-Pro excluded -> read-only)
+CREATE POLICY "Cloud writers can create own projects"
+  ON projects FOR INSERT
+  WITH CHECK (user_id = auth.uid() AND public.is_caller_cloud_writer());
+
+CREATE POLICY "Cloud writers can update own projects"
+  ON projects FOR UPDATE
+  USING (user_id = auth.uid() AND public.is_caller_cloud_writer())
+  WITH CHECK (user_id = auth.uid() AND public.is_caller_cloud_writer());
+
+CREATE POLICY "Cloud writers can delete own projects"
+  ON projects FOR DELETE
+  USING (user_id = auth.uid() AND public.is_caller_cloud_writer());
+
+-- ============================================================
+-- words: own-data policies (shared-project SELECT untouched)
+-- Relies on the denormalized words.user_id column + trg_set_word_user_id
+-- (added in 20260322070000_rls_optimize_words_userid.sql).
+-- ============================================================
+DROP POLICY IF EXISTS "Pro users can view own words" ON words;
+DROP POLICY IF EXISTS "Users can view own words" ON words;
+DROP POLICY IF EXISTS "Active Pro users can create words" ON words;
+DROP POLICY IF EXISTS "Active Pro users can create words in own projects" ON words;
+DROP POLICY IF EXISTS "Active Pro users can update own words" ON words;
+DROP POLICY IF EXISTS "Active Pro users can delete own words" ON words;
+DROP POLICY IF EXISTS "Cloud writers can create own words" ON words;
+DROP POLICY IF EXISTS "Cloud writers can update own words" ON words;
+DROP POLICY IF EXISTS "Cloud writers can delete own words" ON words;
+
+-- READ: any authenticated user can view their own words
+CREATE POLICY "Users can view own words"
+  ON words FOR SELECT
+  USING (user_id = auth.uid());
+
+-- WRITE: active Pro or Free plan (former-Pro excluded -> read-only)
+CREATE POLICY "Cloud writers can create own words"
+  ON words FOR INSERT
+  WITH CHECK (user_id = auth.uid() AND public.is_caller_cloud_writer());
+
+CREATE POLICY "Cloud writers can update own words"
+  ON words FOR UPDATE
+  USING (user_id = auth.uid() AND public.is_caller_cloud_writer())
+  WITH CHECK (user_id = auth.uid() AND public.is_caller_cloud_writer());
+
+CREATE POLICY "Cloud writers can delete own words"
+  ON words FOR DELETE
+  USING (user_id = auth.uid() AND public.is_caller_cloud_writer());
+
+-- ============================================================
+-- Abuse prevention: Free-plan hard limits enforced in the database.
+-- Statement-level AFTER triggers with transition tables => correct for
+-- multi-row (batch) inserts, where a per-row BEFORE trigger could be bypassed
+-- because sibling rows in the same statement are not yet visible to a COUNT().
+-- Active Pro users are skipped (unlimited).
+-- ============================================================
+
+-- Free plan is limited to 100 words total (matches FREE_WORD_LIMIT in src/lib/utils.ts).
+CREATE OR REPLACE FUNCTION public.enforce_free_word_limit()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_user_id UUID;
+  v_count INTEGER;
+BEGIN
+  FOR v_user_id IN SELECT DISTINCT user_id FROM new_words LOOP
+    IF public.user_is_active_pro(v_user_id) THEN
+      CONTINUE; -- Pro = unlimited
+    END IF;
+
+    SELECT COUNT(*) INTO v_count FROM words WHERE user_id = v_user_id;
+    IF v_count > 100 THEN
+      RAISE EXCEPTION 'FREE_WORD_LIMIT_EXCEEDED: free plan is limited to 100 words'
+        USING ERRCODE = 'check_violation';
+    END IF;
+  END LOOP;
+  RETURN NULL;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_enforce_free_word_limit ON words;
+CREATE TRIGGER trg_enforce_free_word_limit
+  AFTER INSERT ON words
+  REFERENCING NEW TABLE AS new_words
+  FOR EACH STATEMENT
+  EXECUTE FUNCTION public.enforce_free_word_limit();
+
+-- Free plan is capped at a generous number of wordbooks to stop empty-project
+-- spam. The ceiling is well above any realistic Free usage (100 words total)
+-- so it never blocks legitimate users or the first-sync bootstrap of existing
+-- local-only data.
+CREATE OR REPLACE FUNCTION public.enforce_free_project_limit()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_user_id UUID;
+  v_count INTEGER;
+BEGIN
+  FOR v_user_id IN SELECT DISTINCT user_id FROM new_projects LOOP
+    IF public.user_is_active_pro(v_user_id) THEN
+      CONTINUE; -- Pro = unlimited
+    END IF;
+
+    SELECT COUNT(*) INTO v_count FROM projects WHERE user_id = v_user_id;
+    IF v_count > 500 THEN
+      RAISE EXCEPTION 'FREE_PROJECT_LIMIT_EXCEEDED: free plan is limited to 500 wordbooks'
+        USING ERRCODE = 'check_violation';
+    END IF;
+  END LOOP;
+  RETURN NULL;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_enforce_free_project_limit ON projects;
+CREATE TRIGGER trg_enforce_free_project_limit
+  AFTER INSERT ON projects
+  REFERENCING NEW TABLE AS new_projects
+  FOR EACH STATEMENT
+  EXECUTE FUNCTION public.enforce_free_project_limit();

--- a/supabase/migrations/20260706100000_open_cloud_sync_to_free_with_limits.sql
+++ b/supabase/migrations/20260706100000_open_cloud_sync_to_free_with_limits.sql
@@ -7,9 +7,9 @@
 --   1. Lets any authenticated user read AND write their OWN projects/words.
 --   2. Keeps former-Pro (cancelled/expired) users READ-ONLY (unchanged invariant):
 --      the write policies allow "active Pro OR free plan" and exclude former-Pro.
---   3. Enforces the Free-plan 100-word cap AT THE DB LEVEL so it cannot be
---      bypassed by calling PostgREST directly (the previous cap was client-only).
---      A generous project-count ceiling guards against empty-project spam.
+--   3. Enforces the Free-plan limit of 50 wordbooks (projects) AT THE DB LEVEL
+--      so it cannot be bypassed by calling PostgREST directly. Words per
+--      wordbook are NOT capped for Free users; the limit is on wordbook count.
 --
 -- Active Pro users remain UNLIMITED. Sharing policies (share_id based) are
 -- intentionally left untouched — this migration only changes own-data access.
@@ -126,50 +126,21 @@ CREATE POLICY "Cloud writers can delete own words"
   USING (user_id = auth.uid() AND public.is_caller_cloud_writer());
 
 -- ============================================================
--- Abuse prevention: Free-plan hard limits enforced in the database.
--- Statement-level AFTER triggers with transition tables => correct for
+-- Abuse prevention: Free-plan wordbook (project) cap enforced in the database.
+-- The Free limit is on WORDBOOK COUNT (50), not word count — words per
+-- wordbook are unlimited for Free users.
+-- Statement-level AFTER trigger with a transition table => correct for
 -- multi-row (batch) inserts, where a per-row BEFORE trigger could be bypassed
 -- because sibling rows in the same statement are not yet visible to a COUNT().
 -- Active Pro users are skipped (unlimited).
 -- ============================================================
 
--- Free plan is limited to 100 words total (matches FREE_WORD_LIMIT in src/lib/utils.ts).
-CREATE OR REPLACE FUNCTION public.enforce_free_word_limit()
-RETURNS TRIGGER
-LANGUAGE plpgsql
-SECURITY DEFINER
-SET search_path = public
-AS $$
-DECLARE
-  v_user_id UUID;
-  v_count INTEGER;
-BEGIN
-  FOR v_user_id IN SELECT DISTINCT user_id FROM new_words LOOP
-    IF public.user_is_active_pro(v_user_id) THEN
-      CONTINUE; -- Pro = unlimited
-    END IF;
-
-    SELECT COUNT(*) INTO v_count FROM words WHERE user_id = v_user_id;
-    IF v_count > 100 THEN
-      RAISE EXCEPTION 'FREE_WORD_LIMIT_EXCEEDED: free plan is limited to 100 words'
-        USING ERRCODE = 'check_violation';
-    END IF;
-  END LOOP;
-  RETURN NULL;
-END;
-$$;
-
+-- Drop the earlier word-count cap if a prior version of this migration created
+-- it — the Free limit is now on wordbook count, not word count.
 DROP TRIGGER IF EXISTS trg_enforce_free_word_limit ON words;
-CREATE TRIGGER trg_enforce_free_word_limit
-  AFTER INSERT ON words
-  REFERENCING NEW TABLE AS new_words
-  FOR EACH STATEMENT
-  EXECUTE FUNCTION public.enforce_free_word_limit();
+DROP FUNCTION IF EXISTS public.enforce_free_word_limit();
 
--- Free plan is capped at a generous number of wordbooks to stop empty-project
--- spam. The ceiling is well above any realistic Free usage (100 words total)
--- so it never blocks legitimate users or the first-sync bootstrap of existing
--- local-only data.
+-- Free plan is limited to 50 wordbooks (matches FREE_WORDBOOK_LIMIT in src/lib/utils.ts).
 CREATE OR REPLACE FUNCTION public.enforce_free_project_limit()
 RETURNS TRIGGER
 LANGUAGE plpgsql
@@ -186,8 +157,8 @@ BEGIN
     END IF;
 
     SELECT COUNT(*) INTO v_count FROM projects WHERE user_id = v_user_id;
-    IF v_count > 500 THEN
-      RAISE EXCEPTION 'FREE_PROJECT_LIMIT_EXCEEDED: free plan is limited to 500 wordbooks'
+    IF v_count > 50 THEN
+      RAISE EXCEPTION 'FREE_WORDBOOK_LIMIT_EXCEEDED: free plan is limited to 50 wordbooks'
         USING ERRCODE = 'check_violation';
     END IF;
   END LOOP;


### PR DESCRIPTION
## 概要

無料プランにクラウド同期（クロスデバイス）を解放し、コスト暴走・乱用を防ぐため上限をサーバ側で強制する。上限は **単語帳（プロジェクト）数 = 50** で、1冊あたりの単語数は無制限。あわせて、サインアップ時のデフォルト公式単語帳を **Supabase(DB) へサーバ側で永続化** する。

## 変更内容

### 1. 同期の解放
- `getRepository`: 無料ユーザーも `HybridWordRepository` を返す（従来は `LocalWordRepository`＝IndexedDBのみ）
- 同期起動 gate を「active Pro のみ」→「active Pro または無料（former-Pro以外）」へ拡張（use-auth / OfflineSyncProvider / SyncStatusIndicator）
- former-Pro（解約/期限切れ）は従来どおり read-only 維持

### 2. 上限を「単語数」→「単語帳数(50)」へ（異常行動対策）
`supabase/migrations/20260706100000_open_cloud_sync_to_free_with_limits.sql`
- RLS: projects/words の自分のデータの READ を全認証ユーザーに開放。WRITE は「active Pro または free プラン」に限定し former-Pro を除外
- `enforce_free_project_limit` トリガ: 無料は **50冊超で拒否**（active Pro は無制限）。バッチ insert を正しく判定するため statement-level + 遷移テーブルで実装、PostgREST 直叩きでもバイパス不可
- 単語数上限（旧 `enforce_free_word_limit`）は撤廃 → **1冊の単語数は無制限**
- クライアント: `FREE_WORDBOOK_LIMIT=50` を追加、`use-word-count` は単語数ブロックを撤廃（表示専用化）、`CreateWordbookSheet` で無料ユーザーの単語帳作成を50冊で事前チェック

### 3. デフォルト単語帳を DB へ永続化
- `import-default.ts` に `persistDefaultOfficialWordbooksToDb`（projects + words + word_translations を service-role で挿入、公式slugで重複排除）
- `/api/auth/signup-verify` でサーバ側に永続化し、payload 返却を廃止
- `signup/page.tsx` のローカルインポート処理を削除 → クライアントは full sync で反映

### ドキュメント
- `CLAUDE.md`（ティア表／リポジトリパターン／Free Plan 注記）、`docs/boundaries.md` を更新

## テスト
- `tsc --noEmit`（src配下）: エラーなし
- `eslint`（変更ファイル）/ `security:sql` ガード: パス
- `import-default` / `hybrid-repository` / `remote-repository` / `sync-queue` / `subscription/status` / `utils` 単体テスト: パス
- `words/create` の既存失敗テスト1件は本変更前から失敗（本PRとは無関係）

## レビュー時の注意 / 挙動メモ
- 無料ユーザーが51冊目を作ろうとすると、`CreateWordbookSheet` では事前チェックで明確なメッセージ表示。共有インポート等の他経路はサーバトリガでブロックされ、ローカルの余剰分は次回同期で自己修復される（ローカルデータは失われない）
- デフォルト単語帳の DB 永続化は、②で無料同期を有効化したことに依存（サインアップ後の full sync でローカルへ反映）

🤖 Generated with [Claude Code](https://claude.com/claude-code)