### PR TITLE
Fix desktop flashcard: show English example sentence and shrink oversized buttons

### DIFF
--- a/src/app/desktop.css
+++ b/src/app/desktop.css
@@ -576,9 +576,9 @@
 .ds-fc-face .ph { font-family: var(--font-mono); font-size: 15px; color: var(--color-muted); }
 .ds-fc-face .ja { font-size: 30px; font-weight: 700; }
 .ds-fc-face .hint { position: absolute; bottom: 18px; font-family: var(--font-mono); font-size: 11px; color: var(--color-muted); display: flex; align-items: center; gap: 5px; }
-.ds-fc-controls { display: flex; gap: 32px; margin-top: 26px; }
-.ds-fc-big { display: flex; align-items: center; justify-content: center; gap: 10px; padding: 16px 40px; border-radius: var(--radius-lg); font-family: var(--font-display); font-weight: 700; font-size: 16px; cursor: pointer; border: 1.5px solid var(--solid-ink); box-shadow: 3px 4px 0 var(--solid-ink); transition: transform var(--dur-fast), box-shadow var(--dur-fast); transform: scale(1.3); transform-origin: center; }
-.ds-fc-big:hover { transform: scale(1.3) translate(1px,1px); box-shadow: 2px 3px 0 var(--solid-ink); }
+.ds-fc-controls { display: flex; gap: 20px; margin-top: 26px; }
+.ds-fc-big { display: flex; align-items: center; justify-content: center; gap: 8px; padding: 11px 26px; border-radius: var(--radius-lg); font-family: var(--font-display); font-weight: 700; font-size: 15px; cursor: pointer; border: 1.5px solid var(--solid-ink); box-shadow: 3px 4px 0 var(--solid-ink); transition: transform var(--dur-fast), box-shadow var(--dur-fast); }
+.ds-fc-big:hover { transform: translate(1px,1px); box-shadow: 2px 3px 0 var(--solid-ink); }
 .ds-fc-big.know { background: var(--color-accent); color: #fff; border-color: var(--color-accent-ink); box-shadow: 3px 4px 0 var(--color-accent-ink); }
 .ds-fc-big.dunno { background: #fff; color: var(--color-ink); }
 

--- a/src/app/flashcard/[projectId]/page.tsx
+++ b/src/app/flashcard/[projectId]/page.tsx
@@ -577,8 +577,24 @@ export default function FlashcardPage() {
               <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap', justifyContent: 'center' }}>
                 {currentWord?.partOfSpeechTags?.map((tag) => <span key={tag} className="ds-tag accent">{getPartOfSpeechLabel(tag)}</span>)}
               </div>
-              {currentWord?.exampleSentenceJa && (
-                <div className="muted" style={{ fontSize: 14, maxWidth: 460, lineHeight: 1.6 }}>{currentWord.exampleSentenceJa}</div>
+              {currentWord?.exampleSentence && (
+                <div
+                  style={{
+                    maxWidth: 460,
+                    width: '100%',
+                    borderRadius: 12,
+                    border: '1px solid var(--color-border)',
+                    background: 'var(--color-surface)',
+                    padding: '12px 16px',
+                    textAlign: 'left',
+                  }}
+                >
+                  <div className="mono" style={{ fontSize: 10, fontWeight: 700, letterSpacing: '0.08em', textTransform: 'uppercase', color: 'var(--color-muted)', marginBottom: 6 }}>例文</div>
+                  <div style={{ fontSize: 15, lineHeight: 1.6, color: 'var(--color-ink)' }}>{currentWord.exampleSentence}</div>
+                  {currentWord.exampleSentenceJa && (
+                    <div className="muted" style={{ fontSize: 13, lineHeight: 1.6, marginTop: 6 }}>{currentWord.exampleSentenceJa}</div>
+                  )}
+                </div>
               )}
               <div className="hint"><Icon name="touch_app" style={{ fontSize: 14 }} />クリックで戻る</div>
             </div>


### PR DESCRIPTION
## Summary

Fixes two issues on the desktop flashcard view (`/flashcard/[projectId]`, the `lg:` layout):

1. **Missing English example sentence** — The desktop back face only rendered `exampleSentenceJa` (the Japanese translation), so the English example was never shown. It now renders the English `exampleSentence` in a labeled 例文 block with the Japanese translation underneath, matching the mobile layout.

2. **Oversized bottom buttons** — The three controls (前へ / 回転 / 次へ) used `.ds-fc-big` with `transform: scale(1.3)` on top of `16px 40px` padding, making them look too large. Removed the `scale(1.3)` blowup (base + hover) and trimmed padding, gap, and font-size to a sensible size.

## Changes

- `src/app/flashcard/[projectId]/page.tsx` — desktop back face now shows the English example sentence + Japanese translation.
- `src/app/desktop.css` — `.ds-fc-big` / `.ds-fc-controls` sizing reduced (no more `scale(1.3)`, smaller padding/gap).

## Notes

Only the desktop (`lg:`) flashcard layout is affected; the mobile layout already displayed the English example and is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y34Z7iwbzoFiKMrDgjX9ph

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y34Z7iwbzoFiKMrDgjX9ph)_