### PR TITLE
ホーム保存済み単語の空表示を非表示に & 英検デフォルト単語帳インポートのバグ修正

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -668,32 +668,34 @@ export default function HomePage() {
         </SolidPanel>
       </div>
 
-      <div className="px-[18px] pb-3.5">
-        <Link href="/favorites" className="block">
-          <SolidPanel className="!rounded-2xl" faceClassName="!p-3">
-            <div className="flex items-center gap-2.5">
-              <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full border-2 border-[var(--solid-ink)] bg-[var(--color-accent)] text-white">
-                <Icon name="bookmark" size={17} filled />
-              </span>
-              <div className="min-w-0 flex-1">
-                <div className="font-mono text-[10px] font-semibold uppercase tracking-[0.02em] text-[var(--color-muted)]">
-                  SAVED WORDS
-                </div>
-                <div className="text-sm font-bold text-[var(--solid-ink)]">保存済み単語</div>
-              </div>
-              <div className="flex items-baseline gap-0.5">
-                <span className="font-display text-lg font-extrabold tabular-nums text-[var(--solid-ink)]">
-                  {favoriteCount}
+      {favoriteCount > 0 && (
+        <div className="px-[18px] pb-3.5">
+          <Link href="/favorites" className="block">
+            <SolidPanel className="!rounded-2xl" faceClassName="!p-3">
+              <div className="flex items-center gap-2.5">
+                <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full border-2 border-[var(--solid-ink)] bg-[var(--color-accent)] text-white">
+                  <Icon name="bookmark" size={17} filled />
                 </span>
-                <span className="text-[11px] font-bold text-[var(--color-muted)]">語</span>
+                <div className="min-w-0 flex-1">
+                  <div className="font-mono text-[10px] font-semibold uppercase tracking-[0.02em] text-[var(--color-muted)]">
+                    SAVED WORDS
+                  </div>
+                  <div className="text-sm font-bold text-[var(--solid-ink)]">保存済み単語</div>
+                </div>
+                <div className="flex items-baseline gap-0.5">
+                  <span className="font-display text-lg font-extrabold tabular-nums text-[var(--solid-ink)]">
+                    {favoriteCount}
+                  </span>
+                  <span className="text-[11px] font-bold text-[var(--color-muted)]">語</span>
+                </div>
+                <span className="inline-flex text-[var(--color-accent)]">
+                  <Icon name="chevron_right" size={14} />
+                </span>
               </div>
-              <span className="inline-flex text-[var(--color-accent)]">
-                <Icon name="chevron_right" size={14} />
-              </span>
-            </div>
-          </SolidPanel>
-        </Link>
-      </div>
+            </SolidPanel>
+          </Link>
+        </div>
+      )}
 
       <div className="flex items-baseline justify-between px-5 pb-2.5 pt-3">
         <div>

--- a/src/lib/official-wordbooks/import-default.test.ts
+++ b/src/lib/official-wordbooks/import-default.test.ts
@@ -1,7 +1,11 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 
-import { fetchDefaultOfficialWordbooksForLocalImport } from './import-default';
+import {
+  fetchDefaultOfficialWordbooksForLocalImport,
+  persistDefaultOfficialWordbooksToDb,
+  type DefaultOfficialWordbookImportItem,
+} from './import-default';
 
 type QueryAction = 'select' | 'insert' | 'upsert' | 'delete';
 
@@ -366,4 +370,152 @@ test('default official wordbook local payload includes every active default word
     'official-pre1-2',
   ]);
   assert.equal(findOperations(client, 'official_wordbooks', 'insert').length, 0);
+});
+
+// ============================================================
+// persistDefaultOfficialWordbooksToDb
+// ============================================================
+
+interface CapturedInserts {
+  projectInserts: unknown[];
+  wordInsertBatches: Array<Array<Record<string, unknown>>>;
+  translationUpserts: unknown[];
+  deletedProjectIds: string[];
+}
+
+/**
+ * Minimal service-role admin client stub for persistDefaultOfficialWordbooksToDb.
+ * Captures the exact rows handed to `.insert()` so the test can assert the
+ * bulk-insert payload is well-formed.
+ */
+function createFakeAdminClient(
+  captured: CapturedInserts,
+  overrides: { wordInsertError?: { message: string } } = {},
+) {
+  return {
+    from(table: string) {
+      if (table === 'projects') {
+        return {
+          select: () => ({
+            eq: async () => ({ data: [], error: null }),
+          }),
+          insert: async (payload: unknown) => {
+            captured.projectInserts.push(payload);
+            return { error: null };
+          },
+          delete: () => ({
+            eq: async (_column: string, value: string) => {
+              captured.deletedProjectIds.push(value);
+              return { error: null };
+            },
+          }),
+        };
+      }
+      if (table === 'words') {
+        return {
+          insert: async (rows: Array<Record<string, unknown>>) => {
+            captured.wordInsertBatches.push(rows);
+            return { error: overrides.wordInsertError ?? null };
+          },
+        };
+      }
+      if (table === 'word_translations') {
+        return {
+          upsert: async (rows: unknown) => {
+            captured.translationUpserts.push(rows);
+            return { error: null };
+          },
+        };
+      }
+      throw new Error(`Unexpected table: ${table}`);
+    },
+  };
+}
+
+function makeHeterogeneousWordbook(slug: string): DefaultOfficialWordbookImportItem {
+  return {
+    officialWordbookId: `ow-${slug}`,
+    officialSlug: slug,
+    title: `単語帳 ${slug}`,
+    sourceLabels: ['official', 'eiken:3'],
+    words: [
+      // Word with several optional fields populated.
+      {
+        english: 'improve',
+        japanese: '改善する',
+        distractors: ['悪化する', '維持する'],
+        vocabularyType: 'active',
+        japaneseSource: 'scan',
+        exampleSentence: 'We must improve the plan.',
+        exampleSentenceJa: '計画を改善しなければならない。',
+        partOfSpeechTags: ['verb'],
+        customSections: [{ id: 'memo', title: 'Memo', content: 'Core verb' }],
+      },
+      // Word with NONE of the optional fields — this is what previously produced
+      // a different JSON key set and triggered PostgREST's PGRST102 error.
+      {
+        english: 'run',
+        japanese: '走る',
+        distractors: ['歩く', '座る'],
+      },
+    ],
+  };
+}
+
+test('persistDefaultOfficialWordbooksToDb inserts homogeneous word rows for heterogeneous words', async () => {
+  const captured: CapturedInserts = {
+    projectInserts: [],
+    wordInsertBatches: [],
+    translationUpserts: [],
+    deletedProjectIds: [],
+  };
+  const client = createFakeAdminClient(captured);
+
+  await persistDefaultOfficialWordbooksToDb(
+    client as never,
+    'user-1',
+    [makeHeterogeneousWordbook('merken-eiken-3-1')],
+  );
+
+  assert.equal(captured.wordInsertBatches.length, 1);
+  const rows = captured.wordInsertBatches[0];
+  assert.equal(rows.length, 2);
+
+  // Every row in a bulk insert must expose the same JSON keys, otherwise
+  // PostgREST rejects the batch with "All object keys must match" (PGRST102).
+  const keySets = rows.map((row) => Object.keys(row).sort());
+  assert.deepEqual(keySets[0], keySets[1]);
+
+  // No key may serialize away as `undefined` (JSON.stringify drops those and
+  // re-introduces the key-set mismatch).
+  for (const row of rows) {
+    for (const [key, value] of Object.entries(row)) {
+      assert.notEqual(value, undefined, `word row key "${key}" must not be undefined`);
+    }
+    // custom_sections is NOT NULL in the DB — it must be an array, never null.
+    assert.ok(Array.isArray(row.custom_sections), 'custom_sections must be an array');
+  }
+});
+
+test('persistDefaultOfficialWordbooksToDb isolates a failing wordbook and rolls back its empty project', async () => {
+  const captured: CapturedInserts = {
+    projectInserts: [],
+    wordInsertBatches: [],
+    translationUpserts: [],
+    deletedProjectIds: [],
+  };
+  const client = createFakeAdminClient(captured, {
+    wordInsertError: { message: 'simulated words insert failure' },
+  });
+
+  // Should not throw even though the words insert fails.
+  await persistDefaultOfficialWordbooksToDb(
+    client as never,
+    'user-1',
+    [makeHeterogeneousWordbook('merken-eiken-3-1')],
+  );
+
+  // The just-created (empty) project is rolled back so no empty wordbook remains.
+  assert.equal(captured.projectInserts.length, 1);
+  assert.equal(captured.deletedProjectIds.length, 1);
 });

--- a/src/lib/official-wordbooks/import-default.ts
+++ b/src/lib/official-wordbooks/import-default.ts
@@ -261,6 +261,42 @@ function newId(): string {
 }
 
 /**
+ * PostgREST bulk insert (supabase-js `.insert([...])`) requires every object in
+ * the array to expose the SAME set of JSON keys. `mapWordToInsertWithId` leaves
+ * absent optional fields as `undefined`, and `JSON.stringify` strips those keys,
+ * so a wordbook whose words vary in which optional fields are populated (e.g.
+ * only some have an example sentence or part-of-speech tags) yields rows with
+ * different key sets. PostgREST then rejects the whole batch with
+ * "All object keys must match" (PGRST102), which aborted the signup import after
+ * the first (empty) project was created — leaving the user with a single empty
+ * wordbook. Coerce every optional column to an explicit value so all rows are
+ * uniform. NOT NULL columns fall back to their table default instead of null.
+ */
+function toHomogeneousWordInsertRow(
+  row: ReturnType<typeof mapWordToInsertWithId>,
+): Record<string, unknown> {
+  return {
+    ...row,
+    japanese_source: row.japanese_source ?? null,
+    vocabulary_type: row.vocabulary_type ?? null,
+    lexicon_entry_id: row.lexicon_entry_id ?? null,
+    lexicon_sense_id: row.lexicon_sense_id ?? null,
+    example_sentence: row.example_sentence ?? null,
+    example_sentence_ja: row.example_sentence_ja ?? null,
+    pronunciation: row.pronunciation ?? null,
+    part_of_speech_tags: row.part_of_speech_tags ?? null,
+    related_words: row.related_words ?? null,
+    usage_patterns: row.usage_patterns ?? null,
+    insights_generated_at: row.insights_generated_at ?? null,
+    insights_version: row.insights_version ?? null,
+    word_order_quiz: row.word_order_quiz ?? null,
+    last_reviewed_at: row.last_reviewed_at ?? null,
+    next_review_at: row.next_review_at ?? null,
+    custom_sections: row.custom_sections ?? [],
+  };
+}
+
+/**
  * Persist default official wordbooks directly into the user's Supabase rows
  * (projects + words + word_translations) at signup time, instead of only
  * writing them to the browser's IndexedDB. This uses the service-role admin
@@ -300,67 +336,82 @@ export async function persistDefaultOfficialWordbooksToDb(
       continue;
     }
 
-    const projectId = newId();
-    const project: Project = {
-      id: projectId,
-      userId,
-      title: wordbook.title,
-      sourceLabels: wordbook.sourceLabels,
-      createdAt: nowIso,
-      ...(wordbook.iconImage ? { iconImage: wordbook.iconImage } : {}),
-      ...(officialSlug ? { importedFromOfficialSlug: officialSlug } : {}),
-    };
+    // Import each wordbook independently so a single failure never aborts the
+    // remaining ones (previously one bad batch left the user with just one
+    // wordbook). A wordbook whose words fail to insert has its just-created
+    // project rolled back so we never leave an empty wordbook behind.
+    try {
+      const projectId = newId();
+      const project: Project = {
+        id: projectId,
+        userId,
+        title: wordbook.title,
+        sourceLabels: wordbook.sourceLabels,
+        createdAt: nowIso,
+        ...(wordbook.iconImage ? { iconImage: wordbook.iconImage } : {}),
+        ...(officialSlug ? { importedFromOfficialSlug: officialSlug } : {}),
+      };
 
-    const { error: projectError } = await adminClient
-      .from('projects')
-      .insert(mapProjectToInsertWithId(project));
-    if (projectError) {
-      throw new Error(`Failed to insert default wordbook project: ${projectError.message}`);
-    }
-    if (officialSlug) importedSlugs.add(officialSlug);
-
-    if (wordbook.words.length === 0) continue;
-
-    const wordIds = wordbook.words.map(() => newId());
-    const wordRows = wordbook.words.map((word, index) => mapWordToInsertWithId({
-      id: wordIds[index],
-      projectId,
-      english: word.english,
-      japanese: word.japanese,
-      japaneseSource: word.japaneseSource,
-      vocabularyType: word.vocabularyType ?? undefined,
-      lexiconEntryId: word.lexiconEntryId,
-      lexiconSenseId: word.lexiconSenseId,
-      distractors: word.distractors ?? [],
-      exampleSentence: word.exampleSentence,
-      exampleSentenceJa: word.exampleSentenceJa,
-      pronunciation: word.pronunciation,
-      partOfSpeechTags: word.partOfSpeechTags,
-      relatedWords: word.relatedWords,
-      usagePatterns: word.usagePatterns,
-      wordOrderQuiz: word.wordOrderQuiz,
-      customSections: word.customSections,
-      status: 'new',
-      createdAt: nowIso,
-      isFavorite: false,
-      ...srDefaults,
-    } as Word));
-
-    const { error: wordsError } = await adminClient.from('words').insert(wordRows);
-    if (wordsError) {
-      throw new Error(`Failed to insert default wordbook words: ${wordsError.message}`);
-    }
-
-    const translationRows = buildWordTranslationInsertRows(wordbook.words, wordIds);
-    if (translationRows.length > 0) {
-      const { error: translationError } = await adminClient
-        .from('word_translations')
-        .upsert(translationRows, { onConflict: 'word_id,normalized_translation_ja' });
-      // Translations are a non-critical enrichment: never fail the whole signup
-      // import if the child table is unavailable or momentarily out of sync.
-      if (translationError && !isWordTranslationsSchemaError(translationError)) {
-        console.error('[import-default] Failed to insert word translations:', translationError.message);
+      const { error: projectError } = await adminClient
+        .from('projects')
+        .insert(mapProjectToInsertWithId(project));
+      if (projectError) {
+        throw new Error(`Failed to insert default wordbook project: ${projectError.message}`);
       }
+      if (officialSlug) importedSlugs.add(officialSlug);
+
+      if (wordbook.words.length === 0) continue;
+
+      const wordIds = wordbook.words.map(() => newId());
+      const wordRows = wordbook.words.map((word, index) => toHomogeneousWordInsertRow(mapWordToInsertWithId({
+        id: wordIds[index],
+        projectId,
+        english: word.english,
+        japanese: word.japanese,
+        japaneseSource: word.japaneseSource,
+        vocabularyType: word.vocabularyType ?? undefined,
+        lexiconEntryId: word.lexiconEntryId,
+        lexiconSenseId: word.lexiconSenseId,
+        distractors: word.distractors ?? [],
+        exampleSentence: word.exampleSentence,
+        exampleSentenceJa: word.exampleSentenceJa,
+        pronunciation: word.pronunciation,
+        partOfSpeechTags: word.partOfSpeechTags,
+        relatedWords: word.relatedWords,
+        usagePatterns: word.usagePatterns,
+        wordOrderQuiz: word.wordOrderQuiz,
+        customSections: word.customSections,
+        status: 'new',
+        createdAt: nowIso,
+        isFavorite: false,
+        ...srDefaults,
+      } as Word)));
+
+      const { error: wordsError } = await adminClient.from('words').insert(wordRows);
+      if (wordsError) {
+        // Roll back the empty project so the user never sees a wordbook with no
+        // words, then let the loop continue with the other wordbooks.
+        await adminClient.from('projects').delete().eq('id', projectId);
+        if (officialSlug) importedSlugs.delete(officialSlug);
+        throw new Error(`Failed to insert default wordbook words: ${wordsError.message}`);
+      }
+
+      const translationRows = buildWordTranslationInsertRows(wordbook.words, wordIds);
+      if (translationRows.length > 0) {
+        const { error: translationError } = await adminClient
+          .from('word_translations')
+          .upsert(translationRows, { onConflict: 'word_id,normalized_translation_ja' });
+        // Translations are a non-critical enrichment: never fail the whole signup
+        // import if the child table is unavailable or momentarily out of sync.
+        if (translationError && !isWordTranslationsSchemaError(translationError)) {
+          console.error('[import-default] Failed to insert word translations:', translationError.message);
+        }
+      }
+    } catch (wordbookError) {
+      console.error(
+        `[import-default] Failed to import official wordbook "${officialSlug ?? wordbook.title}":`,
+        wordbookError instanceof Error ? wordbookError.message : wordbookError,
+      );
     }
   }
 }


### PR DESCRIPTION
## 概要

2件の不具合を修正します。いずれも無料プランへのクラウド同期開放（#356）に伴う挙動です。

### 1. ホーム: 保存済み単語カードが常に表示される
保存済み単語が0件でもホームに「保存済み単語 0 語」の導線カードが出ていた。
`favoriteCount > 0` の場合のみ表示するように修正。

- `src/app/page.tsx`: 保存済み単語カードを `{favoriteCount > 0 && (...)}` で囲む

### 2. 英検デフォルト単語帳が「1冊だけ・単語0件」でインポートされる
サインアップで級を選ぶと、その級のデフォルト公式単語帳（各級 **5冊 × 50語**）が
Supabase に永続化されるはずが、**最初の1冊（空プロジェクト）だけ**残る状態になっていた。

**原因**

`persistDefaultOfficialWordbooksToDb` の `words` への一括 insert が失敗し、
ループが最初のプロジェクト作成直後に中断していた。

`mapWordToInsertWithId` は未設定の任意フィールドを `undefined` のまま返し、
`JSON.stringify` がそのキーを落とす。公式単語帳は語ごとに任意フィールドの有無が
異なる（例文・品詞タグ等が一部の語のみ）ため、バッチ内で行ごとに JSON キー集合が
不一致になる。PostgREST の一括 insert は全オブジェクトのキー一致を要求するため、
`"All object keys must match"`（PGRST102）でバッチ全体が拒否されていた。
※本番DBの公式データ（各級5冊×50語）自体は正常に存在していることを確認済み。

**修正**

- `toHomogeneousWordInsertRow` を追加し、全行のキー集合を揃える
  （任意列は明示的に `null`、NOT NULL の `custom_sections` は `[]` にフォールバック）。
  実績のある `/api/words/create` と同じ方針。
- 各単語帳を `try/catch` で独立処理し、1冊の失敗が残り4冊を巻き込まないようにする。
  単語 insert が失敗した場合は作成済みの空プロジェクトを削除し、空の単語帳を残さない。

## テスト

- `src/lib/official-wordbooks/import-default.test.ts` に回帰テストを2件追加
  - 任意フィールドが不揃いな語でも、insert する全行のキー集合が一致すること
  - 1冊の insert 失敗時に例外を投げず、空プロジェクトをロールバックすること
- `npx tsc --noEmit`（プロジェクト設定）: エラー0件
- `import-default.test.ts`: 全6件パス

## 補足（本PR対象外・要相談）

- 本修正は**今後のサインアップ**を正常化するもの。バグ発生後（#356 リリース後）に
  級を選んでサインアップした既存ユーザーには、既に空の単語帳が残っている（該当3件を確認）。
  必要であれば別途データ補填（バックフィル）を実施可能です。
- OAuthサインアップ経路（`/api/onboarding/profile`）は元々デフォルト単語帳を配布して
  いない既知のギャップがあります（本バグとは別問題）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01V686Dd2mNZsDP4KywjXY8t)_