### PR TITLE
Google認証登録時にユーザ名・デフォルト単語帳が保存されない問題を修正

### DIFF
--- a/src/app/api/onboarding/profile/route.test.ts
+++ b/src/app/api/onboarding/profile/route.test.ts
@@ -86,6 +86,8 @@ test('onboarding profile POST fills empty fields and mirrors handle to account_i
     {
       resolveUser: async () => ({ id: 'user-1' }),
       getAdmin: () => admin as never,
+      // Keep this test focused on profile writes; the wordbook seed is a no-op.
+      seedDefaultOfficialWordbooksForUser: async () => 0,
     },
   );
 
@@ -99,6 +101,51 @@ test('onboarding profile POST fills empty fields and mirrors handle to account_i
     account_id: 'kenta_123',
     eiken_level: 'pre2',
   }]);
+});
+
+test('onboarding profile POST seeds default wordbooks when the eiken level is first applied', async () => {
+  const admin = new FakeProfileAdmin(EMPTY_ROW);
+  const seedCalls: Array<{ userId: string; level: unknown }> = [];
+
+  const response = await handleOnboardingProfilePost(
+    request({ eiken_level: 'pre2' }),
+    {
+      resolveUser: async () => ({ id: 'user-1' }),
+      getAdmin: () => admin as never,
+      seedDefaultOfficialWordbooksForUser: async (_client, userId, level) => {
+        seedCalls.push({ userId, level });
+        return 5;
+      },
+    },
+  );
+
+  assert.equal(response.status, 200);
+  assert.deepEqual(await response.json(), { success: true, applied: true });
+  assert.equal(seedCalls.length, 1);
+  assert.equal(seedCalls[0].userId, 'user-1');
+  assert.equal(seedCalls[0].level, 'pre2');
+});
+
+test('onboarding profile POST does not seed wordbooks when the eiken level is already set', async () => {
+  const admin = new FakeProfileAdmin({ ...EMPTY_ROW, eiken_level: '2' });
+  let seedCalled = false;
+
+  const response = await handleOnboardingProfilePost(
+    request({ display_name: '山田太郎', eiken_level: '5' }),
+    {
+      resolveUser: async () => ({ id: 'user-1' }),
+      getAdmin: () => admin as never,
+      seedDefaultOfficialWordbooksForUser: async () => {
+        seedCalled = true;
+        return 0;
+      },
+    },
+  );
+
+  assert.equal(response.status, 200);
+  // display_name still applied, but the already-set eiken level is untouched and
+  // must not trigger a re-seed.
+  assert.equal(seedCalled, false);
 });
 
 test('onboarding profile POST never overwrites existing profile values', async () => {

--- a/src/app/api/onboarding/profile/route.ts
+++ b/src/app/api/onboarding/profile/route.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 import { resolveAuthenticatedUser } from '@/app/api/share-import/shared';
 import { parseJsonWithSchema } from '@/lib/api/validation';
 import { getSupabaseAdmin } from '@/lib/supabase/admin';
+import { seedDefaultOfficialWordbooksForUser } from '@/lib/official-wordbooks/import-default';
 
 /**
  * Applies onboarding profile fields (display name / handle / eiken level)
@@ -33,6 +34,7 @@ type ProfileRow = {
 type OnboardingProfileRouteDeps = {
   resolveUser?: typeof resolveAuthenticatedUser;
   getAdmin?: typeof getSupabaseAdmin;
+  seedDefaultOfficialWordbooksForUser?: typeof seedDefaultOfficialWordbooksForUser;
 };
 
 const ACCOUNT_ID_FORMAT = /^[a-z0-9_]{4,24}$/;
@@ -121,6 +123,24 @@ export async function handleOnboardingProfilePost(
     if (error) {
       console.error('Failed to apply onboarding profile:', error);
       return NextResponse.json({ error: 'プロフィール情報の保存に失敗しました' }, { status: 500 });
+    }
+
+    // OAuth users establish their EIKEN level here (the provider redirect happens
+    // before signup-verify can seed anything), so seed their default wordbooks
+    // now that the level is recorded for the first time. This backs up the
+    // auth-callback cookie flow for contexts where sessionStorage is the only
+    // channel that survived the redirect; persist de-dupes so double-seeding is
+    // harmless. A seeding failure must never block onboarding.
+    if (payload.eiken_level && eiken_level) {
+      try {
+        await (deps.seedDefaultOfficialWordbooksForUser ?? seedDefaultOfficialWordbooksForUser)(
+          admin,
+          user.id,
+          eiken_level,
+        );
+      } catch (seedError) {
+        console.error('Failed to seed default official wordbooks during onboarding:', seedError);
+      }
     }
 
     return NextResponse.json({ success: true, applied: true });

--- a/src/app/auth/callback/route.ts
+++ b/src/app/auth/callback/route.ts
@@ -12,12 +12,14 @@ import {
   isUniqueSignupProfileViolation,
   saveSignupProfileFields,
 } from '@/lib/auth/signup-profile';
+import { seedDefaultOfficialWordbooksForUser } from '@/lib/official-wordbooks/import-default';
 import { NextResponse } from 'next/server';
 
 type AuthCallbackDeps = {
   createServerClient?: typeof createClient;
   getAdmin?: typeof getSupabaseAdmin;
   saveSignupProfileFields?: typeof saveSignupProfileFields;
+  seedDefaultOfficialWordbooksForUser?: typeof seedDefaultOfficialWordbooksForUser;
 };
 
 function clearOAuthCookies(response: NextResponse): void {
@@ -53,6 +55,27 @@ export async function handleAuthCallbackGet(request: Request, deps: AuthCallback
 
         if (profileError) {
           console.error('Failed to save OAuth onboarding profile:', profileError);
+        }
+
+        // Seed the default official wordbooks for the chosen EIKEN level. OAuth
+        // signups never reach signup-verify, so this is their equivalent seed.
+        // Awaited before the redirect so the wordbooks exist in Supabase by the
+        // time the client runs its first sync (the sessionStorage fallback in
+        // /api/onboarding/profile does not fire when it is lost across the OAuth
+        // round-trip). persist de-dupes by official slug, so if that fallback
+        // also runs it never creates duplicates. A seeding failure must not
+        // block the user from entering the app.
+        const eikenLevel = onboardingFields.eiken_level;
+        if (eikenLevel) {
+          try {
+            await (deps.seedDefaultOfficialWordbooksForUser ?? seedDefaultOfficialWordbooksForUser)(
+              admin,
+              data.user.id,
+              eikenLevel,
+            );
+          } catch (seedError) {
+            console.error('Failed to seed OAuth default wordbooks:', seedError);
+          }
         }
       }
 

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -29,6 +29,7 @@ import {
   type SignupStep,
 } from '@/lib/auth/signup-flow';
 import { storePendingOnboarding } from '@/lib/auth/pending-onboarding';
+import type { SignupProfileFields } from '@/lib/auth/signup-profile';
 import { usePageBackground } from '@/hooks/use-page-background';
 
 const SIGNUP_BG = '#f3f0e9';
@@ -154,6 +155,17 @@ function SignupForm() {
     if (validateOnboardingData(onboarding).ok && handleAvailable !== false) {
       storePendingOnboarding(onboarding);
     }
+  };
+
+  // Carry the collected onboarding profile through the OAuth redirect in a
+  // cookie so the auth callback persists it (and seeds default wordbooks)
+  // server-side — the reliable channel when sessionStorage does not survive the
+  // provider round-trip (PWA / in-app browser). A taken handle is dropped by the
+  // callback, which still saves the name + level, so it is safe to include here.
+  const oauthOnboardingFields: SignupProfileFields = {
+    ...(displayName.trim() ? { display_name: displayName.trim() } : {}),
+    ...(userHandle && handleAvailable !== false ? { user_handle: userHandle } : {}),
+    eiken_level: eikenLevel,
   };
 
   const handleFormSubmit = async (event: FormEvent<HTMLFormElement>) => {
@@ -445,6 +457,7 @@ function SignupForm() {
             disabled={loading}
             onError={(message) => setError(message || null)}
             onBeforeRedirect={stashOnboardingForOAuth}
+            onboardingFields={oauthOnboardingFields}
           />
 
           <div className="muted" style={{ fontSize: 12, textAlign: 'center', marginTop: 18, lineHeight: 1.6 }}>
@@ -540,6 +553,7 @@ function SignupForm() {
               disabled={loading}
               onError={(message) => setError(message || null)}
               onBeforeRedirect={stashOnboardingForOAuth}
+              onboardingFields={oauthOnboardingFields}
             />
 
             <div className="flex items-center gap-2.5 px-6 pb-3.5 pt-1.5">

--- a/src/components/auth/OAuthProviderButtons.tsx
+++ b/src/components/auth/OAuthProviderButtons.tsx
@@ -9,6 +9,7 @@ import {
   getOAuthProviderLabel,
   type AuthOAuthProvider,
 } from '@/lib/auth/oauth';
+import type { SignupProfileFields } from '@/lib/auth/signup-profile';
 
 const PROVIDERS: { id: AuthOAuthProvider; mark: string }[] = [
   { id: 'google', mark: 'G' },
@@ -27,12 +28,19 @@ export function OAuthProviderButtons({
   disabled = false,
   onError,
   onBeforeRedirect,
+  onboardingFields,
 }: {
   redirectPath: string;
   disabled?: boolean;
   onError: (message: string) => void;
   /** Runs just before the OAuth redirect starts (e.g. to stash signup data). */
   onBeforeRedirect?: () => void;
+  /**
+   * Onboarding profile (name / handle / eiken level) to carry through the OAuth
+   * redirect via a cookie so the callback persists it server-side — the
+   * reliable channel that survives PWA/standalone/in-app-browser round-trips.
+   */
+  onboardingFields?: SignupProfileFields | null;
 }) {
   const { signInWithOAuth } = useAuth();
   const [loadingProvider, setLoadingProvider] = useState<AuthOAuthProvider | null>(null);
@@ -47,7 +55,7 @@ export function OAuthProviderButtons({
     setLoadingProvider(provider);
     onError('');
     onBeforeRedirect?.();
-    const result = await signInWithOAuth(provider, redirectPath);
+    const result = await signInWithOAuth(provider, redirectPath, onboardingFields);
     if (!result.success) {
       onError(result.error || `${getOAuthProviderLabel(provider)}ログインに失敗しました`);
       setLoadingProvider(null);

--- a/src/components/desktop/DesktopAuth.tsx
+++ b/src/components/desktop/DesktopAuth.tsx
@@ -9,6 +9,7 @@ import {
   getOAuthProviderLabel,
   type AuthOAuthProvider,
 } from '@/lib/auth/oauth';
+import type { SignupProfileFields } from '@/lib/auth/signup-profile';
 
 const AUTH_BOOKS = [
   { title: '鉄壁', color: '#f2c94c' },
@@ -180,12 +181,18 @@ export function DesktopAuthOAuth({
   disabled,
   onError,
   onBeforeRedirect,
+  onboardingFields,
 }: {
   redirectPath: string;
   disabled?: boolean;
   onError: (message: string) => void;
   /** Runs just before the OAuth redirect starts (e.g. to stash signup data). */
   onBeforeRedirect?: () => void;
+  /**
+   * Onboarding profile carried through the OAuth redirect via a cookie so the
+   * callback persists it server-side (survives PWA/in-app-browser round-trips).
+   */
+  onboardingFields?: SignupProfileFields | null;
 }) {
   const { signInWithOAuth } = useAuth();
   const [loadingProvider, setLoadingProvider] = useState<AuthOAuthProvider | null>(null);
@@ -197,7 +204,7 @@ export function DesktopAuthOAuth({
     setLoadingProvider(provider);
     onError('');
     onBeforeRedirect?.();
-    const result = await signInWithOAuth(provider, redirectPath);
+    const result = await signInWithOAuth(provider, redirectPath, onboardingFields);
     if (!result.success) {
       onError(result.error || `${getOAuthProviderLabel(provider)}ログインに失敗しました`);
       setLoadingProvider(null);

--- a/src/lib/official-wordbooks/import-default.ts
+++ b/src/lib/official-wordbooks/import-default.ts
@@ -415,3 +415,25 @@ export async function persistDefaultOfficialWordbooksToDb(
     }
   }
 }
+
+/**
+ * Fetch + persist the default official wordbooks for a user's chosen EIKEN
+ * level in one step. Shared by every signup path that establishes a level:
+ * the email/password path (signup-verify) and the OAuth paths (the auth
+ * callback cookie flow and the onboarding-profile sessionStorage flow).
+ * persist de-dupes by imported_from_official_slug, so calling this from more
+ * than one path for the same user never creates duplicate wordbooks. Returns
+ * the number of wordbooks persisted (0 when the level is unset or has no
+ * default wordbooks). Errors propagate; the caller decides how to handle them.
+ */
+export async function seedDefaultOfficialWordbooksForUser(
+  adminClient: SupabaseClient,
+  userId: string,
+  eikenLevel: OfficialWordbookEikenLevel | null | undefined,
+): Promise<number> {
+  if (!eikenLevel) return 0;
+  const wordbooks = await fetchDefaultOfficialWordbooksForLocalImport(adminClient, eikenLevel);
+  if (!wordbooks || wordbooks.length === 0) return 0;
+  await persistDefaultOfficialWordbooksToDb(adminClient, userId, wordbooks);
+  return wordbooks.length;
+}


### PR DESCRIPTION
## 概要

OAuth(Google/Apple)でサインアップすると **表示名(ユーザ名) が保存されず**、**デフォルト英検単語帳も配布されない** 問題を修正します。メール/パスワード登録では `signup-verify` が両方を確定しますが、OAuth はプロバイダのリダイレクトが先に走るため、この経路が抜けていました。

## 原因

`signInWithOAuth(provider, redirect, onboardingFields)` は、リダイレクトを跨いで残る **cookie** にオンボーディング項目(表示名/ハンドル/英検級)を載せ、`/auth/callback` がそれを読んで `saveSignupProfileFields` でサーバ側保存する堅牢な経路を備えていました。しかし OAuthボタン(`OAuthProviderButtons` / `DesktopAuthOAuth`)が第3引数 `onboardingFields` を **一切渡していなかった** ため、毎回 cookie を期限切れにしており、この経路が完全に死んでいました。

結果、`sessionStorage` 経由の脆いフォールバックのみに依存し、OAuthラウンドトリップで `sessionStorage` が失われる文脈(PWA / 標準モード / アプリ内ブラウザ)では **表示名が保存されず**、さらに **デフォルト単語帳の seed はどのOAuth経路にも存在しなかった** ため単語帳も配布されませんでした。

## 修正

**フロントエンド(cookie経路を有効化 → 表示名/級をサーバ側で確実に保存)**
- `OAuthProviderButtons` / `DesktopAuthOAuth` に `onboardingFields` プロップを追加し、`signInWithOAuth(provider, redirect, onboardingFields)` へ引き渡す。
- `signup/page.tsx` の両OAuthボタン(モバイル/デスクトップ)へ現在の入力値を渡す。ハンドル重複時は callback 側が自動でハンドルのみ落として名前+級を保存するため、そのまま渡して安全。

**バックエンド(デフォルト単語帳の seed)**
- `auth/callback/route.ts`: プロフィール保存後、選択級のデフォルト公式単語帳を seed(リダイレクト前に await し、クライアント初回同期までに Supabase へ確定)。
- 共通ヘルパー `seedDefaultOfficialWordbooksForUser` を追加し、callback と onboarding-profile 経路で共有。`persist` は公式slugで重複排除するため、両経路が走っても単語帳は重複しない。
- `/api/onboarding/profile`: sessionStorage 経路のフォールバックとして、級が初回設定されたときに seed。

## テスト

- `src/app/api/onboarding/profile/route.test.ts` に seed 検証テストを2件追加(級を初回設定したとき seed される / 既設定なら seed しない)し、既存テストを共通ヘルパー注入方式へ更新。
- `npx tsc --noEmit`(プロジェクト設定): エラー0件 / lint: エラー0件。
- 全ユニットテスト: 800/802 pass。残り2件の失敗(`words/create`・`otp.contract`)は `main` でも失敗する既存のもので、本変更とは無関係。

## 補足

- 本PRは `main` にマージ済みの PR #358(ホーム保存済み単語の非表示 & 英検インポート修正)の続きです。#358 のコミットは含みません。
- バグ発生後にOAuth登録済みの既存ユーザーのデータ補填(バックフィル)は、ユーザーの指示により本PRでは行いません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01V686Dd2mNZsDP4KywjXY8t)_