### PR TITLE
Gemini Controlled Generation (responseSchema) 導入 — Phase 1

### DIFF
--- a/cloud-run-scan/src/index.ts
+++ b/cloud-run-scan/src/index.ts
@@ -98,6 +98,8 @@ interface GenerateRequest {
   temperature: number;
   maxOutputTokens: number;
   responseFormat?: 'json' | 'text';
+  // Gemini Controlled Generation schema forwarded from the web app. Only honored for Gemini + json.
+  responseSchema?: Record<string, unknown>;
   requestId?: string;
   feature?: string;
   env?: AppEnv;
@@ -165,6 +167,10 @@ async function runGeminiRequest(body: GenerateRequest): Promise<ProviderGenerate
 
   if (body.responseFormat === 'json') {
     generateConfig.responseMimeType = 'application/json';
+    // Controlled Generation: constrain output to the shape the web app requested.
+    if (body.responseSchema) {
+      generateConfig.responseSchema = body.responseSchema;
+    }
   }
 
   const response = await geminiClient.models.generateContent({

--- a/src/lib/ai/config.ts
+++ b/src/lib/ai/config.ts
@@ -26,12 +26,35 @@ const EXTRACTION_MODEL: GeminiModel = 'gemini-2.5-flash';
 const QUESTION_GENERATION_MODEL: GeminiModel = 'gemini-2.5-flash';
 const OPENAI_MODEL: OpenAIModel = 'gpt-4o';
 
+/**
+ * Provider-agnostic subset of a Gemini / JSON-Schema "controlled generation" schema.
+ *
+ * Kept minimal and JSON-serializable (no `@google/genai` types) so it survives the
+ * round-trip to the Cloud Run gateway and does not couple the shared abstraction to a
+ * Gemini-specific SDK type. `type` uses the uppercase strings of Gemini's `Type` enum
+ * (e.g. 'OBJECT', 'ARRAY', 'STRING').
+ */
+export interface ResponseSchema {
+  type: string;
+  description?: string;
+  nullable?: boolean;
+  enum?: string[];
+  items?: ResponseSchema;
+  properties?: Record<string, ResponseSchema>;
+  required?: string[];
+  propertyOrdering?: string[];
+  minItems?: number;
+  maxItems?: number;
+}
+
 export interface AIModelConfig {
   provider: AIProvider;
   model: string;
   temperature: number;
   maxOutputTokens: number;
   responseFormat?: 'json' | 'text';
+  // Optional Gemini Controlled Generation schema. Only honored when responseFormat === 'json'.
+  responseSchema?: ResponseSchema;
 }
 
 export interface AIConfig {

--- a/src/lib/ai/generate-example-sentences.test.ts
+++ b/src/lib/ai/generate-example-sentences.test.ts
@@ -4,8 +4,82 @@ import test from 'node:test';
 import {
   __internal,
   generateExampleSentences,
+  EXAMPLE_SENTENCE_RESPONSE_SCHEMA,
   type ExampleSeedWord,
 } from './generate-example-sentences';
+import { PART_OF_SPEECH_TAGS } from './part-of-speech';
+import type { AIProvider } from './providers';
+
+function createProvider(generateText: AIProvider['generateText']): AIProvider {
+  return {
+    name: 'mock-provider',
+    generate: async () => ({ success: false, error: 'not used in tests' }),
+    generateText,
+  };
+}
+
+test('generateSingle passes the Controlled Generation schema + json format on the provider config', async () => {
+  let receivedConfig: Parameters<AIProvider['generateText']>[1] | undefined;
+  const provider = createProvider(async (_prompt, config) => {
+    receivedConfig = config;
+    return {
+      success: true,
+      content: JSON.stringify({
+        partOfSpeechTags: ['noun'],
+        exampleSentence: 'The plan improved our workflow.',
+        exampleSentenceJa: 'その計画は作業を改善した。',
+      }),
+    };
+  });
+
+  const result = await __internal.generateSingle(
+    { id: '1', english: 'plan', japanese: '計画' },
+    { gemini: 'test-key' },
+    undefined,
+    { getProviderFromConfig: () => provider },
+  );
+
+  assert.equal(receivedConfig?.responseFormat, 'json');
+  assert.deepEqual(receivedConfig?.responseSchema, EXAMPLE_SENTENCE_RESPONSE_SCHEMA);
+  assert.equal(receivedConfig?.maxOutputTokens, 512);
+  assert.equal(result.exampleSentence, 'The plan improved our workflow.');
+  assert.deepEqual(result.partOfSpeechTags, ['noun']);
+});
+
+test('generateSingle still rejects via Zod when the provider returns a malformed shape', async () => {
+  const provider = createProvider(async () => ({
+    success: true,
+    // Structurally-plausible but incomplete: exampleSentenceJa missing -> Zod must still reject.
+    content: JSON.stringify({
+      partOfSpeechTags: ['noun'],
+      exampleSentence: 'Missing the Japanese field.',
+    }),
+  }));
+
+  await assert.rejects(
+    () => __internal.generateSingle(
+      { id: '1', english: 'plan', japanese: '計画' },
+      { gemini: 'test-key' },
+      undefined,
+      { getProviderFromConfig: () => provider },
+    ),
+    /Invalid example response|Failed to parse/,
+  );
+});
+
+test('EXAMPLE_SENTENCE_RESPONSE_SCHEMA mirrors the Zod shape and sources the POS enum', () => {
+  assert.equal(EXAMPLE_SENTENCE_RESPONSE_SCHEMA.type, 'OBJECT');
+  assert.deepEqual(EXAMPLE_SENTENCE_RESPONSE_SCHEMA.required, ['exampleSentence', 'exampleSentenceJa']);
+  assert.deepEqual(EXAMPLE_SENTENCE_RESPONSE_SCHEMA.propertyOrdering, [
+    'partOfSpeechTags',
+    'exampleSentence',
+    'exampleSentenceJa',
+  ]);
+  assert.deepEqual(
+    EXAMPLE_SENTENCE_RESPONSE_SCHEMA.properties?.partOfSpeechTags?.items?.enum,
+    [...PART_OF_SPEECH_TAGS],
+  );
+});
 
 test('parseSingleExampleResponse accepts string partOfSpeechTags inside code fences', () => {
   const parsed = __internal.parseSingleExampleResponse(`\`\`\`json

--- a/src/lib/ai/generate-example-sentences.ts
+++ b/src/lib/ai/generate-example-sentences.ts
@@ -7,9 +7,9 @@
  */
 
 import { z } from 'zod';
-import { AI_CONFIG } from '@/lib/ai/config';
+import { AI_CONFIG, type ResponseSchema } from '@/lib/ai/config';
 import { getProviderFromConfig } from '@/lib/ai/providers';
-import { normalizePartOfSpeechTags } from '@/lib/ai/part-of-speech';
+import { normalizePartOfSpeechTags, PART_OF_SPEECH_TAGS } from '@/lib/ai/part-of-speech';
 import { parseJsonResponse } from '@/lib/ai/utils/json';
 import { getSupabaseAdmin } from '@/lib/supabase/admin';
 import { buildExampleGenreGuidance } from '@/lib/preferences/example-genres';
@@ -93,6 +93,24 @@ const singleExampleSchema = z.object({
   exampleSentence: z.string(),
   exampleSentenceJa: z.string(),
 });
+
+/**
+ * Gemini Controlled Generation schema mirroring `singleExampleSchema`.
+ * `partOfSpeechTags` intentionally omitted from `required` (it has a Zod default([])).
+ */
+export const EXAMPLE_SENTENCE_RESPONSE_SCHEMA: ResponseSchema = {
+  type: 'OBJECT',
+  properties: {
+    partOfSpeechTags: {
+      type: 'ARRAY',
+      items: { type: 'STRING', enum: [...PART_OF_SPEECH_TAGS] },
+    },
+    exampleSentence: { type: 'STRING' },
+    exampleSentenceJa: { type: 'STRING' },
+  },
+  required: ['exampleSentence', 'exampleSentenceJa'],
+  propertyOrdering: ['partOfSpeechTags', 'exampleSentence', 'exampleSentenceJa'],
+};
 
 const CONCURRENCY = 5;
 
@@ -231,6 +249,7 @@ export const __internal = {
   classifyExampleGenerationError,
   createSummary,
   buildSingleExamplePrompt,
+  generateSingle,
 };
 
 // ---------- Core ----------
@@ -376,9 +395,11 @@ async function generateSingle(
   word: ExampleSeedWord,
   apiKeys: { gemini?: string; openai?: string },
   genres?: readonly string[],
+  deps: { getProviderFromConfig?: typeof getProviderFromConfig } = {},
 ): Promise<GeneratedExample> {
   const config = AI_CONFIG.defaults.openai;
-  const provider = getProviderFromConfig(config, apiKeys);
+  const resolveProvider = deps.getProviderFromConfig ?? getProviderFromConfig;
+  const provider = resolveProvider(config, apiKeys);
 
   const aiResponse = await provider.generateText(
     buildSingleExamplePrompt(word, genres),
@@ -386,6 +407,7 @@ async function generateSingle(
       ...config,
       maxOutputTokens: 512,
       responseFormat: 'json',
+      responseSchema: EXAMPLE_SENTENCE_RESPONSE_SCHEMA,
     },
   );
 

--- a/src/lib/ai/generate-word-order-quiz.test.ts
+++ b/src/lib/ai/generate-word-order-quiz.test.ts
@@ -5,7 +5,17 @@ import { WORD_ORDER_BLANK_TOKEN } from '@/lib/quiz/word-order';
 import {
   buildWordOrderPrompt,
   normalizeGeneratedWordOrderResult,
+  WORD_ORDER_RESPONSE_SCHEMA,
 } from './generate-word-order-quiz';
+
+test('WORD_ORDER_RESPONSE_SCHEMA mirrors the results/{id,tokens} shape', () => {
+  assert.equal(WORD_ORDER_RESPONSE_SCHEMA.type, 'OBJECT');
+  assert.deepEqual(WORD_ORDER_RESPONSE_SCHEMA.required, ['results']);
+  const item = WORD_ORDER_RESPONSE_SCHEMA.properties?.results?.items;
+  assert.equal(item?.type, 'OBJECT');
+  assert.deepEqual(item?.required, ['id', 'sentenceTokens', 'answerTokens', 'decoyTokens']);
+  assert.equal(item?.properties?.sentenceTokens?.type, 'ARRAY');
+});
 
 const word = {
   id: 'word-1',

--- a/src/lib/ai/generate-word-order-quiz.ts
+++ b/src/lib/ai/generate-word-order-quiz.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 import type { WordOrderQuizCache } from '@/types';
-import { AI_CONFIG } from '@/lib/ai/config';
+import { AI_CONFIG, type ResponseSchema } from '@/lib/ai/config';
 import { getProviderFromConfig } from '@/lib/ai/providers';
 import { parseJsonResponse } from '@/lib/ai/utils/json';
 import {
@@ -28,6 +28,31 @@ const wordOrderResponseSchema = z.object({
     decoyTokens: z.array(z.string().trim().min(1).max(80)).length(3),
   })).default([]),
 });
+
+/**
+ * Gemini Controlled Generation schema mirroring `wordOrderResponseSchema`.
+ * Array-length bounds are left to Zod to avoid over-constraining structured output.
+ */
+export const WORD_ORDER_RESPONSE_SCHEMA: ResponseSchema = {
+  type: 'OBJECT',
+  properties: {
+    results: {
+      type: 'ARRAY',
+      items: {
+        type: 'OBJECT',
+        properties: {
+          id: { type: 'STRING' },
+          sentenceTokens: { type: 'ARRAY', items: { type: 'STRING' } },
+          answerTokens: { type: 'ARRAY', items: { type: 'STRING' } },
+          decoyTokens: { type: 'ARRAY', items: { type: 'STRING' } },
+        },
+        required: ['id', 'sentenceTokens', 'answerTokens', 'decoyTokens'],
+        propertyOrdering: ['id', 'sentenceTokens', 'answerTokens', 'decoyTokens'],
+      },
+    },
+  },
+  required: ['results'],
+};
 
 const WORD_ORDER_PROMPT = `あなたは英語学習アプリの語順整序クイズ作成者です。
 複数語の英語表現について、下の単語チップを選んで英文を完成させる問題を作ってください。
@@ -97,6 +122,7 @@ export async function generateWordOrderQuizForWords(
     temperature: 0.4,
     maxOutputTokens: 4096,
     responseFormat: 'json' as const,
+    responseSchema: WORD_ORDER_RESPONSE_SCHEMA,
   };
   const provider = getProviderFromConfig(config, {
     gemini: process.env.GOOGLE_AI_API_KEY,

--- a/src/lib/ai/part-of-speech.ts
+++ b/src/lib/ai/part-of-speech.ts
@@ -1,3 +1,23 @@
+/**
+ * Canonical part-of-speech values (the normalized *outputs* of PART_OF_SPEECH_ALIASES).
+ * Single source for the Controlled Generation enum so it can't drift from normalization.
+ */
+export const PART_OF_SPEECH_TAGS = [
+  'noun',
+  'verb',
+  'adjective',
+  'adverb',
+  'idiom',
+  'phrasal_verb',
+  'preposition',
+  'conjunction',
+  'pronoun',
+  'determiner',
+  'interjection',
+  'auxiliary',
+  'other',
+] as const;
+
 const PART_OF_SPEECH_ALIASES: Record<string, string> = {
   noun: 'noun',
   名詞: 'noun',

--- a/src/lib/ai/pronunciation-lookup.test.ts
+++ b/src/lib/ai/pronunciation-lookup.test.ts
@@ -1,7 +1,15 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 
-import { __internal } from '@/lib/ai/pronunciation-lookup';
+import { __internal, PRONUNCIATION_RESPONSE_SCHEMA } from '@/lib/ai/pronunciation-lookup';
+
+test('PRONUNCIATION_RESPONSE_SCHEMA mirrors the results/{id,pronunciation} shape', () => {
+  assert.equal(PRONUNCIATION_RESPONSE_SCHEMA.type, 'OBJECT');
+  assert.deepEqual(PRONUNCIATION_RESPONSE_SCHEMA.required, ['results']);
+  const item = PRONUNCIATION_RESPONSE_SCHEMA.properties?.results?.items;
+  assert.equal(item?.type, 'OBJECT');
+  assert.deepEqual(item?.required, ['id', 'pronunciation']);
+});
 
 test('normalizePronunciation keeps slash-wrapped IPA', () => {
   assert.equal(__internal.normalizePronunciation('/əˈdæpt/'), '/əˈdæpt/');

--- a/src/lib/ai/pronunciation-lookup.ts
+++ b/src/lib/ai/pronunciation-lookup.ts
@@ -6,7 +6,7 @@
  */
 
 import { z } from 'zod';
-import { AI_CONFIG } from '@/lib/ai/config';
+import { AI_CONFIG, type ResponseSchema } from '@/lib/ai/config';
 import { getProviderFromConfig } from '@/lib/ai/providers';
 import { parseJsonResponse } from '@/lib/ai/utils/json';
 import {
@@ -24,6 +24,26 @@ const pronunciationResponseSchema = z.object({
     pronunciation: z.string().trim().max(MAX_PRONUNCIATION_LENGTH).optional().default(''),
   })).default([]),
 });
+
+/** Gemini Controlled Generation schema mirroring `pronunciationResponseSchema`. */
+export const PRONUNCIATION_RESPONSE_SCHEMA: ResponseSchema = {
+  type: 'OBJECT',
+  properties: {
+    results: {
+      type: 'ARRAY',
+      items: {
+        type: 'OBJECT',
+        properties: {
+          id: { type: 'STRING' },
+          pronunciation: { type: 'STRING' },
+        },
+        required: ['id', 'pronunciation'],
+        propertyOrdering: ['id', 'pronunciation'],
+      },
+    },
+  },
+  required: ['results'],
+};
 
 const PRONUNCIATION_PROMPT = `あなたは英語発音辞典の編集者です。
 与えられた英単語または英語フレーズについて、標準的なIPA発音記号を生成してください。
@@ -88,6 +108,7 @@ async function generatePronunciationBatch(
     temperature: 0,
     maxOutputTokens: 2048,
     responseFormat: 'json' as const,
+    responseSchema: PRONUNCIATION_RESPONSE_SCHEMA,
   };
   const provider = getProviderFromConfig(config, {
     gemini: process.env.GOOGLE_AI_API_KEY,

--- a/src/lib/ai/providers/cloud-run.ts
+++ b/src/lib/ai/providers/cloud-run.ts
@@ -75,6 +75,8 @@ export class CloudRunProvider implements AIProvider {
           temperature: config.temperature,
           maxOutputTokens: config.maxOutputTokens,
           responseFormat: config.responseFormat,
+          // Controlled Generation schema; undefined drops out of the JSON body.
+          responseSchema: config.responseSchema,
         }),
       });
 

--- a/src/lib/ai/providers/gemini.ts
+++ b/src/lib/ai/providers/gemini.ts
@@ -56,6 +56,11 @@ export class GeminiProvider implements AIProvider {
       // JSON modeを設定
       if (config.responseFormat === 'json') {
         generateConfig.responseMimeType = 'application/json';
+        // Controlled Generation: constrain output to a known shape when provided.
+        // Must be paired with responseMimeType, so it is set inside the same block.
+        if (config.responseSchema) {
+          generateConfig.responseSchema = config.responseSchema;
+        }
       }
 
       const response = await this.client.models.generateContent({

--- a/src/lib/lexicon/ai.prompt.test.ts
+++ b/src/lib/lexicon/ai.prompt.test.ts
@@ -4,11 +4,21 @@ import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 
 import { JAPANESE_PARENTHESIS_RULES } from '@/lib/ai/prompts/japanese-format';
+import { POS_CLASSIFICATION_RESPONSE_SCHEMA } from '@/lib/lexicon/ai';
+import { LEXICON_POS_VALUES } from '../../../shared/lexicon';
 
 const aiSource = readFileSync(
   fileURLToPath(new URL('./ai.ts', import.meta.url)),
   'utf8',
 );
+
+test('POS_CLASSIFICATION_RESPONSE_SCHEMA sources its pos enum from LEXICON_POS_VALUES', () => {
+  assert.equal(POS_CLASSIFICATION_RESPONSE_SCHEMA.type, 'OBJECT');
+  assert.deepEqual(POS_CLASSIFICATION_RESPONSE_SCHEMA.required, ['results']);
+  const item = POS_CLASSIFICATION_RESPONSE_SCHEMA.properties?.results?.items;
+  assert.deepEqual(item?.required, ['english', 'pos']);
+  assert.deepEqual(item?.properties?.pos?.enum, [...LEXICON_POS_VALUES]);
+});
 
 test('lexicon translation prompts reject one-sided parentheses', () => {
   assert.match(JAPANESE_PARENTHESIS_RULES, /片側だけの括弧は出力禁止/);

--- a/src/lib/lexicon/ai.ts
+++ b/src/lib/lexicon/ai.ts
@@ -1,4 +1,4 @@
-import { AI_CONFIG, type AIModelConfig, getAPIKeys } from '@/lib/ai/config';
+import { AI_CONFIG, type AIModelConfig, type ResponseSchema, getAPIKeys } from '@/lib/ai/config';
 import { getProviderFromConfig, isCloudRunConfigured } from '@/lib/ai/providers';
 import {
   LEXICON_POS_VALUES,
@@ -119,6 +119,27 @@ const batchPosClassificationResponseSchema = z.object({
     pos: z.enum(LEXICON_POS_VALUES),
   }).strict()),
 }).strict();
+
+/** Gemini Controlled Generation schema mirroring `batchPosClassificationResponseSchema`. */
+export const POS_CLASSIFICATION_RESPONSE_SCHEMA: ResponseSchema = {
+  type: 'OBJECT',
+  properties: {
+    results: {
+      type: 'ARRAY',
+      items: {
+        type: 'OBJECT',
+        properties: {
+          english: { type: 'STRING' },
+          japaneseHint: { type: 'STRING', nullable: true },
+          pos: { type: 'STRING', enum: [...LEXICON_POS_VALUES] },
+        },
+        required: ['english', 'pos'],
+        propertyOrdering: ['english', 'japaneseHint', 'pos'],
+      },
+    },
+  },
+  required: ['results'],
+};
 
 type LexiconAIKind = 'translate' | 'validateHint' | 'classifyPos';
 
@@ -400,6 +421,7 @@ ${chunk.map((item, index) => (
       ...aiClient.config,
       maxOutputTokens: Math.min(8192, Math.max(768, chunk.length * 72)),
       responseFormat: 'json',
+      responseSchema: POS_CLASSIFICATION_RESPONSE_SCHEMA,
     });
 
     if (!result.success || !result.content?.trim()) {


### PR DESCRIPTION
## 背景 / 目的

現状、GeminiへのJSON要求は `responseMimeType:'application/json'`（"JSONで出せ"）だけで、**出力形状のスキーマ強制はない**。そのため markdown フェンス除去・前置き除去・truncation 修復（`src/lib/ai/utils/json.ts`）や各サイトの salvage ロジックといった防御的パースが積み重なっている。

Gemini "Controlled Generation"（`responseSchema`）を JSON mime type と併用することで、生成時に既知の形状へ制約できる。これは**構造的な失敗クラス**（形状違い / フェンス / 前置き混入）を前段で潰すもので、Zod検証（invariant #3）や `maxOutputTokens` truncation の代替ではない — 両者は意味検証・安全網としてそのまま残す。

`@google/genai`（app ^1.44.0 / gateway ^1.0.0）は Gemini Developer API・Vertex 双方で `responseSchema` をサポートしており、SDKアップグレードやVertex移行は不要。

これは段階導入の **Phase 1**（配線 ＋ フラットで安全な生成サイトのみ）。

## 変更内容

### 配線（config → providers → gateway）
- `src/lib/ai/config.ts`: provider非依存・JSONシリアライズ可能な `ResponseSchema` 型と `AIModelConfig.responseSchema` を追加（`@google/genai` の型に結合させない）。
- `src/lib/ai/providers/gemini.ts`: `responseMimeType` と同じ JSON ブロック内で `responseSchema` を送出（必須ペアリングを保証）。
- `src/lib/ai/providers/cloud-run.ts`: POSTボディに `responseSchema` を追加（undefined はJSONから落ちる）。
- `cloud-run-scan/src/index.ts`（別デプロイのゲートウェイ）: `GenerateRequest` に `responseSchema` を追加し、`runGeminiRequest` で転送。

### 適用サイト（フラット・既存Zodスキーマに対応するもののみ）
各サイトに既存Zodスキーマを写した `ResponseSchema` const を定義し、config に載せる。**既存の Zod parse と salvage/repair は一切変更していない。**
- 例文生成 `src/lib/ai/generate-example-sentences.ts`（`EXAMPLE_SENTENCE_RESPONSE_SCHEMA`）
- 発音記号 `src/lib/ai/pronunciation-lookup.ts`（`PRONUNCIATION_RESPONSE_SCHEMA`）
- 語彙POS分類 `src/lib/lexicon/ai.ts` classifyPos 経路のみ（`POS_CLASSIFICATION_RESPONSE_SCHEMA`、enum は既存 `LEXICON_POS_VALUES`）
- 語順クイズ `src/lib/ai/generate-word-order-quiz.ts`（`WORD_ORDER_RESPONSE_SCHEMA`）

### その他
- `src/lib/ai/part-of-speech.ts`: 正規化出力の単一ソースとして `PART_OF_SPEECH_TAGS` を追加（例文スキーマの enum ドリフト防止）。
- 配列長など厳密な境界は Zod に委ね、responseSchema 側は構造・`required`・`propertyOrdering`・`enum` に留めて構造化出力の失敗モードを増やさない方針。

## テスト
- `generate-example-sentences.test.ts`: responseSchema が provider config に載ること / 不完全ペイロードを Zod が引き続き弾くこと（スキーマは検証を置き換えない）/ スキーマ形状と POS enum ソース。
- 各サイト（pronunciation / POS / word-order）にスキーマ形状のガードテストを追加。

## 検証
- `npm test`（web unit）: 追加4ファイルすべてグリーン。全体は既存の base 失敗2件（`otp.contract` / `words/create` — 本変更と無関係、mainでも失敗）を除きグリーン。
- `npm run lint:web`: 0 errors。
- `npm run build`（app typecheck）: 成功。
- ゲートウェイ `cloud-run-scan` `tsc --noEmit`: 成功。

## ロールアウト / 注意
- **本番で効かせるにはゲートウェイの再デプロイが必要。** `CLOUD_RUN_URL` 設定時は `cloud-run-scan` 経由になるため、アプリは `responseSchema` を送るが、`.github/workflows/deploy-cloud-run-scan.yml` で再デプロイするまでゲートウェイは未知フィールドを無視する（＝**アプリ側変更は本番で無害な空振り**、現状と同一挙動）。app と gateway は前後方互換なので同時投入で問題なし。
- OpenAI 経路（gateway フォールバック）は `json_object` のみで responseSchema を無視するが、Zod + salvage が正しさを担保するため Phase 1 では許容。OpenAI structured output は Phase 2。

## Phase 2（本PR対象外）
語/イディオム/丸囲み/ハイライト/英検/複合/誤答の抽出（loose な `AIResponseSchema` の契約整理が前提）、再帰SVOパーサ木、quiz-content / translate / hint-validate / enrich / insights、OpenAI `json_schema`、zod→JSON-Schema 自動生成。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A1n6vxuXRsDGJmDLjW5ayR

---
_Generated by [Claude Code](https://claude.ai/code/session_01A1n6vxuXRsDGJmDLjW5ayR)_