### PR TITLE
PWAオフライン対応: Service Workerにキャッシュ戦略を実装

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -1,9 +1,58 @@
+// MERKEN Service Worker
+// Handles PWA offline support (caching) + Web Push notifications.
+//
+// Caching strategy:
+//   - Navigations (HTML)      -> network-first, fall back to cached shell, then /offline
+//   - Static assets (_next,   -> stale-while-revalidate (content-hashed, safe to cache)
+//     scripts, styles, fonts,
+//     images, manifest)
+//   - API / auth requests     -> never handled here (network-only; data goes through
+//                                IndexedDB + the sync queue)
+//   - Cross-origin requests   -> left to the browser (Supabase, Google Fonts, ads, AI, etc.)
+//
+// Bump SW_VERSION whenever the caching logic changes so old caches are purged on activate.
+
+const SW_VERSION = 'v1';
 const CACHE_PREFIX = 'scanvocab-';
+const PRECACHE = `${CACHE_PREFIX}precache-${SW_VERSION}`;
+const RUNTIME = `${CACHE_PREFIX}runtime-${SW_VERSION}`;
+const ACTIVE_CACHES = new Set([PRECACHE, RUNTIME]);
+
+const OFFLINE_URL = '/offline';
 const DEFAULT_NOTIFICATION_URL = '/';
 
+// Minimal shell assets that must be available offline even before the user
+// has visited the corresponding pages. Kept small and stable so install is fast
+// and resilient (each asset is fetched independently so one 404 can't break install).
+const PRECACHE_URLS = [
+  OFFLINE_URL,
+  '/manifest.json',
+  '/icon-192.png',
+  '/icon-512.png',
+];
+
+// ---------------------------------------------------------------------------
+// Lifecycle
+// ---------------------------------------------------------------------------
+
 self.addEventListener('install', (event) => {
-  self.skipWaiting();
-  event.waitUntil(Promise.resolve());
+  event.waitUntil((async () => {
+    const cache = await caches.open(PRECACHE);
+    await Promise.all(
+      PRECACHE_URLS.map(async (url) => {
+        try {
+          const response = await fetch(new Request(url, { cache: 'reload' }));
+          if (response && response.ok) {
+            await cache.put(url, response.clone());
+          }
+        } catch {
+          // Ignore individual precache failures — offline support degrades
+          // gracefully rather than blocking the whole install.
+        }
+      })
+    );
+    await self.skipWaiting();
+  })());
 });
 
 self.addEventListener('activate', (event) => {
@@ -11,7 +60,7 @@ self.addEventListener('activate', (event) => {
     const cacheNames = await caches.keys();
     await Promise.all(
       cacheNames
-        .filter((name) => name.startsWith(CACHE_PREFIX))
+        .filter((name) => name.startsWith(CACHE_PREFIX) && !ACTIVE_CACHES.has(name))
         .map((name) => caches.delete(name))
     );
     await self.clients.claim();
@@ -23,6 +72,103 @@ self.addEventListener('message', (event) => {
     self.skipWaiting();
   }
 });
+
+// ---------------------------------------------------------------------------
+// Fetch / caching
+// ---------------------------------------------------------------------------
+
+function isStaticAsset(url, request) {
+  if (url.pathname.startsWith('/_next/static/')) return true;
+  if (url.pathname.startsWith('/_next/image')) return true;
+  if (url.pathname === '/manifest.json') return true;
+
+  const destination = request.destination;
+  if (
+    destination === 'style' ||
+    destination === 'script' ||
+    destination === 'font' ||
+    destination === 'image'
+  ) {
+    return true;
+  }
+
+  return /\.(?:js|css|woff2?|ttf|otf|png|jpe?g|gif|svg|webp|avif|ico)$/i.test(url.pathname);
+}
+
+async function networkFirstNavigation(request) {
+  const runtime = await caches.open(RUNTIME);
+
+  try {
+    const response = await fetch(request);
+    // Cache successful, non-opaque navigations so the shell loads offline next time.
+    if (response && response.ok && response.type === 'basic') {
+      runtime.put(request, response.clone()).catch(() => {});
+    }
+    return response;
+  } catch {
+    const cached = await runtime.match(request);
+    if (cached) return cached;
+
+    const offline = await caches.match(OFFLINE_URL);
+    if (offline) return offline;
+
+    return new Response('Offline', {
+      status: 503,
+      statusText: 'Service Unavailable',
+      headers: { 'Content-Type': 'text/plain; charset=utf-8' },
+    });
+  }
+}
+
+async function staleWhileRevalidate(request) {
+  const runtime = await caches.open(RUNTIME);
+  const cached = await runtime.match(request);
+
+  const networkFetch = fetch(request)
+    .then((response) => {
+      if (response && response.ok && response.type === 'basic') {
+        runtime.put(request, response.clone()).catch(() => {});
+      }
+      return response;
+    })
+    .catch(() => undefined);
+
+  return cached || (await networkFetch) || Response.error();
+}
+
+self.addEventListener('fetch', (event) => {
+  const { request } = event;
+
+  // Only handle GET; let the browser deal with everything else (POST, etc.).
+  if (request.method !== 'GET') return;
+
+  const url = new URL(request.url);
+
+  // Only same-origin. Cross-origin (Supabase, Google Fonts, AI, ads) goes to network.
+  if (url.origin !== self.location.origin) return;
+
+  // Never intercept API / auth / server actions — those must stay network-only.
+  if (url.pathname.startsWith('/api/')) return;
+
+  // Skip Next.js RSC / data payloads so we never serve stale server components.
+  if (request.headers.get('RSC') === '1' || url.searchParams.has('_rsc')) return;
+
+  // Skip range requests (media streaming) — the browser handles these better.
+  if (request.headers.has('range')) return;
+
+  if (request.mode === 'navigate' || request.destination === 'document') {
+    event.respondWith(networkFirstNavigation(request));
+    return;
+  }
+
+  if (isStaticAsset(url, request)) {
+    event.respondWith(staleWhileRevalidate(request));
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Web Push
+// ---------------------------------------------------------------------------
 
 self.addEventListener('push', (event) => {
   let payload = {};

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,6 +4,7 @@ import { ThemeProvider } from '@/components/theme-provider';
 import { ToastProvider } from '@/components/ui/toast';
 import { ServiceWorkerRegistration } from '@/components/pwa/ServiceWorkerRegistration';
 import { OfflineSyncProvider } from '@/components/pwa/OfflineSyncProvider';
+import { OfflineBanner } from '@/components/pwa/OfflineBanner';
 import { StatsSync } from '@/components/StatsSync';
 import { PendingOnboardingSync } from '@/components/onboarding/PendingOnboardingSync';
 import { HomeOpenLogger } from '@/components/analytics/HomeOpenLogger';
@@ -143,6 +144,7 @@ export default function RootLayout({
             <OfflineSyncProvider>
               <PersistentAppShell>{children}</PersistentAppShell>
               <StatusBarCover />
+              <OfflineBanner />
             </OfflineSyncProvider>
           </ToastProvider>
           <StatsSync />

--- a/src/components/pwa/OfflineBanner.tsx
+++ b/src/components/pwa/OfflineBanner.tsx
@@ -1,0 +1,30 @@
+'use client';
+
+import { useOnlineStatus } from '@/hooks/use-online-status';
+import { Icon } from '@/components/ui/Icon';
+
+/**
+ * App-wide slim banner shown while the device is offline, for every tier.
+ * The app itself keeps working from IndexedDB; this just tells the user why
+ * network-dependent actions (scanning, sync) may be paused. Sits below the
+ * status-bar cover so it never overlaps the notch.
+ */
+export function OfflineBanner() {
+  const isOnline = useOnlineStatus();
+
+  if (isOnline) return null;
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className="pointer-events-none fixed inset-x-0 z-[9991] flex justify-center px-3"
+      style={{ top: 'calc(env(safe-area-inset-top, 0px) + 8px)' }}
+    >
+      <div className="pointer-events-auto flex items-center gap-1.5 rounded-full bg-[var(--color-foreground)]/85 px-3 py-1.5 text-xs font-medium text-[var(--color-background)] shadow-lg backdrop-blur">
+        <Icon name="wifi_off" size={14} />
+        <span>オフライン - 変更は再接続時に同期されます</span>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## 概要

PWAをオフラインで利用可能にしました。

これまで `public/sw.js` は Web Push 通知のみを処理しており、`fetch` ハンドラやキャッシュを一切持っていませんでした。そのためオフライン時にアプリのシェル（HTML / JS / CSS）が読み込めず、アプリが起動できませんでした（既存の `/offline` フォールバックページにも到達不可能でした）。データ層（Dexie/IndexedDB + 同期キュー）はもともとオフライン動作しますが、そもそもアプリを開けない状態でした。

本PRで Service Worker にキャッシュ戦略を追加し、一度オンラインで開けばオフラインでもアプリが起動・利用できるようにしました。

## 変更内容

### `public/sw.js`（Service Worker）
- **ナビゲーション（HTML）**: network-first → キャッシュ済みシェル → `/offline` フォールバックの順にフォールバック
- **静的アセット**（`/_next/static/`・スクリプト・スタイル・フォント・画像・`manifest.json`）: stale-while-revalidate（コンテンツハッシュ付きで安全にキャッシュ）
- **API / 認証**（`/api/...`）: インターセプトせずネットワーク専用（データは IndexedDB + 同期キュー経由のため）
- **クロスオリジン**（Supabase・Google Fonts・AI・広告など）: ブラウザに委譲
- `install` で `/offline` とアイコンをプリキャッシュ（個別に取得し、1件の失敗が install 全体を壊さないよう防御的に実装）
- `activate` で旧バージョンのキャッシュのみ削除（現行バージョンは保持）
- RSC / データペイロード（`RSC` ヘッダ・`_rsc` クエリ）と range リクエストはスキップし、古い応答の配信を防止
- 既存の Web Push（`push` / `notificationclick`）ハンドラはそのまま維持
- `SW_VERSION` によるキャッシュのバージョニング

### `src/components/pwa/OfflineBanner.tsx`（新規）
- 全ティア向けの細いオフラインバナー。オフライン時に「変更は再接続時に同期されます」と表示。ステータスバーカバーの下に配置し、ノッチに被らないよう調整。

### `src/app/layout.tsx`
- `OfflineBanner` をマウント。

## 動作確認
- `npm run build` 成功（`/offline` は静的ルート `○` としてビルドされプリキャッシュ可能）
- 変更ファイルの ESLint はエラーなし（既存のフォント関連 warning のみ）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WZiK4vxYDivfPqgvrnLnw6

---
_Generated by [Claude Code](https://claude.ai/code/session_01WZiK4vxYDivfPqgvrnLnw6)_