### PR TITLE
fix(pwa): Service Workerのfetchキャッシュを撤去しPWA起動時のフリーズを解消

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -1,77 +1,33 @@
 // MERKEN Service Worker
-// Handles PWA offline support + Web Push notifications.
+// Web Push notifications only. Intentionally NO fetch/caching handler.
 //
-// Caching strategy (deliberately conservative to guarantee the app never gets
-// stranded on a stale/broken shell):
-//   - Navigations (HTML)      -> network-ONLY. On success the browser always gets a
-//                                fresh document (identical to having no SW, so the
-//                                online experience can never break). Only when the
-//                                network fails do we serve the dedicated /offline page.
-//                                We never serve a cached app shell, because Next.js
-//                                pre-renders "/" as a loading screen that only becomes
-//                                the app after its JS chunks hydrate — serving a cached
-//                                shell whose chunk hashes changed on a later deploy would
-//                                strand the page on that loading screen.
-//   - Immutable static assets -> cache-first. Only /_next/static/** and /_next/image are
-//                                content-hashed (safe to cache forever) plus a tiny
-//                                precache list (icons, manifest, offline page).
-//   - API / auth / RSC        -> never handled here (network-only; data goes through
-//                                IndexedDB + the sync queue).
-//   - Cross-origin requests   -> left to the browser (Supabase, Google Fonts, ads, AI...).
+// A fetch/caching handler was tried (offline support) but it broke the installed
+// standalone PWA: because the service worker controls the PWA from launch, any
+// mismatch between a cached app shell and its JS chunks left the PWA stranded on
+// its loading screen. A plain browser tab was unaffected because a freshly
+// registered worker does not control the first load. Keeping this worker
+// caching-free means the PWA loads exactly like a normal page (network), which is
+// reliable. Offline support, if revisited, should use a build-integrated precache
+// (e.g. Serwist) so the shell and its chunks are always cached atomically.
 //
-// Bump SW_VERSION whenever the caching logic changes so old caches are purged on activate.
+// The activate handler deletes every legacy `scanvocab-` cache, so users whose
+// installs were poisoned by the previous caching worker recover automatically on
+// the next launch.
 
-const SW_VERSION = 'v2';
 const CACHE_PREFIX = 'scanvocab-';
-const PRECACHE = `${CACHE_PREFIX}precache-${SW_VERSION}`;
-const RUNTIME = `${CACHE_PREFIX}runtime-${SW_VERSION}`;
-const ACTIVE_CACHES = new Set([PRECACHE, RUNTIME]);
-
-const OFFLINE_URL = '/offline';
 const DEFAULT_NOTIFICATION_URL = '/';
 
-// Small, stable shell assets fetched at install so the offline fallback is always
-// available. The /offline page is statically pre-rendered, so its HTML shows the
-// offline message even if its JS chunks are not cached.
-const PRECACHE_URLS = [
-  OFFLINE_URL,
-  '/manifest.json',
-  '/icon-192.png',
-  '/icon-512.png',
-];
-
-// ---------------------------------------------------------------------------
-// Lifecycle
-// ---------------------------------------------------------------------------
-
 self.addEventListener('install', (event) => {
-  event.waitUntil((async () => {
-    const cache = await caches.open(PRECACHE);
-    await Promise.all(
-      PRECACHE_URLS.map(async (url) => {
-        try {
-          const response = await fetch(new Request(url, { cache: 'reload' }));
-          if (response && response.ok) {
-            await cache.put(url, response.clone());
-          }
-        } catch {
-          // Ignore individual precache failures — offline support degrades
-          // gracefully rather than blocking the whole install.
-        }
-      })
-    );
-    await self.skipWaiting();
-  })());
+  self.skipWaiting();
+  event.waitUntil(Promise.resolve());
 });
 
 self.addEventListener('activate', (event) => {
   event.waitUntil((async () => {
-    // Purge every cache that isn't part of the current version. Bumping
-    // SW_VERSION therefore clears any stale app-shell cached by older workers.
     const cacheNames = await caches.keys();
     await Promise.all(
       cacheNames
-        .filter((name) => name.startsWith(CACHE_PREFIX) && !ACTIVE_CACHES.has(name))
+        .filter((name) => name.startsWith(CACHE_PREFIX))
         .map((name) => caches.delete(name))
     );
     await self.clients.claim();
@@ -83,93 +39,6 @@ self.addEventListener('message', (event) => {
     self.skipWaiting();
   }
 });
-
-// ---------------------------------------------------------------------------
-// Fetch / caching
-// ---------------------------------------------------------------------------
-
-// Only content-hashed Next.js output is safe to cache forever. Everything else
-// (HTML shells, dynamic assets) is left to the network so we never serve stale.
-function isImmutableAsset(url) {
-  return url.pathname.startsWith('/_next/static/') || url.pathname.startsWith('/_next/image');
-}
-
-function isPrecachedAsset(url) {
-  return PRECACHE_URLS.includes(url.pathname);
-}
-
-// Network-only navigation with an offline-page fallback. Never returns a cached
-// app shell, so a chunk-hash mismatch across deploys can never strand the app.
-async function navigateOrOffline(request) {
-  try {
-    return await fetch(request);
-  } catch {
-    const offline = await caches.match(OFFLINE_URL);
-    if (offline) return offline;
-    return new Response('Offline', {
-      status: 503,
-      statusText: 'Service Unavailable',
-      headers: { 'Content-Type': 'text/plain; charset=utf-8' },
-    });
-  }
-}
-
-async function cacheFirst(request, cacheName) {
-  const cache = await caches.open(cacheName);
-  const cached = await cache.match(request);
-  if (cached) return cached;
-
-  try {
-    const response = await fetch(request);
-    if (response && response.ok && response.type === 'basic') {
-      cache.put(request, response.clone()).catch(() => {});
-    }
-    return response;
-  } catch (error) {
-    const fallback = await cache.match(request);
-    if (fallback) return fallback;
-    throw error;
-  }
-}
-
-self.addEventListener('fetch', (event) => {
-  const { request } = event;
-
-  // Only handle GET; let the browser deal with everything else (POST, etc.).
-  if (request.method !== 'GET') return;
-
-  const url = new URL(request.url);
-
-  // Only same-origin. Cross-origin (Supabase, Google Fonts, AI, ads) goes to network.
-  if (url.origin !== self.location.origin) return;
-
-  // Never intercept API / auth / server actions — those must stay network-only.
-  if (url.pathname.startsWith('/api/')) return;
-
-  // Skip Next.js RSC / data payloads so we never serve stale server components.
-  if (request.headers.get('RSC') === '1' || url.searchParams.has('_rsc')) return;
-
-  // Skip range requests (media streaming) — the browser handles these better.
-  if (request.headers.has('range')) return;
-
-  if (request.mode === 'navigate' || request.destination === 'document') {
-    event.respondWith(navigateOrOffline(request));
-    return;
-  }
-
-  if (isImmutableAsset(url)) {
-    event.respondWith(cacheFirst(request, RUNTIME));
-    return;
-  }
-
-  if (isPrecachedAsset(url)) {
-    event.respondWith(cacheFirst(request, PRECACHE));
-  }
-});
-
-// ---------------------------------------------------------------------------
-// Web Push
-// ---------------------------------------------------------------------------
 
 self.addEventListener('push', (event) => {
   let payload = {};


### PR DESCRIPTION
## 概要

インストール済みの**スタンドアロンPWA（ログイン済み）**で、起動時に画面が「ロード中」のまま固まる不具合を修正します。#364 / #366 の Service Worker fetch キャッシュが原因でした。

## 原因（切り分け結果）

ユーザー確認により、**インストール済みPWAでのみ固まり、通常のブラウザタブでは正常**であることが判明しました。

- Service Worker は**インストール済みPWAを起動時から制御**します。
- #364 で追加した fetch キャッシュ処理により、キャッシュされたアプリシェルと参照する JS チャンクの不整合が起きると、ハイドレーションが完了せず、`/` がプリレンダーする `HomeLoadingScreen` のまま固まっていました。
- 通常のブラウザタブは、登録直後の SW が初回ロードを制御しないため影響を受けませんでした（＝これが決定的な切り分け）。
- #364 より前の「Web Push 通知のみ・fetch 非介入」の SW では、スタンドアロンPWAは正常に動作していました。

## 修正

`public/sw.js` を #364 以前の**プッシュ通知専用（fetch 非介入）**版に戻します。

- **fetch ハンドラを撤去** → PWA は通常ページと同様にネットワークから読み込むため、シェル/チャンク不整合による固まりが構造的に発生しなくなる。
- **`activate` で全 `scanvocab-` キャッシュを削除** → 以前の caching SW で汚染された既存インストールも、次回起動時に自動回復。
- **Web Push 通知ハンドラは維持**。

diff は `public/sw.js` のみ（-146 / +15 行）。

## 復旧について

デプロイ後、影響を受けたユーザーの PWA は次回起動時に新しい SW が有効化され、古いキャッシュが削除されて自動回復します。すぐに直らない場合は、PWA を完全に終了して再起動すると確実です。

## オフライン対応の今後

オフライン対応（オフラインでのアプリ利用）を再開する場合は、シェルと全チャンクをアトミックにプリキャッシュするビルド統合方式（Serwist 等）で実装すべきです。手書きの fetch キャッシュは本件のようにチャンク不整合で固まるリスクがあります。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WZiK4vxYDivfPqgvrnLnw6

---
_Generated by [Claude Code](https://claude.ai/code/session_01WZiK4vxYDivfPqgvrnLnw6)_