### PR TITLE
フラッシュカードの状態保存を廃止しクイズ出題順と同期

### DIFF
--- a/docs/_discovery_notes.md
+++ b/docs/_discovery_notes.md
@@ -374,7 +374,6 @@ The following `localStorage` keys are used by the client:
 | `scanvocab_activity_history` | `src/lib/utils.ts` | 180-day activity heatmap |
 | `scanvocab_last_sync` | `src/lib/db/hybrid-repository.ts` | Last full sync timestamp |
 | `scanvocab_sync_user` | `src/lib/db/hybrid-repository.ts` | User ID of last sync |
-| `flashcard_progress_{projectId}` / `flashcard_progress_{projectId}_favorites` | `src/app/flashcard/[projectId]/page.tsx` | Flashcard resume word IDs, current index, and sort order |
 | `merken_was_authenticated` | `src/hooks/use-auth.ts` | Session expiry detection |
 | `merken_sub_cache` | `src/hooks/use-auth.ts` | Subscription cache (1 hour TTL) |
 | `merken_activity_logged` | `src/hooks/use-auth.ts` | Daily activity deduplication |
@@ -390,7 +389,6 @@ The following `localStorage` keys are used by the client:
 | `scanvocab_existing_project_id` | `src/app/scan/confirm/page.tsx` | ID when adding to existing project |
 | `sentence_quiz_progress_{projectId}` | `src/app/scan/confirm/page.tsx` | Pre-generated sentence quiz |
 | `quiz_state_{projectId}` | `src/app/quiz/[projectId]/page.tsx` | Quiz resume state (30 min TTL) |
-| `flashcard_session_{projectId}` / `flashcard_session_{projectId}_favorites` | `src/app/flashcard/[projectId]/page.tsx` | Short-term flashcard resume word IDs, current index, and sort order |
 
 ---
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -209,27 +209,23 @@ Notes:
 
 ---
 
-## Data Flow: Flashcard Word Loading and Resume
+## Data Flow: Flashcard Word Loading (quiz-synced order)
 
 `src/app/flashcard/[projectId]/page.tsx` owns the active flashcard word list in React state:
 
 ```
-repository/get cache -> Word[] -> sort/restore order -> setWords(finalWords)
+repository/get cache -> Word[] -> sortWordsByPriority() -> setWords(sorted)
 ```
 
 Load priority:
 
 1. Restore immediately from Home cache when available (`getCachedProjectWords()`).
 2. Load fresh words through the selected repository (`localRepository`, `hybridRepository`, or `readonlyRemoteRepository`).
-3. If a recent flashcard progress record exists, restore the previous sort mode and current card from saved progress.
+3. Sort the loaded list with `sortWordsByPriority()` and always start at the first card (`currentIndex = 0`).
 
-Progress is persisted in browser storage:
+Flashcards no longer persist any resume state. The `flashcard_session_*` / `flashcard_progress_*` records and the flashcard sort-mode selector (mastery vs. part-of-speech) have been removed.
 
-- `flashcard_session_{projectId}` in `sessionStorage` for short-term resume.
-- `flashcard_progress_{projectId}` in `localStorage` for longer resume.
-- Favorites mode appends `_favorites` to the key.
-
-Important behavior: saved `wordIds` identify the previous current card and historical order, but they are not the source of truth for the current project word list. When words have been added to the project after progress was saved, the flashcard page must include those new words in the restored list. Current behavior sorts the full repository-loaded word list by saved `sortOrder` (`mastery` by default), then restores `currentIndex` to the same word ID when it still exists. This keeps newly added `new` words in the expected priority position for mastery order.
+Important behavior: the flashcard order is intentionally kept in sync with the quiz question order. Both the flashcard page and the quiz (`src/app/quiz/[projectId]/page.tsx` -> `sortWordsByPriority` / `generateQuizQuestions`) sort words with the same `sortWordsByPriority` comparator, so the two features present overlapping words in the same sequence. Because there is no saved order to migrate, this ordering logic runs entirely on the frontend and stays correct without any server-side or PWA data update.
 
 ---
 

--- a/docs/invariants.md
+++ b/docs/invariants.md
@@ -143,13 +143,13 @@ Source: `src/lib/db/hybrid-repository.ts` lines 107-113.
 
 **Consequence of violation**: New users cannot complete real registration, or existing users get surprising auth state changes.
 
-### INV-16: Flashcard progress restore must include newly added words
+### INV-16: Flashcard order stays synced with quiz order (no persisted state)
 
-`src/app/flashcard/[projectId]/page.tsx` may restore card order from `flashcard_session_*` or `flashcard_progress_*` storage records. Those records store historical `wordIds` for resume order only; they are not the source of truth for the current project word list.
+`src/app/flashcard/[projectId]/page.tsx` must derive its card order purely from the current repository/cache word list, sorted with `sortWordsByPriority` — the same comparator the quiz uses. It must not persist or restore flashcard resume state (the retired `flashcard_session_*` / `flashcard_progress_*` records) and must not offer an alternate sort mode that would diverge from the quiz question order.
 
-When repository-loaded words contain IDs that are missing from saved progress, the flashcard page must include those words after applying the active saved sort mode. In mastery order, newly added `new` words must participate in the normal priority sort rather than being forced to the end by stale progress.
+The ordering logic must remain frontend-only: it recomputes on every load from live data, so it never needs a server-side migration or PWA data update to stay correct.
 
-**Consequence of violation**: Words added to an existing wordbook can be present in IndexedDB/Supabase and visible in the project page, but missing from flashcards until progress storage is cleared.
+**Consequence of violation**: The flashcard sequence drifts from the quiz question order, or stale persisted state hides newly added words / pins an outdated order that a PWA update cannot easily correct.
 
 ---
 

--- a/src/app/flashcard/[projectId]/page.tsx
+++ b/src/app/flashcard/[projectId]/page.tsx
@@ -125,66 +125,11 @@ function nextWordStatus(current: string): 'new' | 'review' | 'mastered' {
   return 'new';
 }
 
-type FlashcardSortOrder = 'mastery' | 'partOfSpeech';
-
-const FLASHCARD_SORT_OPTIONS: Array<{ value: FlashcardSortOrder; label: string; icon: string }> = [
-  { value: 'mastery', label: '習得度順', icon: 'trending_up' },
-  { value: 'partOfSpeech', label: '品詞順', icon: 'category' },
-];
-
-function getPrimaryPartOfSpeech(word: Word): string {
-  return word.partOfSpeechTags?.[0]?.trim().toLowerCase() || 'zzz';
-}
-
-function sortFlashcardWords(wordList: Word[], order: FlashcardSortOrder): Word[] {
-  if (order === 'mastery') return sortWordsByPriority(wordList);
-  return [...wordList].sort((a, b) => {
-    const posDiff = getPrimaryPartOfSpeech(a).localeCompare(getPrimaryPartOfSpeech(b), undefined, { sensitivity: 'base' });
-    if (posDiff !== 0) return posDiff;
-    return a.english.localeCompare(b.english, undefined, { sensitivity: 'base' });
-  });
-}
-
-/* ---------- Progress storage ---------- */
-const getProgressKey = (projectId: string, favoritesOnly: boolean) =>
-  `flashcard_progress_${projectId}${favoritesOnly ? '_favorites' : ''}`;
-const getSessionKey = (projectId: string, favoritesOnly: boolean) =>
-  `flashcard_session_${projectId}${favoritesOnly ? '_favorites' : ''}`;
-
-interface FlashcardProgress {
-  wordIds: string[];
-  currentIndex: number;
-  savedAt: number;
-  sortOrder?: FlashcardSortOrder;
-}
-
-interface RestoredFlashcardProgress {
-  words: Word[];
-  currentIndex: number;
-  sortOrder: FlashcardSortOrder;
-}
-
-function getSavedSortOrder(progress: FlashcardProgress): FlashcardSortOrder {
-  return progress.sortOrder === 'partOfSpeech' ? 'partOfSpeech' : 'mastery';
-}
-
-function restoreFlashcardProgress(wordList: Word[], progress: FlashcardProgress): RestoredFlashcardProgress | null {
-  if (wordList.length === 0 || progress.wordIds.length === 0) return null;
-
-  const restoredSortOrder = getSavedSortOrder(progress);
-  const sortedWords = sortFlashcardWords(wordList, restoredSortOrder);
-  const currentWordId = progress.wordIds[progress.currentIndex];
-  const restoredIndex = currentWordId
-    ? sortedWords.findIndex(word => word.id === currentWordId)
-    : -1;
-
-  return {
-    words: sortedWords,
-    currentIndex: restoredIndex >= 0
-      ? restoredIndex
-      : Math.min(progress.currentIndex, sortedWords.length - 1),
-    sortOrder: restoredSortOrder,
-  };
+// フラッシュカードはクイズと同じ優先度順（sortWordsByPriority）でカードを並べる。
+// 表示順はクイズ出題順と常に一致し、状態保存は行わない。ロジックはすべて
+// フロントエンドで完結するため、順番仕様の変更にサーバー更新は不要。
+function sortFlashcardWords(wordList: Word[]): Word[] {
+  return sortWordsByPriority(wordList);
 }
 
 export default function FlashcardPage() {
@@ -200,8 +145,6 @@ export default function FlashcardPage() {
   const [currentIndex, setCurrentIndex] = useState(0);
   const [isFlipped, setIsFlipped] = useState(false);
   const [loading, setLoading] = useState(true);
-  const [sortOrder, setSortOrder] = useState<FlashcardSortOrder>('mastery');
-  const [sortMenuOpen, setSortMenuOpen] = useState(false);
 
   /* Swipe state */
   const [swipeX, setSwipeX] = useState(0);
@@ -226,24 +169,15 @@ export default function FlashcardPage() {
     cacheRestoredRef.current = true;
     const cachedWords = getCachedProjectWords()[projectId];
     if (cachedWords && cachedWords.length > 0 && !favoritesOnly && !collectionId) {
-      const sorted = sortFlashcardWords(cachedWords, 'mastery');
-      setWords(sorted);
+      setWords(sortFlashcardWords(cachedWords));
       hasLoadedRef.current = true;
       setLoading(false);
     }
   }, [projectId, favoritesOnly, collectionId]);
 
-  const saveProgress = useCallback((wordList: Word[], index: number) => {
-    const progress: FlashcardProgress = { wordIds: wordList.map(w => w.id), currentIndex: index, savedAt: Date.now(), sortOrder };
-    const str = JSON.stringify(progress);
-    localStorage.setItem(getProgressKey(projectId, favoritesOnly), str);
-    sessionStorage.setItem(getSessionKey(projectId, favoritesOnly), str);
-  }, [projectId, favoritesOnly, sortOrder]);
-
   const backToProject = useCallback(() => {
-    if (words.length > 0) saveProgress(words, currentIndex);
     router.back();
-  }, [words, currentIndex, saveProgress, router]);
+  }, [router]);
 
   useEffect(() => {
     if (authLoading) return;
@@ -264,53 +198,6 @@ export default function FlashcardPage() {
           return false;
         };
 
-        /* Try session storage first */
-        const sessionProgressStr = sessionStorage.getItem(getSessionKey(projectId, favoritesOnly));
-        if (sessionProgressStr) {
-          try {
-            const progress: FlashcardProgress = JSON.parse(sessionProgressStr);
-            if (progress.savedAt > Date.now() - 30 * 60 * 1000 && progress.wordIds.length > 0) {
-              let wordsData: Word[];
-              if (collectionId) {
-                wordsData = await loadCollectionWords(collectionId);
-              } else if (projectId === 'all' && favoritesOnly) {
-                const userId = user ? user.id : getGuestUserId();
-                const projects = await repository.getProjects(userId);
-                const allWordsArrays = await Promise.all(projects.map(p => repository.getWords(p.id)));
-                wordsData = allWordsArrays.flat().filter(w => w.isFavorite);
-              } else {
-                const hasAccess = await ensureProjectAccess();
-                if (!hasAccess) { backToProject(); return; }
-                wordsData = await repository.getWords(projectId);
-                if (wordsData.length === 0 && user && navigator.onLine) {
-                  try { wordsData = await remoteRepository.getWords(projectId); } catch { /* ignore */ }
-                }
-              }
-              const restored = restoreFlashcardProgress(wordsData, progress);
-              if (restored) {
-                setSortOrder(restored.sortOrder);
-                setWords(restored.words);
-                setCurrentIndex(restored.currentIndex);
-                hasLoadedRef.current = true;
-                setLoading(false);
-                return;
-              }
-            }
-          } catch { /* fall through */ }
-        }
-
-        /* Try localStorage progress */
-        const localProgressStr = localStorage.getItem(getProgressKey(projectId, favoritesOnly));
-        let savedProgress: FlashcardProgress | null = null;
-        if (localProgressStr) {
-          try {
-            const progress: FlashcardProgress = JSON.parse(localProgressStr);
-            if (progress.savedAt > Date.now() - 7 * 24 * 60 * 60 * 1000) {
-              savedProgress = progress;
-            }
-          } catch { /* ignore */ }
-        }
-
         let loadedWords: Word[];
         if (collectionId) {
           loadedWords = await loadCollectionWords(collectionId);
@@ -330,21 +217,9 @@ export default function FlashcardPage() {
 
         if (loadedWords.length === 0) { backToProject(); return; }
 
-        const sorted = sortFlashcardWords(loadedWords, 'mastery');
-        let finalWords = sorted;
-        let finalIndex = 0;
-
-        if (savedProgress) {
-          const restored = restoreFlashcardProgress(loadedWords, savedProgress);
-          if (restored) {
-            setSortOrder(restored.sortOrder);
-            finalWords = restored.words;
-            finalIndex = restored.currentIndex;
-          }
-        }
-
-        setWords(finalWords);
-        setCurrentIndex(finalIndex);
+        // クイズと同じ優先度順に並べて、常に先頭カードから開始する。
+        setWords(sortFlashcardWords(loadedWords));
+        setCurrentIndex(0);
         hasLoadedRef.current = true;
       } catch (error) {
         console.error('Failed to load flashcard words:', error);
@@ -355,20 +230,6 @@ export default function FlashcardPage() {
     };
     loadWords();
   }, [authLoading, projectId, favoritesOnly, collectionId, repository, user, backToProject, words.length]);
-
-  /* Save on unload */
-  useEffect(() => {
-    const handleSave = () => { if (words.length > 0) saveProgress(words, currentIndex); };
-    const handleVisibilityChange = () => { if (document.visibilityState === 'hidden') handleSave(); };
-    window.addEventListener('beforeunload', handleSave);
-    document.addEventListener('visibilitychange', handleVisibilityChange);
-    window.addEventListener('pagehide', handleSave);
-    return () => {
-      window.removeEventListener('beforeunload', handleSave);
-      document.removeEventListener('visibilitychange', handleVisibilityChange);
-      window.removeEventListener('pagehide', handleSave);
-    };
-  }, [words, currentIndex, saveProgress]);
 
   const currentWord = words[currentIndex];
 
@@ -430,19 +291,6 @@ export default function FlashcardPage() {
     else if (swipeX > 80) handlePrev(true);
     setSwipeX(0);
     setTimeout(() => { isSwiping.current = false; }, 50);
-  };
-
-  const handleSortOrderChange = (nextOrder: FlashcardSortOrder) => {
-    const sorted = sortFlashcardWords(words, nextOrder);
-    setSortOrder(nextOrder);
-    setSortMenuOpen(false);
-    setWords(sorted); setCurrentIndex(0); setIsFlipped(false);
-    saveProgress(sorted, 0);
-  };
-
-  const handleSaveCurrentProgress = () => {
-    saveProgress(words, currentIndex);
-    setSortMenuOpen(false);
   };
 
   /* Keyboard nav */
@@ -634,61 +482,8 @@ export default function FlashcardPage() {
           </div>
         </div>
 
-        <div className="relative">
-          <HeaderBtn
-            onClick={() => setSortMenuOpen((open) => !open)}
-            aria-label="詳細"
-            aria-expanded={sortMenuOpen}
-            aria-haspopup="menu"
-          >
-            <Icon name="more_horiz" size={18} />
-          </HeaderBtn>
-          {sortMenuOpen && (
-            <>
-              <button
-                type="button"
-                aria-label="詳細メニューを閉じる"
-                className="fixed inset-0 z-10 cursor-default bg-transparent"
-                onClick={() => setSortMenuOpen(false)}
-              />
-              <div
-                role="menu"
-                className="absolute right-0 top-[48px] z-20 w-[132px] rounded-[14px] border-2 border-[var(--solid-ink)] bg-white p-1.5"
-              >
-                {FLASHCARD_SORT_OPTIONS.map((option) => {
-                  const selected = sortOrder === option.value;
-                  return (
-                    <button
-                      key={option.value}
-                      type="button"
-                      role="menuitemradio"
-                      aria-checked={selected}
-                      onClick={() => handleSortOrderChange(option.value)}
-                      className={`flex w-full items-center justify-between rounded-[10px] px-2.5 py-2 text-left text-xs font-bold text-[var(--solid-ink)] ${
-                        selected ? 'bg-[rgba(26,26,26,0.06)]' : 'hover:bg-[rgba(26,26,26,0.04)]'
-                      }`}
-                    >
-                      <span className="inline-flex items-center gap-1.5">
-                        <Icon name={option.icon} size={14} />
-                        {option.label}
-                      </span>
-                      {selected && <Icon name="check" size={14} />}
-                    </button>
-                  );
-                })}
-                <button
-                  type="button"
-                  role="menuitem"
-                  onClick={handleSaveCurrentProgress}
-                  className="flex w-full items-center gap-1.5 rounded-[10px] px-2.5 py-2 text-left text-xs font-bold text-[var(--solid-ink)] hover:bg-[rgba(26,26,26,0.04)]"
-                >
-                  <Icon name="save" size={14} />
-                  保存
-                </button>
-              </div>
-            </>
-          )}
-        </div>
+        {/* 並び替え・保存メニューは廃止。進捗表示を中央に保つためのスペーサー。 */}
+        <div className="h-[38px] w-[38px]" aria-hidden="true" />
       </div>
 
       {/* Card area (no ghost cards) */}


### PR DESCRIPTION
## 概要

フラッシュカードの状態保存仕様を廃止し、フラッシュカードの表示順をクイズの出題順と同期させました。順番のロジックは毎回ライブデータから再計算するフロントエンド完結の処理にしたため、順番仕様を変えてもサーバーや PWA のデータ更新は不要です（PWA は更新が届きにくいため）。

## 背景

- フラッシュカードは `flashcard_progress_*`（localStorage）/ `flashcard_session_*`（sessionStorage）に「単語ID・現在位置・並び順」を保存し、再入場時に復元していました。
- 独自の並び替え（習得度順／品詞順）を持ち、保存された並び順で復元されるため、クイズの出題順（`sortWordsByPriority`）とずれることがありました。

## 変更内容

`src/app/flashcard/[projectId]/page.tsx`
- 状態保存・復元を全廃
  - `saveProgress` / `restoreFlashcardProgress` と localStorage・sessionStorage への読み書きを削除
  - `beforeunload` / `visibilitychange` / `pagehide` での保存 useEffect を削除
  - `backToProject` の保存処理を削除
- クイズ出題順との同期
  - 並び替えは廃止し、クイズと同じ `sortWordsByPriority`（優先度順）に統一
  - 読み込みごとに順番を再計算し、常に先頭カード（`currentIndex = 0`）から開始
  - ヘッダーの並び替え／「保存」メニューを削除（進捗表示を中央に保つスペーサーに置換）
- Home キャッシュからの即時復元（Phase 0）も同じ優先度順に統一

ドキュメント更新
- `docs/architecture.md`: フラッシュカード読み込みの節をクイズ同期・状態非保存の内容に更新
- `docs/invariants.md`: INV-16 を「クイズ出題順との同期・状態非保存・フロントエンド完結」に改訂
- `docs/_discovery_notes.md`: 廃止した storage キーを一覧から削除

## 挙動の変化

- 再入場すると保存位置ではなく先頭カードから開始します（状態保存の廃止による意図した挙動）。
- フラッシュカードとクイズで重複する単語は同じ順序で並びます。
- 習得済み単語はフラッシュカードでは末尾に表示されます（クイズと同じ比較関数を使用）。

## 確認

- `npx tsc --noEmit`: 変更ファイルに型エラーなし（既存の `translation-targets.test.ts` の型エラーは本 PR と無関係）
- `npx eslint 'src/app/flashcard/[projectId]/page.tsx'`: エラー・警告なし
- `npm test`: 824 pass / 2 fail（2件の fail は本変更前から既存で、signup-verify・words/create のもの。フラッシュカードとは無関係）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LxBDckgtfYJakt6JJGxdtX)_