### PR TITLE
復習ウィジット: 復習予定が無い新規アカウント向けの表示を追加

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -151,6 +151,10 @@ type HomeStats = {
   review: number;
   newW: number;
   favoriteCount: number;
+  // False until at least one word has an actual review schedule (been quizzed).
+  // Distinguishes a brand-new account (default wordbook imported, nothing studied
+  // yet) from a user who has words waiting between review intervals.
+  hasReviewSchedule: boolean;
 };
 
 type HomeProjectStats = ProjectWithStats & {
@@ -222,6 +226,7 @@ function buildHomeStats(allWords: Word[]): HomeStats {
     review: statusCounts.learningTotal,
     newW: statusCounts.unlearnedTotal,
     favoriteCount: allWords.filter((word) => word.isFavorite).length,
+    hasReviewSchedule: allWords.some((word) => Boolean(word.nextReviewAt) || Boolean(word.lastReviewedAt)),
   };
 }
 
@@ -310,6 +315,7 @@ const EMPTY_STATS: HomeStats = {
   review: 0,
   newW: 0,
   favoriteCount: 0,
+  hasReviewSchedule: false,
 };
 
 export default function HomePage() {
@@ -498,7 +504,7 @@ export default function HomePage() {
     }
   }, [pendingGeneratingWordbook?.linkedJobId, recentScanJobs]);
 
-  const { dueCount, completedToday, streakDays, totalWords, mastered, review, newW, favoriteCount } = stats;
+  const { dueCount, completedToday, streakDays, totalWords, mastered, review, newW, favoriteCount, hasReviewSchedule } = stats;
   const unmasteredCount = newW + review;
   const goalTotal = dueCount + completedToday;
   const goalProgress = goalTotal > 0 ? Math.round((completedToday / goalTotal) * 100) : 0;
@@ -506,8 +512,17 @@ export default function HomePage() {
   const learnProgress = dailyLearnTarget > 0
     ? Math.min(100, Math.round((completedToday / dailyLearnTarget) * 100))
     : 0;
-  const goalState: 'review' | 'learn' | 'empty' =
-    dueCount > 0 ? 'review' : totalWords === 0 ? 'empty' : 'learn';
+  // `start`: brand-new account with a default wordbook but no review schedule yet
+  // (nothing quizzed). Showing the full unlearned backlog as the goal is
+  // demotivating, so surface a small, achievable daily learning target instead.
+  const goalState: 'review' | 'learn' | 'empty' | 'start' =
+    dueCount > 0
+      ? 'review'
+      : totalWords === 0
+        ? 'empty'
+        : !hasReviewSchedule
+          ? 'start'
+          : 'learn';
   // The reel-saved backing wordbook is an internal bucket for 保存済み — keep it
   // out of the browsable マイ単語帳 list (its words still count in `stats`).
   const listProjects = useMemo(() => excludeReelSavedProjects(projects), [projects]);
@@ -605,6 +620,32 @@ export default function HomePage() {
               </div>
             </SolidPanel>
           </button>
+        ) : goalState === 'start' ? (
+          <Link href="/quiz/all?learn=1&from=/" className="block">
+            <SolidPanel className="!rounded-2xl" faceClassName="!p-3 min-h-[120px]">
+              <div className="font-mono text-[10px] font-semibold uppercase tracking-[0.02em] text-[var(--color-muted)]">
+                TODAY&apos;S GOAL
+              </div>
+              <div className="mt-2 flex items-baseline gap-1">
+                <span className="font-display text-[30px] font-extrabold tabular-nums leading-none text-[var(--solid-ink)]">
+                  {dailyLearnTarget}
+                </span>
+                <span className="text-sm font-bold text-[var(--solid-ink)]">語</span>
+              </div>
+              <div className="mt-0.5 text-[11px] tabular-nums text-[var(--color-muted)]">
+                まずはここから
+              </div>
+              <div className="mt-2.5 h-[5px] overflow-hidden rounded-full bg-[rgba(26,26,26,0.08)]">
+                <div className="h-full bg-[var(--color-accent)]" style={{ width: `${learnProgress}%` }} />
+              </div>
+              <div className="mt-3 flex items-center gap-[3px] text-[var(--solid-ink)]">
+                <span className="text-[13px] font-bold">学習を始める</span>
+                <span className="inline-flex text-[var(--color-accent)]">
+                  <Icon name="chevron_right" size={12} />
+                </span>
+              </div>
+            </SolidPanel>
+          </Link>
         ) : goalState === 'learn' ? (
           <Link href="/quiz/all?learn=1&from=/" className="block">
             <SolidPanel className="!rounded-2xl" faceClassName="!p-3 min-h-[120px]">

--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -171,6 +171,7 @@ export default function ProjectListPage() {
         sort={sort}
         summaryStats={summaryStats}
         reviewHref={summaryStats.totalWords > 0 ? '/quiz/all?review=1&from=/projects' : '/projects'}
+        learnHref={summaryStats.totalWords > 0 ? '/quiz/all?learn=1&from=/projects' : '/projects'}
         onQueryChange={setQuery}
         onSortChange={setSort}
       />

--- a/src/components/desktop/DesktopHome.tsx
+++ b/src/components/desktop/DesktopHome.tsx
@@ -33,6 +33,7 @@ type DesktopHomeStats = {
   activeW: number;
   review: number;
   newW: number;
+  hasReviewSchedule: boolean;
 };
 
 type DesktopPendingScan = {
@@ -194,7 +195,11 @@ export function DesktopHomeView({
 
         <div style={{ display: 'flex', flexDirection: 'column', gap: 18, position: 'sticky', top: 0 }}>
           {showUpgrade && <DesktopUpgradeCard onDismiss={onDismissUpgrade} />}
-          <DesktopStudySidebar stats={stats} reviewHref={stats.totalWords > 0 ? '/quiz/all?review=1&from=/' : '/projects'} />
+          <DesktopStudySidebar
+            stats={stats}
+            reviewHref={stats.totalWords > 0 ? '/quiz/all?review=1&from=/' : '/projects'}
+            learnHref={stats.totalWords > 0 ? '/quiz/all?learn=1&from=/' : '/projects'}
+          />
         </div>
       </div>
     </div>

--- a/src/components/desktop/DesktopProjects.tsx
+++ b/src/components/desktop/DesktopProjects.tsx
@@ -33,6 +33,7 @@ export function DesktopProjectsView({
   sort,
   summaryStats,
   reviewHref,
+  learnHref,
   onQueryChange,
   onSortChange,
 }: {
@@ -43,6 +44,7 @@ export function DesktopProjectsView({
   sort: 'newest' | 'words' | 'lastUsed';
   summaryStats: DesktopStudySummaryStats;
   reviewHref: string;
+  learnHref?: string;
   onQueryChange: (value: string) => void;
   onSortChange: (value: 'newest' | 'words' | 'lastUsed') => void;
 }) {
@@ -126,7 +128,7 @@ export function DesktopProjectsView({
           </div>
         </div>
 
-        <DesktopStudySidebar stats={summaryStats} reviewHref={reviewHref} />
+        <DesktopStudySidebar stats={summaryStats} reviewHref={reviewHref} learnHref={learnHref} />
             </div>
     </div>
   );

--- a/src/components/desktop/DesktopStats.tsx
+++ b/src/components/desktop/DesktopStats.tsx
@@ -39,6 +39,9 @@ export function DesktopStatsView({
         activeW,
         review,
         newW: newWords,
+        // Any word progressed beyond 'new' means it has been quizzed and carries
+        // a review schedule; a brand-new account has none of these.
+        hasReviewSchedule: mastered + activeW + review > 0,
       }
     : EMPTY_DESKTOP_STUDY_SUMMARY;
 
@@ -125,7 +128,11 @@ export function DesktopStatsView({
           )}
         </div>
 
-        <DesktopStudySidebar stats={summaryStats} reviewHref={summaryStats.totalWords > 0 ? '/quiz/all?review=1&from=/stats' : '/projects'} />
+        <DesktopStudySidebar
+          stats={summaryStats}
+          reviewHref={summaryStats.totalWords > 0 ? '/quiz/all?review=1&from=/stats' : '/projects'}
+          learnHref={summaryStats.totalWords > 0 ? '/quiz/all?learn=1&from=/stats' : '/projects'}
+        />
       </div>
     </div>
   );

--- a/src/components/desktop/DesktopStudySidebar.tsx
+++ b/src/components/desktop/DesktopStudySidebar.tsx
@@ -7,13 +7,25 @@ import type { DesktopStudySummaryStats } from '@/lib/desktop-study-summary';
 export function DesktopStudySidebar({
   stats,
   reviewHref,
+  learnHref,
 }: {
   stats: DesktopStudySummaryStats;
   reviewHref: string;
+  /** Where "学習を始める" links in the brand-new (no review schedule) state.
+   *  Falls back to reviewHref if a caller doesn't supply it. */
+  learnHref?: string;
 }) {
   const totalGoal = stats.dueCount + stats.completedToday;
   const goalProgress = totalGoal > 0 ? Math.round((stats.completedToday / totalGoal) * 100) : 0;
   const masteryPercent = stats.totalWords > 0 ? Math.round((stats.mastered / stats.totalWords) * 100) : 0;
+  // Brand-new account: default wordbook imported but nothing quizzed yet, so no
+  // word has a review schedule. Show a small, achievable learning target rather
+  // than "0語 復習を始める" (which would launch an empty review).
+  const isFreshStart = stats.totalWords > 0 && !stats.hasReviewSchedule && stats.dueCount === 0;
+  const dailyLearnTarget = Math.min(stats.newW + stats.review, 10);
+  const learnProgress = dailyLearnTarget > 0
+    ? Math.min(100, Math.round((stats.completedToday / dailyLearnTarget) * 100))
+    : 0;
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column', gap: 16, position: 'sticky', top: 0 }}>
@@ -21,19 +33,25 @@ export function DesktopStudySidebar({
         <div className="muted" style={{ fontSize: 12.5, fontWeight: 600 }}>今日の目標</div>
         <div style={{ display: 'flex', alignItems: 'baseline', gap: 5, marginTop: 6 }}>
           <span className="tnum" style={{ fontFamily: 'var(--font-display)', fontWeight: 800, fontSize: 40, lineHeight: 1 }}>
-            {stats.dueCount}
+            {isFreshStart ? dailyLearnTarget : stats.dueCount}
           </span>
           <span style={{ fontSize: 16, fontWeight: 700 }}>語</span>
         </div>
         <div className="ds-prog" style={{ marginTop: 14 }}>
-          <div className="fi" style={{ width: `${goalProgress}%` }} />
+          <div className="fi" style={{ width: `${isFreshStart ? learnProgress : goalProgress}%` }} />
         </div>
         <div className="mono muted" style={{ fontSize: 11, marginTop: 6 }}>
-          {stats.completedToday} / {totalGoal} 完了
+          {isFreshStart ? 'まずはここから' : `${stats.completedToday} / ${totalGoal} 完了`}
         </div>
-        <DesktopButton href={reviewHref} variant="accent" icon="play_arrow" className="w-full">
-          復習を始める
-        </DesktopButton>
+        {isFreshStart ? (
+          <DesktopButton href={learnHref ?? reviewHref} variant="accent" icon="play_arrow" className="w-full">
+            学習を始める
+          </DesktopButton>
+        ) : (
+          <DesktopButton href={reviewHref} variant="accent" icon="play_arrow" className="w-full">
+            復習を始める
+          </DesktopButton>
+        )}
       </div>
 
       <div className="ds-card" style={{ padding: '20px 22px', display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 14 }}>

--- a/src/lib/desktop-study-summary.ts
+++ b/src/lib/desktop-study-summary.ts
@@ -13,6 +13,9 @@ export type DesktopStudySummaryStats = {
   activeW: number;
   review: number;
   newW: number;
+  // False for a brand-new account whose words have never been quizzed (no review
+  // schedule yet). Lets the sidebar show a small learning target instead of "0語".
+  hasReviewSchedule: boolean;
 };
 
 export const EMPTY_DESKTOP_STUDY_SUMMARY: DesktopStudySummaryStats = {
@@ -24,6 +27,7 @@ export const EMPTY_DESKTOP_STUDY_SUMMARY: DesktopStudySummaryStats = {
   activeW: 0,
   review: 0,
   newW: 0,
+  hasReviewSchedule: false,
 };
 
 export function buildDesktopStudySummaryStats(words: Word[]): DesktopStudySummaryStats {
@@ -40,5 +44,6 @@ export function buildDesktopStudySummaryStats(words: Word[]): DesktopStudySummar
     activeW: statusCounts.activeTotal,
     review: statusCounts.learningTotal,
     newW: statusCounts.unlearnedTotal,
+    hasReviewSchedule: words.some((word) => Boolean(word.nextReviewAt) || Boolean(word.lastReviewedAt)),
   };
 }


### PR DESCRIPTION
## 背景 / 課題

アカウント作成直後は、EIKEN級に応じたデフォルト単語帳が自動でインポートされます（`persistDefaultOfficialWordbooksToDb`）。このとき各単語は `status: 'new'`・`nextReviewAt`/`lastReviewedAt` 無しで作成されます。

`getWordsDueForReview()` は新規単語を「復習対象」に含めないため `dueCount` は正しく 0 になりますが、ホームの「今日の目標(TODAY'S GOAL)」カードは `dueCount === 0 && totalWords > 0` のとき `'learn'` 状態にフォールバックし、**未習得の全単語数**（デフォルト単語帳の全語数）を目標として表示していました。

→ まだクイズを一問も解いていないのに大量の語数が表示され、やる気を削ぐ状態でした。「復習時期が何もない」場合の専用表示が無かったのが原因です。

## 変更内容

「どの単語にも復習予定(`nextReviewAt`/`lastReviewedAt`)が無い」状態を `hasReviewSchedule` フラグで検出し、この場合は全語数の代わりに **本日の少量ゴール（最大10語）＋「学習を始める」導線** を表示する新しい状態を追加しました。

- **モバイルWeb（`src/app/page.tsx`）**: `goalState` に `'start'` を追加。`totalWords > 0 && !hasReviewSchedule` のとき、`dailyLearnTarget`（`min(未習得数, 10)`）と「まずはここから / 学習を始める」を表示。
- **デスクトップ学習サイドバー（`DesktopStudySidebar`）**: `isFreshStart` 状態を追加し、「0語 復習を始める（中身が空の復習に遷移）」の代わりに「10語 学習を始める」を表示。ホーム / 学習の推移 / 単語帳の各ページに統一適用（`learnHref` を各呼び出し元から供給）。
- 最初のクイズで復習予定が生まれると `hasReviewSchedule` が true になり、自動的に従来の表示（`'learn'` / `'review'`）へ戻ります。

RNアプリ（`mobile/`）は既に「復習待ちなし」の空状態を持つため今回は変更していません。

## 表示イメージ（no-schedule 状態）

```
┌ 今日の目標 ───────┐
│  10 語            │
│  まずはここから    │
│ [ 学習を始める → ]│
└──────────────────┘
```

## 影響範囲

- `HomeStats` / `DesktopStudySummaryStats` / `DesktopHomeStats` に `hasReviewSchedule: boolean` を追加（各 builder・EMPTY 定数も更新）。
- ロジック（`getWordsDueForReview`・SM-2・`summarizeWordMemory`）は未変更。既存の `'learn'`/`'review'`/`'empty'` 状態の挙動は変わりません。

## 確認

- `npx tsc --noEmit`: 変更ファイルにエラーなし
- `eslint`: 変更ファイルにエラーなし（既存の未使用変数warningのみ）
- `npm test`（`home-page-selectors` / `spaced-repetition` / `words/memory`）: 全て pass
- `npm run build`: Compiled successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C1MWE3euatqfbz9jhqxeha

---
_Generated by [Claude Code](https://claude.ai/code/session_01C1MWE3euatqfbz9jhqxeha)_