### PR TITLE
単語一覧の並び順をクイズ・フラッシュカードと同期

### DIFF
--- a/src/app/project/[id]/page.legacy.tsx
+++ b/src/app/project/[id]/page.legacy.tsx
@@ -231,7 +231,7 @@ export default function ProjectDetailPage() {
   // Word list toolbar: search, filter, sort
   const [wordSearchText, setWordSearchText] = useState('');
   const [wordShowSearch, setWordShowSearch] = useState(false);
-  const [wordSortOrder, setWordSortOrder] = useState<'createdAsc' | 'alphabetical' | 'statusAsc'>('createdAsc');
+  const [wordSortOrder, setWordSortOrder] = useState<'priority' | 'createdAsc' | 'alphabetical' | 'statusAsc'>('createdAsc');
   const [wordFilterBookmark, setWordFilterBookmark] = useState(false);
   const [wordFilterActiveness, setWordFilterActiveness] = useState<'all' | 'active' | 'passive'>('all');
   const [wordFilterPos, setWordFilterPos] = useState<string | null>(null);

--- a/src/app/project/[id]/page.tsx
+++ b/src/app/project/[id]/page.tsx
@@ -84,7 +84,7 @@ export default function ProjectPage() {
   const [loading, setLoading] = useState(true);
   const [wordsLoaded, setWordsLoaded] = useState(false);
   const [query, setQuery] = useState('');
-  const [wordSortOrder, setWordSortOrder] = useState<ProjectWordSortOrder>('statusAsc');
+  const [wordSortOrder, setWordSortOrder] = useState<ProjectWordSortOrder>('priority');
   const [wordShowSortSheet, setWordShowSortSheet] = useState(false);
   const [wordShowFilterSheet, setWordShowFilterSheet] = useState(false);
   const [wordFilterBookmark, setWordFilterBookmark] = useState(false);
@@ -951,7 +951,7 @@ export default function ProjectPage() {
         query={query}
         onQueryChange={setQuery}
         filterActive={wordFilterActive}
-        sortActive={wordSortOrder !== 'createdAsc'}
+        sortActive={wordSortOrder !== 'priority'}
         selectMode={selectMode}
         selectedWordIds={selectedWordIds}
         onOpenFilterSheet={() => setWordShowFilterSheet(true)}
@@ -1142,7 +1142,7 @@ export default function ProjectPage() {
           onClick={() => setWordShowSortSheet(true)}
           aria-label="並べ替え"
           className={`inline-flex h-[32px] w-[32px] shrink-0 items-center justify-center rounded-full border-2 border-[var(--solid-ink)] transition-all duration-100 active:translate-x-px active:translate-y-px ${
-            wordSortOrder !== 'createdAsc'
+            wordSortOrder !== 'priority'
               ? 'bg-[var(--solid-ink)] text-white'
               : 'bg-white text-[var(--solid-ink)]'
           }`}

--- a/src/app/project/[id]/words/page.tsx
+++ b/src/app/project/[id]/words/page.tsx
@@ -15,6 +15,7 @@ import { useToast } from '@/components/ui/toast';
 import { useWordCount } from '@/hooks/use-word-count';
 import { getRepository } from '@/lib/db';
 import { remoteRepository } from '@/lib/db/remote-repository';
+import { sortWordsByPriority } from '@/lib/spaced-repetition';
 import { invalidateHomeCache } from '@/lib/home-cache';
 import { getNextVocabularyType } from '@/lib/vocabulary-type';
 import type { Project, Word, SubscriptionStatus } from '@/types';
@@ -88,7 +89,8 @@ export default function WordListPage() {
             console.error('Remote fallback failed:', e);
           }
         }
-        setWords(wordList);
+        // クイズ・フラッシュカードと同じ学習優先度順で表示する。
+        setWords(sortWordsByPriority(wordList));
       } catch (error) {
         console.error('Failed to load:', error);
         router.push('/');

--- a/src/components/project/ProjectDetailSheet.tsx
+++ b/src/components/project/ProjectDetailSheet.tsx
@@ -156,7 +156,7 @@ function WordRow({ word, onCycleStatus, onCycleVocabularyType, onToggleFavorite 
   );
 }
 
-type SortOrder = 'createdAsc' | 'alphabetical' | 'statusAsc';
+type SortOrder = 'priority' | 'createdAsc' | 'alphabetical' | 'statusAsc';
 
 export function ProjectDetailSheet({ projectId, onClose }: { projectId: string; onClose: () => void }) {
   const { user, subscription, isPro: _isPro, loading: authLoading } = useAuth();

--- a/src/components/project/WordListSheets.tsx
+++ b/src/components/project/WordListSheets.tsx
@@ -3,7 +3,7 @@
 import { Icon } from '@/components/ui';
 
 type Activeness = 'all' | 'active' | 'passive';
-type SortOrder = 'createdAsc' | 'alphabetical' | 'statusAsc';
+type SortOrder = 'priority' | 'createdAsc' | 'alphabetical' | 'statusAsc';
 
 const POS_LABEL_MAP: Record<string, string> = {
   noun: '名詞',
@@ -233,6 +233,7 @@ type WordSortSheetProps = {
 };
 
 const SORT_OPTIONS: Array<{ value: SortOrder; label: string; description: string; icon: string }> = [
+  { value: 'priority', label: '学習順', description: 'クイズ・カードと同じ並び順', icon: 'school' },
   { value: 'createdAsc', label: '追加順', description: '追加した順に表示', icon: 'schedule' },
   { value: 'alphabetical', label: 'アルファベット', description: 'A → Z の順に表示', icon: 'sort_by_alpha' },
   { value: 'statusAsc', label: '未習得順', description: '未習得の単語を先に表示', icon: 'trending_up' },

--- a/src/lib/project/project-page-selectors.test.ts
+++ b/src/lib/project/project-page-selectors.test.ts
@@ -1,7 +1,8 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 
-import type { WordStatus, VocabularyType } from '@/types';
+import type { WordStatus, VocabularyType, Word } from '@/types';
+import { sortWordsByPriority } from '@/lib/spaced-repetition';
 import {
   countProjectWordStats,
   getProjectPartOfSpeechLabel,
@@ -23,6 +24,7 @@ function word(
     japanese = id,
     createdAt = '2026-05-01T00:00:00.000Z',
     status = 'new',
+    nextReviewAt,
     isFavorite = false,
     vocabularyType = null,
     partOfSpeechTags,
@@ -36,6 +38,7 @@ function word(
     japanese?: string;
     createdAt?: string;
     status?: WordStatus;
+    nextReviewAt?: string;
     isFavorite?: boolean;
     vocabularyType?: VocabularyType | null;
     partOfSpeechTags?: string[];
@@ -52,6 +55,7 @@ function word(
     japanese,
     createdAt,
     status,
+    nextReviewAt,
     isFavorite,
     vocabularyType,
     partOfSpeechTags,
@@ -199,6 +203,29 @@ test('selectFilteredProjectWords sorts by status ascending', () => {
   ];
 
   assert.deepEqual(selectIds(words, { sortOrder: 'statusAsc' }), ['missing', 'new', 'review', 'mastered']);
+});
+
+test('selectFilteredProjectWords "priority" order matches quiz/flashcard sortWordsByPriority', () => {
+  const now = Date.now();
+  const past = new Date(now - 24 * 60 * 60 * 1000).toISOString();
+  const future = new Date(now + 24 * 60 * 60 * 1000).toISOString();
+  const words = [
+    word('mastered-old', { status: 'mastered', createdAt: '2026-05-01T00:00:00.000Z' }),
+    word('new-due', { status: 'new', createdAt: '2026-05-04T00:00:00.000Z', nextReviewAt: past }),
+    word('review-future', { status: 'review', createdAt: '2026-05-02T00:00:00.000Z', nextReviewAt: future }),
+    word('new-fresh-b', { status: 'new', createdAt: '2026-05-03T00:00:00.000Z' }),
+    word('new-fresh-a', { status: 'new', createdAt: '2026-05-02T00:00:00.000Z' }),
+  ];
+
+  // The selector must produce exactly the same sequence as the shared
+  // spaced-repetition comparator used by the quiz and flashcard screens.
+  const expected = sortWordsByPriority(words as unknown as Word[]).map((item) => item.id);
+
+  assert.deepEqual(selectIds(words, { sortOrder: 'priority' }), expected);
+  // Sanity check: due word first (bucket 0); then the never-scheduled bucket by
+  // status (new words in createdAt-asc order, then mastered); then the
+  // future-scheduled review word last (bucket 2 is deprioritized below bucket 1).
+  assert.deepEqual(expected, ['new-due', 'new-fresh-a', 'new-fresh-b', 'mastered-old', 'review-future']);
 });
 
 test('selectFilteredProjectWords sorts by createdAt ascending by default', () => {

--- a/src/lib/project/project-page-selectors.ts
+++ b/src/lib/project/project-page-selectors.ts
@@ -1,7 +1,9 @@
 import type { VocabularyType, WordStatus } from '@/types';
 import { summarizeWordMemory } from '@/lib/words/memory';
+import { compareWordsByPriority } from '@/lib/spaced-repetition';
 
-export type ProjectWordSortOrder = 'createdAsc' | 'alphabetical' | 'statusAsc';
+// 'priority' はクイズ・フラッシュカードと同じ学習優先度順（sortWordsByPriority）。
+export type ProjectWordSortOrder = 'priority' | 'createdAsc' | 'alphabetical' | 'statusAsc';
 export type ProjectWordActivenessFilter = 'all' | 'active' | 'passive';
 
 export interface ProjectWordStats {
@@ -27,6 +29,8 @@ export interface ProjectPageWord {
   english: string;
   japanese: string;
   createdAt: string;
+  id?: string;
+  nextReviewAt?: string;
   projectId?: string;
   status?: WordStatus;
   isFavorite?: boolean;
@@ -122,6 +126,16 @@ export function selectFilteredProjectWords<T extends ProjectPageWord>(
     return [...result].sort(
       (a, b) => (STATUS_SORT_ORDER[a.status ?? 'new'] ?? 0) - (STATUS_SORT_ORDER[b.status ?? 'new'] ?? 0),
     );
+  }
+
+  if (options.sortOrder === 'priority') {
+    // クイズ・フラッシュカードと完全に同じ並び（復習期限→ステータス→作成日昇順→id）。
+    const now = new Date();
+    return [...result].sort((a, b) => compareWordsByPriority(
+      { id: a.id ?? '', status: a.status ?? 'new', createdAt: a.createdAt, nextReviewAt: a.nextReviewAt },
+      { id: b.id ?? '', status: b.status ?? 'new', createdAt: b.createdAt, nextReviewAt: b.nextReviewAt },
+      now,
+    ));
   }
 
   return [...result].sort(

--- a/src/lib/spaced-repetition.ts
+++ b/src/lib/spaced-repetition.ts
@@ -204,14 +204,26 @@ export function getReviewCount(words: Word[]): number {
   return getWordsDueForReview(words).length;
 }
 
-const STATUS_PRIORITY: Record<Word['status'], number> = {
+const STATUS_PRIORITY: Record<WordStatus, number> = {
   new: 0,
   review: 1,
   active: 2,
   mastered: 3,
 };
 
-function getReviewBucket(word: Word, nowMs: number): number {
+/**
+ * Minimal fields needed to order words by study priority. Word satisfies this,
+ * but so can lighter shapes (e.g. the project word-list selector) so the quiz,
+ * flashcard, and word-list screens can all share one canonical ordering.
+ */
+export interface WordPriorityFields {
+  id: string;
+  status: WordStatus;
+  createdAt: string;
+  nextReviewAt?: string;
+}
+
+function getReviewBucket(word: WordPriorityFields, nowMs: number): number {
   if (!word.nextReviewAt) return 1;
   const nextMs = Date.parse(word.nextReviewAt);
   if (Number.isNaN(nextMs)) return 1;
@@ -222,7 +234,7 @@ function getReviewBucket(word: Word, nowMs: number): number {
  * Compare words by study priority.
  * Lower return value means higher priority.
  */
-export function compareWordsByPriority(a: Word, b: Word, now: Date = new Date()): number {
+export function compareWordsByPriority(a: WordPriorityFields, b: WordPriorityFields, now: Date = new Date()): number {
   const nowMs = now.getTime();
 
   const reviewBucketDiff = getReviewBucket(a, nowMs) - getReviewBucket(b, nowMs);


### PR DESCRIPTION
## 概要

単語一覧の並び順を、クイズ・フラッシュカードと同じ「学習優先度順」(`sortWordsByPriority`) に揃えました。前回 PR (#370) でフラッシュカードをクイズ順に統一しましたが、単語一覧だけ別のソートになっていたため、その差を解消します。

## 背景（何が違っていたか）

- **単語帳詳細画面** (`/project/[id]`): 並べ替えUIの既定が `statusAsc`（ステータス順のみ、復習期限や作成日のタイブレークなし）→ クイズ/カードと部分的にしか一致しない。
- **専用の単語一覧ページ** (`/project/[id]/words`): `getWords()` の生の順（作成日の**新しい順**）そのまま → クイズ/カードと全く逆。
- クイズ・カードは `sortWordsByPriority`（復習期限 → ステータス → 作成日**昇順** → id）。

## 変更内容

- `src/lib/spaced-repetition.ts`
  - `compareWordsByPriority` の引数型を最小構造体 `WordPriorityFields`（`id` / `status` / `createdAt` / `nextReviewAt`）に緩和。挙動は不変。クイズ・カード・単語一覧が**単一の正準ソート**を共有できるようにする狙い。
- `src/lib/project/project-page-selectors.ts`
  - `ProjectWordSortOrder` に `'priority'` を追加。
  - `selectFilteredProjectWords` の `'priority'` 分岐で `compareWordsByPriority` を再利用（重複実装せず、ドリフトを防止）。
- `src/app/project/[id]/page.tsx`
  - 単語リストの並べ替え既定を `'priority'`（学習順）に変更。並べ替えボタンのハイライト基準も `'priority'` を中立扱いに調整。作成順/アルファベット/未習得順は選択肢として維持。
- `src/components/project/WordListSheets.tsx`
  - 並べ替えシートに「学習順（クイズ・カードと同じ並び順）」を追加（先頭・既定）。
- `src/app/project/[id]/words/page.tsx`
  - 読み込んだ単語を `sortWordsByPriority` で並べて表示（クイズ/カードと一致）。
- 型整合のため、未使用のレガシー/シート (`page.legacy.tsx` / `ProjectDetailSheet.tsx`) のローカル型にも `'priority'` を追記。
- `src/lib/project/project-page-selectors.test.ts`
  - `'priority'` 順が `sortWordsByPriority` と完全一致することを固定するテストを追加。

## 挙動の変化

- 単語帳詳細画面を開くと、初期表示がクイズ・カードと同じ「学習順」になります。ユーザーは並べ替えメニューから従来の順（追加順／アルファベット／未習得順）も引き続き選べます。
- 専用の単語一覧ページも学習順で表示されます（このルートは現状どこからもリンクされていないオーファンですが、一貫性のため合わせました）。

## 確認

- `npx tsc --noEmit`: 変更対象ファイルに型エラーなし（既存の `translation-targets.test.ts` の型エラーは本 PR と無関係）
- ESLint（変更ファイル）: エラー 0（既存の未使用変数 warning のみ）
- `npm test`: 825 pass / 2 fail。2件の fail は本変更前から既存（signup-verify・words/create）でフラッシュカード/単語一覧とは無関係。新規の priority テストは pass。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LxBDckgtfYJakt6JJGxdtX)_