### PR TITLE
feat(quiz): タイプ入力クイズでキーボードを自動表示

### DIFF
--- a/src/app/quiz/[projectId]/page.tsx
+++ b/src/app/quiz/[projectId]/page.tsx
@@ -4,7 +4,7 @@ import { type ReactNode, useState, useEffect, useCallback, useMemo, useRef } fro
 import { useRouter, useParams, useSearchParams, usePathname } from 'next/navigation';
 import { Icon } from '@/components/ui/Icon';
 import { SolidButton } from '@/components/redesign/SolidPage';
-import { TypeInQuizField, ReviewProjectFilterSheet, type ReviewFilterProject } from '@/components/quiz';
+import { TypeInQuizField, ReviewProjectFilterSheet, type ReviewFilterProject, type TypeInQuizFieldHandle } from '@/components/quiz';
 import { TranslationDisplay } from '@/components/word/TranslationDisplay';
 import { getRepository } from '@/lib/db';
 import { remoteRepository } from '@/lib/db/remote-repository';
@@ -113,6 +113,16 @@ function isWordOrderQuestion(question: QuizQuestion | undefined): question is Wo
 
 function isMultipleChoiceQuestion(question: QuizQuestion | undefined): question is MultipleChoiceQuizQuestion {
   return question !== undefined && question.type !== 'word-order';
+}
+
+// Mirrors the type-in mode decision made per question in the quiz screen:
+// non-word-order questions for active-vocabulary or active-status words are
+// answered by typing rather than choosing an option.
+function isTypeInQuizQuestion(question: QuizQuestion | undefined): boolean {
+  return (
+    isMultipleChoiceQuestion(question) &&
+    (question.word.vocabularyType === 'active' || question.word.status === 'active')
+  );
 }
 
 function chipKey(token: string): string {
@@ -563,6 +573,15 @@ export default function QuizPage() {
   // presentation time. Answering promotes the word's status (e.g. active →
   // mastered), and we must not let that flip the UI to multiple-choice mid-question.
   const typeInModeRef = useRef<{ key: string; value: boolean }>({ key: '', value: false });
+  // Desktop and mobile layouts each render a TypeInQuizField (one is always
+  // display:none). Focusing the hidden one is a silent no-op, so we can safely
+  // focus both to reach whichever layout is currently visible.
+  const typeInFieldMobileRef = useRef<TypeInQuizFieldHandle>(null);
+  const typeInFieldDesktopRef = useRef<TypeInQuizFieldHandle>(null);
+  const focusTypeInField = useCallback(() => {
+    typeInFieldMobileRef.current?.focus();
+    typeInFieldDesktopRef.current?.focus();
+  }, []);
 
   const subscriptionStatus: SubscriptionStatus = subscription?.status || 'free';
   const wasPro = subscription?.plan === 'pro' && subscriptionStatus !== 'active';
@@ -1063,6 +1082,15 @@ export default function QuizPage() {
   // user type Japanese, regardless of quiz direction or active source.
   const typeInExpectedAnswer = currentQuestion?.word.english ?? '';
 
+  // Auto-focus the input whenever a new, unanswered type-in question is shown so
+  // the user does not have to tap the field every time. On Android a
+  // programmatic focus opens the software keyboard directly; on iOS the keyboard
+  // only opens from the "next" tap gesture, which `moveToNext` handles.
+  useEffect(() => {
+    if (!isTypeInMode || isRevealed) return;
+    focusTypeInField();
+  }, [currentIndex, isTypeInMode, isRevealed, focusTypeInField]);
+
   const applyAnswerOutcome = async (word: Word, isCorrect: boolean, marker?: QuizAnswerResult) => {
     playAnswerFeedbackSound(isCorrect);
     setResults((prev) => ({ correct: prev.correct + (isCorrect ? 1 : 0), total: prev.total + 1 }));
@@ -1189,8 +1217,13 @@ export default function QuizPage() {
 
   const moveToNext = () => {
     if (isTransitioning) return;
-    setIsTransitioning(true);
     const advanceState = getQuizAdvanceState(currentIndex, questions.length);
+    // Reopen the software keyboard for the next question while we are still
+    // inside this tap gesture (iOS only opens the keyboard from a user gesture).
+    if (!advanceState.isComplete && isTypeInQuizQuestion(questions[advanceState.nextIndex])) {
+      focusTypeInField();
+    }
+    setIsTransitioning(true);
     if (advanceState.isComplete) {
       setIsComplete(true);
       setIsTransitioning(advanceState.isTransitioning);
@@ -1598,6 +1631,7 @@ export default function QuizPage() {
         ) : (
           <div style={{ width: '100%', maxWidth: 520 }}>
             <TypeInQuizField
+              ref={typeInFieldDesktopRef}
               answer={typeInExpectedAnswer}
               spaceAsGap={isActiveVocab}
               value={typeInAnswer}
@@ -1850,6 +1884,7 @@ export default function QuizPage() {
         ) : (
           <div className="mt-[18px] w-full space-y-4">
             <TypeInQuizField
+              ref={typeInFieldMobileRef}
               answer={typeInExpectedAnswer}
               spaceAsGap={isActiveVocab}
               value={typeInAnswer}

--- a/src/components/quiz/TypeInQuizField.tsx
+++ b/src/components/quiz/TypeInQuizField.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useRef, type ChangeEvent } from 'react';
+import { forwardRef, useImperativeHandle, useRef, type ChangeEvent } from 'react';
 import { Icon } from '@/components/ui/Icon';
 
 export type TypeInQuizFieldResult = 'correct' | 'wrong' | null;
@@ -31,10 +31,15 @@ export interface TypeInQuizFieldProps {
   variant?: 'plain' | 'solid';
 }
 
+export interface TypeInQuizFieldHandle {
+  /** Focus the underlying input, reopening the mobile keyboard when called from a tap gesture. */
+  focus: () => void;
+}
+
 /**
  * Typing quiz field: bold characters for input, gray first-letter hint, underscores for remaining slots.
  */
-export function TypeInQuizField({
+export const TypeInQuizField = forwardRef<TypeInQuizFieldHandle, TypeInQuizFieldProps>(function TypeInQuizField({
   answer,
   spaceAsGap = false,
   value,
@@ -44,8 +49,20 @@ export function TypeInQuizField({
   disabled,
   result,
   variant = 'plain',
-}: TypeInQuizFieldProps) {
+}, ref) {
   const inputRef = useRef<HTMLInputElement>(null);
+  useImperativeHandle(ref, () => ({
+    focus: () => {
+      const el = inputRef.current;
+      if (!el) return;
+      // While an answer is revealed the input is `disabled`, which blocks focus.
+      // To reopen the keyboard for the next question we focus inside the "next"
+      // tap gesture (iOS only shows the software keyboard from a user gesture),
+      // before React re-renders the input as enabled -- so force-enable first.
+      if (el.disabled) el.disabled = false;
+      el.focus();
+    },
+  }), []);
   const target: string[] = [];
   const slots: Slot[] = [];
   for (const ch of answer) {
@@ -210,4 +227,4 @@ export function TypeInQuizField({
       {input}
     </div>
   );
-}
+});

--- a/src/components/quiz/index.ts
+++ b/src/components/quiz/index.ts
@@ -1,3 +1,3 @@
 export { QuizOption } from './quiz-option';
-export { TypeInQuizField } from './TypeInQuizField';
+export { TypeInQuizField, type TypeInQuizFieldHandle } from './TypeInQuizField';
 export { ReviewProjectFilterSheet, type ReviewFilterProject } from './ReviewProjectFilterSheet';


### PR DESCRIPTION
## 概要

Active単語などのタイプ入力式クイズで、問題が切り替わるたびに毎回入力フォームをタップしないとキーボードが出てこない問題を解消しました。新しい問題が表示されると自動でフォームにフォーカスが移り、キーボードが立ち上がります。

## 背景

`TypeInQuizField` の `<input>` には `autoFocus` が付いていますが、これは初回マウント時にしか発火しません。同じ入力欄を使い回して次の問題を表示する構造のため、2問目以降はフォーカスが移らず、ユーザーが毎回フォームをタップする必要がありました。

## 変更内容

- **`TypeInQuizField` を `forwardRef` 化**し、命令的な `focus()` を公開。回答表示中は `disabled` でフォーカスを受け付けないため、`focus()` 内で一時的に有効化してからフォーカスする（iOS はユーザー操作ジェスチャー内でないとソフトキーボードが開かないため、この処理を「次へ」タップ内で完結させる）。
- **新しい未回答のタイプ入力問題が表示されたら自動でフォーカスする `useEffect` を追加**。Android ではこのプログラム的フォーカスでソフトキーボードが開く。
- **`moveToNext`（「次へ」タップ）で、次の問題が入力式なら同じジェスチャー内でフォーカス**。iOS でも連続するタイプ入力問題ではキーボードが開いたまま次の問題へ遷移する。
- 次問がタイプ入力かどうかを判定する `isTypeInQuizQuestion` ヘルパーを追加（画面側の type-in 判定ロジックと一致）。
- デスクトップ／モバイル両レイアウトの `TypeInQuizField` にそれぞれ ref を付与（非表示側への `focus()` は no-op なので安全に両方呼ぶ）。

## 挙動

| 環境 | 1問目 | 2問目以降（連続する入力問題） |
|------|-------|------------------------------|
| Android | 自動でキーボード表示 | 自動でキーボード表示 |
| iOS | 初回のみ1タップ必要（ジェスチャー起点がないため） | 「次へ」タップのジェスチャーで自動表示 |
| Desktop | 自動フォーカス（クリック不要で入力可能） | 自動フォーカス |

## テスト

- `npx tsc --noEmit` … 変更ファイルは型エラーなし（既存の無関係な test ファイルの1件のみ）
- `npx eslint`（変更ファイル）… 警告・エラーなし
- `tsx --test`（quiz 系ユニットテスト）… 31 件すべて pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01H22zANHFR5eUUeKxPFk2n8)_