### PR TITLE
fix(home): 復習完了時に「0語」ではなく「復習完了」を表示

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -532,14 +532,16 @@ export default function HomePage() {
   // `start`: brand-new account with a default wordbook but no review schedule yet
   // (nothing quizzed). Showing the full unlearned backlog as the goal is
   // demotivating, so surface a small, achievable daily learning target instead.
-  const goalState: 'review' | 'learn' | 'empty' | 'start' =
+  const goalState: 'review' | 'learn' | 'empty' | 'start' | 'done' =
     dueCount > 0
       ? 'review'
       : totalWords === 0
         ? 'empty'
         : !hasReviewSchedule
           ? 'start'
-          : 'learn';
+          : unmasteredCount === 0
+            ? 'done'
+            : 'learn';
   // The reel-saved backing wordbook is an internal bucket for 保存済み — keep it
   // out of the browsable マイ単語帳 list (its words still count in `stats`).
   const listProjects = useMemo(() => excludeReelSavedProjects(projects), [projects]);
@@ -698,6 +700,22 @@ export default function HomePage() {
               </div>
             </SolidPanel>
           </Link>
+        ) : goalState === 'done' ? (
+          <div className="block">
+            <SolidPanel className="!rounded-2xl" faceClassName="!p-3 min-h-[120px]">
+              <div className="font-mono text-[10px] font-semibold uppercase tracking-[0.02em] text-[var(--color-muted)]">
+                TODAY&apos;S GOAL
+              </div>
+              <div className="mt-5 flex items-center gap-1.5">
+                <span className="inline-flex text-[var(--color-success)]">
+                  <Icon name="check_circle" size={26} filled />
+                </span>
+                <span className="font-display text-[20px] font-extrabold leading-tight text-[var(--solid-ink)]">
+                  復習完了
+                </span>
+              </div>
+            </SolidPanel>
+          </div>
         ) : goalState === 'learn' ? (
           <Link href="/quiz/all?learn=1&from=/" className="block">
             <SolidPanel className="!rounded-2xl" faceClassName="!p-3 min-h-[120px]">

--- a/src/components/desktop/DesktopStudySidebar.tsx
+++ b/src/components/desktop/DesktopStudySidebar.tsx
@@ -22,6 +22,9 @@ export function DesktopStudySidebar({
   // word has a review schedule. Show a small, achievable learning target rather
   // than "0語 復習を始める" (which would launch an empty review).
   const isFreshStart = stats.totalWords > 0 && !stats.hasReviewSchedule && stats.dueCount === 0;
+  // Review schedule exists but nothing is due right now: the review is done for
+  // now, so show "復習完了" rather than "0語 復習を始める" (an empty review).
+  const isReviewDone = stats.totalWords > 0 && stats.hasReviewSchedule && stats.dueCount === 0;
   const dailyLearnTarget = Math.min(stats.newW + stats.review, 10);
   const learnProgress = dailyLearnTarget > 0
     ? Math.min(100, Math.round((stats.completedToday / dailyLearnTarget) * 100))
@@ -31,26 +34,39 @@ export function DesktopStudySidebar({
     <div style={{ display: 'flex', flexDirection: 'column', gap: 16, position: 'sticky', top: 0 }}>
       <div className="ds-card" style={{ padding: '20px 22px' }}>
         <div className="muted" style={{ fontSize: 12.5, fontWeight: 600 }}>今日の目標</div>
-        <div style={{ display: 'flex', alignItems: 'baseline', gap: 5, marginTop: 6 }}>
-          <span className="tnum" style={{ fontFamily: 'var(--font-display)', fontWeight: 800, fontSize: 40, lineHeight: 1 }}>
-            {isFreshStart ? dailyLearnTarget : stats.dueCount}
-          </span>
-          <span style={{ fontSize: 16, fontWeight: 700 }}>語</span>
-        </div>
-        <div className="ds-prog" style={{ marginTop: 14 }}>
-          <div className="fi" style={{ width: `${isFreshStart ? learnProgress : goalProgress}%` }} />
-        </div>
-        <div className="mono muted" style={{ fontSize: 11, marginTop: 6 }}>
-          {isFreshStart ? 'まずはここから' : `${stats.completedToday} / ${totalGoal} 完了`}
-        </div>
-        {isFreshStart ? (
-          <DesktopButton href={learnHref ?? reviewHref} variant="accent" icon="play_arrow" className="w-full">
-            学習を始める
-          </DesktopButton>
+        {isReviewDone ? (
+          <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginTop: 18 }}>
+            <span className="inline-flex" style={{ color: 'var(--color-success)' }}>
+              <Icon name="check_circle" size={28} filled />
+            </span>
+            <span style={{ fontFamily: 'var(--font-display)', fontWeight: 800, fontSize: 24, lineHeight: 1 }}>
+              復習完了
+            </span>
+          </div>
         ) : (
-          <DesktopButton href={reviewHref} variant="accent" icon="play_arrow" className="w-full">
-            復習を始める
-          </DesktopButton>
+          <>
+            <div style={{ display: 'flex', alignItems: 'baseline', gap: 5, marginTop: 6 }}>
+              <span className="tnum" style={{ fontFamily: 'var(--font-display)', fontWeight: 800, fontSize: 40, lineHeight: 1 }}>
+                {isFreshStart ? dailyLearnTarget : stats.dueCount}
+              </span>
+              <span style={{ fontSize: 16, fontWeight: 700 }}>語</span>
+            </div>
+            <div className="ds-prog" style={{ marginTop: 14 }}>
+              <div className="fi" style={{ width: `${isFreshStart ? learnProgress : goalProgress}%` }} />
+            </div>
+            <div className="mono muted" style={{ fontSize: 11, marginTop: 6 }}>
+              {isFreshStart ? 'まずはここから' : `${stats.completedToday} / ${totalGoal} 完了`}
+            </div>
+            {isFreshStart ? (
+              <DesktopButton href={learnHref ?? reviewHref} variant="accent" icon="play_arrow" className="w-full">
+                学習を始める
+              </DesktopButton>
+            ) : (
+              <DesktopButton href={reviewHref} variant="accent" icon="play_arrow" className="w-full">
+                復習を始める
+              </DesktopButton>
+            )}
+          </>
         )}
       </div>
 


### PR DESCRIPTION
## 概要

復習を終えて対象の単語が 0 になった後も、ホームの「今日の目標」カードが **「0語」** と表示され続けていた問題を修正しました。復習すべき単語が無くなった状態では、数値の代わりに **「復習完了」** を表示します。

## 背景

「復習終わって0語になってもまだ0語と表示される。復習完了とだけ表示してほしい」という要望への対応です。復習対象がゼロのときに「0語」という数字が出るのは、達成状態を伝えられておらず分かりづらいものでした。

## 変更内容

### モバイル (`src/app/page.tsx`)
- `goalState` に `'done'` を追加。
- 対象語 (`dueCount`) が 0 かつ未習得語 (`unmasteredCount`) も 0 のとき、`'done'` 状態となりチェックアイコン付きで **「復習完了」** を表示。
- まだ未習得語が残っている場合は従来どおり `'learn'`（学習カード）を表示するため、挙動は変わりません。

### デスクトップ (`src/components/desktop/DesktopStudySidebar.tsx`)
- `isReviewDone`（復習スケジュールあり かつ 期限到来語が 0）を追加。
- この状態では「0語 復習を始める」の代わりに **「復習完了」** を表示。空の復習が起動する導線を無くしました。
- `isFreshStart`（新規アカウント）の学習ターゲット表示は従来どおり。

## 動作確認

- `npx eslint`（変更2ファイル）: エラーなし
- `npx tsc --noEmit`（`src/`）: 変更箇所に型エラーなし

## 影響範囲

表示のみの変更です。データ・ロジック・サブスクリプション周りには影響しません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RMnifvxhU2xNJyiicRp39K)_