### PR TITLE
fix(level-test): 未実証レベルでの判定バグ修正 + 出題単語のふり返りリスト

### DIFF
--- a/src/app/level-test/page.tsx
+++ b/src/app/level-test/page.tsx
@@ -11,6 +11,7 @@ import { useAuth } from '@/hooks/use-auth';
 import { triggerHaptic } from '@/lib/haptics';
 import { loadLevelTestBank, type LevelTestBank } from '@/lib/level-test/bank';
 import {
+  EIKEN_LEVEL_LABELS,
   LEVEL_TEST_QUESTION_COUNT,
   answerQuestion,
   buildQuestion,
@@ -27,6 +28,7 @@ import {
   clearLevelTestSession,
   loadLevelTestSession,
   saveLevelTestSession,
+  type AnsweredWord,
 } from '@/lib/level-test/session';
 
 // 語彙レベル診断。未ログインで完全動作し、DBには一切アクセスしない
@@ -66,8 +68,10 @@ export default function LevelTestPage() {
 
   const [state, setState] = useState<LevelTestState>(() => createInitialState());
   const usedKeysRef = useRef<Set<string>>(new Set());
+  const answeredWordsRef = useRef<AnsweredWord[]>([]);
   const [current, setCurrent] = useState<CurrentQuestion | null>(null);
   const [selectedIndex, setSelectedIndex] = useState<number | null>(null);
+  const [answeredWords, setAnsweredWords] = useState<AnsweredWord[]>([]);
   const [resultPayload, setResultPayload] = useState<LevelTestResultPayload | null>(null);
   const [resultCode, setResultCode] = useState<string | null>(null);
   const [shareOpen, setShareOpen] = useState(false);
@@ -115,6 +119,7 @@ export default function LevelTestPage() {
         const restored = session.state;
         const used = new Set(session.usedKeys);
         usedKeysRef.current = used;
+        answeredWordsRef.current = [...session.answeredWords];
         setState(restored);
         setScreen('quiz');
         if (session.currentQuestion) {
@@ -133,7 +138,9 @@ export default function LevelTestPage() {
     clearLevelTestSession();
     const initial = createInitialState();
     usedKeysRef.current = new Set();
+    answeredWordsRef.current = [];
     setState(initial);
+    setAnsweredWords([]);
     setResultPayload(null);
     setResultCode(null);
     setScreen('quiz');
@@ -142,6 +149,7 @@ export default function LevelTestPage() {
       saveLevelTestSession({
         state: initial,
         usedKeys: [],
+        answeredWords: [],
         currentQuestion: { levelIndex: question.levelIndex, wordIndex: question.wordIndex },
       });
     }
@@ -153,6 +161,7 @@ export default function LevelTestPage() {
     // 表示は共有ページと同じdecode済みペイロードを使う(表示条件を揃える)
     const payload = decodeLevelTestResult(code);
     clearLevelTestSession();
+    setAnsweredWords([...answeredWordsRef.current]);
     setResultCode(code);
     setResultPayload(payload ?? {
       v: 1,
@@ -180,6 +189,11 @@ export default function LevelTestPage() {
 
     const used = usedKeysRef.current;
     used.add(usedKeyFor(current.levelIndex, current.wordIndex));
+    answeredWordsRef.current.push({
+      levelIndex: current.levelIndex,
+      wordIndex: current.wordIndex,
+      correct,
+    });
 
     if (advanceTimerRef.current) clearTimeout(advanceTimerRef.current);
     advanceTimerRef.current = setTimeout(() => {
@@ -191,6 +205,7 @@ export default function LevelTestPage() {
       saveLevelTestSession({
         state: nextState,
         usedKeys: [...used],
+        answeredWords: [...answeredWordsRef.current],
         currentQuestion: question
           ? { levelIndex: question.levelIndex, wordIndex: question.wordIndex }
           : null,
@@ -217,6 +232,16 @@ export default function LevelTestPage() {
             診断結果
           </div>
           <LevelTestResultCard payload={resultPayload} variant="own" />
+
+          {bank && answeredWords.length > 0 && (
+            <motion.div
+              initial={{ opacity: 0, y: 10 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ delay: 1.15 }}
+            >
+              <AnsweredWordsPanel bank={bank} answeredWords={answeredWords} />
+            </motion.div>
+          )}
 
           <motion.div
             initial={{ opacity: 0, y: 10 }}
@@ -366,6 +391,62 @@ function StartScreen({
             MERKENのアカウントをお持ちの方はログイン
           </Link>
         )}
+      </div>
+    </div>
+  );
+}
+
+// 出題された全単語の○×ふり返りリスト(結果画面のレベル表示の下に出す)。
+// 回答履歴は端末内(sessionStorage/メモリ)にのみあるため、共有ページでは表示されない。
+function AnsweredWordsPanel({
+  bank,
+  answeredWords,
+}: {
+  bank: LevelTestBank;
+  answeredWords: AnsweredWord[];
+}) {
+  const wrongCount = answeredWords.filter((answered) => !answered.correct).length;
+
+  return (
+    <div className="mt-4 rounded-[20px] border-2 border-[var(--solid-ink)] bg-[var(--color-surface)] p-4 shadow-[3px_3px_0_var(--solid-ink)]">
+      <div className="mb-1 flex items-baseline justify-between gap-2">
+        <div className="font-display text-[16px] font-extrabold text-[var(--solid-ink)]">
+          出題された単語をふり返ろう
+        </div>
+        {wrongCount > 0 && (
+          <div className="shrink-0 text-[11px] font-bold text-[var(--color-muted)]">
+            間違えた単語 {wrongCount}語
+          </div>
+        )}
+      </div>
+      <div className="divide-y divide-[var(--color-border)]">
+        {answeredWords.map((answered, index) => {
+          const word = bank.levels[answered.levelIndex]?.[answered.wordIndex];
+          if (!word) return null;
+          const gradeLabel = EIKEN_LEVEL_LABELS[answered.levelIndex].replace('英検', '');
+          return (
+            <div key={`${answered.levelIndex}-${answered.wordIndex}-${index}`} className="flex items-center gap-2.5 py-2.5">
+              {answered.correct ? (
+                <Icon name="check" size={18} className="shrink-0 text-[var(--color-success,#15803d)]" />
+              ) : (
+                <Icon name="close" size={18} className="shrink-0 text-[var(--color-error,#dc2626)]" />
+              )}
+              <div className="min-w-0 flex-1">
+                <div className="flex items-center gap-1.5">
+                  <span className="truncate font-display text-[15px] font-extrabold text-[var(--solid-ink)]">
+                    {word.english}
+                  </span>
+                  <span className="shrink-0 rounded-[6px] border border-[var(--color-border)] bg-[var(--color-background)] px-1.5 py-0.5 font-mono text-[9px] font-bold text-[var(--color-muted)]">
+                    {gradeLabel}
+                  </span>
+                </div>
+              </div>
+              <div className={`max-w-[45%] truncate text-right text-[12px] font-bold ${answered.correct ? 'text-[var(--color-muted)]' : 'text-[var(--color-error,#dc2626)]'}`}>
+                {word.japanese}
+              </div>
+            </div>
+          );
+        })}
       </div>
     </div>
   );

--- a/src/lib/level-test/engine.test.ts
+++ b/src/lib/level-test/engine.test.ts
@@ -153,6 +153,33 @@ test('an all-wrong 20-question run ends at level 0', () => {
   assert.equal(result.askedByLevel.reduce((a, b) => a + b, 0), LEVEL_TEST_QUESTION_COUNT);
 });
 
+test('a level-up on the final answer does not award an unproven level', () => {
+  // 実際に報告されたバグ: 途中で1級に到達→1級の1問を誤答して降格→
+  // 最後の2問連続正解で20問目にちょうど再昇格すると、1級で1問も
+  // 正解していないのに1級判定になっていた。
+  const answers = [
+    true, true, // 4級 -> 3級
+    true, true, // -> 準2級
+    true, true, // -> 2級
+    true, true, // -> 準1級
+    true, true, // -> 1級
+    false, // 1級の1問目を誤答 -> 準1級へ降格
+    false, true, false, true, false, true, false, true, true, // 最後の2連続正解で1級へ再昇格
+  ];
+  assert.equal(answers.length, LEVEL_TEST_QUESTION_COUNT);
+
+  let state = createInitialState();
+  state = answerMany(state, answers);
+  assert.equal(isFinished(state), true);
+  assert.equal(state.levelIndex, MAX_LEVEL_INDEX); // 内部状態としては1級にいる
+
+  const result = buildResult(state);
+  assert.equal(result.correctByLevel[MAX_LEVEL_INDEX], 0);
+  // 正解実績のない1級ではなく、実績のある準1級で判定される
+  assert.equal(result.finalLevel, MAX_LEVEL_INDEX - 1);
+  assert.equal(result.maxLevel, MAX_LEVEL_INDEX);
+});
+
 test('per-level tallies stay consistent through a mixed run', () => {
   let state = createInitialState();
   const answers = [true, true, false, true, true, false, false, true, true, true,

--- a/src/lib/level-test/engine.ts
+++ b/src/lib/level-test/engine.ts
@@ -135,8 +135,16 @@ export function answerQuestion(
 }
 
 export function buildResult(state: LevelTestState): LevelTestResult {
+  // 最終問題の正解でレベルアップした直後に終了すると、そのレベルでは
+  // 一度も正解していない(あるいは出題すらされていない)のに判定されてしまう。
+  // 判定レベルは「正解実績のあるレベル」まで下げる。
+  let finalLevel = state.levelIndex;
+  while (finalLevel > MIN_LEVEL_INDEX && state.correctByLevel[finalLevel] === 0) {
+    finalLevel -= 1;
+  }
+
   return {
-    finalLevel: state.levelIndex,
+    finalLevel,
     maxLevel: state.maxLevelIndex,
     clearedMax: state.clearedMax,
     correctTotal: state.correctByLevel.reduce((sum, count) => sum + count, 0),

--- a/src/lib/level-test/session.ts
+++ b/src/lib/level-test/session.ts
@@ -3,13 +3,21 @@ import type { LevelTestState } from './engine';
 // 診断の途中経過を sessionStorage に保存して中断再開できるようにする。
 // メインクイズ(quiz-state.ts)と同じ30分TTL。
 
-// v2: LevelTestState に wrongStreak が追加された(古いスナップショットは捨てる)
-export const LEVEL_TEST_SESSION_KEY = 'level_test_state_v2';
+// v3: 回答履歴(answeredWords)が追加された(古いスナップショットは捨てる)
+export const LEVEL_TEST_SESSION_KEY = 'level_test_state_v3';
 export const LEVEL_TEST_SESSION_TTL_MS = 30 * 60 * 1000;
+
+// 出題された単語1問分の記録(結果画面の○×リスト用)
+export type AnsweredWord = {
+  levelIndex: number;
+  wordIndex: number;
+  correct: boolean;
+};
 
 export type LevelTestSessionSnapshot = {
   state: LevelTestState;
   usedKeys: string[];
+  answeredWords: AnsweredWord[];
   // 表示中の問題(回答前にリロードされても同じ問題を復元する)
   currentQuestion: { levelIndex: number; wordIndex: number } | null;
   savedAt: number;
@@ -41,7 +49,7 @@ export function loadLevelTestSession(): LevelTestSessionSnapshot | null {
       clearLevelTestSession();
       return null;
     }
-    if (!parsed.state || !Array.isArray(parsed.usedKeys)) return null;
+    if (!parsed.state || !Array.isArray(parsed.usedKeys) || !Array.isArray(parsed.answeredWords)) return null;
     return parsed;
   } catch {
     return null;


### PR DESCRIPTION
# 概要

#377 マージ後のフォローアップ2件です。

## 1. 判定バグ修正(1級 0/1なのに1級判定になる)

**原因**: 最終問題(20問目)の正解でちょうどレベルアップして終了すると、内部状態の`levelIndex`が昇格先のレベルになったまま判定されていた。報告ケースでは、途中で1級に到達→1級の1問を誤答して降格→最後の2問連続正解で20問目に再昇格、という流れで「1級で正解0問」のまま1級判定になっていた。

**修正**: `buildResult`(`src/lib/level-test/engine.ts`)で、判定レベルにそのレベルでの正解が1問も無い場合は**正解実績のある最も高いレベルまで下げる**ように変更。報告ケースは準1級(5/7)判定になる。再現シナリオのユニットテストを追加。

共有コードのデコーダは変更していないため、既存の共有URLはそのまま有効です。

## 2. 出題単語のふり返りリスト

結果画面のレベル表示(レベル別正答バー)の下に、**出題された20語すべての○×リスト**を追加:
- 緑✓/赤✗ + 単語 + 出題時の級チップ + 正しい意味(誤答は赤字)
- ヘッダーに「間違えた単語 N語」カウンタ
- 回答履歴は端末内(sessionStorage、キーv3に更新)にのみ保持し、**共有URLには含めない**(URLサイズとプライバシーの観点。共有ページは従来どおりサマリーのみ)

# テスト・検証
- `engine.test.ts`にバグ再現テストを追加、level-test関連29テスト全て成功
- `npm run lint:web` エラー0、`npm run build` 成功
- Playwright E2Eで20問完走→結果画面に20行の○×リスト表示をスクリーンショット確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014pqRwbcureW64kkkLp6vhc

---
_Generated by [Claude Code](https://claude.ai/code/session_014pqRwbcureW64kkkLp6vhc)_