### PR TITLE
語彙レベル診断をベイズ推定型の適応テストに変更

### DIFF
--- a/src/app/level-test/page.tsx
+++ b/src/app/level-test/page.tsx
@@ -18,7 +18,7 @@ import {
   buildResult,
   createInitialState,
   isFinished,
-  pickQuestionIndex,
+  selectNextQuestion,
   usedKeyFor,
   type LevelTestQuestion,
   type LevelTestState,
@@ -99,8 +99,8 @@ export default function LevelTestPage() {
     };
   }, []);
 
-  const presentQuestion = useCallback((bankData: LevelTestBank, levelIndex: number, used: Set<string>) => {
-    const picked = pickQuestionIndex(bankData, levelIndex, used);
+  const presentQuestion = useCallback((bankData: LevelTestBank, quizState: LevelTestState, used: Set<string>) => {
+    const picked = selectNextQuestion(bankData, quizState, used);
     if (!picked) return null;
     const word = bankData.levels[picked.levelIndex][picked.wordIndex];
     const next: CurrentQuestion = { ...picked, question: buildQuestion(word) };
@@ -130,7 +130,7 @@ export default function LevelTestPage() {
             return;
           }
         }
-        presentQuestion(bank, restored.levelIndex, used);
+        presentQuestion(bank, restored, used);
         return;
       }
     }
@@ -144,7 +144,7 @@ export default function LevelTestPage() {
     setResultPayload(null);
     setResultCode(null);
     setScreen('quiz');
-    const question = presentQuestion(bank, initial.levelIndex, usedKeysRef.current);
+    const question = presentQuestion(bank, initial, usedKeysRef.current);
     if (question) {
       saveLevelTestSession({
         state: initial,
@@ -164,13 +164,19 @@ export default function LevelTestPage() {
     setAnsweredWords([...answeredWordsRef.current]);
     setResultCode(code);
     setResultPayload(payload ?? {
-      v: 1,
+      v: 2,
       finalLevel: result.finalLevel,
-      maxLevel: result.maxLevel,
+      maxLevel: result.upperLevel,
       clearedMax: result.clearedMax,
       correctTotal: result.correctTotal,
       askedByLevel: result.askedByLevel,
       correctByLevel: result.correctByLevel,
+      ability: result.ability,
+      lowerLevel: result.lowerLevel,
+      upperLevel: result.upperLevel,
+      lowerAbility: result.lowerAbility,
+      upperAbility: result.upperAbility,
+      confidence: result.confidence,
     });
     setScreen('result');
   }, []);
@@ -183,8 +189,13 @@ export default function LevelTestPage() {
     setSelectedIndex(optionIndex);
     triggerHaptic();
 
-    // 正誤やレベル変動は途中では見せない(結果画面まで分からない)
-    const { state: nextState } = answerQuestion(state, correct);
+    // 正誤や推定の変動は途中では見せない(結果画面まで分からない)
+    const nextState = answerQuestion(
+      state,
+      { levelIndex: current.levelIndex, wordIndex: current.wordIndex },
+      bank,
+      correct,
+    );
     setState(nextState);
 
     const used = usedKeysRef.current;
@@ -201,7 +212,7 @@ export default function LevelTestPage() {
         finishQuiz(nextState);
         return;
       }
-      const question = presentQuestion(bank, nextState.levelIndex, used);
+      const question = presentQuestion(bank, nextState, used);
       saveLevelTestSession({
         state: nextState,
         usedKeys: [...used],
@@ -383,7 +394,7 @@ function StartScreen({
         </motion.div>
 
         <p className="mt-4 text-center text-[11px] font-bold text-[var(--color-muted)]">
-          2問連続正解でレベルアップ、2問連続不正解でレベルダウン。最後にいたレベルがあなたの語彙レベルです。
+          回答に合わせて出題の難易度が変わる適応式テストです。20問すべての回答から、最も確からしい語彙レベルを推定します。
         </p>
 
         {!user && (

--- a/src/app/level-test/r/[code]/layout.tsx
+++ b/src/app/level-test/r/[code]/layout.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from 'next';
 import { EIKEN_LEVEL_LABELS } from '@/lib/level-test/engine';
 import { decodeLevelTestResult } from '@/lib/level-test/result-code';
-import { formatVocabSize } from '@/lib/level-test/share';
+import { vocabSizeTextFor } from '@/lib/level-test/share';
 
 // 診断結果の共有ページのメタデータ。結果はURLのcodeから復元するので
 // DBアクセスは発生しない。/level-test/r/* は無限に生成できるURL空間なので
@@ -21,7 +21,7 @@ export async function generateMetadata({
   const payload = decodeLevelTestResult(decodeURIComponent(code));
 
   const pageTitle = payload
-    ? `私の語彙レベルは${EIKEN_LEVEL_LABELS[payload.finalLevel]}！推定語彙数${formatVocabSize(payload.finalLevel)}語｜MERKEN`
+    ? `私の語彙レベルは${EIKEN_LEVEL_LABELS[payload.finalLevel]}！推定語彙数${vocabSizeTextFor(payload)}語｜MERKEN`
     : '英語語彙力レベル診断｜MERKEN';
   const description = payload
     ? `20問中${payload.correctTotal}問正解で${EIKEN_LEVEL_LABELS[payload.finalLevel]}レベル判定。あなたの語彙力は英検何級レベル？20問でサクッと診断📚`

--- a/src/app/level-test/r/[code]/opengraph-image.tsx
+++ b/src/app/level-test/r/[code]/opengraph-image.tsx
@@ -1,7 +1,7 @@
 import { ImageResponse } from 'next/og';
-import { EIKEN_LEVEL_LABELS, MAX_LEVEL_INDEX } from '@/lib/level-test/engine';
+import { EIKEN_LEVEL_LABELS } from '@/lib/level-test/engine';
 import { decodeLevelTestResult } from '@/lib/level-test/result-code';
-import { formatVocabSize } from '@/lib/level-test/share';
+import { vocabSizeTextFor } from '@/lib/level-test/share';
 
 // 診断結果の動的シェアカード(OG/Twitter)。結果はURLのcodeから復元するので
 // DBアクセスなし。share/[shareId]/opengraph-image.tsx と同じ構成で、
@@ -45,7 +45,7 @@ export default async function Image({ params }: { params: Promise<{ code: string
   const payload = decodeLevelTestResult(decodeURIComponent(code));
 
   const grade = payload ? EIKEN_LEVEL_LABELS[payload.finalLevel] : null;
-  const vocab = payload ? formatVocabSize(payload.finalLevel) : null;
+  const vocab = payload ? vocabSizeTextFor(payload) : null;
   const accent = payload ? LEVEL_ACCENTS[payload.finalLevel] : LEVEL_ACCENTS[2];
   const crowned = Boolean(payload?.clearedMax);
 

--- a/src/components/level-test/LevelTestResultCard.tsx
+++ b/src/components/level-test/LevelTestResultCard.tsx
@@ -2,9 +2,9 @@
 
 import { motion } from 'framer-motion';
 import { Icon } from '@/components/ui';
-import { EIKEN_LEVEL_LABELS } from '@/lib/level-test/engine';
+import { CONFIDENCE_LABELS, EIKEN_LEVEL_LABELS } from '@/lib/level-test/engine';
 import type { LevelTestResultPayload } from '@/lib/level-test/result-code';
-import { formatVocabSize } from '@/lib/level-test/share';
+import { formatVocabSizeFromTheta, vocabSizeTextFor } from '@/lib/level-test/share';
 
 // 診断結果カード。自分の結果画面(variant='own': 段階的リビール演出あり)と
 // 共有された結果の閲覧ページ(variant='viewer': 即時表示)で共用する。
@@ -40,7 +40,22 @@ export function LevelTestResultCard({
 }) {
   const grade = EIKEN_LEVEL_LABELS[payload.finalLevel] ?? EIKEN_LEVEL_LABELS[0];
   const accent = LEVEL_ACCENT_COLORS[payload.finalLevel] ?? LEVEL_ACCENT_COLORS[0];
-  const vocab = formatVocabSize(payload.finalLevel);
+  const vocab = vocabSizeTextFor(payload);
+
+  // v2(ベイズ推定)のみ: 推定範囲と判定の確かさ。v1の旧共有URLは従来表示のまま。
+  const hasEstimate = payload.ability !== undefined
+    && payload.lowerLevel !== undefined
+    && payload.upperLevel !== undefined
+    && payload.confidence !== undefined;
+  const rangeText = hasEstimate && payload.lowerLevel !== payload.upperLevel
+    ? `${EIKEN_LEVEL_LABELS[payload.lowerLevel!]}〜${(EIKEN_LEVEL_LABELS[payload.upperLevel!] ?? '').replace('英検', '')}`
+    : null;
+  const vocabRangeText = hasEstimate
+    && payload.lowerAbility !== undefined
+    && payload.upperAbility !== undefined
+    && payload.lowerAbility < payload.upperAbility
+    ? `約${formatVocabSizeFromTheta(payload.lowerAbility)}〜${formatVocabSizeFromTheta(payload.upperAbility)}語`
+    : null;
 
   return (
     <div className="w-full rounded-[20px] border-2 border-[var(--solid-ink)] bg-[var(--color-surface)] p-6 shadow-[4px_4px_0_var(--solid-ink)]">
@@ -63,6 +78,14 @@ export function LevelTestResultCard({
             {grade}
           </div>
           <div className="mt-1 font-display text-[14px] font-bold text-[var(--color-muted)]">レベル</div>
+          {hasEstimate && (
+            <div className="mt-2 flex flex-wrap items-center justify-center gap-x-3 gap-y-1 text-[11px] font-bold text-[var(--color-muted)]">
+              {rangeText && <span>推定範囲: {rangeText}</span>}
+              <span className="inline-flex items-center gap-1 rounded-full border border-[var(--color-border)] bg-[var(--color-background)] px-2 py-0.5">
+                判定の確かさ: {CONFIDENCE_LABELS[payload.confidence!]}
+              </span>
+            </div>
+          )}
         </motion.div>
 
         <motion.div {...revealProps(variant, 1)} className="mt-4">
@@ -71,6 +94,11 @@ export function LevelTestResultCard({
             <span className="font-display text-[24px] font-extrabold text-[var(--solid-ink)]">{vocab}</span>
             <span className="text-[13px] font-bold text-[var(--solid-ink)]">語</span>
           </div>
+          {vocabRangeText && (
+            <div className="mt-1.5 text-[11px] font-bold text-[var(--color-muted)]">
+              推定範囲 {vocabRangeText}
+            </div>
+          )}
           <div className="mt-2 text-[12px] font-bold text-[var(--color-muted)]">
             20問中{payload.correctTotal}問正解
           </div>

--- a/src/lib/level-test/engine.test.ts
+++ b/src/lib/level-test/engine.test.ts
@@ -4,235 +4,325 @@ import assert from 'node:assert/strict';
 import {
   EIKEN_LEVEL_LABELS,
   LEVEL_TEST_QUESTION_COUNT,
-  LEVEL_TEST_START_LEVEL,
   MAX_LEVEL_INDEX,
   MIN_LEVEL_INDEX,
+  THETA_GRID,
   VOCAB_SIZE_BY_LEVEL,
   answerQuestion,
   buildQuestion,
   buildResult,
   createInitialState,
+  estimateVocabularySize,
+  expectedInformationGain,
   isFinished,
-  pickQuestionIndex,
+  levelFromTheta,
+  posteriorMean,
+  posteriorQuantile,
+  posteriorStandardDeviation,
+  probabilityOfCorrect,
+  questionDifficulty,
+  selectNextQuestion,
+  updatePosterior,
   usedKeyFor,
   type LevelTestState,
 } from './engine';
 import type { LevelTestBank } from './bank';
 
-function answerMany(state: LevelTestState, answers: boolean[]): LevelTestState {
-  let current = state;
-  for (const correct of answers) {
-    current = answerQuestion(current, correct).state;
-  }
-  return current;
+// 再現性のためのシード付きPRNG(mulberry32)
+function seededRandom(seed: number): () => number {
+  let state = seed >>> 0;
+  return () => {
+    state = (state + 0x6d2b79f5) >>> 0;
+    let t = state;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
 }
 
-test('createInitialState starts at 英検4級 with firstAtLevel armed', () => {
-  const state = createInitialState();
-  assert.equal(state.levelIndex, LEVEL_TEST_START_LEVEL);
-  assert.equal(state.firstAtLevel, true);
-  assert.equal(state.answeredCount, 0);
-  assert.equal(state.wrongStreak, 0);
-  assert.equal(state.askedByLevel.length, 7);
-  assert.equal(EIKEN_LEVEL_LABELS.length, 7);
-  assert.equal(VOCAB_SIZE_BY_LEVEL.length, 7);
-});
-
-test('two consecutive correct answers level up and re-arm firstAtLevel', () => {
-  const state = createInitialState(1);
-
-  const first = answerQuestion(state, true);
-  assert.deepEqual(first.events, ['correct']);
-  assert.equal(first.state.levelIndex, 1);
-  assert.equal(first.state.streak, 1);
-
-  const second = answerQuestion(first.state, true);
-  assert.deepEqual(second.events, ['correct', 'level-up']);
-  assert.equal(second.state.levelIndex, 2);
-  assert.equal(second.state.streak, 0);
-  assert.equal(second.state.firstAtLevel, true);
-  assert.equal(second.state.maxLevelIndex, 2);
-});
-
-test('wrong on the first question after a level-up drops one level', () => {
-  let state = createInitialState(1);
-  state = answerMany(state, [true, true]); // -> level 2, firstAtLevel
-  const dropped = answerQuestion(state, false);
-  assert.deepEqual(dropped.events, ['wrong', 'level-down']);
-  assert.equal(dropped.state.levelIndex, 1);
-  // 降格直後の誤答1回では連鎖降格しない(wrongStreakは降格でリセット)
-  const again = answerQuestion(dropped.state, false);
-  assert.deepEqual(again.events, ['wrong']);
-  assert.equal(again.state.levelIndex, 1);
-  // ただしそこからさらに誤答が続く(2連続誤答)と降格する
-  const cascade = answerQuestion(again.state, false);
-  assert.deepEqual(cascade.events, ['wrong', 'level-down']);
-  assert.equal(cascade.state.levelIndex, 0);
-});
-
-test('wrong on the very first question drops from the start level', () => {
-  const state = createInitialState(1);
-  const result = answerQuestion(state, false);
-  assert.deepEqual(result.events, ['wrong', 'level-down']);
-  assert.equal(result.state.levelIndex, 0);
-});
-
-test('a single non-first wrong answer keeps the level and resets the streak', () => {
-  let state = createInitialState(1);
-  state = answerQuestion(state, true).state; // streak 1, firstAtLevel consumed
-  const wrong = answerQuestion(state, false);
-  assert.deepEqual(wrong.events, ['wrong']);
-  assert.equal(wrong.state.levelIndex, 1);
-  assert.equal(wrong.state.streak, 0);
-  assert.equal(wrong.state.wrongStreak, 1);
-});
-
-test('two consecutive wrong answers at the same level drop one level', () => {
-  let state = createInitialState(1);
-  state = answerQuestion(state, true).state; // firstAtLevel consumed
-  const first = answerQuestion(state, false);
-  assert.deepEqual(first.events, ['wrong']);
-  const second = answerQuestion(first.state, false);
-  assert.deepEqual(second.events, ['wrong', 'level-down']);
-  assert.equal(second.state.levelIndex, 0);
-  assert.equal(second.state.wrongStreak, 0);
-
-  // 間に正解を挟むと連続誤答カウントはリセットされる
-  let mixed = createInitialState(1);
-  mixed = answerQuestion(mixed, true).state;
-  mixed = answerQuestion(mixed, false).state; // wrongStreak 1
-  mixed = answerQuestion(mixed, true).state; // reset
-  const afterReset = answerQuestion(mixed, false);
-  assert.deepEqual(afterReset.events, ['wrong']);
-  assert.equal(afterReset.state.levelIndex, 1);
-});
-
-test('level floor: wrong answers at level 0 never drop below 0', () => {
-  let state = createInitialState(0);
-  state = answerMany(state, [false, false, false]);
-  assert.equal(state.levelIndex, MIN_LEVEL_INDEX);
-});
-
-test('level ceiling: two consecutive correct at max level sets clearedMax once', () => {
-  const state = createInitialState(MAX_LEVEL_INDEX);
-  const first = answerQuestion(state, true);
-  const second = answerQuestion(first.state, true);
-  assert.ok(second.events.includes('max-cleared'));
-  assert.equal(second.state.levelIndex, MAX_LEVEL_INDEX);
-  assert.equal(second.state.clearedMax, true);
-
-  // 2回目の2連続正解では max-cleared は再発火しない
-  const third = answerQuestion(second.state, true);
-  const fourth = answerQuestion(third.state, true);
-  assert.ok(!fourth.events.includes('max-cleared'));
-});
-
-test('a perfect 20-question run from the start level reaches 英検1級 with clearedMax', () => {
-  let state = createInitialState();
-  for (let i = 0; i < LEVEL_TEST_QUESTION_COUNT; i += 1) {
-    state = answerQuestion(state, true).state;
-  }
-  assert.equal(isFinished(state), true);
-  assert.equal(state.levelIndex, MAX_LEVEL_INDEX);
-  assert.equal(state.clearedMax, true);
-
-  const result = buildResult(state);
-  assert.equal(result.finalLevel, MAX_LEVEL_INDEX);
-  assert.equal(result.correctTotal, LEVEL_TEST_QUESTION_COUNT);
-  assert.equal(result.askedByLevel.reduce((a, b) => a + b, 0), LEVEL_TEST_QUESTION_COUNT);
-});
-
-test('an all-wrong 20-question run ends at level 0', () => {
-  let state = createInitialState();
-  for (let i = 0; i < LEVEL_TEST_QUESTION_COUNT; i += 1) {
-    state = answerQuestion(state, false).state;
-  }
-  assert.equal(state.levelIndex, MIN_LEVEL_INDEX);
-  const result = buildResult(state);
-  assert.equal(result.correctTotal, 0);
-  assert.equal(result.askedByLevel.reduce((a, b) => a + b, 0), LEVEL_TEST_QUESTION_COUNT);
-});
-
-test('a level-up on the final answer does not award an unproven level', () => {
-  // 実際に報告されたバグ: 途中で1級に到達→1級の1問を誤答して降格→
-  // 最後の2問連続正解で20問目にちょうど再昇格すると、1級で1問も
-  // 正解していないのに1級判定になっていた。
-  const answers = [
-    true, true, // 4級 -> 3級
-    true, true, // -> 準2級
-    true, true, // -> 2級
-    true, true, // -> 準1級
-    true, true, // -> 1級
-    false, // 1級の1問目を誤答 -> 準1級へ降格
-    false, true, false, true, false, true, false, true, true, // 最後の2連続正解で1級へ再昇格
-  ];
-  assert.equal(answers.length, LEVEL_TEST_QUESTION_COUNT);
-
-  let state = createInitialState();
-  state = answerMany(state, answers);
-  assert.equal(isFinished(state), true);
-  assert.equal(state.levelIndex, MAX_LEVEL_INDEX); // 内部状態としては1級にいる
-
-  const result = buildResult(state);
-  assert.equal(result.correctByLevel[MAX_LEVEL_INDEX], 0);
-  // 正解実績のない1級ではなく、実績のある準1級で判定される
-  assert.equal(result.finalLevel, MAX_LEVEL_INDEX - 1);
-  assert.equal(result.maxLevel, MAX_LEVEL_INDEX);
-});
-
-test('per-level tallies stay consistent through a mixed run', () => {
-  let state = createInitialState();
-  const answers = [true, true, false, true, true, false, false, true, true, true,
-    true, false, true, true, false, true, true, true, true, false];
-  state = answerMany(state, answers);
-  assert.equal(isFinished(state), true);
-
-  const result = buildResult(state);
-  assert.equal(result.askedByLevel.reduce((a, b) => a + b, 0), LEVEL_TEST_QUESTION_COUNT);
-  assert.equal(result.correctTotal, answers.filter(Boolean).length);
-  for (let i = 0; i < 7; i += 1) {
-    assert.ok(result.correctByLevel[i] <= result.askedByLevel[i]);
-  }
-  assert.ok(result.maxLevel >= result.finalLevel);
-});
-
+const WORDS_PER_LEVEL = 40;
 const TEST_BANK: LevelTestBank = {
   version: 1,
   levels: Array.from({ length: 7 }, (_, levelIndex) =>
-    Array.from({ length: 4 }, (_, wordIndex) => ({
+    Array.from({ length: WORDS_PER_LEVEL }, (_, wordIndex) => ({
       english: `word-${levelIndex}-${wordIndex}`,
       japanese: `訳${levelIndex}-${wordIndex}`,
       distractors: ['誤1', '誤2', '誤3'] as [string, string, string],
     }))),
 };
 
-test('pickQuestionIndex never repeats a used word', () => {
+// 真の能力thetaを持つ仮想ユーザーに1回分の診断を受けさせる
+function simulateRun(trueTheta: number, seed: number): LevelTestState {
+  const random = seededRandom(seed);
+  let state = createInitialState();
   const used = new Set<string>();
-  for (let i = 0; i < 4; i += 1) {
-    const picked = pickQuestionIndex(TEST_BANK, 2, used, () => 0.5);
+  while (!isFinished(state)) {
+    const picked = selectNextQuestion(TEST_BANK, state, used, random);
+    assert.ok(picked, 'question bank should not exhaust in 20 questions');
+    used.add(usedKeyFor(picked!.levelIndex, picked!.wordIndex));
+    const difficulty = questionDifficulty(picked!.levelIndex, picked!.wordIndex, WORDS_PER_LEVEL);
+    const correct = random() < probabilityOfCorrect(trueTheta, difficulty);
+    state = answerQuestion(state, picked!, TEST_BANK, correct);
+  }
+  return state;
+}
+
+test('createInitialState starts with a uniform posterior and zero tallies', () => {
+  const state = createInitialState();
+  assert.equal(state.answeredCount, 0);
+  assert.equal(state.posterior.length, THETA_GRID.length);
+  assert.equal(state.askedByLevel.length, 7);
+  assert.equal(state.correctByLevel.length, 7);
+  assert.equal(EIKEN_LEVEL_LABELS.length, 7);
+  assert.equal(VOCAB_SIZE_BY_LEVEL.length, 7);
+  const sum = state.posterior.reduce((total, p) => total + p, 0);
+  assert.ok(Math.abs(sum - 1) < 1e-9);
+  // 一様分布なので事後平均はグリッド中央
+  assert.ok(Math.abs(posteriorMean(state.posterior) - 3) < 1e-9);
+});
+
+test('probabilityOfCorrect keeps the guessing floor and slip ceiling', () => {
+  // 実力が難易度よりはるかに低くても四択の当て推量(約25%)は残る
+  assert.ok(probabilityOfCorrect(-1, 6) > 0.24);
+  assert.ok(probabilityOfCorrect(-1, 6) < 0.3);
+  // 実力が十分でもうっかりミスを考慮して100%にはならない
+  assert.ok(probabilityOfCorrect(7, 0) < 0.96);
+  assert.ok(probabilityOfCorrect(7, 0) > 0.9);
+  // 能力に対して単調増加
+  let previous = 0;
+  for (const theta of [-1, 0, 1, 2, 3, 4, 5, 6, 7]) {
+    const p = probabilityOfCorrect(theta, 3);
+    assert.ok(p > previous);
+    previous = p;
+  }
+});
+
+test('questionDifficulty spreads ±0.3 around the level base by word index', () => {
+  assert.equal(questionDifficulty(4, 0, WORDS_PER_LEVEL), 4 - 0.3);
+  assert.ok(Math.abs(questionDifficulty(4, WORDS_PER_LEVEL - 1, WORDS_PER_LEVEL) - 4.3) < 1e-9);
+  // 単語1語しかない級では基準値そのまま(ゼロ除算しない)
+  assert.equal(questionDifficulty(2, 0, 1), 2);
+});
+
+test('updatePosterior treats answers as evidence, not verdicts', () => {
+  const uniform = createInitialState().posterior;
+  const meanBefore = posteriorMean(uniform);
+
+  // 難しい問題への正解は上位レベルを支持する強い証拠
+  const afterHardCorrect = updatePosterior(uniform, 5.5, true);
+  assert.ok(posteriorMean(afterHardCorrect) > meanBefore + 0.3);
+
+  // 簡単な問題への不正解は下位レベルを支持する強い証拠
+  const afterEasyWrong = updatePosterior(uniform, 0.5, false);
+  assert.ok(posteriorMean(afterEasyWrong) < meanBefore - 0.3);
+
+  // 難しい問題への不正解は自然な結果なので弱い証拠(変化が小さい)
+  const afterHardWrong = updatePosterior(uniform, 6.5, false);
+  assert.ok(Math.abs(posteriorMean(afterHardWrong) - meanBefore) <
+    Math.abs(posteriorMean(afterEasyWrong) - meanBefore));
+
+  // 1問で可能性を消さない: どの更新後も全域で確率が正
+  for (const p of afterEasyWrong) assert.ok(p > 0);
+});
+
+test('expectedInformationGain prefers mid-difficulty questions under a uniform prior', () => {
+  const uniform = createInitialState().posterior;
+  const midGain = expectedInformationGain(uniform, 3);
+  const easyGain = expectedInformationGain(uniform, -0.7);
+  const hardGain = expectedInformationGain(uniform, 6.7);
+  assert.ok(midGain > easyGain);
+  assert.ok(midGain > hardGain);
+});
+
+test('selectNextQuestion never repeats a used word and returns null when exhausted', () => {
+  const random = seededRandom(42);
+  const smallBank: LevelTestBank = {
+    version: 1,
+    levels: Array.from({ length: 7 }, (_, levelIndex) =>
+      Array.from({ length: 2 }, (_, wordIndex) => ({
+        english: `w-${levelIndex}-${wordIndex}`,
+        japanese: `j-${levelIndex}-${wordIndex}`,
+        distractors: ['a', 'b', 'c'] as [string, string, string],
+      }))),
+  };
+  const state = createInitialState();
+  const used = new Set<string>();
+  for (let i = 0; i < 14; i += 1) {
+    const picked = selectNextQuestion(smallBank, state, used, random);
     assert.ok(picked);
     const key = usedKeyFor(picked!.levelIndex, picked!.wordIndex);
     assert.ok(!used.has(key));
     used.add(key);
   }
+  assert.equal(selectNextQuestion(smallBank, state, used, random), null);
 });
 
-test('pickQuestionIndex falls back to the nearest level when exhausted', () => {
+test('confirmation phase (last 4 questions) probes below and above the estimate', () => {
+  const random = seededRandom(7);
+  // 準1級相当の事後分布を作る(θ=5付近の証拠を積む)
+  let state = createInitialState();
   const used = new Set<string>();
-  for (let wordIndex = 0; wordIndex < 4; wordIndex += 1) used.add(usedKeyFor(2, wordIndex));
-
-  const picked = pickQuestionIndex(TEST_BANK, 2, used, () => 0);
-  assert.ok(picked);
-  // 易しい側(下のレベル)を優先してフォールバックする
-  assert.equal(picked!.levelIndex, 1);
-});
-
-test('pickQuestionIndex returns null when the whole bank is used', () => {
-  const used = new Set<string>();
-  for (let levelIndex = 0; levelIndex < 7; levelIndex += 1) {
-    for (let wordIndex = 0; wordIndex < 4; wordIndex += 1) used.add(usedKeyFor(levelIndex, wordIndex));
+  for (let i = 0; i < 16; i += 1) {
+    const ref = { levelIndex: 5, wordIndex: i };
+    used.add(usedKeyFor(ref.levelIndex, ref.wordIndex));
+    state = answerQuestion(state, ref, TEST_BANK, i % 2 === 0);
   }
-  assert.equal(pickQuestionIndex(TEST_BANK, 3, used), null);
+  assert.equal(state.answeredCount, 16);
+  const mean = posteriorMean(state.posterior);
+
+  const below = selectNextQuestion(TEST_BANK, state, used, random);
+  assert.ok(below);
+  const belowDifficulty = questionDifficulty(below!.levelIndex, below!.wordIndex, WORDS_PER_LEVEL);
+  assert.ok(belowDifficulty < mean, '17問目は境界の下側を確認する');
+
+  used.add(usedKeyFor(below!.levelIndex, below!.wordIndex));
+  state = answerQuestion(state, below!, TEST_BANK, true);
+  const above = selectNextQuestion(TEST_BANK, state, used, random);
+  assert.ok(above);
+  const aboveDifficulty = questionDifficulty(above!.levelIndex, above!.wordIndex, WORDS_PER_LEVEL);
+  assert.ok(aboveDifficulty > posteriorMean(state.posterior), '18問目は境界の上側を確認する');
+});
+
+test('a perfect 20-question run is judged 英検1級 with clearedMax', () => {
+  const random = seededRandom(3);
+  let state = createInitialState();
+  const used = new Set<string>();
+  while (!isFinished(state)) {
+    const picked = selectNextQuestion(TEST_BANK, state, used, random);
+    assert.ok(picked);
+    used.add(usedKeyFor(picked!.levelIndex, picked!.wordIndex));
+    state = answerQuestion(state, picked!, TEST_BANK, true);
+  }
+  const result = buildResult(state);
+  assert.equal(result.finalLevel, MAX_LEVEL_INDEX);
+  assert.equal(result.correctTotal, LEVEL_TEST_QUESTION_COUNT);
+  assert.ok(result.ability > 5.5);
+  // 全問正解なら出題は最難関帯へ吸い寄せられ、1級問題も2問以上出題される
+  assert.ok(result.askedByLevel[MAX_LEVEL_INDEX] >= 2);
+  assert.equal(result.clearedMax, true);
+});
+
+test('an all-wrong 20-question run is judged 英検5級', () => {
+  const random = seededRandom(9);
+  let state = createInitialState();
+  const used = new Set<string>();
+  while (!isFinished(state)) {
+    const picked = selectNextQuestion(TEST_BANK, state, used, random);
+    assert.ok(picked);
+    used.add(usedKeyFor(picked!.levelIndex, picked!.wordIndex));
+    state = answerQuestion(state, picked!, TEST_BANK, false);
+  }
+  const result = buildResult(state);
+  assert.equal(result.finalLevel, MIN_LEVEL_INDEX);
+  assert.equal(result.correctTotal, 0);
+  assert.equal(result.clearedMax, false);
+});
+
+test('simulated users converge near their true ability', () => {
+  for (const trueTheta of [1, 3, 5]) {
+    let totalError = 0;
+    const runs = 10;
+    for (let seed = 0; seed < runs; seed += 1) {
+      const state = simulateRun(trueTheta, seed * 101 + 17);
+      const result = buildResult(state);
+      totalError += Math.abs(result.ability - trueTheta);
+      // 個々の推定も大外れしない(20問+四択の当て推量なので±2レベル弱まで許容)
+      assert.ok(Math.abs(result.ability - trueTheta) < 1.8,
+        `theta=${trueTheta} seed=${seed}: ability=${result.ability}`);
+      // タリーの整合
+      assert.equal(result.askedByLevel.reduce((a, b) => a + b, 0), LEVEL_TEST_QUESTION_COUNT);
+      for (let i = 0; i < 7; i += 1) {
+        assert.ok(result.correctByLevel[i] <= result.askedByLevel[i]);
+      }
+      assert.ok(result.lowerAbility <= result.ability && result.ability <= result.upperAbility);
+      assert.ok(result.lowerLevel <= result.finalLevel && result.finalLevel <= result.upperLevel);
+    }
+    // 平均誤差は1レベル未満
+    assert.ok(totalError / runs < 1, `theta=${trueTheta}: mean error ${totalError / runs}`);
+  }
+});
+
+test('flipping only the final answer barely moves the estimate (anti-swing)', () => {
+  // 「最後にどちらへ動いたか」で結果が1レベル揺れる旧方式の問題が
+  // 解消されていることを確認する。19問同一系列+最終問の正誤反転で
+  // 事後平均の差が0.35(レベル差の1/3強)未満に収まること。
+  const random = seededRandom(29);
+  let state = createInitialState();
+  const used = new Set<string>();
+  let lastPicked: { levelIndex: number; wordIndex: number } | null = null;
+  for (let i = 0; i < LEVEL_TEST_QUESTION_COUNT; i += 1) {
+    const picked = selectNextQuestion(TEST_BANK, state, used, random);
+    assert.ok(picked);
+    used.add(usedKeyFor(picked!.levelIndex, picked!.wordIndex));
+    if (i === LEVEL_TEST_QUESTION_COUNT - 1) {
+      lastPicked = picked;
+      break;
+    }
+    // 準1級相当のユーザーを模して正誤を交ぜる
+    state = answerQuestion(state, picked!, TEST_BANK, i % 3 !== 2);
+  }
+  const withCorrect = buildResult(answerQuestion(state, lastPicked!, TEST_BANK, true));
+  const withWrong = buildResult(answerQuestion(state, lastPicked!, TEST_BANK, false));
+  assert.ok(Math.abs(withCorrect.ability - withWrong.ability) < 0.35);
+});
+
+test('buildResult maps posterior statistics to level, range, and confidence', () => {
+  // θ=4.6付近に集中した事後分布を手で作る
+  let posterior = createInitialState().posterior;
+  for (let i = 0; i < 10; i += 1) {
+    posterior = updatePosterior(posterior, 4.6, i % 2 === 0);
+    posterior = updatePosterior(posterior, 4.0, true);
+  }
+  const state: LevelTestState = {
+    posterior,
+    answeredCount: 20,
+    askedByLevel: [0, 0, 0, 0, 10, 10, 0],
+    correctByLevel: [0, 0, 0, 0, 9, 4, 0],
+  };
+  const result = buildResult(state);
+  assert.equal(result.finalLevel, levelFromTheta(result.ability));
+  assert.ok(result.lowerAbility <= result.ability && result.ability <= result.upperAbility);
+  const sd = posteriorStandardDeviation(posterior);
+  if (sd <= 0.4) assert.equal(result.confidence, 'high');
+  else if (sd <= 0.8) assert.equal(result.confidence, 'medium');
+  else assert.equal(result.confidence, 'low');
+  assert.equal(result.correctTotal, 13);
+  // 1級問題に正解実績がないのでclearedMaxにはならない
+  assert.equal(result.clearedMax, false);
+});
+
+test('posteriorQuantile walks the cumulative distribution', () => {
+  const uniform = createInitialState().posterior;
+  const median = posteriorQuantile(uniform, 0.5);
+  assert.ok(Math.abs(median - 3) < 0.1);
+  assert.ok(posteriorQuantile(uniform, 0.05) < median);
+  assert.ok(posteriorQuantile(uniform, 0.95) > median);
+});
+
+test('levelFromTheta clamps and rounds to the nearest level', () => {
+  assert.equal(levelFromTheta(-1), MIN_LEVEL_INDEX);
+  assert.equal(levelFromTheta(7), MAX_LEVEL_INDEX);
+  assert.equal(levelFromTheta(4.4), 4);
+  assert.equal(levelFromTheta(4.6), 5);
+});
+
+test('estimateVocabularySize interpolates between level anchors monotonically', () => {
+  // アンカーで一致(100語丸め)
+  for (let level = 0; level <= MAX_LEVEL_INDEX; level += 1) {
+    assert.equal(estimateVocabularySize(level), VOCAB_SIZE_BY_LEVEL[level]);
+  }
+  // 中間は両端の間、範囲外はクランプ
+  const between = estimateVocabularySize(5.5);
+  assert.ok(between > VOCAB_SIZE_BY_LEVEL[5] && between < VOCAB_SIZE_BY_LEVEL[6]);
+  assert.equal(estimateVocabularySize(-2), VOCAB_SIZE_BY_LEVEL[0]);
+  assert.equal(estimateVocabularySize(9), VOCAB_SIZE_BY_LEVEL[6]);
+  // 単調非減少
+  let previous = 0;
+  for (let theta = 0; theta <= 6; theta += 0.25) {
+    const size = estimateVocabularySize(theta);
+    assert.ok(size >= previous);
+    previous = size;
+  }
 });
 
 test('buildQuestion shuffles four options and tracks the correct index', () => {

--- a/src/lib/level-test/engine.ts
+++ b/src/lib/level-test/engine.ts
@@ -2,21 +2,22 @@ import { EIKEN_LEVEL_ORDER } from '@/lib/ai/prompts/eiken';
 import { shuffleArray } from '@/lib/utils';
 import type { BankWord, LevelTestBank } from './bank';
 
-// 語彙レベル診断の適応アルゴリズム(純粋ロジック)。
+// 語彙レベル診断のベイズ推定型適応アルゴリズム(純粋ロジック)。
 //
-// - 全20問。同一レベルで2問連続正解するとレベルアップ。
-// - レベルアップ直後の1問目を誤答すると即1レベル降格(連鎖降格はしない)。
-// - それ以外でも同一レベルで2問連続誤答すると1レベル降格。
-// - 20問終了時点のレベルが測定結果。
+// ユーザーの潜在能力θを「各能力値である確率」の分布(事後分布)として持ち、
+// 回答のたびに尤度で更新する。級を直接上下させる階段型の状態遷移は使わない。
+//
+// - 正解確率はIRT(項目反応理論)の3PL風モデル:
+//   guessing + (1 - guessing - slip) * sigmoid(discrimination * (theta - difficulty))
+//   四択の当て推量(25%)と、知っていても間違えるうっかりミス(5%)を織り込む。
+// - 次の問題は期待情報利得(EIG)が最大の問題を選ぶ。終盤4問は推定境界の
+//   上下から交互に出題し、最後の1問で結果が揺れないか確認する。
+// - 全20問。結果は「最後にいたレベル」ではなく、全回答を最もよく説明する
+//   事後平均θから決める。90%信用区間と判定の確かさも併せて返す。
 
 export const LEVEL_TEST_QUESTION_COUNT = 20;
 export const MIN_LEVEL_INDEX = 0;
 export const MAX_LEVEL_INDEX = EIKEN_LEVEL_ORDER.length - 1; // 6
-// 4級スタート: 初手を誤答すると5級へ降格するので初心者も適正判定でき、
-// 上級者が易しすぎる問題に費やす問数も最小限になる。
-export const LEVEL_TEST_START_LEVEL = 1;
-const STREAK_TO_LEVEL_UP = 2;
-const WRONG_STREAK_TO_LEVEL_DOWN = 2;
 
 // index 0..6 = 英検5級..1級(EIKEN_LEVEL_ORDER と同順)
 export const EIKEN_LEVEL_LABELS = [
@@ -29,45 +30,143 @@ export const EIKEN_LEVEL_LABELS = [
   '英検1級',
 ] as const;
 
-// 各級合格の目安としてよく引用される推定語彙数。定数1箇所で調整できるようにする。
+// 各級合格の目安としてよく引用される推定語彙数。θ→語彙数変換のアンカーにも使う。
 export const VOCAB_SIZE_BY_LEVEL = [600, 1300, 2100, 3600, 5100, 7500, 12000] as const;
 
+// ---------------------------------------------------------------------------
+// θグリッドとIRTパラメータ
+// ---------------------------------------------------------------------------
+
+// θはレベルインデックスと同じ尺度(0=5級 .. 6=1級)。級の外側にも裾を持たせる。
+export const THETA_MIN = -1;
+export const THETA_MAX = 7;
+export const THETA_STEP = 0.05;
+export const THETA_GRID: readonly number[] = Array.from(
+  { length: Math.round((THETA_MAX - THETA_MIN) / THETA_STEP) + 1 },
+  (_, index) => THETA_MIN + index * THETA_STEP,
+);
+
+// 全問題共通の初期パラメータ。実データが集まったら問題ごとの調整に置き換える。
+const DEFAULT_DISCRIMINATION = 1.2;
+const DEFAULT_GUESSING = 0.25; // 四択
+const DEFAULT_SLIP = 0.05;
+
+// 級内の難易度ばらつき幅(基準値±0.3)
+const WITHIN_LEVEL_DIFFICULTY_SPREAD = 0.3;
+
+// 級=カテゴリ、difficulty=実際の難しさとして分離する。バンクは頻度順に
+// 並んでいるため、級内の語インデックスを難易度オフセットの近似に使う
+// (先頭=易しい: 基準-0.3、末尾=難しい: 基準+0.3)。
+export function questionDifficulty(
+  levelIndex: number,
+  wordIndex: number,
+  levelWordCount: number,
+): number {
+  const base = levelIndex;
+  if (levelWordCount <= 1) return base;
+  const ratio = wordIndex / (levelWordCount - 1);
+  return base - WITHIN_LEVEL_DIFFICULTY_SPREAD + ratio * WITHIN_LEVEL_DIFFICULTY_SPREAD * 2;
+}
+
+function sigmoid(x: number): number {
+  return 1 / (1 + Math.exp(-x));
+}
+
+export function probabilityOfCorrect(theta: number, difficulty: number): number {
+  const knowledgeProbability = sigmoid(DEFAULT_DISCRIMINATION * (theta - difficulty));
+  return DEFAULT_GUESSING + (1 - DEFAULT_GUESSING - DEFAULT_SLIP) * knowledgeProbability;
+}
+
+// ---------------------------------------------------------------------------
+// 事後分布の更新
+// ---------------------------------------------------------------------------
+
+export function createInitialPosterior(): number[] {
+  return THETA_GRID.map(() => 1 / THETA_GRID.length);
+}
+
+function normalize(values: number[]): number[] {
+  const total = values.reduce((sum, value) => sum + value, 0);
+  if (total <= 0 || !Number.isFinite(total)) {
+    return values.map(() => 1 / values.length);
+  }
+  return values.map((value) => value / total);
+}
+
+export function updatePosterior(
+  posterior: readonly number[],
+  difficulty: number,
+  correct: boolean,
+): number[] {
+  const updated = posterior.map((priorProbability, index) => {
+    const correctProbability = probabilityOfCorrect(THETA_GRID[index], difficulty);
+    const likelihood = correct ? correctProbability : 1 - correctProbability;
+    return priorProbability * likelihood;
+  });
+  return normalize(updated);
+}
+
+export function posteriorMean(posterior: readonly number[]): number {
+  return posterior.reduce((sum, probability, index) => sum + probability * THETA_GRID[index], 0);
+}
+
+export function posteriorStandardDeviation(posterior: readonly number[]): number {
+  const mean = posteriorMean(posterior);
+  const variance = posterior.reduce((sum, probability, index) => {
+    const difference = THETA_GRID[index] - mean;
+    return sum + probability * difference ** 2;
+  }, 0);
+  return Math.sqrt(variance);
+}
+
+export function posteriorQuantile(posterior: readonly number[], target: number): number {
+  let cumulative = 0;
+  for (let index = 0; index < posterior.length; index += 1) {
+    cumulative += posterior[index];
+    if (cumulative >= target) return THETA_GRID[index];
+  }
+  return THETA_GRID[THETA_GRID.length - 1];
+}
+
+function entropy(probabilities: readonly number[]): number {
+  return probabilities.reduce((sum, probability) => {
+    if (probability <= 0) return sum;
+    return sum - probability * Math.log(probability);
+  }, 0);
+}
+
+// 回答(正解/不正解の両ケース)後にどれだけ不確実性が減るかの期待値。
+export function expectedInformationGain(
+  posterior: readonly number[],
+  difficulty: number,
+): number {
+  const currentEntropy = entropy(posterior);
+  const probabilityCorrect = posterior.reduce(
+    (sum, probability, index) => sum + probability * probabilityOfCorrect(THETA_GRID[index], difficulty),
+    0,
+  );
+  const expectedEntropy =
+    probabilityCorrect * entropy(updatePosterior(posterior, difficulty, true)) +
+    (1 - probabilityCorrect) * entropy(updatePosterior(posterior, difficulty, false));
+  return currentEntropy - expectedEntropy;
+}
+
+// ---------------------------------------------------------------------------
+// 診断の状態
+// ---------------------------------------------------------------------------
+
 export type LevelTestState = {
-  levelIndex: number;
+  // THETA_GRID上の事後確率(初期は一様分布)
+  posterior: number[];
   answeredCount: number;
-  // 現在のレベルでの連続正解数
-  streak: number;
-  // 現在のレベルでの連続誤答数(2でレベルダウン)
-  wrongStreak: number;
-  // 次の回答が「レベルアップ(または開始)直後の1問目」かどうか
-  firstAtLevel: boolean;
-  maxLevelIndex: number;
-  clearedMax: boolean;
   askedByLevel: number[];
   correctByLevel: number[];
 };
 
-export type LevelTestEvent = 'correct' | 'wrong' | 'level-up' | 'level-down' | 'max-cleared';
-
-export type LevelTestResult = {
-  finalLevel: number;
-  maxLevel: number;
-  clearedMax: boolean;
-  correctTotal: number;
-  askedByLevel: number[];
-  correctByLevel: number[];
-};
-
-export function createInitialState(startLevel: number = LEVEL_TEST_START_LEVEL): LevelTestState {
-  const levelIndex = Math.min(MAX_LEVEL_INDEX, Math.max(MIN_LEVEL_INDEX, startLevel));
+export function createInitialState(): LevelTestState {
   return {
-    levelIndex,
+    posterior: createInitialPosterior(),
     answeredCount: 0,
-    streak: 0,
-    wrongStreak: 0,
-    firstAtLevel: true,
-    maxLevelIndex: levelIndex,
-    clearedMax: false,
     askedByLevel: EIKEN_LEVEL_ORDER.map(() => 0),
     correctByLevel: EIKEN_LEVEL_ORDER.map(() => 0),
   };
@@ -77,76 +176,178 @@ export function isFinished(state: LevelTestState): boolean {
   return state.answeredCount >= LEVEL_TEST_QUESTION_COUNT;
 }
 
+export type QuestionRef = {
+  levelIndex: number;
+  wordIndex: number;
+};
+
 export function answerQuestion(
   state: LevelTestState,
+  question: QuestionRef,
+  bank: LevelTestBank,
   correct: boolean,
-): { state: LevelTestState; events: LevelTestEvent[] } {
-  const next: LevelTestState = {
-    ...state,
-    askedByLevel: [...state.askedByLevel],
-    correctByLevel: [...state.correctByLevel],
+): LevelTestState {
+  const levelWordCount = bank.levels[question.levelIndex]?.length ?? 1;
+  const difficulty = questionDifficulty(question.levelIndex, question.wordIndex, levelWordCount);
+
+  const askedByLevel = [...state.askedByLevel];
+  const correctByLevel = [...state.correctByLevel];
+  askedByLevel[question.levelIndex] += 1;
+  if (correct) correctByLevel[question.levelIndex] += 1;
+
+  return {
+    posterior: updatePosterior(state.posterior, difficulty, correct),
+    answeredCount: state.answeredCount + 1,
+    askedByLevel,
+    correctByLevel,
   };
-  const events: LevelTestEvent[] = [correct ? 'correct' : 'wrong'];
+}
 
-  next.askedByLevel[next.levelIndex] += 1;
-  next.answeredCount += 1;
+// ---------------------------------------------------------------------------
+// 出題選択
+// ---------------------------------------------------------------------------
 
-  if (correct) {
-    next.correctByLevel[next.levelIndex] += 1;
-    next.streak += 1;
-    next.wrongStreak = 0;
-    next.firstAtLevel = false;
+export function usedKeyFor(levelIndex: number, wordIndex: number): string {
+  return `${levelIndex}:${wordIndex}`;
+}
 
-    if (next.streak >= STREAK_TO_LEVEL_UP) {
-      if (next.levelIndex < MAX_LEVEL_INDEX) {
-        next.levelIndex += 1;
-        next.streak = 0;
-        next.firstAtLevel = true;
-        next.maxLevelIndex = Math.max(next.maxLevelIndex, next.levelIndex);
-        events.push('level-up');
-      } else {
-        next.streak = 0;
-        if (!next.clearedMax) {
-          next.clearedMax = true;
-          events.push('max-cleared');
-        }
+// 終盤の「確認」フェーズ問数と、境界からの距離
+const CONFIRMATION_QUESTION_COUNT = 4;
+const CONFIRMATION_OFFSET = 0.7;
+// 各級からサンプリングする候補語数。局所的な語の得意不得意に左右されないよう
+// ランダムに引き直す(品詞・分野の変化付けを兼ねる)。
+const CANDIDATES_PER_LEVEL = 3;
+
+type Candidate = QuestionRef & { difficulty: number };
+
+function sampleCandidates(
+  bank: LevelTestBank,
+  usedKeys: ReadonlySet<string>,
+  random: () => number,
+): Candidate[] {
+  const candidates: Candidate[] = [];
+  for (let levelIndex = 0; levelIndex <= MAX_LEVEL_INDEX; levelIndex += 1) {
+    const words = bank.levels[levelIndex] ?? [];
+    const unusedIndexes: number[] = [];
+    for (let wordIndex = 0; wordIndex < words.length; wordIndex += 1) {
+      if (!usedKeys.has(usedKeyFor(levelIndex, wordIndex))) {
+        unusedIndexes.push(wordIndex);
       }
     }
-    return { state: next, events };
+    for (let pick = 0; pick < CANDIDATES_PER_LEVEL && unusedIndexes.length > 0; pick += 1) {
+      const position = Math.floor(random() * unusedIndexes.length);
+      const wordIndex = unusedIndexes.splice(position, 1)[0];
+      candidates.push({
+        levelIndex,
+        wordIndex,
+        difficulty: questionDifficulty(levelIndex, wordIndex, words.length),
+      });
+    }
+  }
+  return candidates;
+}
+
+// 現在の事後分布を最もよく判別できる問題を選ぶ。
+// - 序盤〜中盤(収束): 候補の中でEIG最大の問題。一様事前分布から始まるため
+//   序盤は自然に中間難易度→実力付近へ寄っていく(探索を兼ねる)。
+// - 終盤4問(確認): 推定境界の下(θ̂-0.7)と上(θ̂+0.7)へ交互に出題し、
+//   推定が一時的な偶然でないか確かめる。
+export function selectNextQuestion(
+  bank: LevelTestBank,
+  state: LevelTestState,
+  usedKeys: ReadonlySet<string>,
+  random: () => number = Math.random,
+): QuestionRef | null {
+  const candidates = sampleCandidates(bank, usedKeys, random);
+  if (candidates.length === 0) return null;
+
+  const confirmationIndex =
+    state.answeredCount - (LEVEL_TEST_QUESTION_COUNT - CONFIRMATION_QUESTION_COUNT);
+  if (confirmationIndex >= 0) {
+    const mean = posteriorMean(state.posterior);
+    // 下→上→下→上 の順で境界の両側を確認する
+    const direction = confirmationIndex % 2 === 0 ? -1 : 1;
+    const targetDifficulty = mean + direction * CONFIRMATION_OFFSET;
+    const best = candidates.reduce((bestSoFar, candidate) =>
+      Math.abs(candidate.difficulty - targetDifficulty) <
+      Math.abs(bestSoFar.difficulty - targetDifficulty)
+        ? candidate
+        : bestSoFar,
+    );
+    return { levelIndex: best.levelIndex, wordIndex: best.wordIndex };
   }
 
-  next.streak = 0;
-  next.wrongStreak += 1;
-
-  // レベルアップ直後の1問目の誤答は即降格、それ以外は2連続誤答で降格
-  const shouldDrop =
-    (next.firstAtLevel || next.wrongStreak >= WRONG_STREAK_TO_LEVEL_DOWN)
-    && next.levelIndex > MIN_LEVEL_INDEX;
-  next.firstAtLevel = false;
-  if (shouldDrop) {
-    next.levelIndex -= 1;
-    next.wrongStreak = 0;
-    events.push('level-down');
-  } else if (next.wrongStreak >= WRONG_STREAK_TO_LEVEL_DOWN) {
-    // 最下位レベルではこれ以上下がらないのでカウントだけリセットする
-    next.wrongStreak = 0;
+  let best = candidates[0];
+  let bestGain = expectedInformationGain(state.posterior, best.difficulty);
+  for (let index = 1; index < candidates.length; index += 1) {
+    const gain = expectedInformationGain(state.posterior, candidates[index].difficulty);
+    if (gain > bestGain) {
+      best = candidates[index];
+      bestGain = gain;
+    }
   }
-  return { state: next, events };
+  return { levelIndex: best.levelIndex, wordIndex: best.wordIndex };
+}
+
+// ---------------------------------------------------------------------------
+// 結果算出
+// ---------------------------------------------------------------------------
+
+export type LevelTestConfidence = 'high' | 'medium' | 'low';
+
+export const CONFIDENCE_LABELS: Record<LevelTestConfidence, string> = {
+  high: '高い',
+  medium: '標準',
+  low: '暫定',
+};
+
+export type LevelTestResult = {
+  // 事後平均θ(連続値)。級はこの値を表示用に丸めたラベルにすぎない。
+  ability: number;
+  finalLevel: number;
+  // 90%信用区間(5%〜95%分位点)のθと、それをレベルに丸めた推定範囲
+  lowerAbility: number;
+  upperAbility: number;
+  lowerLevel: number;
+  upperLevel: number;
+  confidence: LevelTestConfidence;
+  clearedMax: boolean;
+  correctTotal: number;
+  askedByLevel: number[];
+  correctByLevel: number[];
+};
+
+export function levelFromTheta(theta: number): number {
+  const bounded = Math.max(MIN_LEVEL_INDEX, Math.min(MAX_LEVEL_INDEX, theta));
+  return Math.round(bounded);
+}
+
+function confidenceFromStandardDeviation(sd: number): LevelTestConfidence {
+  if (sd <= 0.4) return 'high';
+  if (sd <= 0.8) return 'medium';
+  return 'low';
 }
 
 export function buildResult(state: LevelTestState): LevelTestResult {
-  // 最終問題の正解でレベルアップした直後に終了すると、そのレベルでは
-  // 一度も正解していない(あるいは出題すらされていない)のに判定されてしまう。
-  // 判定レベルは「正解実績のあるレベル」まで下げる。
-  let finalLevel = state.levelIndex;
-  while (finalLevel > MIN_LEVEL_INDEX && state.correctByLevel[finalLevel] === 0) {
-    finalLevel -= 1;
-  }
+  const ability = posteriorMean(state.posterior);
+  const sd = posteriorStandardDeviation(state.posterior);
+  const lowerTheta = posteriorQuantile(state.posterior, 0.05);
+  const upperTheta = posteriorQuantile(state.posterior, 0.95);
+
+  const finalLevel = levelFromTheta(ability);
+  const askedAtMax = state.askedByLevel[MAX_LEVEL_INDEX];
+  const correctAtMax = state.correctByLevel[MAX_LEVEL_INDEX];
 
   return {
+    ability,
     finalLevel,
-    maxLevel: state.maxLevelIndex,
-    clearedMax: state.clearedMax,
+    lowerAbility: Math.min(ability, lowerTheta),
+    upperAbility: Math.max(ability, upperTheta),
+    lowerLevel: Math.min(finalLevel, levelFromTheta(lowerTheta)),
+    upperLevel: Math.max(finalLevel, levelFromTheta(upperTheta)),
+    confidence: confidenceFromStandardDeviation(sd),
+    // 1級判定かつ1級問題(2問以上)を全問正解したときだけ「完全制覇」
+    clearedMax: finalLevel === MAX_LEVEL_INDEX && askedAtMax >= 2 && correctAtMax === askedAtMax,
     correctTotal: state.correctByLevel.reduce((sum, count) => sum + count, 0),
     askedByLevel: [...state.askedByLevel],
     correctByLevel: [...state.correctByLevel],
@@ -154,44 +355,24 @@ export function buildResult(state: LevelTestState): LevelTestResult {
 }
 
 // ---------------------------------------------------------------------------
-// 出題サンプリング(同一セッション内で単語を繰り返さない)
+// θ→推定語彙数の変換
 // ---------------------------------------------------------------------------
 
-export function usedKeyFor(levelIndex: number, wordIndex: number): string {
-  return `${levelIndex}:${wordIndex}`;
+// 級のアンカー(θ=レベルインデックス、語彙数=VOCAB_SIZE_BY_LEVEL)を線形補間する。
+// 根拠のある個別キャリブレーションが得られるまでの暫定対応表。
+export function estimateVocabularySize(theta: number): number {
+  const bounded = Math.max(MIN_LEVEL_INDEX, Math.min(MAX_LEVEL_INDEX, theta));
+  const lowerIndex = Math.min(MAX_LEVEL_INDEX - 1, Math.floor(bounded));
+  const ratio = bounded - lowerIndex;
+  const size =
+    VOCAB_SIZE_BY_LEVEL[lowerIndex] +
+    ratio * (VOCAB_SIZE_BY_LEVEL[lowerIndex + 1] - VOCAB_SIZE_BY_LEVEL[lowerIndex]);
+  return Math.round(size / 100) * 100;
 }
 
-// 現在レベルの未出題語からランダムに1語選ぶ。レベルが枯渇していた場合は
-// 近いレベル(易しい側優先)へフォールバックする。250語/レベルに対して
-// 20問なので実運用では枯渇しないが、防御的に実装しておく。
-export function pickQuestionIndex(
-  bank: LevelTestBank,
-  levelIndex: number,
-  usedKeys: ReadonlySet<string>,
-  random: () => number = Math.random,
-): { levelIndex: number; wordIndex: number } | null {
-  const candidateLevels: number[] = [levelIndex];
-  for (let distance = 1; distance <= MAX_LEVEL_INDEX; distance += 1) {
-    if (levelIndex - distance >= MIN_LEVEL_INDEX) candidateLevels.push(levelIndex - distance);
-    if (levelIndex + distance <= MAX_LEVEL_INDEX) candidateLevels.push(levelIndex + distance);
-  }
-
-  for (const candidateLevel of candidateLevels) {
-    const words = bank.levels[candidateLevel] ?? [];
-    const unusedIndexes: number[] = [];
-    for (let wordIndex = 0; wordIndex < words.length; wordIndex += 1) {
-      if (!usedKeys.has(usedKeyFor(candidateLevel, wordIndex))) {
-        unusedIndexes.push(wordIndex);
-      }
-    }
-    if (unusedIndexes.length > 0) {
-      const picked = unusedIndexes[Math.floor(random() * unusedIndexes.length)];
-      return { levelIndex: candidateLevel, wordIndex: picked };
-    }
-  }
-
-  return null;
-}
+// ---------------------------------------------------------------------------
+// 問題の組み立て
+// ---------------------------------------------------------------------------
 
 export type LevelTestQuestion = {
   prompt: string;

--- a/src/lib/level-test/result-code.test.ts
+++ b/src/lib/level-test/result-code.test.ts
@@ -6,41 +6,99 @@ import {
   answerQuestion,
   buildResult,
   createInitialState,
+  isFinished,
+  probabilityOfCorrect,
+  selectNextQuestion,
+  usedKeyFor,
   type LevelTestResult,
 } from './engine';
+import type { LevelTestBank } from './bank';
 import { decodeLevelTestResult, encodeLevelTestResult } from './result-code';
 
-function resultFromRun(answers: boolean[]): LevelTestResult {
+function seededRandom(seed: number): () => number {
+  let state = seed >>> 0;
+  return () => {
+    state = (state + 0x6d2b79f5) >>> 0;
+    let t = state;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+const WORDS_PER_LEVEL = 40;
+const TEST_BANK: LevelTestBank = {
+  version: 1,
+  levels: Array.from({ length: 7 }, (_, levelIndex) =>
+    Array.from({ length: WORDS_PER_LEVEL }, (_, wordIndex) => ({
+      english: `word-${levelIndex}-${wordIndex}`,
+      japanese: `訳${levelIndex}-${wordIndex}`,
+      distractors: ['誤1', '誤2', '誤3'] as [string, string, string],
+    }))),
+};
+
+// answerFor(i) が i問目の正誤を返す形で1回分の診断を実行する
+function resultFromRun(answerFor: (index: number) => boolean, seed = 1): LevelTestResult {
+  const random = seededRandom(seed);
   let state = createInitialState();
-  for (const correct of answers) {
-    state = answerQuestion(state, correct).state;
+  const used = new Set<string>();
+  let index = 0;
+  while (!isFinished(state)) {
+    const picked = selectNextQuestion(TEST_BANK, state, used, random);
+    if (!picked) throw new Error('bank exhausted');
+    used.add(usedKeyFor(picked.levelIndex, picked.wordIndex));
+    state = answerQuestion(state, picked, TEST_BANK, answerFor(index));
+    index += 1;
   }
   return buildResult(state);
 }
 
-const PERFECT = resultFromRun(Array(LEVEL_TEST_QUESTION_COUNT).fill(true));
-const ALL_WRONG = resultFromRun(Array(LEVEL_TEST_QUESTION_COUNT).fill(false));
-const MIXED = resultFromRun([true, true, false, true, true, false, false, true, true, true,
-  true, false, true, true, false, true, true, true, true, false]);
+// 真の能力θ=4.5相当の確率的な回答者
+function abilityAnswerer(trueTheta: number, seed: number): (index: number) => boolean {
+  const random = seededRandom(seed);
+  return () => random() < probabilityOfCorrect(trueTheta, 4.5);
+}
+
+const PERFECT = resultFromRun(() => true);
+const ALL_WRONG = resultFromRun(() => false);
+const MIXED = resultFromRun((index) => index % 3 !== 2, 5);
 
 test('encode/decode round-trips across edge payloads', () => {
   for (const result of [PERFECT, ALL_WRONG, MIXED]) {
     const code = encodeLevelTestResult(result);
     const decoded = decodeLevelTestResult(code);
     assert.ok(decoded, `decode failed for code ${code}`);
+    assert.equal(decoded!.v, 2);
     assert.equal(decoded!.finalLevel, result.finalLevel);
-    assert.equal(decoded!.maxLevel, result.maxLevel);
     assert.equal(decoded!.clearedMax, result.clearedMax);
     assert.equal(decoded!.correctTotal, result.correctTotal);
     assert.deepEqual(decoded!.askedByLevel, result.askedByLevel);
     assert.deepEqual(decoded!.correctByLevel, result.correctByLevel);
+    assert.equal(decoded!.confidence, result.confidence);
+    // θは0.05刻みの量子化を挟むので誤差込みで一致
+    assert.ok(Math.abs(decoded!.ability! - result.ability) <= 0.05);
+    assert.ok(Math.abs(decoded!.lowerAbility! - result.lowerAbility) <= 0.05);
+    assert.ok(Math.abs(decoded!.upperAbility! - result.upperAbility) <= 0.05);
+    assert.ok(decoded!.lowerAbility! <= decoded!.ability!);
+    assert.ok(decoded!.ability! <= decoded!.upperAbility!);
+    assert.ok(decoded!.lowerLevel! <= decoded!.finalLevel);
+    assert.ok(decoded!.finalLevel <= decoded!.upperLevel!);
+  }
+});
+
+test('round-trips hold for many simulated ability levels (quantization boundaries)', () => {
+  for (let seed = 0; seed < 20; seed += 1) {
+    const result = resultFromRun(abilityAnswerer(1 + (seed % 5), seed * 13 + 3), seed);
+    const decoded = decodeLevelTestResult(encodeLevelTestResult(result));
+    assert.ok(decoded, `decode failed for seed ${seed} (ability=${result.ability})`);
+    assert.equal(decoded!.correctTotal, result.correctTotal);
   }
 });
 
 test('codes are URL-safe and compact', () => {
   const code = encodeLevelTestResult(MIXED);
   assert.match(code, /^[A-Za-z0-9_-]+$/);
-  assert.equal(code.length, 24);
+  assert.equal(code.length, 28);
 });
 
 test('tampered checksum decodes to null', () => {
@@ -74,7 +132,48 @@ test('semantically invalid payloads decode to null', () => {
     correctTotal: MIXED.correctTotal + 1,
   };
   assert.equal(decodeLevelTestResult(encodeLevelTestResult(inconsistentCorrect)), null);
+});
 
-  const maxBelowFinal: LevelTestResult = { ...PERFECT, maxLevel: PERFECT.finalLevel - 1 };
-  assert.equal(decodeLevelTestResult(encodeLevelTestResult(maxBelowFinal)), null);
+// 階段型アルゴリズム時代(v1)の共有URLが引き続き表示できること。
+// このコードは旧エンコーダで生成した固定値
+// (finalLevel=5, maxLevel=6, clearedMax=false, correctTotal=14,
+//  askedByLevel=[0,2,2,3,4,5,4], correctByLevel=[0,2,2,2,3,3,2])。
+test('legacy v1 codes still decode (shared URLs stay valid)', () => {
+  const v1Bytes = [
+    1,
+    (5 & 0x07) | ((6 & 0x07) << 3),
+    14,
+    0, 2, 2, 3, 4, 5, 4,
+    0, 2, 2, 2, 3, 3, 2,
+  ];
+  let sum = 0;
+  for (const byte of v1Bytes) sum = (sum + byte) & 0xff;
+  v1Bytes.push(((sum * 31) + 7) & 0xff);
+
+  const alphabet = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_';
+  let code = '';
+  for (let i = 0; i < v1Bytes.length; i += 3) {
+    const b0 = v1Bytes[i];
+    const b1 = v1Bytes[i + 1];
+    const b2 = v1Bytes[i + 2];
+    code += alphabet[b0 >> 2];
+    code += alphabet[((b0 & 0x03) << 4) | ((b1 ?? 0) >> 4)];
+    if (b1 === undefined) break;
+    code += alphabet[((b1 & 0x0f) << 2) | ((b2 ?? 0) >> 6)];
+    if (b2 === undefined) break;
+    code += alphabet[b2 & 0x3f];
+  }
+
+  const decoded = decodeLevelTestResult(code);
+  assert.ok(decoded, 'v1 code should decode');
+  assert.equal(decoded!.v, 1);
+  assert.equal(decoded!.finalLevel, 5);
+  assert.equal(decoded!.maxLevel, 6);
+  assert.equal(decoded!.clearedMax, false);
+  assert.equal(decoded!.correctTotal, 14);
+  assert.deepEqual(decoded!.askedByLevel, [0, 2, 2, 3, 4, 5, 4]);
+  // v2で追加されたフィールドはv1には無い
+  assert.equal(decoded!.ability, undefined);
+  assert.equal(decoded!.confidence, undefined);
+  assert.equal(LEVEL_TEST_QUESTION_COUNT, 20);
 });

--- a/src/lib/level-test/result-code.ts
+++ b/src/lib/level-test/result-code.ts
@@ -2,6 +2,11 @@ import {
   LEVEL_TEST_QUESTION_COUNT,
   MAX_LEVEL_INDEX,
   MIN_LEVEL_INDEX,
+  THETA_MIN,
+  THETA_STEP,
+  THETA_GRID,
+  levelFromTheta,
+  type LevelTestConfidence,
   type LevelTestResult,
 } from './engine';
 
@@ -11,30 +16,53 @@ import {
 // このコードだけから復元できる必要がある。ブラウザとNode(OG画像ルート)の
 // 両方で動くよう、Buffer/btoaに依存しない自前のbase64urlコーデックを使う。
 //
-// バイトレイアウト(全18バイト -> base64urlで24文字):
-//   byte 0      : エンコーディングバージョン(1)
-//   byte 1      : finalLevel(bit 0-2) | maxLevel(bit 3-5) | clearedMax(bit 6)
+// v2 バイトレイアウト(全21バイト -> base64urlで28文字):
+//   byte 0      : エンコーディングバージョン(2)
+//   byte 1      : finalLevel(bit 0-2) | confidence(bit 3-4) | clearedMax(bit 6)
 //   byte 2      : correctTotal(0..20)
-//   bytes 3-9   : askedByLevel[0..6]
-//   bytes 10-16 : correctByLevel[0..6]
-//   byte 17     : チェックサム
+//   byte 3      : 量子化θ(事後平均。(theta - THETA_MIN) / THETA_STEP)
+//   byte 4      : 量子化θ(5%分位点)
+//   byte 5      : 量子化θ(95%分位点)
+//   bytes 6-12  : askedByLevel[0..6]
+//   bytes 13-19 : correctByLevel[0..6]
+//   byte 20     : チェックサム
+//
+// v1(階段型アルゴリズム時代の18バイトレイアウト)は過去の共有URLを
+// 壊さないためデコードのみ引き続き受理する。
 //
 // チェックサムは改ざん防止ではなく「URLの手打ちミス・切り詰めを弾く」ためのもの。
 // クライアント側で符号化する以上、偽造は原理的に防げない(低リスクと割り切る)。
 
-export const RESULT_CODE_VERSION = 1;
-const PAYLOAD_BYTES = 18;
+export const RESULT_CODE_VERSION = 2;
+const V1_PAYLOAD_BYTES = 18;
+const V2_PAYLOAD_BYTES = 21;
 const LEVEL_COUNT = 7;
+const THETA_Q_MAX = THETA_GRID.length - 1; // 160
 
 export type LevelTestResultPayload = {
   v: number;
   finalLevel: number;
+  // v1の名残り。v2ではupperLevelと同値を入れる(表示互換のため)
   maxLevel: number;
   clearedMax: boolean;
   correctTotal: number;
   askedByLevel: number[];
   correctByLevel: number[];
+  // v2で追加(v1のデコード結果には無い)
+  ability?: number;
+  lowerLevel?: number;
+  upperLevel?: number;
+  lowerAbility?: number;
+  upperAbility?: number;
+  confidence?: LevelTestConfidence;
 };
+
+const CONFIDENCE_TO_BITS: Record<LevelTestConfidence, number> = {
+  high: 0,
+  medium: 1,
+  low: 2,
+};
+const BITS_TO_CONFIDENCE: readonly LevelTestConfidence[] = ['high', 'medium', 'low'];
 
 const BASE64URL_ALPHABET = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_';
 
@@ -78,36 +106,108 @@ function base64UrlToBytes(code: string): number[] | null {
   return bytes;
 }
 
-function checksumOf(bytes: readonly number[]): number {
+function checksumOf(bytes: readonly number[], payloadBytes: number): number {
   let sum = 0;
-  for (let i = 0; i < PAYLOAD_BYTES - 1; i += 1) {
+  for (let i = 0; i < payloadBytes - 1; i += 1) {
     sum = (sum + bytes[i]) & 0xff;
   }
   return ((sum * 31) + 7) & 0xff;
 }
 
+function quantizeTheta(theta: number): number {
+  const q = Math.round((theta - THETA_MIN) / THETA_STEP);
+  return Math.max(0, Math.min(THETA_Q_MAX, q));
+}
+
+function dequantizeTheta(q: number): number {
+  return THETA_MIN + q * THETA_STEP;
+}
+
 export function encodeLevelTestResult(result: LevelTestResult): string {
+  const abilityQ = quantizeTheta(result.ability);
+  // 量子化誤差でlower <= ability <= upperが崩れないようクランプする
+  const lowerQ = Math.min(abilityQ, quantizeTheta(result.lowerAbility));
+  const upperQ = Math.max(abilityQ, quantizeTheta(result.upperAbility));
+  // デコード側は量子化後のθからレベルを再計算して整合性を検証するため、
+  // 符号化するレベルも量子化後のθから導出する(丸め境界での不一致を防ぐ)
+  const finalLevel = levelFromTheta(dequantizeTheta(abilityQ));
+  const clearedMax = result.clearedMax && finalLevel === MAX_LEVEL_INDEX;
   const bytes: number[] = [
     RESULT_CODE_VERSION,
-    (result.finalLevel & 0x07) | ((result.maxLevel & 0x07) << 3) | (result.clearedMax ? 0x40 : 0),
+    (finalLevel & 0x07)
+      | ((CONFIDENCE_TO_BITS[result.confidence] & 0x03) << 3)
+      | (clearedMax ? 0x40 : 0),
     result.correctTotal & 0xff,
+    abilityQ,
+    lowerQ,
+    upperQ,
   ];
   for (let i = 0; i < LEVEL_COUNT; i += 1) bytes.push((result.askedByLevel[i] ?? 0) & 0xff);
   for (let i = 0; i < LEVEL_COUNT; i += 1) bytes.push((result.correctByLevel[i] ?? 0) & 0xff);
-  bytes.push(checksumOf(bytes));
+  bytes.push(checksumOf(bytes, V2_PAYLOAD_BYTES));
   return bytesToBase64Url(bytes);
 }
 
-// 失敗時は例外ではなくnullを返す(ページ側でフォールバック表示する)。
-export function decodeLevelTestResult(code: string): LevelTestResultPayload | null {
-  if (typeof code !== 'string' || code.length === 0 || code.length > 64) return null;
+function decodeV2(bytes: number[]): LevelTestResultPayload | null {
+  if (bytes[V2_PAYLOAD_BYTES - 1] !== checksumOf(bytes, V2_PAYLOAD_BYTES)) return null;
 
-  const bytes = base64UrlToBytes(code);
-  if (!bytes || bytes.length !== PAYLOAD_BYTES) return null;
-  if (bytes[PAYLOAD_BYTES - 1] !== checksumOf(bytes)) return null;
+  const finalLevel = bytes[1] & 0x07;
+  const confidenceBits = (bytes[1] >> 3) & 0x03;
+  const clearedMax = (bytes[1] & 0x40) !== 0;
+  const correctTotal = bytes[2];
+  const abilityQ = bytes[3];
+  const lowerQ = bytes[4];
+  const upperQ = bytes[5];
+  const askedByLevel = bytes.slice(6, 6 + LEVEL_COUNT);
+  const correctByLevel = bytes.slice(6 + LEVEL_COUNT, 6 + LEVEL_COUNT * 2);
 
-  const version = bytes[0];
-  if (version !== RESULT_CODE_VERSION) return null;
+  const confidence = BITS_TO_CONFIDENCE[confidenceBits];
+  if (!confidence) return null;
+
+  // 意味的な不変条件の検証。カジュアルなURL改変はここでnullに落ちる。
+  if (finalLevel < MIN_LEVEL_INDEX || finalLevel > MAX_LEVEL_INDEX) return null;
+  if (correctTotal > LEVEL_TEST_QUESTION_COUNT) return null;
+  if (abilityQ > THETA_Q_MAX || lowerQ > THETA_Q_MAX || upperQ > THETA_Q_MAX) return null;
+  if (!(lowerQ <= abilityQ && abilityQ <= upperQ)) return null;
+
+  const ability = dequantizeTheta(abilityQ);
+  const lowerAbility = dequantizeTheta(lowerQ);
+  const upperAbility = dequantizeTheta(upperQ);
+  if (levelFromTheta(ability) !== finalLevel) return null;
+
+  let askedSum = 0;
+  let correctSum = 0;
+  for (let i = 0; i < LEVEL_COUNT; i += 1) {
+    if (correctByLevel[i] > askedByLevel[i]) return null;
+    askedSum += askedByLevel[i];
+    correctSum += correctByLevel[i];
+  }
+  if (askedSum !== LEVEL_TEST_QUESTION_COUNT) return null;
+  if (correctSum !== correctTotal) return null;
+
+  const lowerLevel = Math.min(finalLevel, levelFromTheta(lowerAbility));
+  const upperLevel = Math.max(finalLevel, levelFromTheta(upperAbility));
+  if (clearedMax && finalLevel !== MAX_LEVEL_INDEX) return null;
+
+  return {
+    v: 2,
+    finalLevel,
+    maxLevel: upperLevel,
+    clearedMax,
+    correctTotal,
+    askedByLevel,
+    correctByLevel,
+    ability,
+    lowerLevel,
+    upperLevel,
+    lowerAbility,
+    upperAbility,
+    confidence,
+  };
+}
+
+function decodeV1(bytes: number[]): LevelTestResultPayload | null {
+  if (bytes[V1_PAYLOAD_BYTES - 1] !== checksumOf(bytes, V1_PAYLOAD_BYTES)) return null;
 
   const finalLevel = bytes[1] & 0x07;
   const maxLevel = (bytes[1] >> 3) & 0x07;
@@ -116,7 +216,6 @@ export function decodeLevelTestResult(code: string): LevelTestResultPayload | nu
   const askedByLevel = bytes.slice(3, 3 + LEVEL_COUNT);
   const correctByLevel = bytes.slice(3 + LEVEL_COUNT, 3 + LEVEL_COUNT * 2);
 
-  // 意味的な不変条件の検証。カジュアルなURL改変はここでnullに落ちる。
   if (finalLevel < MIN_LEVEL_INDEX || finalLevel > MAX_LEVEL_INDEX) return null;
   if (maxLevel < finalLevel || maxLevel > MAX_LEVEL_INDEX) return null;
   if (correctTotal > LEVEL_TEST_QUESTION_COUNT) return null;
@@ -132,5 +231,17 @@ export function decodeLevelTestResult(code: string): LevelTestResultPayload | nu
   if (correctSum !== correctTotal) return null;
   if (clearedMax && maxLevel !== MAX_LEVEL_INDEX) return null;
 
-  return { v: version, finalLevel, maxLevel, clearedMax, correctTotal, askedByLevel, correctByLevel };
+  return { v: 1, finalLevel, maxLevel, clearedMax, correctTotal, askedByLevel, correctByLevel };
+}
+
+// 失敗時は例外ではなくnullを返す(ページ側でフォールバック表示する)。
+export function decodeLevelTestResult(code: string): LevelTestResultPayload | null {
+  if (typeof code !== 'string' || code.length === 0 || code.length > 64) return null;
+
+  const bytes = base64UrlToBytes(code);
+  if (!bytes) return null;
+
+  if (bytes.length === V2_PAYLOAD_BYTES && bytes[0] === 2) return decodeV2(bytes);
+  if (bytes.length === V1_PAYLOAD_BYTES && bytes[0] === 1) return decodeV1(bytes);
+  return null;
 }

--- a/src/lib/level-test/session.ts
+++ b/src/lib/level-test/session.ts
@@ -1,10 +1,11 @@
-import type { LevelTestState } from './engine';
+import { THETA_GRID, type LevelTestState } from './engine';
 
 // 診断の途中経過を sessionStorage に保存して中断再開できるようにする。
 // メインクイズ(quiz-state.ts)と同じ30分TTL。
 
-// v3: 回答履歴(answeredWords)が追加された(古いスナップショットは捨てる)
-export const LEVEL_TEST_SESSION_KEY = 'level_test_state_v3';
+// v4: ベイズ推定化で state が事後分布(posterior)を持つ形に変わった
+// (階段型時代の古いスナップショットはキーが違うので読まれず自然消滅する)
+export const LEVEL_TEST_SESSION_KEY = 'level_test_state_v4';
 export const LEVEL_TEST_SESSION_TTL_MS = 30 * 60 * 1000;
 
 // 出題された単語1問分の記録(結果画面の○×リスト用)
@@ -26,6 +27,19 @@ export type LevelTestSessionSnapshot = {
 export function isLevelTestSessionExpired(savedAt: number, now: number = Date.now()): boolean {
   if (!Number.isFinite(savedAt)) return true;
   return now - savedAt > LEVEL_TEST_SESSION_TTL_MS;
+}
+
+// 事後分布が壊れたまま復元すると以降の推定が全て狂うので厳しめに検証する。
+function isValidPosterior(value: unknown): value is number[] {
+  if (!Array.isArray(value) || value.length !== THETA_GRID.length) return false;
+  let sum = 0;
+  for (const probability of value) {
+    if (typeof probability !== 'number' || !Number.isFinite(probability) || probability < 0) {
+      return false;
+    }
+    sum += probability;
+  }
+  return Math.abs(sum - 1) < 1e-6;
 }
 
 export function saveLevelTestSession(snapshot: Omit<LevelTestSessionSnapshot, 'savedAt'>): void {
@@ -50,6 +64,7 @@ export function loadLevelTestSession(): LevelTestSessionSnapshot | null {
       return null;
     }
     if (!parsed.state || !Array.isArray(parsed.usedKeys) || !Array.isArray(parsed.answeredWords)) return null;
+    if (!isValidPosterior(parsed.state.posterior)) return null;
     return parsed;
   } catch {
     return null;

--- a/src/lib/level-test/share.test.ts
+++ b/src/lib/level-test/share.test.ts
@@ -1,7 +1,13 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 
-import { buildLevelTestShareMessages, buildLevelTestShareUrl, formatVocabSize } from './share';
+import {
+  buildLevelTestShareMessages,
+  buildLevelTestShareUrl,
+  formatVocabSize,
+  formatVocabSizeFromTheta,
+  vocabSizeTextFor,
+} from './share';
 
 test('buildLevelTestShareUrl builds the public result URL', () => {
   assert.equal(
@@ -17,6 +23,19 @@ test('buildLevelTestShareUrl builds the public result URL', () => {
 test('formatVocabSize renders a grouped Japanese number', () => {
   assert.equal(formatVocabSize(5), '7,500');
   assert.equal(formatVocabSize(0), '600');
+});
+
+test('formatVocabSizeFromTheta interpolates between level anchors', () => {
+  assert.equal(formatVocabSizeFromTheta(5), '7,500');
+  // 準1級と1級の中間(θ=5.5)は7,500と12,000の間
+  assert.equal(formatVocabSizeFromTheta(5.5), '9,800');
+});
+
+test('vocabSizeTextFor prefers theta-based estimation and falls back to the level table', () => {
+  // v2ペイロード(abilityあり)はθから補間
+  assert.equal(vocabSizeTextFor({ finalLevel: 5, ability: 5.5 }), '9,800');
+  // v1ペイロード(abilityなし)は級の固定値
+  assert.equal(vocabSizeTextFor({ finalLevel: 5 }), '7,500');
 });
 
 test('share messages interpolate the grade label and vocab size on every platform', () => {

--- a/src/lib/level-test/share.ts
+++ b/src/lib/level-test/share.ts
@@ -1,4 +1,4 @@
-import { EIKEN_LEVEL_LABELS, VOCAB_SIZE_BY_LEVEL } from './engine';
+import { EIKEN_LEVEL_LABELS, VOCAB_SIZE_BY_LEVEL, estimateVocabularySize } from './engine';
 import type { LevelTestResultPayload } from './result-code';
 
 // 診断結果のシェア文言。group-share.ts の GroupShareMessages と同じ形で、
@@ -22,17 +22,31 @@ export function buildLevelTestShareUrl(origin: string, code: string): string {
   return `${base}/level-test/r/${encodeURIComponent(code)}`;
 }
 
+// v1(階段型時代)の共有コードには能力値θが無いので級の固定値で表示する。
 export function formatVocabSize(level: number): string {
   const size = VOCAB_SIZE_BY_LEVEL[level] ?? VOCAB_SIZE_BY_LEVEL[0];
   return size.toLocaleString('ja-JP');
 }
 
+export function formatVocabSizeFromTheta(theta: number): string {
+  return estimateVocabularySize(theta).toLocaleString('ja-JP');
+}
+
+// v2ならθ由来の推定語彙数、v1なら級の固定値。表示・シェア文言の共通入口。
+export function vocabSizeTextFor(
+  payload: Pick<LevelTestResultPayload, 'finalLevel' | 'ability'>,
+): string {
+  return payload.ability !== undefined
+    ? formatVocabSizeFromTheta(payload.ability)
+    : formatVocabSize(payload.finalLevel);
+}
+
 export function buildLevelTestShareMessages(
-  payload: Pick<LevelTestResultPayload, 'finalLevel' | 'clearedMax'>,
+  payload: Pick<LevelTestResultPayload, 'finalLevel' | 'clearedMax' | 'ability'>,
   url: string,
 ): LevelTestShareMessages {
   const grade = EIKEN_LEVEL_LABELS[payload.finalLevel] ?? EIKEN_LEVEL_LABELS[0];
-  const vocab = formatVocabSize(payload.finalLevel);
+  const vocab = vocabSizeTextFor(payload);
   const crown = payload.clearedMax ? '最高レベル完全制覇👑 ' : '';
 
   const native = `${crown}私の語彙レベルは【${grade}】、推定語彙数${vocab}語でした！🎉 あなたも20問でサクッと診断してみよう📚`;


### PR DESCRIPTION
## 概要

エンジニアのフィードバックに従い、`/level-test`(語彙レベル診断)の判定アルゴリズムを「2問連続正解で昇格・2問連続誤答で降格」の階段型状態遷移から、**IRT(項目反応理論)ベースのベイズ推定型適応テスト**に置き換えました。最後の1〜2問の正誤で結果が1レベル動く「ブレ」を解消します。

## 変更内容

### アルゴリズム(`src/lib/level-test/engine.ts`)
- 潜在能力θ(-1〜7、0.05刻みの161点グリッド)を**確率分布(事後分布)**として保持し、回答のたびに尤度で更新
- 正解確率は3PL風モデル: `guessing + (1 - guessing - slip) × sigmoid(discrimination × (θ - difficulty))`(四択の当て推量25%・うっかりミス5%を織り込む)
- 問題難易度は級(基準値0〜6)+ 級内の語インデックス(頻度順)による±0.3のオフセットで導出(バンク形式は変更なし)
- 出題選択は**期待情報利得(EIG)最大**の候補(各級から3語ずつランダム抽出)。終盤4問は推定境界の下(θ̂-0.7)と上(θ̂+0.7)へ交互に出題する「確認」フェーズ
- 結果は最後にいた級ではなく**全回答を最もよく説明する事後平均θ**から判定。90%信用区間による推定範囲と、判定の確かさ(事後SD ≤0.4=高い / ≤0.8=標準 / それ以上=暫定)も算出
- 推定語彙数はθ→語彙数アンカー(級ごとの目安値)の**線形補間**で別途変換し、範囲付きで表示
- 問題数は従来どおり20問固定(早期終了は将来対応)

### 共有コード(`src/lib/level-test/result-code.ts`)
- v2レイアウト(21バイト→28文字): θ・90%区間・確かさを追加
- **既存のv1共有URLは引き続きデコード可能**(過去のシェアリンクを壊さない)

### UI
- 結果カードに「推定範囲: 英検◯級〜◯級」「判定の確かさ」チップ、「推定範囲 約X〜Y語」を追加(v1の旧共有結果は従来表示のままフォールバック)
- スタート画面の説明文を新方式(適応式テスト)の説明に更新
- 中断再開スナップショットはv4(事後分布の妥当性検証付き)

## テスト・検証

- `npm run lint` ✅(エラーは既存の `gcp-budget-guard/` のみ)
- `npm test` ✅(level-test関連33件を含む873件パス。失敗2件は変更前のツリーでも再現する既存の問題)
- `npm run build` ✅
- 実バンク(bank-v1.json)でのシミュレーション: 真の実力θ=0.5/2.5/4.5/6の仮想ユーザーで出題が実力帯へ適応し、判定・範囲・語彙数・共有コードのラウンドトリップが整合することを確認
- 最終問題の正誤を反転させても事後平均の差が0.35未満に収まること(ブレ抑制)をテストで固定
- Playwrightで実機フロー確認: 20問回答→結果表示(新しい範囲・確かさ表示)、途中リロード→「続きから再開」で4問目から再開

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JFnUJFv4Tcu29Chvs8RXaR

---
_Generated by [Claude Code](https://claude.ai/code/session_01JFnUJFv4Tcu29Chvs8RXaR)_