### PR TITLE
語彙レベル診断に「わからない」選択肢と1問10秒タイマーを追加

### DIFF
--- a/src/app/level-test/page.tsx
+++ b/src/app/level-test/page.tsx
@@ -13,6 +13,7 @@ import { loadLevelTestBank, type LevelTestBank } from '@/lib/level-test/bank';
 import {
   EIKEN_LEVEL_LABELS,
   LEVEL_TEST_QUESTION_COUNT,
+  LEVEL_TEST_QUESTION_TIME_MS,
   answerQuestion,
   buildQuestion,
   buildResult,
@@ -20,6 +21,7 @@ import {
   isFinished,
   selectNextQuestion,
   usedKeyFor,
+  type LevelTestAnswer,
   type LevelTestQuestion,
   type LevelTestState,
 } from '@/lib/level-test/engine';
@@ -41,6 +43,9 @@ type CurrentQuestion = {
   wordIndex: number;
   question: LevelTestQuestion;
 };
+
+// 選択状態。数値=選択肢のindex、'unknown'=「わからない」(タップまたは時間切れ)
+type Selection = number | 'unknown';
 
 // 正誤やレベル変動は途中で見せず、結果画面まで分からないテンポ重視の構成。
 // タップの押下感が伝わる程度の短い間を置いて次の問題へ進む。
@@ -70,7 +75,7 @@ export default function LevelTestPage() {
   const usedKeysRef = useRef<Set<string>>(new Set());
   const answeredWordsRef = useRef<AnsweredWord[]>([]);
   const [current, setCurrent] = useState<CurrentQuestion | null>(null);
-  const [selectedIndex, setSelectedIndex] = useState<number | null>(null);
+  const [selectedIndex, setSelectedIndex] = useState<Selection | null>(null);
   const [answeredWords, setAnsweredWords] = useState<AnsweredWord[]>([]);
   const [resultPayload, setResultPayload] = useState<LevelTestResultPayload | null>(null);
   const [resultCode, setResultCode] = useState<string | null>(null);
@@ -181,12 +186,17 @@ export default function LevelTestPage() {
     setScreen('result');
   }, []);
 
-  const handleSelect = useCallback((optionIndex: number) => {
+  const handleSelect = useCallback((selection: Selection) => {
     // selectedIndexが立っている間は次の問題への遷移待ち(二重回答ガード)
     if (!bank || !current || selectedIndex !== null) return;
 
-    const correct = optionIndex === current.question.correctIndex;
-    setSelectedIndex(optionIndex);
+    const answer: LevelTestAnswer =
+      selection === 'unknown'
+        ? 'unknown'
+        : selection === current.question.correctIndex
+          ? 'correct'
+          : 'wrong';
+    setSelectedIndex(selection);
     triggerHaptic();
 
     // 正誤や推定の変動は途中では見せない(結果画面まで分からない)
@@ -194,7 +204,7 @@ export default function LevelTestPage() {
       state,
       { levelIndex: current.levelIndex, wordIndex: current.wordIndex },
       bank,
-      correct,
+      answer,
     );
     setState(nextState);
 
@@ -203,7 +213,8 @@ export default function LevelTestPage() {
     answeredWordsRef.current.push({
       levelIndex: current.levelIndex,
       wordIndex: current.wordIndex,
-      correct,
+      correct: answer === 'correct',
+      ...(answer === 'unknown' ? { unknown: true } : {}),
     });
 
     if (advanceTimerRef.current) clearTimeout(advanceTimerRef.current);
@@ -394,7 +405,7 @@ function StartScreen({
         </motion.div>
 
         <p className="mt-4 text-center text-[11px] font-bold text-[var(--color-muted)]">
-          回答に合わせて出題の難易度が変わる適応式テストです。20問すべての回答から、最も確からしい語彙レベルを推定します。
+          回答に合わせて出題の難易度が変わる適応式テストです。制限時間は1問10秒(時間切れは「わからない」扱い)。20問すべての回答から、最も確からしい語彙レベルを推定します。
         </p>
 
         {!user && (
@@ -439,6 +450,8 @@ function AnsweredWordsPanel({
             <div key={`${answered.levelIndex}-${answered.wordIndex}-${index}`} className="flex items-center gap-2.5 py-2.5">
               {answered.correct ? (
                 <Icon name="check" size={18} className="shrink-0 text-[var(--color-success,#15803d)]" />
+              ) : answered.unknown ? (
+                <Icon name="question_mark" size={18} className="shrink-0 text-[var(--color-muted)]" />
               ) : (
                 <Icon name="close" size={18} className="shrink-0 text-[var(--color-error,#dc2626)]" />
               )}
@@ -463,6 +476,57 @@ function AnsweredWordsPanel({
   );
 }
 
+// 1問10秒のカウントダウン。時間切れでonTimeUp(=「わからない」扱い)を呼ぶ。
+// 問題ごとにkeyでリマウントしてリセットし、回答済み(locked)の間は凍結する。
+function QuestionTimer({ locked, onTimeUp }: { locked: boolean; onTimeUp: () => void }) {
+  const [remainingMs, setRemainingMs] = useState(LEVEL_TEST_QUESTION_TIME_MS);
+  const onTimeUpRef = useRef(onTimeUp);
+  useEffect(() => {
+    onTimeUpRef.current = onTimeUp;
+  }, [onTimeUp]);
+
+  useEffect(() => {
+    if (locked) return;
+    const startedAt = Date.now();
+    const interval = setInterval(() => {
+      const left = LEVEL_TEST_QUESTION_TIME_MS - (Date.now() - startedAt);
+      if (left <= 0) {
+        setRemainingMs(0);
+        clearInterval(interval);
+        onTimeUpRef.current();
+        return;
+      }
+      setRemainingMs(left);
+    }, 100);
+    return () => clearInterval(interval);
+  }, [locked]);
+
+  const remainingSeconds = Math.ceil(remainingMs / 1000);
+  const timeRatio = remainingMs / LEVEL_TEST_QUESTION_TIME_MS;
+  const timeCritical = !locked && remainingMs <= 3000;
+
+  return (
+    <div className="mt-2 flex items-center gap-2">
+      <div className="h-1.5 flex-1 overflow-hidden rounded-full border border-[var(--color-border)] bg-[var(--color-surface)]">
+        <div
+          className="h-full rounded-full transition-[width] duration-100 ease-linear"
+          style={{
+            width: `${timeRatio * 100}%`,
+            background: timeCritical ? '#dc2626' : 'var(--color-accent)',
+          }}
+        />
+      </div>
+      <div
+        className={`w-7 shrink-0 text-right font-mono text-[12px] font-bold ${
+          timeCritical ? 'text-[#dc2626]' : 'text-[var(--color-muted)]'
+        }`}
+      >
+        {remainingSeconds}s
+      </div>
+    </div>
+  );
+}
+
 function QuizScreen({
   state,
   current,
@@ -471,12 +535,13 @@ function QuizScreen({
 }: {
   state: LevelTestState;
   current: CurrentQuestion;
-  selectedIndex: number | null;
-  onSelect: (index: number) => void;
+  selectedIndex: Selection | null;
+  onSelect: (selection: Selection) => void;
 }) {
   const questionNumber = Math.min(state.answeredCount + 1, LEVEL_TEST_QUESTION_COUNT);
   const progressPercent = (state.answeredCount / LEVEL_TEST_QUESTION_COUNT) * 100;
   const isLocked = selectedIndex !== null;
+  const questionKey = `${current.levelIndex}:${current.wordIndex}`;
 
   return (
     <div
@@ -501,6 +566,13 @@ function QuizScreen({
             {questionNumber}/{LEVEL_TEST_QUESTION_COUNT}
           </div>
         </div>
+
+        {/* 残り時間バー(時間切れは「わからない」扱い)。keyで問題ごとにリセット */}
+        <QuestionTimer
+          key={questionKey}
+          locked={isLocked}
+          onTimeUp={() => onSelect('unknown')}
+        />
       </div>
 
       {/* 問題 */}
@@ -541,6 +613,21 @@ function QuizScreen({
               </button>
             );
           })}
+
+          {/* わからない(時間切れでも自動的にこの扱いになる) */}
+          <button
+            type="button"
+            disabled={isLocked}
+            onClick={() => onSelect('unknown')}
+            className={`flex w-full items-center justify-center gap-1.5 rounded-[14px] border-2 border-dashed px-4 py-3 text-[14px] font-bold transition-all duration-100 active:translate-y-[1px] disabled:active:translate-y-0 ${
+              selectedIndex === 'unknown'
+                ? 'border-[var(--solid-ink)] bg-[var(--solid-ink)] text-white'
+                : 'border-[var(--color-muted)] bg-transparent text-[var(--color-muted)]'
+            }`}
+          >
+            <Icon name="help" size={18} />
+            わからない
+          </button>
         </div>
       </div>
     </div>

--- a/src/components/level-test/LevelTestResultCard.tsx
+++ b/src/components/level-test/LevelTestResultCard.tsx
@@ -50,11 +50,16 @@ export function LevelTestResultCard({
   const rangeText = hasEstimate && payload.lowerLevel !== payload.upperLevel
     ? `${EIKEN_LEVEL_LABELS[payload.lowerLevel!]}〜${(EIKEN_LEVEL_LABELS[payload.upperLevel!] ?? '').replace('英検', '')}`
     : null;
-  const vocabRangeText = hasEstimate
-    && payload.lowerAbility !== undefined
-    && payload.upperAbility !== undefined
-    && payload.lowerAbility < payload.upperAbility
-    ? `約${formatVocabSizeFromTheta(payload.lowerAbility)}〜${formatVocabSizeFromTheta(payload.upperAbility)}語`
+  // 上下限が同じ語数に丸まる場合(グリッド端に張り付いた場合など)は
+  // 「約600〜600語」のような縮退した範囲を出さない
+  const lowerVocab = hasEstimate && payload.lowerAbility !== undefined
+    ? formatVocabSizeFromTheta(payload.lowerAbility)
+    : null;
+  const upperVocab = hasEstimate && payload.upperAbility !== undefined
+    ? formatVocabSizeFromTheta(payload.upperAbility)
+    : null;
+  const vocabRangeText = lowerVocab && upperVocab && lowerVocab !== upperVocab
+    ? `約${lowerVocab}〜${upperVocab}語`
     : null;
 
   return (

--- a/src/lib/level-test/engine.test.ts
+++ b/src/lib/level-test/engine.test.ts
@@ -62,7 +62,7 @@ function simulateRun(trueTheta: number, seed: number): LevelTestState {
     used.add(usedKeyFor(picked!.levelIndex, picked!.wordIndex));
     const difficulty = questionDifficulty(picked!.levelIndex, picked!.wordIndex, WORDS_PER_LEVEL);
     const correct = random() < probabilityOfCorrect(trueTheta, difficulty);
-    state = answerQuestion(state, picked!, TEST_BANK, correct);
+    state = answerQuestion(state, picked!, TEST_BANK, correct ? 'correct' : 'wrong');
   }
   return state;
 }
@@ -109,20 +109,44 @@ test('updatePosterior treats answers as evidence, not verdicts', () => {
   const meanBefore = posteriorMean(uniform);
 
   // 難しい問題への正解は上位レベルを支持する強い証拠
-  const afterHardCorrect = updatePosterior(uniform, 5.5, true);
+  const afterHardCorrect = updatePosterior(uniform, 5.5, 'correct');
   assert.ok(posteriorMean(afterHardCorrect) > meanBefore + 0.3);
 
   // 簡単な問題への不正解は下位レベルを支持する強い証拠
-  const afterEasyWrong = updatePosterior(uniform, 0.5, false);
+  const afterEasyWrong = updatePosterior(uniform, 0.5, 'wrong');
   assert.ok(posteriorMean(afterEasyWrong) < meanBefore - 0.3);
 
   // 難しい問題への不正解は自然な結果なので弱い証拠(変化が小さい)
-  const afterHardWrong = updatePosterior(uniform, 6.5, false);
+  const afterHardWrong = updatePosterior(uniform, 6.5, 'wrong');
   assert.ok(Math.abs(posteriorMean(afterHardWrong) - meanBefore) <
     Math.abs(posteriorMean(afterEasyWrong) - meanBefore));
 
   // 1問で可能性を消さない: どの更新後も全域で確率が正
   for (const p of afterEasyWrong) assert.ok(p > 0);
+});
+
+test('「わからない」 is stronger evidence of not knowing than a wrong pick', () => {
+  const uniform = createInitialState().posterior;
+  const meanBefore = posteriorMean(uniform);
+
+  // 誤答には25%の当て推量で正解し損ねただけの可能性が混ざるが、
+  // わからないには混ざらないので、同じ難易度なら推定をより強く下げる
+  const afterWrong = updatePosterior(uniform, 3, 'wrong');
+  const afterUnknown = updatePosterior(uniform, 3, 'unknown');
+  assert.ok(posteriorMean(afterUnknown) < posteriorMean(afterWrong));
+  assert.ok(posteriorMean(afterUnknown) < meanBefore);
+
+  // 知っていたのに時間切れ等で申告した可能性を残すため、高θの確率もゼロにしない
+  for (const p of afterUnknown) assert.ok(p > 0);
+});
+
+test('answerQuestion with 「わからない」 counts as asked but not correct', () => {
+  const state = createInitialState();
+  const next = answerQuestion(state, { levelIndex: 3, wordIndex: 0 }, TEST_BANK, 'unknown');
+  assert.equal(next.answeredCount, 1);
+  assert.equal(next.askedByLevel[3], 1);
+  assert.equal(next.correctByLevel[3], 0);
+  assert.ok(posteriorMean(next.posterior) < posteriorMean(state.posterior));
 });
 
 test('expectedInformationGain prefers mid-difficulty questions under a uniform prior', () => {
@@ -165,7 +189,7 @@ test('confirmation phase (last 4 questions) probes below and above the estimate'
   for (let i = 0; i < 16; i += 1) {
     const ref = { levelIndex: 5, wordIndex: i };
     used.add(usedKeyFor(ref.levelIndex, ref.wordIndex));
-    state = answerQuestion(state, ref, TEST_BANK, i % 2 === 0);
+    state = answerQuestion(state, ref, TEST_BANK, i % 2 === 0 ? 'correct' : 'wrong');
   }
   assert.equal(state.answeredCount, 16);
   const mean = posteriorMean(state.posterior);
@@ -176,7 +200,7 @@ test('confirmation phase (last 4 questions) probes below and above the estimate'
   assert.ok(belowDifficulty < mean, '17問目は境界の下側を確認する');
 
   used.add(usedKeyFor(below!.levelIndex, below!.wordIndex));
-  state = answerQuestion(state, below!, TEST_BANK, true);
+  state = answerQuestion(state, below!, TEST_BANK, 'correct');
   const above = selectNextQuestion(TEST_BANK, state, used, random);
   assert.ok(above);
   const aboveDifficulty = questionDifficulty(above!.levelIndex, above!.wordIndex, WORDS_PER_LEVEL);
@@ -191,7 +215,7 @@ test('a perfect 20-question run is judged 英検1級 with clearedMax', () => {
     const picked = selectNextQuestion(TEST_BANK, state, used, random);
     assert.ok(picked);
     used.add(usedKeyFor(picked!.levelIndex, picked!.wordIndex));
-    state = answerQuestion(state, picked!, TEST_BANK, true);
+    state = answerQuestion(state, picked!, TEST_BANK, 'correct');
   }
   const result = buildResult(state);
   assert.equal(result.finalLevel, MAX_LEVEL_INDEX);
@@ -210,7 +234,7 @@ test('an all-wrong 20-question run is judged 英検5級', () => {
     const picked = selectNextQuestion(TEST_BANK, state, used, random);
     assert.ok(picked);
     used.add(usedKeyFor(picked!.levelIndex, picked!.wordIndex));
-    state = answerQuestion(state, picked!, TEST_BANK, false);
+    state = answerQuestion(state, picked!, TEST_BANK, 'wrong');
   }
   const result = buildResult(state);
   assert.equal(result.finalLevel, MIN_LEVEL_INDEX);
@@ -259,10 +283,10 @@ test('flipping only the final answer barely moves the estimate (anti-swing)', ()
       break;
     }
     // 準1級相当のユーザーを模して正誤を交ぜる
-    state = answerQuestion(state, picked!, TEST_BANK, i % 3 !== 2);
+    state = answerQuestion(state, picked!, TEST_BANK, i % 3 !== 2 ? 'correct' : 'wrong');
   }
-  const withCorrect = buildResult(answerQuestion(state, lastPicked!, TEST_BANK, true));
-  const withWrong = buildResult(answerQuestion(state, lastPicked!, TEST_BANK, false));
+  const withCorrect = buildResult(answerQuestion(state, lastPicked!, TEST_BANK, 'correct'));
+  const withWrong = buildResult(answerQuestion(state, lastPicked!, TEST_BANK, 'wrong'));
   assert.ok(Math.abs(withCorrect.ability - withWrong.ability) < 0.35);
 });
 
@@ -270,8 +294,8 @@ test('buildResult maps posterior statistics to level, range, and confidence', ()
   // θ=4.6付近に集中した事後分布を手で作る
   let posterior = createInitialState().posterior;
   for (let i = 0; i < 10; i += 1) {
-    posterior = updatePosterior(posterior, 4.6, i % 2 === 0);
-    posterior = updatePosterior(posterior, 4.0, true);
+    posterior = updatePosterior(posterior, 4.6, i % 2 === 0 ? 'correct' : 'wrong');
+    posterior = updatePosterior(posterior, 4.0, 'correct');
   }
   const state: LevelTestState = {
     posterior,

--- a/src/lib/level-test/engine.ts
+++ b/src/lib/level-test/engine.ts
@@ -18,6 +18,8 @@ import type { BankWord, LevelTestBank } from './bank';
 export const LEVEL_TEST_QUESTION_COUNT = 20;
 export const MIN_LEVEL_INDEX = 0;
 export const MAX_LEVEL_INDEX = EIKEN_LEVEL_ORDER.length - 1; // 6
+// 1問あたりの制限時間。時間切れは「わからない」として扱う(UI側で使用)。
+export const LEVEL_TEST_QUESTION_TIME_MS = 10_000;
 
 // index 0..6 = 英検5級..1級(EIKEN_LEVEL_ORDER と同順)
 export const EIKEN_LEVEL_LABELS = [
@@ -50,6 +52,10 @@ export const THETA_GRID: readonly number[] = Array.from(
 const DEFAULT_DISCRIMINATION = 1.2;
 const DEFAULT_GUESSING = 0.25; // 四択
 const DEFAULT_SLIP = 0.05;
+// 「わからない」回答時に、実は知っていた(時間切れ・自信不足)可能性の床。
+// 誤答の尤度比(0.75/0.05=15倍)より強い証拠になるよう 1/UNKNOWN_SLIP > 15、
+// かつ時間切れの巻き込みを考慮してゼロにはしない。
+const UNKNOWN_SLIP = 0.05;
 
 // 級内の難易度ばらつき幅(基準値±0.3)
 const WITHIN_LEVEL_DIFFICULTY_SPREAD = 0.3;
@@ -72,9 +78,31 @@ function sigmoid(x: number): number {
   return 1 / (1 + Math.exp(-x));
 }
 
+// 単語を「知っている」確率(IRTの2PL部分)
+function knowledgeProbability(theta: number, difficulty: number): number {
+  return sigmoid(DEFAULT_DISCRIMINATION * (theta - difficulty));
+}
+
 export function probabilityOfCorrect(theta: number, difficulty: number): number {
-  const knowledgeProbability = sigmoid(DEFAULT_DISCRIMINATION * (theta - difficulty));
-  return DEFAULT_GUESSING + (1 - DEFAULT_GUESSING - DEFAULT_SLIP) * knowledgeProbability;
+  return DEFAULT_GUESSING + (1 - DEFAULT_GUESSING - DEFAULT_SLIP) * knowledgeProbability(theta, difficulty);
+}
+
+// 回答の種類。「わからない」は誤答よりも「知らない」ことを強く支持する証拠になる
+// (誤答には25%の当て推量で偶然正解し損ねただけの可能性が混ざるが、
+//  わからないの申告には当て推量が混ざらないため)。
+export type LevelTestAnswer = 'correct' | 'wrong' | 'unknown';
+
+// 観測(正解/誤答/わからない)のθに対する尤度。
+// 「わからない」は P(知らない) に比例し、知っていたのに時間切れ等で
+// 申告してしまう可能性(UNKNOWN_SLIP)を床として残す。
+export function answerLikelihood(
+  theta: number,
+  difficulty: number,
+  answer: LevelTestAnswer,
+): number {
+  if (answer === 'correct') return probabilityOfCorrect(theta, difficulty);
+  if (answer === 'wrong') return 1 - probabilityOfCorrect(theta, difficulty);
+  return 1 - (1 - UNKNOWN_SLIP) * knowledgeProbability(theta, difficulty);
 }
 
 // ---------------------------------------------------------------------------
@@ -96,13 +124,11 @@ function normalize(values: number[]): number[] {
 export function updatePosterior(
   posterior: readonly number[],
   difficulty: number,
-  correct: boolean,
+  answer: LevelTestAnswer,
 ): number[] {
-  const updated = posterior.map((priorProbability, index) => {
-    const correctProbability = probabilityOfCorrect(THETA_GRID[index], difficulty);
-    const likelihood = correct ? correctProbability : 1 - correctProbability;
-    return priorProbability * likelihood;
-  });
+  const updated = posterior.map((priorProbability, index) =>
+    priorProbability * answerLikelihood(THETA_GRID[index], difficulty, answer),
+  );
   return normalize(updated);
 }
 
@@ -146,8 +172,8 @@ export function expectedInformationGain(
     0,
   );
   const expectedEntropy =
-    probabilityCorrect * entropy(updatePosterior(posterior, difficulty, true)) +
-    (1 - probabilityCorrect) * entropy(updatePosterior(posterior, difficulty, false));
+    probabilityCorrect * entropy(updatePosterior(posterior, difficulty, 'correct')) +
+    (1 - probabilityCorrect) * entropy(updatePosterior(posterior, difficulty, 'wrong'));
   return currentEntropy - expectedEntropy;
 }
 
@@ -185,7 +211,7 @@ export function answerQuestion(
   state: LevelTestState,
   question: QuestionRef,
   bank: LevelTestBank,
-  correct: boolean,
+  answer: LevelTestAnswer,
 ): LevelTestState {
   const levelWordCount = bank.levels[question.levelIndex]?.length ?? 1;
   const difficulty = questionDifficulty(question.levelIndex, question.wordIndex, levelWordCount);
@@ -193,10 +219,10 @@ export function answerQuestion(
   const askedByLevel = [...state.askedByLevel];
   const correctByLevel = [...state.correctByLevel];
   askedByLevel[question.levelIndex] += 1;
-  if (correct) correctByLevel[question.levelIndex] += 1;
+  if (answer === 'correct') correctByLevel[question.levelIndex] += 1;
 
   return {
-    posterior: updatePosterior(state.posterior, difficulty, correct),
+    posterior: updatePosterior(state.posterior, difficulty, answer),
     answeredCount: state.answeredCount + 1,
     askedByLevel,
     correctByLevel,

--- a/src/lib/level-test/result-code.test.ts
+++ b/src/lib/level-test/result-code.test.ts
@@ -47,7 +47,7 @@ function resultFromRun(answerFor: (index: number) => boolean, seed = 1): LevelTe
     const picked = selectNextQuestion(TEST_BANK, state, used, random);
     if (!picked) throw new Error('bank exhausted');
     used.add(usedKeyFor(picked.levelIndex, picked.wordIndex));
-    state = answerQuestion(state, picked, TEST_BANK, answerFor(index));
+    state = answerQuestion(state, picked, TEST_BANK, answerFor(index) ? 'correct' : 'wrong');
     index += 1;
   }
   return buildResult(state);

--- a/src/lib/level-test/session.ts
+++ b/src/lib/level-test/session.ts
@@ -13,6 +13,8 @@ export type AnsweredWord = {
   levelIndex: number;
   wordIndex: number;
   correct: boolean;
+  // 「わからない」を選んだ(または時間切れ)。correct=false と組で使う
+  unknown?: boolean;
 };
 
 export type LevelTestSessionSnapshot = {


### PR DESCRIPTION
## 概要

#381(ベイズ推定化)のフォローアップとして、語彙レベル診断に2つの機能を追加します。

1. **「わからない」選択肢**: 4択の下に破線スタイルのボタンを追加
2. **1問10秒タイマー**: 残り時間バー+秒数を表示し、時間切れは自動的に「わからない」として回答

## 変更内容

### アルゴリズム(`src/lib/level-test/engine.ts`)
- 回答を `'correct' | 'wrong' | 'unknown'` の3値に拡張(`LevelTestAnswer`)
- 「わからない」の尤度は `1 - 0.95k`(k=単語を知っている確率)。誤答(`0.75 - 0.7k`)には25%の当て推量で偶然正解し損ねただけの可能性が混ざるのに対し、「わからない」の申告には混ざらないため、**誤答より強く「知らない」ことを支持する証拠**として事後分布を更新する(尤度比: 誤答15倍 / わからない20倍)
- 知っていたのに時間切れ等で「わからない」になる可能性を床(5%)として残し、1問で高レベルの可能性を消さない
- 集計上は「出題数にカウント・正解数にはカウントしない」扱いで、結果コード(v2)の形式変更は不要

### UI(`src/app/level-test/page.tsx`)
- `QuestionTimer` コンポーネント: 問題ごとに `key` でリマウントしてリセット、回答済みの間は凍結。残り3秒で赤色警告。時間切れで「わからない」を自動送信
- ふり返りリストでは「わからない」を ? アイコン(グレー)で誤答(×・赤)と区別
- スタート画面の説明文に制限時間の記載を追加
- 語彙数の推定範囲が上下限とも同じ値に丸まる場合(「約600〜600語」)は範囲表示を省略

## テスト・検証

- level-test関連35件を含む875件パス(失敗2件は #381 以前から存在する無関係の既存問題)
- 新規テスト: 「わからない」が誤答より事後平均を強く下げること、高θの確率がゼロにならないこと、出題数のみカウントされること
- `npm run lint`(level-testファイルはクリーン)/ `npm run build` ✅
- Playwrightで実機確認: タイマーのカウントダウン表示、「わからない」タップでの回答、**10秒放置での自動回答(2/20→3/20)**、ふり返りリストの?アイコン表示

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JFnUJFv4Tcu29Chvs8RXaR

---
_Generated by [Claude Code](https://claude.ai/code/session_01JFnUJFv4Tcu29Chvs8RXaR)_