### PR TITLE
語彙レベル診断の結果画面でシェアボタンを最上部に移動

### DIFF
--- a/src/app/level-test/page.tsx
+++ b/src/app/level-test/page.tsx
@@ -253,6 +253,25 @@ export default function LevelTestPage() {
           <div className="mb-4 text-center font-display text-[22px] font-extrabold text-[var(--solid-ink)]">
             診断結果
           </div>
+
+          {/* シェア導線は画面最上部(カードの上)に置く。カードのリビール演出後に現れる */}
+          <motion.div
+            initial={{ opacity: 0, y: 10 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ delay: 1.3 }}
+            className="mb-4"
+          >
+            <SolidButton
+              variant="accent"
+              size="lg"
+              iconLeft="ios_share"
+              className="w-full"
+              onClick={() => setShareOpen(true)}
+            >
+              結果をシェアする
+            </SolidButton>
+          </motion.div>
+
           <LevelTestResultCard payload={resultPayload} variant="own" />
 
           {bank && answeredWords.length > 0 && (
@@ -271,15 +290,6 @@ export default function LevelTestPage() {
             transition={{ delay: 1.3 }}
             className="mt-5 space-y-3"
           >
-            <SolidButton
-              variant="accent"
-              size="lg"
-              iconLeft="ios_share"
-              className="w-full"
-              onClick={() => setShareOpen(true)}
-            >
-              結果をシェアする
-            </SolidButton>
             <SolidButton size="md" className="w-full" iconLeft="refresh" onClick={() => startQuiz(false)}>
               もう一度測定する
             </SolidButton>


### PR DESCRIPTION
## 概要

`/level-test` の結果画面で、「結果をシェアする」ボタンを最下部のボタン群(ふり返りリストの下)から**「診断結果」見出しの直下(結果カードの上)**へ移動しました。スクロールせずにシェア導線が見えるようになります。

## 変更内容

- `src/app/level-test/page.tsx` の result 画面のみ(ロジック変更なし)
  - シェアボタンを見出し直下に移動。結果カードの段階的リビール演出(~1.15s)の後にフェードインする(表示タイミングは従来の下部配置と同じ delay 1.3)
  - 最下部のボタン群には「もう一度測定する」「ホームに戻る/無料登録」が残る
  - `LevelTestShareSheet` の配線は変更なし

## 検証

- Playwright で実機確認: シェアボタンが結果カードより上に表示(Y=81 < カードY=186)、ボタンは1つのみ、タップでシェアシートが開く、下部の「もう一度測定する」も動作
- `npm run lint`(level-test ファイルはクリーン)/ `npm run build` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JFnUJFv4Tcu29Chvs8RXaR

---
_Generated by [Claude Code](https://claude.ai/code/session_01JFnUJFv4Tcu29Chvs8RXaR)_