### PR TITLE
Extract morphology formula display into reusable component

### DIFF
--- a/src/components/desktop/DesktopProjectDetail.tsx
+++ b/src/components/desktop/DesktopProjectDetail.tsx
@@ -16,7 +16,9 @@ import {
   desktopThumbColor,
 } from '@/components/desktop/desktop-data';
 import { DesktopVocabularyTypeBadge } from '@/components/desktop/DesktopVocabularyTypeBadge';
+import { MorphologyFormulaChips } from '@/components/word/MorphologyFormulaChips';
 import { TranslationDisplay } from '@/components/word/TranslationDisplay';
+import { hasDisplayableMorphology } from '@/lib/morphology/format';
 import { getWrongAnswers, type WrongAnswer } from '@/lib/utils';
 import type { Project, Word, WordStatus } from '@/types';
 
@@ -792,6 +794,18 @@ function DesktopWordDetailModal({
                 </div>
               )}
             </div>
+
+          {hasDisplayableMorphology(word.morphology) && (
+            <div>
+              <div className="mono" style={{ fontSize: 10, letterSpacing: '0.08em', textTransform: 'uppercase', color: 'var(--color-accent-ink)', fontWeight: 700, display: 'flex', alignItems: 'center', gap: 6, marginBottom: 10 }}>
+                <Icon name="account_tree" style={{ fontSize: 14 }} />語源
+              </div>
+              <MorphologyFormulaChips morphology={word.morphology} />
+              <div style={{ fontSize: 13, color: 'var(--color-secondary-text)', lineHeight: 1.75, marginTop: 12, whiteSpace: 'pre-line' }}>
+                {word.morphology.explanation}
+              </div>
+            </div>
+          )}
 
           {word.relatedWords && word.relatedWords.length > 0 && (
             <div>

--- a/src/components/desktop/DesktopScan.tsx
+++ b/src/components/desktop/DesktopScan.tsx
@@ -7,6 +7,7 @@ import { desktopPosShort, desktopThumbColor } from '@/components/desktop/desktop
 import { Icon } from '@/components/ui/Icon';
 import { TranslationDisplay } from '@/components/word/TranslationDisplay';
 import { isBillingEnabled } from '@/lib/billing/feature';
+import { formatMorphologyFormula, hasDisplayableMorphology } from '@/lib/morphology/format';
 import { processImageFile, processImageToBase64 } from '@/lib/image-utils';
 import {
   addHomeImmediateScanResult,
@@ -931,7 +932,19 @@ function DesktopScanConfirmRow({
       </td>
       <td className="en">{word.english || `単語 ${index + 1}`}</td>
       <td className="pos">{desktopPosShort(word.partOfSpeechTags)}</td>
-      <td className="ja">{word.japanese ? <TranslationDisplay word={word} compact /> : '-'}</td>
+      <td className="ja">
+        {word.japanese ? <TranslationDisplay word={word} compact /> : '-'}
+        {hasDisplayableMorphology(word.morphology) && (
+          <div style={{ marginTop: 5, paddingTop: 5, borderTop: '1px dashed var(--color-border)' }}>
+            <div className="mono" style={{ fontSize: 10.5, fontWeight: 700, color: 'var(--solid-ink)' }}>
+              {formatMorphologyFormula(word.morphology)}
+            </div>
+            <div className="muted" style={{ fontSize: 10.5, lineHeight: 1.5, whiteSpace: 'pre-line', marginTop: 2 }}>
+              {word.morphology.explanation}
+            </div>
+          </div>
+        )}
+      </td>
       <td className="cefr"><span className="cefr-pill">{word.cefrLevel || '-'}</span></td>
       <td onClick={(event) => event.stopPropagation()}>
         <div style={{ display: 'flex', gap: 4 }}>

--- a/src/components/word/MorphologyFormulaChips.tsx
+++ b/src/components/word/MorphologyFormulaChips.tsx
@@ -1,0 +1,30 @@
+import type { WordMorphology } from '@/types';
+
+/**
+ * 語源式（un(否定) ＋ anim(心) ＋ ous(形容詞化)）をピル表示する。
+ * モバイルの単語詳細とデスクトップの単語詳細モーダルで共用。
+ * 表示可否は呼び出し側で hasDisplayableMorphology() により判定すること。
+ */
+export function MorphologyFormulaChips({ morphology }: { morphology: WordMorphology }) {
+  return (
+    <div className="flex flex-wrap items-center gap-x-1.5 gap-y-2">
+      {morphology.formula.map((part, index) => (
+        <span key={`${part.text}-${index}`} className="flex items-center gap-1.5">
+          {index > 0 && (
+            <span className="text-[14px] font-bold text-[var(--color-muted)]">＋</span>
+          )}
+          <span
+            className={`rounded-full border-2 px-2.5 py-1 font-display text-[13px] font-bold leading-none ${
+              part.kind === 'root'
+                ? 'border-[var(--color-border)] bg-[var(--color-surface-secondary)] text-[var(--solid-ink)]'
+                : 'border-[var(--color-accent)] bg-[var(--color-accent-light)] text-[var(--color-accent-ink)]'
+            }`}
+          >
+            {part.text}
+            <span className="ml-1 text-[11px] font-semibold opacity-80">({part.meaningJa})</span>
+          </span>
+        </span>
+      ))}
+    </div>
+  );
+}

--- a/src/components/word/WordDetailView.tsx
+++ b/src/components/word/WordDetailView.tsx
@@ -10,6 +10,7 @@ import { getCachedProjectWords, updateProjectWordsCache } from '@/lib/home-cache
 import type { Word, CustomSection, CustomColumn, SubscriptionStatus } from '@/types';
 import { TranslationDisplay } from '@/components/word/TranslationDisplay';
 import { hasDisplayableMorphology } from '@/lib/morphology/format';
+import { MorphologyFormulaChips } from '@/components/word/MorphologyFormulaChips';
 
 function formatCustomSectionValue(value: string, type: CustomColumn['type']): string {
   if (!value) return '';
@@ -512,25 +513,7 @@ export function WordDetailView({
                 <span className="font-mono text-[11px] font-bold text-[var(--color-muted)]">語源</span>
               </div>
               {/* 式: un(否定) ＋ anim(心) ＋ ous(形容詞化) */}
-              <div className="flex flex-wrap items-center gap-x-1.5 gap-y-2">
-                {word.morphology.formula.map((part, index) => (
-                  <span key={`${part.text}-${index}`} className="flex items-center gap-1.5">
-                    {index > 0 && (
-                      <span className="text-[14px] font-bold text-[var(--color-muted)]">＋</span>
-                    )}
-                    <span
-                      className={`rounded-full border-2 px-2.5 py-1 font-display text-[13px] font-bold leading-none ${
-                        part.kind === 'root'
-                          ? 'border-[var(--color-border)] bg-[var(--color-surface-secondary)] text-[var(--solid-ink)]'
-                          : 'border-[var(--color-accent)] bg-[var(--color-accent-light)] text-[var(--color-accent-ink)]'
-                      }`}
-                    >
-                      {part.text}
-                      <span className="ml-1 text-[11px] font-semibold opacity-80">({part.meaningJa})</span>
-                    </span>
-                  </span>
-                ))}
-              </div>
+              <MorphologyFormulaChips morphology={word.morphology} />
               <p className="mt-3 whitespace-pre-line text-[13px] leading-[1.6] text-[var(--color-ink-muted)]">
                 {word.morphology.explanation}
               </p>


### PR DESCRIPTION
## Summary
Refactors the morphology formula (語源式) display logic into a dedicated `MorphologyFormulaChips` component to enable reuse across multiple views. This eliminates code duplication and ensures consistent styling and behavior for etymology formula rendering.

## Changes
- **New component**: `MorphologyFormulaChips.tsx` — Encapsulates the morphology formula chip rendering with proper styling for root vs. affix parts
- **WordDetailView**: Replaced inline formula rendering with `MorphologyFormulaChips` component call
- **DesktopProjectDetail**: Added morphology section to word detail modal using the new component, with proper styling and icon
- **DesktopScan**: Added morphology explanation display in confirmation table using `formatMorphologyFormula()` utility

## Implementation Details
- The component accepts a `WordMorphology` object and renders formula parts as styled chips with Japanese meanings
- Conditional styling differentiates root parts (neutral) from affixes (accent-colored)
- Plus signs (＋) visually separate formula components
- Callers use `hasDisplayableMorphology()` to determine whether to render the section
- Desktop views use both the new component and the existing `formatMorphologyFormula()` utility for text-based display where appropriate

https://claude.ai/code/session_01LtRZPjUbJUcP2rvnMiDCFF