### PR TITLE
スキャン失敗時に理由を明示したエラーを表示する

### DIFF
--- a/src/app/home-client.tsx
+++ b/src/app/home-client.tsx
@@ -92,7 +92,14 @@ type RecentScanJob = {
   id: string;
   status: 'pending' | 'processing' | 'completed' | 'failed';
   project_title: string;
+  error_message?: string | null;
 };
+
+// バックグラウンドスキャンが失敗したのに error_message が無い場合の予備文言。
+// 「単語帳を撮影しなかった（＝単語が写っていない）」ケースを想定した、
+// 理由が伝わる日本語メッセージを表示する。
+const SCAN_JOB_FAILED_FALLBACK_MESSAGE =
+  '画像から単語を読み取れませんでした。単語帳や英単語がはっきり写るように、もう一度撮影してください。';
 
 function withHomeGeneratingFallbackId(
   payload: HomeGeneratingWordbookPayload,
@@ -261,6 +268,8 @@ export function HomeClient() {
   const repository = useMemo(() => getRepository(subscriptionStatus, wasPro), [subscriptionStatus, wasPro]);
 
   const showHomeGeneratingWordbook = useCallback((payload: HomeGeneratingWordbookPayload) => {
+    // 新しいスキャンを開始したら、前回の失敗メッセージが残っていても消す。
+    setError(null);
     setPendingGeneratingWordbook(withHomeGeneratingFallbackId(payload));
   }, []);
 
@@ -423,6 +432,12 @@ export function HomeClient() {
 
     if (linkedJob.status === 'completed') {
       void loadHomeRef.current();
+    }
+
+    // 失敗（単語ゼロなど）した場合、以前は「生成中」カードが理由も出さず
+    // 消えるだけでユーザーが困っていた。サーバーが記録した理由を必ず表示する。
+    if (linkedJob.status === 'failed') {
+      setError(linkedJob.error_message?.trim() || SCAN_JOB_FAILED_FALLBACK_MESSAGE);
     }
   }, [pendingGeneratingWordbook?.linkedJobId, recentScanJobs]);
 

--- a/src/lib/scan/job-processing-input.test.ts
+++ b/src/lib/scan/job-processing-input.test.ts
@@ -4,6 +4,7 @@ import assert from 'node:assert/strict';
 import {
   buildScanJobNoWordsErrorMessage,
   buildScanJobProcessingInput,
+  SCAN_JOB_NO_WORDS_FALLBACK_MESSAGE,
 } from './job-processing-input';
 
 test('buildScanJobProcessingInput keeps multiple image paths and client_local save mode', () => {
@@ -39,8 +40,20 @@ test('buildScanJobNoWordsErrorMessage prefers the first extraction error', () =>
     buildScanJobNoWordsErrorMessage('画像解析に失敗しました'),
     '画像解析に失敗しました',
   );
+});
+
+test('buildScanJobNoWordsErrorMessage returns a clear Japanese reason when no extraction error is present', () => {
   assert.equal(
     buildScanJobNoWordsErrorMessage(null),
-    'No words found in any image',
+    SCAN_JOB_NO_WORDS_FALLBACK_MESSAGE,
+  );
+  assert.equal(
+    buildScanJobNoWordsErrorMessage(undefined),
+    SCAN_JOB_NO_WORDS_FALLBACK_MESSAGE,
+  );
+  // 空白のみのエラーはフォールバック文言に置き換える（英語の技術メッセージを見せない）
+  assert.equal(
+    buildScanJobNoWordsErrorMessage('   '),
+    SCAN_JOB_NO_WORDS_FALLBACK_MESSAGE,
   );
 });

--- a/src/lib/scan/job-processing-input.ts
+++ b/src/lib/scan/job-processing-input.ts
@@ -20,8 +20,15 @@ export function buildScanJobProcessingInput(
   };
 }
 
+// スキャンで1語も抽出できなかったときのエラーメッセージ。
+// 画像ごとの抽出エラー（多くはAIが返す日本語メッセージ）があればそれを優先し、
+// 無い場合は「単語帳が写っていない」ケースを想定した、理由の伝わる日本語文言を返す。
+// （英語の技術的メッセージをそのままユーザーに見せない）
+export const SCAN_JOB_NO_WORDS_FALLBACK_MESSAGE =
+  '画像から単語を読み取れませんでした。単語帳や英単語がはっきり写るように、もう一度撮影してください。';
+
 export function buildScanJobNoWordsErrorMessage(
   firstExtractionError: string | null | undefined,
 ): string {
-  return firstExtractionError || 'No words found in any image';
+  return firstExtractionError?.trim() || SCAN_JOB_NO_WORDS_FALLBACK_MESSAGE;
 }


### PR DESCRIPTION
## 背景 / 問題

単語帳ではない写真（英単語が写っていない写真）を撮影して1語も抽出できなかったとき、ユーザーに理由が伝わらず困っていた。

スキャンはPro限定で、Proはバックグラウンドジョブとして処理される。0語だとジョブは `status: 'failed'` になり `error_message` もDBに記録されるが、ホーム画面（`home-client.tsx`）は `linkedJob.status === 'failed'` を検知しても **「生成中」カードを静かに消すだけで、エラーメッセージを一切表示していなかった**。結果として「撮影したのに何も返ってこない」状態になり、ユーザーが混乱していた。

さらに、抽出エラーが無い（AIは動いたが0語）ケースの予備文言が英語の技術メッセージ `No words found in any image` のままで、仮に表示されても理由が伝わらない状態だった。

## 変更内容

- **`src/app/home-client.tsx`**
  - リンク中のバックグラウンドスキャンジョブが `failed` になったら、サーバーが記録した `error_message`（無ければ理由の伝わる日本語の予備文言）をホームのエラーバナーに表示するようにした。
  - `RecentScanJob` 型に `error_message` を追加。
  - 新しいスキャンを開始したとき（`showHomeGeneratingWordbook`）に、前回の失敗メッセージが残っていればクリアするようにした。
  - 既存の `error` ステート／バナーを再利用しているため、モバイル・デスクトップ両方のホーム表示に自動で反映される。

- **`src/lib/scan/job-processing-input.ts`**
  - 抽出エラーが無いときの予備文言を、英語の `No words found in any image` から理由の伝わる日本語（`SCAN_JOB_NO_WORDS_FALLBACK_MESSAGE`）に変更。
  - 空白のみのエラーもフォールバックに置き換えるようにした。

## テスト

- `src/lib/scan/job-processing-input.test.ts` を新しいフォールバック文言に合わせて更新（`null` / `undefined` / 空白のみ → 日本語文言）。
- `npx tsx --test` で対象テスト（job-processing-input / scan-jobs process contract / home・scan 関連）がすべてパスすることを確認。
- `tsc --noEmit` で変更ファイルに型エラーが無いことを確認（既存の無関係な型エラー1件を除く）。
- ESLint で変更ファイルにエラーが無いことを確認。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CByXDuybovzevMbX96KRDa

---
_Generated by [Claude Code](https://claude.ai/code/session_01CByXDuybovzevMbX96KRDa)_