### PR TITLE
マイ単語帳リストはグリッドに載り切らなかった単語帳のみ表示

### DIFF
--- a/src/app/home-client.tsx
+++ b/src/app/home-client.tsx
@@ -38,6 +38,7 @@ import {
 import { excludeReelSavedProjects } from '@/lib/reels/saved-words';
 import { getWordsDueForReview } from '@/lib/spaced-repetition';
 import { countHomeWordStatuses } from '@/lib/home/home-page-selectors';
+import { homeShortcutContentSlots } from '@/lib/home/shortcut-tiles';
 import { summarizeWordMemory } from '@/lib/words/memory';
 import {
   clearHomeGeneratingWordbook,
@@ -465,7 +466,16 @@ export function HomeClient() {
   // The reel-saved backing wordbook is an internal bucket for 保存済み — keep it
   // out of the browsable マイ単語帳 list (its words still count in `stats`).
   const listProjects = useMemo(() => excludeReelSavedProjects(projects), [projects]);
-  const visibleProjects = listProjects.slice(0, HOME_MY_BOOKS_VISIBLE_LIMIT);
+  // ショートカットグリッドに載り切らなかった単語帳だけを下のマイ単語帳リストに
+  // 出す（重複表示を避ける）。全部グリッドに収まる場合は従来どおり全件を出す
+  // （新規ユーザーのチュートリアルが最初の ProjectRow をアンカーにしているため）。
+  const gridProjectCount = Math.min(
+    listProjects.length,
+    homeShortcutContentSlots(favoriteCount > 0),
+  );
+  const overflowProjects = listProjects.slice(gridProjectCount);
+  const myBooksProjects = overflowProjects.length > 0 ? overflowProjects : listProjects;
+  const visibleProjects = myBooksProjects.slice(0, HOME_MY_BOOKS_VISIBLE_LIMIT);
 
   // The guided flow starts for any user who hasn't studied yet. Word status only
   // advances past 'new' via quiz/study, so any progress means they've quizzed.

--- a/src/components/home/HomeShortcutGrid.tsx
+++ b/src/components/home/HomeShortcutGrid.tsx
@@ -14,7 +14,7 @@ import {
   prefetchGroupOverview,
   seedGroupSummary,
 } from '@/lib/shared-projects/group-overview-cache';
-import { buildHomeShortcutTiles, HOME_SHORTCUT_GRID_SIZE } from '@/lib/home/shortcut-tiles';
+import { buildHomeShortcutTiles, homeShortcutContentSlots } from '@/lib/home/shortcut-tiles';
 import type { HomeRecommendedBook } from '@/lib/home/recommendations-types';
 import type { StudyGroupSummary } from '@/lib/shared-projects/types';
 
@@ -59,7 +59,7 @@ export function HomeShortcutGrid({
     projects,
     groups,
     recommendations,
-    slots: HOME_SHORTCUT_GRID_SIZE - 1 - (showSavedTile ? 1 : 0),
+    slots: homeShortcutContentSlots(showSavedTile),
   });
 
   return (

--- a/src/lib/home/shortcut-tiles.test.ts
+++ b/src/lib/home/shortcut-tiles.test.ts
@@ -1,7 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 
-import { buildHomeShortcutTiles } from './shortcut-tiles';
+import { buildHomeShortcutTiles, homeShortcutContentSlots } from './shortcut-tiles';
 
 const p = (id: string) => ({ id });
 const g = (id: string) => ({ id });
@@ -65,4 +65,20 @@ test('コンテンツが無い新規ユーザーはおすすめのみになる',
 test('全て空なら空配列を返す', () => {
   const tiles = buildHomeShortcutTiles({ projects: [], groups: [], recommendations: [], slots: 7 });
   assert.deepEqual(tiles, []);
+});
+
+test('コンテンツ枠数はgoalタイルと保存済みタイルを除いた残り', () => {
+  // 8枠 - goal 1枠 = 7、保存済みタイル表示時はさらに1枠減って6
+  assert.equal(homeShortcutContentSlots(false), 7);
+  assert.equal(homeShortcutContentSlots(true), 6);
+});
+
+test('溢れた単語帳の計算がグリッドの表示数と一致する', () => {
+  // ホーム側は min(単語帳数, 枠数) をグリッド掲載数として溢れを求める。
+  // グリッド本体（buildHomeShortcutTiles）の project タイル数と一致すること。
+  const projects = Array.from({ length: 10 }, (_, i) => p(`p${i}`));
+  const slots = homeShortcutContentSlots(true);
+  const tiles = buildHomeShortcutTiles({ projects, groups: [], recommendations: [], slots });
+  const gridProjectCount = Math.min(projects.length, slots);
+  assert.equal(tiles.filter((tile) => tile.kind === 'project').length, gridProjectCount);
 });

--- a/src/lib/home/shortcut-tiles.ts
+++ b/src/lib/home/shortcut-tiles.ts
@@ -12,6 +12,16 @@ export type HomeShortcutTile<P, G, B> =
 /** グリッド全体の枠数（TODAY'S GOAL タイル1枠を含む） */
 export const HOME_SHORTCUT_GRID_SIZE = 8;
 
+/**
+ * コンテンツ（単語帳/グループ/おすすめ）に使える枠数。
+ * goal タイル1枠と、保存済み単語タイル（表示時）を除いた残り。
+ * ホーム側は「グリッドに載った単語帳数 = min(単語帳数, この枠数)」として
+ * 溢れた単語帳だけを下のマイ単語帳リストに出す。
+ */
+export function homeShortcutContentSlots(hasSavedTile: boolean): number {
+  return HOME_SHORTCUT_GRID_SIZE - 1 - (hasSavedTile ? 1 : 0);
+}
+
 export function buildHomeShortcutTiles<P, G, B>(options: {
   projects: readonly P[];
   groups: readonly G[];


### PR DESCRIPTION
## 概要

#395 のフォローアップ。単語帳がホーム上部のショートカットグリッドの枠数（保存済みタイル有無で6〜7）を超える場合、下の「マイ単語帳」リストには**グリッドに載り切らなかった単語帳だけ**を表示して重複を避けます。

## 変更内容

- `homeShortcutContentSlots(hasSavedTile)` ヘルパーを `src/lib/home/shortcut-tiles.ts` に追加し、グリッド（`HomeShortcutGrid`）とホーム側の溢れ計算で同じ枠数計算を共有
- `home-client.tsx`: グリッド掲載数 = `min(単語帳数, 枠数)` として溢れた分だけを `visibleProjects` に採用
- 全部グリッドに収まる場合は従来どおり全件表示（新規ユーザーのチュートリアルが最初の ProjectRow をアンカーにしているため）

## テスト

- `shortcut-tiles.test.ts` に2ケース追加（枠数計算、溢れ計算とグリッド掲載数の一致）→ 7 pass
- `tsc --noEmit` クリーン（変更ファイル）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018ine4EeJnPMZWwd6XnK24D

---
_Generated by [Claude Code](https://claude.ai/code/session_018ine4EeJnPMZWwd6XnK24D)_