### PR TITLE
デスクトップUI刷新: ホームSpotify風レイアウト + 共有ライブラリ・設定・フラッシュカード・クイズ改善

### DIFF
--- a/src/app/api/home/recommendations/shared.ts
+++ b/src/app/api/home/recommendations/shared.ts
@@ -1,5 +1,11 @@
 import { getSupabaseAdmin } from '@/lib/supabase/admin';
-import { eikenDistance, eikenLevelsAround } from '@/lib/reels/eiken-cefr';
+import {
+  EIKEN_TO_CEFR_BAND,
+  cefrDistance,
+  eikenDistance,
+  eikenLevelsAround,
+  type CefrLevel,
+} from '@/lib/reels/eiken-cefr';
 import { rankReelCandidates } from '@/lib/reels/ranking';
 import type { ReelBook, ReelCandidate } from '@/lib/reels/types';
 import { getCachedMorphologyByHeadword } from '@/lib/morphology/lexicon';
@@ -22,6 +28,10 @@ export const HOME_REELS_MAX_LIMIT = 16;
 // Pool sizes: the home preview is fetched on (almost) every home visit, so
 // these stay far smaller than the full reel feed's pools.
 const BOOK_CANDIDATE_POOL = 60;
+// CEFR フィットを実測する単語帳数と、1冊あたりのサンプル語数。
+const BOOK_CEFR_SCORED_POOL = 24;
+const BOOK_CEFR_WORDS_PER_BOOK = 40;
+const BOOK_CEFR_WORDS_FETCH_LIMIT = 1200;
 const REEL_SHARED_BOOK_POOL = 12;
 const REEL_OFFICIAL_BOOK_POOL = 12;
 const REEL_WORDS_PER_BOOK = 30;
@@ -62,21 +72,52 @@ type HomeSharedBookRow = {
   created_at: string | null;
 };
 
-/** 級の近さ > 人気 > 新しさ の順に効くスコア。級不明の単語帳は中立扱い。 */
+/**
+ * 級の近さ > 人気 > 新しさ の順に効くスコア。級不明の単語帳は中立扱い。
+ * levelFit は「単語帳内の単語の CEFR × ユーザーの志望英検級」から実測した
+ * 値（cefrLevelFit）があればそれを優先し、無ければ英検タグから推定する。
+ */
 export function scoreSharedBookForHome(
   row: { sharedTags: string[]; likeCount: number; createdAt: string | null },
   userEikenLevel: string | null,
   nowMs: number,
+  cefrLevelFit: number | null = null,
 ): number {
   const { level } = eikenLevelFromTags(row.sharedTags);
   const distance = eikenDistance(userEikenLevel, level);
-  const levelFit = distance === null ? 0.35 : 1 - Math.min(distance, 3) / 3;
+  const tagLevelFit = distance === null ? 0.35 : 1 - Math.min(distance, 3) / 3;
+  const levelFit = cefrLevelFit ?? tagLevelFit;
   const popularity = Math.min(1, Math.log10(Math.max(0, row.likeCount) + 1) / 2);
   const created = row.createdAt ? Date.parse(row.createdAt) : Number.NaN;
   const recency = Number.isNaN(created)
     ? 0
     : Math.exp(-Math.max(0, nowMs - created) / (14 * 86_400_000));
   return 3 * levelFit + popularity + 0.5 * recency;
+}
+
+/**
+ * 単語帳内のサンプル語の CEFR とユーザーの志望英検級（の CEFR バンド）を比較し、
+ * 0〜1 のフィット値を返す。CEFR が引けた語の割合（coverage）が低い場合は
+ * 信頼できないので null（呼び出し側でタグ推定にフォールバック）。
+ */
+export function cefrFitForBand(
+  band: readonly CefrLevel[],
+  wordCefrLevels: readonly (string | null)[],
+): number | null {
+  if (band.length === 0 || wordCefrLevels.length === 0) return null;
+
+  let known = 0;
+  let sum = 0;
+  for (const level of wordCefrLevels) {
+    const distance = cefrDistance([...band], level);
+    if (distance === null) continue;
+    known += 1;
+    sum += Math.max(0, 1 - distance / 3);
+  }
+
+  // CEFR が引けた語が3割未満なら実測値としては採用しない。
+  if (known === 0 || known / wordCefrLevels.length < 0.3) return null;
+  return sum / known;
 }
 
 async function fetchImportedShareIds(
@@ -97,6 +138,53 @@ async function fetchImportedShareIds(
       .map((row) => row.imported_from_share_id)
       .filter((value): value is string => Boolean(value)),
   );
+}
+
+/**
+ * 上位候補の単語帳について、サンプル語の CEFR（lexicon 由来）を単語帳ごとに集める。
+ * best-effort — 失敗しても空 Map を返し、タグ推定にフォールバックさせる。
+ */
+async function fetchBookCefrLevels(
+  admin: SupabaseAdminClient,
+  bookIds: readonly string[],
+): Promise<Map<string, (string | null)[]>> {
+  const result = new Map<string, (string | null)[]>();
+  if (bookIds.length === 0) return result;
+
+  try {
+    const { data, error } = await admin
+      .from('shared_wordbook_words')
+      .select('shared_wordbook_id,english')
+      .in('shared_wordbook_id', bookIds as string[])
+      .order('position', { ascending: true })
+      .limit(BOOK_CEFR_WORDS_FETCH_LIMIT);
+    if (error) return result;
+
+    const sampled: { bookId: string; headword: string }[] = [];
+    const countByBook = new Map<string, number>();
+    for (const row of (data ?? []) as { shared_wordbook_id: string; english: string | null }[]) {
+      const headword = normalizeHeadword(row.english ?? '');
+      if (!headword) continue;
+      const used = countByBook.get(row.shared_wordbook_id) ?? 0;
+      if (used >= BOOK_CEFR_WORDS_PER_BOOK) continue;
+      countByBook.set(row.shared_wordbook_id, used + 1);
+      sampled.push({ bookId: row.shared_wordbook_id, headword });
+    }
+    if (sampled.length === 0) return result;
+
+    const cefrByHeadword = await lookupLexiconCefrLevels(
+      Array.from(new Set(sampled.map((item) => item.headword))),
+      { supabaseAdmin: admin },
+    );
+    for (const { bookId, headword } of sampled) {
+      const levels = result.get(bookId) ?? [];
+      levels.push(cefrByHeadword.get(headword) ?? null);
+      result.set(bookId, levels);
+    }
+    return result;
+  } catch {
+    return result;
+  }
 }
 
 async function buildBookRecommendations(
@@ -121,13 +209,14 @@ async function buildBookRecommendations(
   if (error) throw new Error(error.message || 'home_recommended_books_failed');
 
   const nowMs = Date.now();
-  return ((data ?? []) as HomeSharedBookRow[])
+  const candidates = ((data ?? []) as HomeSharedBookRow[])
     .filter((row) => !importedShareIds.has(row.share_id))
     .map((row) => {
       const sharedTags = toStringArray(row.shared_tags);
       return {
         row,
         sharedTags,
+        // タグ・人気・新しさによる一次スコア（CEFR 実測前の粗い並び）。
         score: scoreSharedBookForHome(
           { sharedTags, likeCount: Number(row.like_count ?? 0), createdAt: row.created_at },
           eikenLevel,
@@ -135,7 +224,34 @@ async function buildBookRecommendations(
         ),
       };
     })
-    .sort((a, b) => b.score - a.score || a.row.id.localeCompare(b.row.id))
+    .sort((a, b) => b.score - a.score || a.row.id.localeCompare(b.row.id));
+
+  // 志望英検級があるユーザーは、上位候補について単語帳内の単語の CEFR を実測し、
+  // 級の CEFR バンドとのフィットでスコアを付け直す（タグだけの推定より正確）。
+  const band = eikenLevel ? EIKEN_TO_CEFR_BAND[eikenLevel] ?? [] : [];
+  if (band.length > 0 && candidates.length > 0) {
+    const scoredPool = candidates.slice(0, BOOK_CEFR_SCORED_POOL);
+    const cefrByBook = await fetchBookCefrLevels(
+      admin,
+      scoredPool.map((candidate) => candidate.row.id),
+    );
+    for (const candidate of scoredPool) {
+      const cefrLevelFit = cefrFitForBand(band, cefrByBook.get(candidate.row.id) ?? []);
+      candidate.score = scoreSharedBookForHome(
+        {
+          sharedTags: candidate.sharedTags,
+          likeCount: Number(candidate.row.like_count ?? 0),
+          createdAt: candidate.row.created_at,
+        },
+        eikenLevel,
+        nowMs,
+        cefrLevelFit,
+      );
+    }
+    candidates.sort((a, b) => b.score - a.score || a.row.id.localeCompare(b.row.id));
+  }
+
+  return candidates
     .slice(0, limit)
     .map(({ row, sharedTags }) => ({
       shareId: row.share_id,

--- a/src/app/api/reels/shared.ts
+++ b/src/app/api/reels/shared.ts
@@ -1,3 +1,4 @@
+import { after } from 'next/server';
 import type { SupabaseClient } from '@supabase/supabase-js';
 import { getSupabaseAdmin } from '@/lib/supabase/admin';
 import type {
@@ -525,13 +526,25 @@ async function fetchUserFeedback(
   return empty;
 }
 
+// interestTags が同じ限り結果も同じなので、ウォームなサーバーインスタンス内で
+// 短時間キャッシュする。これが無いとフィードの毎ページで OpenAI 埋め込みAPIの
+// 往復（数百ms）が発生し、リール表示の体感が大きく悪化する。
+const TAG_SIMILARITY_TTL_MS = 10 * 60 * 1000;
+const TAG_SIMILARITY_CACHE_MAX = 100;
+const tagSimilarityCache = new Map<string, { at: number; value: Record<string, number> }>();
+
 async function fetchTagSimilarity(
   admin: SupabaseAdminClient,
   interestTags: string[],
 ): Promise<Record<string, number>> {
   if (interestTags.length === 0) return {};
+  const cacheKey = interestTags.join('、');
+  const cached = tagSimilarityCache.get(cacheKey);
+  if (cached && Date.now() - cached.at < TAG_SIMILARITY_TTL_MS) {
+    return cached.value;
+  }
   try {
-    const embedding = await createSharedSearchEmbedding(interestTags.join('、'));
+    const embedding = await createSharedSearchEmbedding(cacheKey);
     if (!embedding) return {};
     const { data, error } = await admin.rpc('match_shared_wordbooks_by_tag_embedding', {
       query_embedding: embedding,
@@ -542,6 +555,12 @@ async function fetchTagSimilarity(
     const result: Record<string, number> = {};
     for (const row of (data ?? []) as { id: string; similarity: number }[]) {
       result[row.id] = Number(row.similarity) || 0;
+    }
+    // 成功時のみキャッシュ（失敗は次のリクエストで再試行させる）。
+    tagSimilarityCache.set(cacheKey, { at: Date.now(), value: result });
+    if (tagSimilarityCache.size > TAG_SIMILARITY_CACHE_MAX) {
+      const oldestKey = tagSimilarityCache.keys().next().value;
+      if (oldestKey !== undefined) tagSimilarityCache.delete(oldestKey);
     }
     return result;
   } catch {
@@ -754,41 +773,53 @@ export async function buildReelFeedPage(options: {
   if (grantedSelections.length > 0) {
     // Refresh seen_at on every serve so recycled words rotate to the back
     // of the LRU queue instead of repeating immediately.
-    await admin.from('reel_seen_words').upsert(
-      grantedSelections.map((selection) => ({
-        user_id: options.userId,
-        item_key: selection.candidate.id,
-        seen_at: new Date().toISOString(),
-      })),
-      { onConflict: 'user_id,item_key' },
-    );
+    // レスポンスをブロックしない（次ページの取得はユーザーが数枚めくった後
+    // なので、送信後の書き込みで十分間に合う）。
+    const upsertSeen = async () => {
+      const { error } = await admin.from('reel_seen_words').upsert(
+        grantedSelections.map((selection) => ({
+          user_id: options.userId,
+          item_key: selection.candidate.id,
+          seen_at: new Date().toISOString(),
+        })),
+        { onConflict: 'user_id,item_key' },
+      );
+      if (error) console.error('reel seen upsert failed:', error);
+    };
+    try {
+      after(upsertSeen);
+    } catch {
+      // リクエストスコープ外（テスト等）では従来どおり同期実行する。
+      await upsertSeen();
+    }
   }
 
   const recycledByKey = new Map(
     grantedSelections.map((selection) => [selection.candidate.id, selection.recycled]),
   );
 
-  // 語源（morphology）を lexicon キャッシュから1バッチで結合する。
-  // キャッシュ専用（フィード内で生成はしない）。best-effort — フィードは絶対に壊さない。
   const grantedCandidates = grantedSelections.map((s) => s.candidate);
-  try {
-    const morphologyByHeadword = await getCachedMorphologyByHeadword(
+
+  // 語源（morphology, lexicon キャッシュ専用・best effort）といいね/コメント等の
+  // エンリッチは互いに独立なので並走させ、応答の直列往復を1本減らす。
+  const [morphologyByHeadword, enriched] = await Promise.all([
+    getCachedMorphologyByHeadword(
       grantedCandidates.map((candidate) => normalizeHeadword(candidate.english)),
       { supabaseAdmin: admin },
-    );
-    for (const candidate of grantedCandidates) {
-      const morphology = morphologyByHeadword.get(normalizeHeadword(candidate.english));
-      candidate.morphology = morphology && !morphology.none && morphology.formula.length > 0
-        ? morphology
-        : null;
-    }
-  } catch {
-    // morphology は任意情報。失敗時は全カード2面のまま配信する。
-  }
+    ).catch(() => null), // morphology は任意情報。失敗時は全カード2面のまま配信する。
+    enrichItems(admin, options.userId, grantedCandidates),
+  ]);
 
-  const items = (
-    await enrichItems(admin, options.userId, grantedCandidates)
-  ).map((item) => ({ ...item, isRecycled: recycledByKey.get(item.id) ?? false }));
+  const items = enriched.map((item) => {
+    const morphology = morphologyByHeadword?.get(normalizeHeadword(item.english));
+    return {
+      ...item,
+      morphology: morphology && !morphology.none && morphology.formula.length > 0
+        ? morphology
+        : null,
+      isRecycled: recycledByKey.get(item.id) ?? false,
+    };
+  });
 
   const limitReached = usage.limit !== null && usage.current_count >= usage.limit;
   // The feed never runs dry (seen words recycle); nextCursor is null only

--- a/src/app/desktop.css
+++ b/src/app/desktop.css
@@ -249,6 +249,96 @@
 .ds-book .bk-bar > i { display: block; height: 100%; background: rgba(255,255,255,0.92); }
 .ds-book .bk-foot { font-size: 11px; opacity: 0.9; margin-top: 7px; font-weight: 500; }
 
+/* ── Spotify-style home: shortcut tiles ──────────────────── */
+.ds-shortcut-grid {
+  display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); gap: 10px;
+}
+.ds-shortcut {
+  display: flex; align-items: center; overflow: hidden; height: 56px;
+  border: 1.5px solid var(--solid-ink); border-radius: 12px; background: #fff;
+  color: inherit; text-decoration: none; cursor: pointer; text-align: left;
+  padding: 0; font-family: inherit;
+  transition: transform var(--dur-fast) var(--ease-out), box-shadow var(--dur-fast) var(--ease-out);
+}
+.ds-shortcut:hover { transform: translateY(-1px); box-shadow: 2px 3px 0 var(--solid-ink); }
+.ds-shortcut .art {
+  width: 56px; height: 100%; flex-shrink: 0; border-right: 1.5px solid var(--solid-ink);
+  display: flex; align-items: center; justify-content: center; color: #fff;
+  font-family: var(--font-display); font-weight: 800; font-size: 18px;
+  background-size: cover; background-position: center;
+}
+.ds-shortcut .body { flex: 1; min-width: 0; padding: 0 12px; }
+.ds-shortcut .t {
+  font-size: 12.5px; font-weight: 700; line-height: 1.3;
+  display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; overflow: hidden;
+}
+.ds-shortcut .s {
+  margin-top: 2px; font-size: 10px; font-weight: 700; color: var(--color-muted);
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+}
+.ds-shortcut .s.accent { color: var(--color-accent); }
+
+/* ── Spotify-style shelves + media cards ─────────────────── */
+.ds-shelf { margin-top: 28px; }
+.ds-shelf-head { display: flex; align-items: baseline; justify-content: space-between; gap: 12px; margin-bottom: 14px; }
+.ds-shelf-head h2 { font-size: 20px; margin: 0; }
+.ds-shelf-head .see-all {
+  display: inline-flex; align-items: center; gap: 2px; flex-shrink: 0;
+  font-family: inherit; font-size: 13px; font-weight: 700; color: var(--color-accent);
+  text-decoration: none; background: none; border: none; padding: 0; cursor: pointer;
+}
+.ds-shelf-row {
+  display: grid; grid-auto-flow: column; grid-auto-columns: 168px; gap: 16px;
+  overflow-x: auto; padding: 4px 4px 12px; margin: -4px -4px 0;
+  scroll-snap-type: x proximity; scrollbar-width: none;
+}
+.ds-shelf-row::-webkit-scrollbar { display: none; }
+.ds-shelf-row > * { scroll-snap-align: start; }
+
+/* Media card: square artwork on top, title + subtitle below.
+   ホームのマイ単語帳と共有ライブラリの共有単語帳で共用する。 */
+.ds-media-card {
+  position: relative; display: flex; flex-direction: column; gap: 10px; min-width: 0;
+  color: inherit; text-decoration: none; cursor: pointer;
+  background: none; border: none; padding: 0; text-align: left; font-family: inherit;
+}
+.ds-media-card .art {
+  aspect-ratio: 1 / 1; width: 100%; border-radius: 14px; border: 1.5px solid var(--solid-ink);
+  box-shadow: 3px 4px 0 var(--solid-ink); position: relative; overflow: hidden;
+  display: flex; align-items: center; justify-content: center;
+  color: #fff; font-family: var(--font-display); font-weight: 800; font-size: 34px;
+  background-size: cover; background-position: center;
+  transition: transform var(--dur-fast) var(--ease-out), box-shadow var(--dur-fast) var(--ease-out);
+}
+.ds-media-card:hover .art { transform: translateY(-2px); box-shadow: 3px 6px 0 var(--solid-ink); }
+.ds-media-card .meta { min-width: 0; }
+.ds-media-card .t {
+  font-family: var(--font-display); font-weight: 700; font-size: 14px; line-height: 1.3;
+  display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; overflow: hidden;
+}
+.ds-media-card .s {
+  margin-top: 3px; font-size: 11.5px; color: var(--color-muted);
+  display: flex; align-items: center; gap: 4px; white-space: nowrap; overflow: hidden;
+}
+/* Stretched link: covers the whole card; the play button stacks above it. */
+.ds-media-card .stretch {
+  position: absolute; inset: 0; z-index: 1; border-radius: 14px;
+  background: none; border: none; cursor: pointer; padding: 0;
+}
+.ds-media-card .play {
+  position: absolute; right: 10px; bottom: 10px; z-index: 2;
+  width: 40px; height: 40px; border-radius: 999px;
+  background: var(--color-accent); color: #fff; border: 1.5px solid var(--color-accent-ink);
+  display: inline-flex; align-items: center; justify-content: center;
+  box-shadow: 2px 2px 0 var(--color-accent-ink);
+  opacity: 0; transform: translateY(6px);
+  transition: opacity var(--dur-fast) var(--ease-out), transform var(--dur-fast) var(--ease-out);
+}
+.ds-media-card:hover .play, .ds-media-card:focus-within .play { opacity: 1; transform: none; }
+
+/* Media cards laid out as a wrapping grid (shared library results). */
+.ds-media-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(150px, 1fr)); gap: 18px; }
+
 /* ── Project row (list) ──────────────────────────────────── */
 .ds-prow {
   background: #fff; border: 1.5px solid var(--solid-ink); border-radius: var(--solid-radius);

--- a/src/app/desktop.css
+++ b/src/app/desktop.css
@@ -879,7 +879,8 @@ button.ds-tile { appearance: none; }
 /* ── Word detail modal (floats over current page) ────────── */
 .ds-app { position: relative; }
 .ds-overlay {
-  position: absolute; inset: 0; z-index: 50;
+  /* fixed: メインカラム内から開いてもサイドバーまで背景の影で覆う */
+  position: fixed; inset: 0; z-index: 50;
   background: rgba(26,26,26,0.32);
   backdrop-filter: blur(2px);
   display: flex; align-items: center; justify-content: center;

--- a/src/app/flashcard/[projectId]/page.tsx
+++ b/src/app/flashcard/[projectId]/page.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect, useLayoutEffect, useMemo, useRef, useCallback } from 'react';
 import { useRouter, useParams, useSearchParams } from 'next/navigation';
 import { Icon } from '@/components/ui/Icon';
+import { MorphologyFormulaChips } from '@/components/word/MorphologyFormulaChips';
 import { TranslationDisplay } from '@/components/word/TranslationDisplay';
 import { FlashcardTutorialGuide } from '@/components/onboarding/FlashcardTutorialGuide';
 import { getRepository } from '@/lib/db';
@@ -15,6 +16,7 @@ import { useIsMobileViewport } from '@/hooks/use-is-mobile-viewport';
 import { useTutorialFlow } from '@/hooks/use-tutorial-flow';
 import { getCachedProjectWords, getHasLoaded } from '@/lib/home-cache';
 import { formatPartOfSpeechLabels, getPartOfSpeechLabel } from '@/lib/part-of-speech-labels';
+import { hasDisplayableMorphology } from '@/lib/morphology/format';
 import { triggerHaptic } from '@/lib/haptics';
 import type { Word, SubscriptionStatus } from '@/types';
 
@@ -432,36 +434,82 @@ export default function FlashcardPage() {
               {currentPartOfSpeechLabel && <span className="ds-tag accent">{currentPartOfSpeechLabel}</span>}
               <div className="hint"><Icon name="touch_app" style={{ fontSize: 14 }} />クリックで意味を表示</div>
             </div>
-            <div className="ds-fc-face back">
-              <div className="ja">{currentWord && <TranslationDisplay word={currentWord} />}</div>
-              <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap', justifyContent: 'center' }}>
-                {currentWord?.partOfSpeechTags?.map((tag) => <span key={tag} className="ds-tag accent">{getPartOfSpeechLabel(tag)}</span>)}
-              </div>
-              {currentWord?.exampleSentence && (
-                <div
-                  style={{
-                    maxWidth: 460,
-                    width: '100%',
-                    borderRadius: 12,
-                    border: '1px solid var(--color-border)',
-                    background: 'var(--color-surface)',
-                    padding: '12px 16px',
-                    textAlign: 'left',
-                  }}
-                >
-                  <div className="mono" style={{ fontSize: 10, fontWeight: 700, letterSpacing: '0.08em', textTransform: 'uppercase', color: 'var(--color-muted)', marginBottom: 6 }}>例文</div>
-                  <div style={{ fontSize: 15, lineHeight: 1.6, color: 'var(--color-ink)' }}>{currentWord.exampleSentence}</div>
-                  {currentWord.exampleSentenceJa && (
-                    <div className="muted" style={{ fontSize: 13, lineHeight: 1.6, marginTop: 6 }}>{currentWord.exampleSentenceJa}</div>
-                  )}
+            <div className="ds-fc-face back" style={{ overflowY: 'auto', justifyContent: 'flex-start', padding: '28px 40px 40px' }}>
+              {/* margin:auto で内容が短いときは中央寄せ、長いときは上からスクロール */}
+              <div style={{ margin: 'auto', width: '100%', display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 16 }}>
+                <div className="ja">{currentWord && <TranslationDisplay word={currentWord} />}</div>
+                <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap', justifyContent: 'center' }}>
+                  {currentWord?.partOfSpeechTags?.map((tag) => <span key={tag} className="ds-tag accent">{getPartOfSpeechLabel(tag)}</span>)}
                 </div>
-              )}
-              <div className="hint"><Icon name="touch_app" style={{ fontSize: 14 }} />クリックで戻る</div>
+                {currentWord?.exampleSentence && (
+                  <div
+                    style={{
+                      maxWidth: 460,
+                      width: '100%',
+                      borderRadius: 12,
+                      border: '1px solid var(--color-border)',
+                      background: 'var(--color-surface)',
+                      padding: '12px 16px',
+                      textAlign: 'left',
+                    }}
+                  >
+                    <div className="mono" style={{ fontSize: 10, fontWeight: 700, letterSpacing: '0.08em', textTransform: 'uppercase', color: 'var(--color-muted)', marginBottom: 6 }}>例文</div>
+                    <div style={{ fontSize: 15, lineHeight: 1.6, color: 'var(--color-ink)' }}>{currentWord.exampleSentence}</div>
+                    {currentWord.exampleSentenceJa && (
+                      <div className="muted" style={{ fontSize: 13, lineHeight: 1.6, marginTop: 6 }}>{currentWord.exampleSentenceJa}</div>
+                    )}
+                  </div>
+                )}
+                {currentWord && hasDisplayableMorphology(currentWord.morphology) && (
+                  <div
+                    style={{
+                      maxWidth: 460,
+                      width: '100%',
+                      borderRadius: 12,
+                      border: '1px solid var(--color-border)',
+                      background: 'var(--color-surface)',
+                      padding: '12px 16px',
+                      textAlign: 'left',
+                    }}
+                  >
+                    <div className="mono" style={{ fontSize: 10, fontWeight: 700, letterSpacing: '0.08em', textTransform: 'uppercase', color: 'var(--color-accent-ink)', marginBottom: 8, display: 'flex', alignItems: 'center', gap: 5 }}>
+                      <Icon name="account_tree" style={{ fontSize: 13 }} />語源
+                    </div>
+                    <MorphologyFormulaChips morphology={currentWord.morphology} />
+                    <div className="muted" style={{ fontSize: 13, lineHeight: 1.7, marginTop: 10, whiteSpace: 'pre-line' }}>
+                      {currentWord.morphology.explanation}
+                    </div>
+                  </div>
+                )}
+                <div style={{ display: 'flex', alignItems: 'center', gap: 5, fontFamily: 'var(--font-mono)', fontSize: 11, color: 'var(--color-muted)' }}>
+                  <Icon name="touch_app" style={{ fontSize: 14 }} />クリックで戻る
+                </div>
+              </div>
             </div>
           </div>
         </div>
 
-        <div className="ds-fc-controls">
+        {/* モバイルと同じアクションチップ（回転などのナビの上段） */}
+        <div style={{ display: 'flex', justifyContent: 'center', gap: 18, marginTop: 20 }}>
+          <ActionChip icon="search" label="英辞郎" onClick={handleSearchEijiro} />
+          <ActionChip icon="volume_up" label="発音" onClick={speakWord} />
+          <ActionChip
+            icon="task_alt"
+            label={statusLabel(currentWord?.status ?? 'new')}
+            tint={statusColor(currentWord?.status ?? 'new')}
+            onClick={handleCycleStatus}
+          />
+          <ActionChip
+            icon="bookmark"
+            label="お気に入り"
+            tint={currentWord?.isFavorite ? 'var(--color-accent)' : 'var(--solid-ink)'}
+            filled={currentWord?.isFavorite}
+            onClick={handleToggleFavorite}
+          />
+          <ActionChip icon="delete" label="削除" tint="var(--color-error)" onClick={handleDeleteWord} />
+        </div>
+
+        <div className="ds-fc-controls" style={{ marginTop: 18 }}>
           <button type="button" className="ds-fc-big dunno" onClick={() => { triggerHaptic(); handlePrev(); }}>
             <Icon name="chevron_left" />前へ
           </button>

--- a/src/app/groups/[groupId]/invite-share-sheet.tsx
+++ b/src/app/groups/[groupId]/invite-share-sheet.tsx
@@ -71,23 +71,13 @@ export function GroupInviteShareSheet({
   return (
     <div className="fixed inset-0 z-[100]" style={{ fontFamily: 'var(--font-body)' }}>
       <button type="button" aria-label="閉じる" onClick={onClose} className="absolute inset-0 cursor-default" style={{ background: 'rgba(26,26,26,0.45)', backdropFilter: 'blur(3px)' }} />
-      <div className="absolute inset-x-0 bottom-0 flex justify-center">
+      {/* モバイル: ボトムシート / デスクトップ(lg): 中央モーダル */}
+      <div className="absolute inset-x-0 bottom-0 flex justify-center lg:inset-0 lg:items-center lg:p-6">
         <div
-          className="w-full animate-fade-in-up"
-          style={{
-            maxWidth: 520,
-            background: '#faf7f1',
-            border: '2px solid var(--solid-ink)',
-            borderBottomWidth: 0,
-            borderTopLeftRadius: 20,
-            borderTopRightRadius: 20,
-            padding: '14px 18px max(28px, env(safe-area-inset-bottom))',
-            boxShadow: '0 -8px 24px rgba(26,26,26,0.18)',
-            maxHeight: 'min(82vh, 680px)',
-            overflowY: 'auto',
-          }}
+          className="w-full max-w-[520px] animate-fade-in-up overflow-y-auto rounded-t-[20px] border-2 border-b-0 border-[var(--solid-ink)] bg-[#faf7f1] px-[18px] pb-[max(28px,env(safe-area-inset-bottom))] pt-[14px] shadow-[0_-8px_24px_rgba(26,26,26,0.18)] lg:animate-fade-in lg:rounded-[20px] lg:border-b-2 lg:pb-[22px] lg:shadow-[6px_8px_0_var(--solid-ink)]"
+          style={{ maxHeight: 'min(82vh, 680px)' }}
         >
-          <div className="mb-2.5 flex justify-center">
+          <div className="mb-2.5 flex justify-center lg:hidden">
             <div className="h-1 w-10 rounded-full bg-[rgba(26,26,26,0.2)]" />
           </div>
           <div className="mb-3 flex items-center justify-between gap-3">

--- a/src/app/groups/[groupId]/page.tsx
+++ b/src/app/groups/[groupId]/page.tsx
@@ -121,7 +121,6 @@ export default function GroupPage() {
               {group?.name ?? 'グループ'}
             </h1>
           </div>
-          <DesktopButton href="/shared" icon="arrow_back" variant="ghost">共有ライブラリ</DesktopButton>
           {group && (
             <>
               <button type="button" className="ds-btn" onClick={() => void copyInvite()} title="招待コードをコピー">
@@ -138,11 +137,6 @@ export default function GroupPage() {
         <div className="ds-scroll">
           {stateView ?? (group && (
             <>
-              <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3, minmax(0, 1fr))', gap: 16, marginBottom: 20 }}>
-                <DesktopGroupStat icon="group" label="メンバー" value={group.memberCount} unit="人" />
-                <DesktopGroupStat icon="menu_book" label="共有単語帳" value={group.projectCount} unit="冊" />
-                <DesktopGroupStat icon="bolt" label="今週の解答" value={totalQuiz} unit="問" />
-              </div>
               {loading ? (
                 <LoadingState />
               ) : (
@@ -212,36 +206,6 @@ export default function GroupPage() {
   );
 }
 
-function DesktopGroupStat({ icon, label, value, unit }: { icon: string; label: string; value: number; unit: string }) {
-  return (
-    <div className="ds-card flat" style={{ padding: 16, display: 'flex', alignItems: 'center', gap: 12 }}>
-      <span
-        style={{
-          width: 38,
-          height: 38,
-          borderRadius: 10,
-          border: '2px solid var(--solid-ink)',
-          background: 'var(--color-surface-secondary)',
-          display: 'inline-flex',
-          alignItems: 'center',
-          justifyContent: 'center',
-          flexShrink: 0,
-        }}
-      >
-        <Icon name={icon} size={18} />
-      </span>
-      <div style={{ minWidth: 0 }}>
-        <div className="mono muted" style={{ fontSize: 10, fontWeight: 700, textTransform: 'uppercase', letterSpacing: '0.06em' }}>
-          {label}
-        </div>
-        <div style={{ fontFamily: 'var(--font-display)', fontWeight: 800, fontSize: 20, lineHeight: 1.2 }}>
-          {value}
-          <span style={{ fontSize: 12, color: 'var(--color-secondary-text)', fontWeight: 700 }}> {unit}</span>
-        </div>
-      </div>
-    </div>
-  );
-}
 
 function GroupHeader({
   group,

--- a/src/app/groups/[groupId]/settings/page.tsx
+++ b/src/app/groups/[groupId]/settings/page.tsx
@@ -436,7 +436,8 @@ export default function GroupSettingsPage() {
           </DesktopButton>
         </div>
         <div className="ds-scroll">
-          <div style={{ maxWidth: 720 }}>
+          {/* 中央寄せ（margin auto が無いと左に張り付く） */}
+          <div style={{ width: 'min(100%, 720px)', margin: '0 auto' }}>
             {stateView ?? sections}
           </div>
         </div>

--- a/src/app/home-client.tsx
+++ b/src/app/home-client.tsx
@@ -263,6 +263,8 @@ export function HomeClient() {
 
   const [vocabScanOpen, setVocabScanOpen] = useState(false);
   const [createSheetOpen, setCreateSheetOpen] = useState(false);
+  // デスクトップの新規作成はページ遷移せず中央モーダルで完結させる
+  const [desktopCreateOpen, setDesktopCreateOpen] = useState(false);
   const [searchOpen, setSearchOpen] = useState(false);
   const loadHomeRef = useRef<() => Promise<void>>(() => Promise.resolve());
 
@@ -558,7 +560,11 @@ export function HomeClient() {
         error={error}
         pendingScans={displayedPendingScans}
         joinedGroups={myGroups}
-        onStartScan={() => router.push('/scan')}
+        goal={{ state: goalState, count: goalCount }}
+        recommendedBooks={loading ? [] : recommendedBooks}
+        recommendedReels={recommendedReels}
+        recommendationsLoading={recommendationsLoading}
+        onStartScan={() => setDesktopCreateOpen(true)}
         showUpgrade={showUpgradeBanner}
         onDismissUpgrade={dismissUpgradeBanner}
       />
@@ -680,6 +686,12 @@ export function HomeClient() {
       <CreateWordbookSheet
         isOpen={createSheetOpen}
         onClose={() => setCreateSheetOpen(false)}
+      />
+      {/* デスクトップの新規作成（ボトムシートではなく中央モーダル・遷移なし） */}
+      <CreateWordbookSheet
+        isOpen={desktopCreateOpen}
+        onClose={() => setDesktopCreateOpen(false)}
+        variant="modal"
       />
       {/* 自分の単語帳内の単語検索（ヘッダーの検索ボタンから）。
           開くたびにマウントし直して状態を初期化する */}

--- a/src/app/project/[id]/page.tsx
+++ b/src/app/project/[id]/page.tsx
@@ -1373,7 +1373,7 @@ export default function ProjectPage() {
           type="button"
           onClick={() => setWordShowFilterSheet(true)}
           aria-label="フィルタ"
-          className={`inline-flex h-[32px] w-[32px] shrink-0 items-center justify-center rounded-full border-2 border-[var(--solid-ink)] transition-all duration-100 active:translate-x-px active:translate-y-px ${
+          className={`inline-flex h-[32px] w-[32px] shrink-0 items-center justify-center rounded-[9px] border-2 border-[var(--solid-ink)] transition-all duration-100 active:translate-x-px active:translate-y-px ${
             wordFilterActive
               ? 'bg-[var(--solid-ink)] text-white'
               : 'bg-white text-[var(--solid-ink)]'
@@ -1385,7 +1385,7 @@ export default function ProjectPage() {
           type="button"
           onClick={() => setWordShowSortSheet(true)}
           aria-label="並べ替え"
-          className={`inline-flex h-[32px] w-[32px] shrink-0 items-center justify-center rounded-full border-2 border-[var(--solid-ink)] transition-all duration-100 active:translate-x-px active:translate-y-px ${
+          className={`inline-flex h-[32px] w-[32px] shrink-0 items-center justify-center rounded-[9px] border-2 border-[var(--solid-ink)] transition-all duration-100 active:translate-x-px active:translate-y-px ${
             wordSortOrder !== 'priority'
               ? 'bg-[var(--solid-ink)] text-white'
               : 'bg-white text-[var(--solid-ink)]'
@@ -1397,7 +1397,7 @@ export default function ProjectPage() {
           type="button"
           onClick={() => { if (selectMode) { handleExitSelectMode(); } else { setSelectMode(true); setSelectedWordIds(new Set()); } }}
           aria-label="選択"
-          className={`inline-flex h-[32px] w-[32px] shrink-0 items-center justify-center rounded-full border-2 border-[var(--solid-ink)] transition-all duration-100 active:translate-x-px active:translate-y-px ${
+          className={`inline-flex h-[32px] w-[32px] shrink-0 items-center justify-center rounded-[9px] border-2 border-[var(--solid-ink)] transition-all duration-100 active:translate-x-px active:translate-y-px ${
             selectMode
               ? 'bg-[var(--solid-ink)] text-white'
               : 'bg-white text-[var(--solid-ink)]'

--- a/src/app/quick-response/[projectId]/page.tsx
+++ b/src/app/quick-response/[projectId]/page.tsx
@@ -446,9 +446,70 @@ export default function QuickResponsePage() {
 
   if (isComplete) {
     const percentage = results.total > 0 ? Math.round((results.correct / results.total) * 100) : 0;
+    const completionMessage = percentage === 100
+      ? 'パーフェクト! 素晴らしい!'
+      : percentage >= 80
+      ? 'よくできました!'
+      : percentage >= 60
+      ? 'もう少し! 復習しましょう'
+      : '繰り返し練習しましょう!';
 
     return (
-      <div className="h-screen flex flex-col bg-[var(--color-background)] overflow-hidden">
+      <>
+      {/* Desktop completion（DSスタイル） */}
+      <div className="ds-fixed-main fixed inset-0 z-30 hidden flex-col bg-[var(--color-background)] font-[var(--font-body)] lg:flex">
+        <div className="flex flex-1 items-center justify-center overflow-y-auto" style={{ padding: 32 }}>
+          <div className="ds-card" style={{ width: 'min(100%, 480px)', padding: '28px 32px', textAlign: 'center' }}>
+            <div
+              style={{
+                width: 72,
+                height: 72,
+                margin: '0 auto',
+                borderRadius: 999,
+                border: '1.5px solid var(--solid-ink)',
+                background: 'var(--color-accent-light)',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+              }}
+            >
+              <Icon name="emoji_events" size={36} className="text-[var(--color-accent-ink)]" />
+            </div>
+            <h1 style={{ fontSize: 26, margin: '16px 0 4px' }}>即答チャレンジ完了!</h1>
+            <div className="tnum" style={{ fontFamily: 'var(--font-display)', fontWeight: 800, fontSize: 48, lineHeight: 1.1, marginTop: 10 }}>
+              {percentage}<span style={{ fontSize: 20, color: 'var(--color-secondary-text)' }}>%</span>
+            </div>
+            <p className="muted" style={{ fontSize: 13.5, margin: '6px 0 0' }}>
+              {results.total}問中 {results.correct}問正解
+            </p>
+            {results.timeouts > 0 && (
+              <p style={{ margin: '6px 0 0', fontSize: 12.5, fontWeight: 700, color: 'var(--color-error)', display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 4 }}>
+                <Icon name="timer_off" size={14} />時間切れ {results.timeouts}回
+              </p>
+            )}
+            <p style={{ margin: '14px 0 0', fontSize: 14, fontWeight: 700 }}>{completionMessage}</p>
+            <div style={{ display: 'flex', gap: 10, marginTop: 22, justifyContent: 'center' }}>
+              <button
+                type="button"
+                className="ds-btn accent"
+                onClick={() => {
+                  setCurrentIndex(0);
+                  setResults({ correct: 0, total: 0, timeouts: 0 });
+                  setIsComplete(false);
+                  startQuestion();
+                }}
+              >
+                <Icon name="refresh" />もう一度
+              </button>
+              <button type="button" className="ds-btn dark" onClick={backToProject}>
+                <Icon name="check" />単語一覧に戻る
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div className="h-screen flex flex-col bg-[var(--color-background)] overflow-hidden lg:hidden">
         <header className="sticky top-0 p-4">
           <button
             onClick={backToProject}
@@ -483,15 +544,7 @@ export default function QuickResponsePage() {
               )}
             </div>
 
-            <p className="text-[var(--color-foreground)] mb-8">
-              {percentage === 100
-                ? 'パーフェクト! 素晴らしい!'
-                : percentage >= 80
-                ? 'よくできました!'
-                : percentage >= 60
-                ? 'もう少し! 復習しましょう'
-                : '繰り返し練習しましょう!'}
-            </p>
+            <p className="text-[var(--color-foreground)] mb-8">{completionMessage}</p>
 
             <div className="space-y-3">
               <Button
@@ -519,6 +572,7 @@ export default function QuickResponsePage() {
           </div>
         </main>
       </div>
+      </>
     );
   }
 

--- a/src/app/quiz2/[projectId]/page.tsx
+++ b/src/app/quiz2/[projectId]/page.tsx
@@ -351,7 +351,49 @@ export default function Quiz2Page() {
   if (isComplete) {
     const total = words.length;
     return (
-      <div className="h-screen flex flex-col bg-[var(--color-background)] overflow-hidden fixed inset-0">
+      <>
+      {/* Desktop completion（DSスタイル） */}
+      <div className="ds-fixed-main fixed inset-0 z-30 hidden flex-col bg-[var(--color-background)] font-[var(--font-body)] lg:flex">
+        <div className="flex flex-1 items-center justify-center overflow-y-auto" style={{ padding: 32 }}>
+          <div className="ds-card" style={{ width: 'min(100%, 520px)', padding: '28px 32px' }}>
+            <div className="mono muted" style={{ fontSize: 11, fontWeight: 700, letterSpacing: '0.08em', textTransform: 'uppercase' }}>
+              クイズ２ · 完了
+            </div>
+            <h1 style={{ fontSize: 28, margin: '10px 0 4px' }}>おつかれさま！</h1>
+            <p className="muted" style={{ fontSize: 13.5, margin: 0 }}>{total}語を1周しました</p>
+
+            <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 12, marginTop: 20 }}>
+              <div className="ds-card flat ds-kpi" style={{ padding: '14px 16px' }}>
+                <div className="l">Again</div>
+                <div className="v" style={{ fontSize: 26, color: 'var(--color-error)' }}>{gradeCounts.again}</div>
+              </div>
+              <div className="ds-card flat ds-kpi" style={{ padding: '14px 16px' }}>
+                <div className="l">Hard</div>
+                <div className="v" style={{ fontSize: 26, color: '#92400e' }}>{gradeCounts.hard}</div>
+              </div>
+              <div className="ds-card flat ds-kpi" style={{ padding: '14px 16px' }}>
+                <div className="l">Good</div>
+                <div className="v" style={{ fontSize: 26, color: '#1d4ed8' }}>{gradeCounts.good}</div>
+              </div>
+              <div className="ds-card flat ds-kpi" style={{ padding: '14px 16px' }}>
+                <div className="l">Easy</div>
+                <div className="v" style={{ fontSize: 26, color: 'var(--color-accent-ink)' }}>{gradeCounts.easy}</div>
+              </div>
+            </div>
+
+            <div style={{ display: 'flex', gap: 10, marginTop: 22, justifyContent: 'flex-end' }}>
+              <button type="button" className="ds-btn accent" onClick={handleRestart}>
+                <Icon name="refresh" />もう一度
+              </button>
+              <button type="button" className="ds-btn dark" onClick={backToOrigin}>
+                <Icon name="check" />終了する
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div className="h-screen flex flex-col bg-[var(--color-background)] overflow-hidden fixed inset-0 lg:hidden">
         <header className="sticky top-0 p-4 flex items-center justify-between max-w-lg mx-auto w-full">
           <button
             onClick={backToOrigin}
@@ -401,6 +443,7 @@ export default function Quiz2Page() {
           </div>
         </main>
       </div>
+      </>
     );
   }
 

--- a/src/app/reels/page.tsx
+++ b/src/app/reels/page.tsx
@@ -15,6 +15,10 @@ import { REEL_SAVED_PROJECT_TITLE } from '@/lib/reels/saved-words';
 import { generateWordShareImage } from '@/lib/reels/share-image';
 import type { VocabularyType, WordTranslation } from '@/types';
 import { ReelFeed } from '@/components/reel/ReelFeed';
+import { ReelActionRail } from '@/components/reel/ReelActionRail';
+import { ReelCommentSheet } from '@/components/reel/ReelCommentSheet';
+import { ReelMoreSheet } from '@/components/reel/ReelMoreSheet';
+import { speakReelWord } from '@/components/reel/ReelCard';
 import {
   ReelEmptyState,
   ReelErrorState,
@@ -22,6 +26,7 @@ import {
   ReelSkeleton,
 } from '@/components/reel/ReelStatusCards';
 import { getPinnedReelPreview } from '@/lib/reels/pinned-preview';
+import type { ReelFeedItem } from '@/hooks/use-reel-feed';
 
 type ImportWordTranslation = {
   translationJa: string;
@@ -92,6 +97,18 @@ function ReelsPageInner() {
   } = useReelFeed({ pin });
   const [importingBookId, setImportingBookId] = useState<string | null>(null);
   const savingWordIdsRef = useRef<Set<string>>(new Set());
+  // デスクトップ: アクションレールはカードの外（右側）に置くため、
+  // アクティブなカードの単語をページ側で追跡する。
+  const [activeReelId, setActiveReelId] = useState<string | null>(null);
+  const [desktopMoreOpen, setDesktopMoreOpen] = useState(false);
+  const [desktopCommentsOpen, setDesktopCommentsOpen] = useState(false);
+  const handleActiveItemChange = useCallback((item: ReelFeedItem | null) => {
+    setActiveReelId(item?.id ?? null);
+  }, []);
+  const activeReel = useMemo(
+    () => items.find((item) => item.id === activeReelId) ?? null,
+    [items, activeReelId],
+  );
 
   const subscriptionStatus = subscription?.status || 'free';
   const wasPro = subscription?.plan === 'pro' && subscriptionStatus !== 'active';
@@ -404,10 +421,50 @@ function ReelsPageInner() {
               onShare={(item) => void handleShare(item)}
               onFeedback={(item, feedback) => void handleFeedback(item, feedback)}
               onCommentCountChange={(item, delta) => bumpCommentCount(item.id, delta)}
+              onActiveItemChange={handleActiveItemChange}
             />
           )}
         </div>
+
+        {/* デスクトップ: アクションレールをカードの外（右側）に配置 */}
+        {activeReel && (
+          <div className="hidden lg:flex lg:items-center lg:pl-4">
+            <ReelActionRail
+              item={activeReel}
+              onLike={() => {
+                triggerHaptic();
+                void likeItem(activeReel);
+              }}
+              onSave={() => void handleSaveWord(activeReel)}
+              onSpeak={() => speakReelWord(activeReel.english)}
+              onComment={() => setDesktopCommentsOpen(true)}
+              onShare={() => void handleShare(activeReel)}
+              onMore={() => setDesktopMoreOpen(true)}
+            />
+          </div>
+        )}
       </div>
+
+      {/* デスクトップ外側レールから開くシート */}
+      {activeReel && (
+        <>
+          <ReelMoreSheet
+            item={activeReel}
+            isOpen={desktopMoreOpen}
+            onClose={() => setDesktopMoreOpen(false)}
+            onFeedback={(feedback) => {
+              setDesktopMoreOpen(false);
+              void handleFeedback(activeReel, feedback);
+            }}
+          />
+          <ReelCommentSheet
+            item={activeReel}
+            isOpen={desktopCommentsOpen}
+            onClose={() => setDesktopCommentsOpen(false)}
+            onCountChange={(delta) => bumpCommentCount(activeReel.id, delta)}
+          />
+        </>
+      )}
     </div>
   );
 }

--- a/src/app/reels/page.tsx
+++ b/src/app/reels/page.tsx
@@ -18,8 +18,10 @@ import { ReelFeed } from '@/components/reel/ReelFeed';
 import {
   ReelEmptyState,
   ReelErrorState,
+  ReelPinnedPreviewCard,
   ReelSkeleton,
 } from '@/components/reel/ReelStatusCards';
+import { getPinnedReelPreview } from '@/lib/reels/pinned-preview';
 
 type ImportWordTranslation = {
   translationJa: string;
@@ -72,6 +74,9 @@ function ReelsPageInner() {
   const pin = searchParams?.get('pin') ?? null;
   const { user, subscription, loading: authLoading } = useAuth();
   const { showToast } = useToast();
+  // ホームのリールカードからの遷移時は、フィード応答を待たずに pin 単語を
+  // 即表示する（タップ時にシードされた表示データを使う）。
+  const [pinnedPreview] = useState(() => (pin ? getPinnedReelPreview(pin) : null));
   const {
     items,
     status,
@@ -361,7 +366,7 @@ function ReelsPageInner() {
       >
         <div className="h-full w-full lg:max-w-[420px] lg:rounded-[var(--solid-radius)] lg:border-2 lg:border-[var(--solid-ink)] lg:bg-[var(--color-surface)] lg:overflow-hidden">
           {status === 'loading' && items.length === 0 ? (
-            <ReelSkeleton />
+            pinnedPreview ? <ReelPinnedPreviewCard item={pinnedPreview} /> : <ReelSkeleton />
           ) : status === 'error' && items.length === 0 ? (
             <ReelErrorState onRetry={retry} />
           ) : items.length === 0 && limitReached ? (

--- a/src/app/settings/account/delete/page.tsx
+++ b/src/app/settings/account/delete/page.tsx
@@ -71,6 +71,60 @@ export default function DeleteAccountPage() {
   };
 
   return (
+    <>
+    {/* デスクトップ表示（設定 > データ > アカウント削除 から遷移） */}
+    <div className="hidden h-full min-h-0 flex-col lg:flex">
+      <div className="ds-top">
+        <div style={{ flex: 1, minWidth: 0 }}>
+          <div className="crumb">アカウント / データ</div>
+          <h1>アカウント削除</h1>
+        </div>
+        <button
+          type="button"
+          className="ds-btn"
+          onClick={() => router.push('/settings')}
+        >
+          <Icon name="arrow_back" />
+          設定へ戻る
+        </button>
+      </div>
+      <div className="ds-scroll">
+        <div style={{ width: 'min(100%, 640px)', margin: '0 auto' }}>
+          <div
+            className="ds-card"
+            style={{ padding: 24, borderColor: 'var(--color-error)', boxShadow: '3px 4px 0 var(--color-error)' }}
+          >
+            <div className="mono" style={{ fontSize: 10, fontWeight: 700, letterSpacing: '0.08em', textTransform: 'uppercase', color: 'var(--color-error)' }}>
+              DANGER ZONE
+            </div>
+            <div style={{ marginTop: 10, fontSize: 13.5, lineHeight: 1.8, color: 'var(--color-secondary-text)' }}>
+              <p style={{ margin: 0 }}>アカウントを削除すると、以下のデータが完全に削除されます：</p>
+              <ul style={{ margin: '8px 0 0', paddingLeft: 20 }}>
+                <li>ログイン情報</li>
+                <li>クラウド上の学習データ</li>
+                <li>プロジェクト・単語帳</li>
+              </ul>
+              <p style={{ margin: '8px 0 0' }}>Stripe課金中の場合は、削除時にサブスクリプションも停止します。</p>
+              {isAppStorePro && (
+                <p style={{ margin: '8px 0 0', fontWeight: 700, color: 'var(--color-error)' }}>
+                  App Store課金中の場合は、先にApp Storeでサブスクリプションを解約してください。
+                </p>
+              )}
+            </div>
+            <button
+              type="button"
+              onClick={() => setShowConfirm(true)}
+              className="ds-btn"
+              style={{ marginTop: 18, width: '100%', color: 'var(--color-error)', borderColor: 'var(--color-error)', boxShadow: '2px 3px 0 var(--color-error)' }}
+            >
+              <Icon name="delete" />
+              アカウントを削除する
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+
     <div className="relative min-h-screen bg-[var(--color-background)] pb-[110px] pt-3 font-[var(--font-body)] lg:hidden">
       <div className="px-[18px] pb-[14px] pt-1">
         <button
@@ -111,8 +165,10 @@ export default function DeleteAccountPage() {
           </button>
         </div>
       </div>
+    </div>
 
-      <Modal isOpen={showConfirm} onClose={closeModal} showCloseButton={false} closeOnBackdrop={!deleteLoading}>
+    {/* 削除確認モーダル（モバイル・デスクトップ共通） */}
+    <Modal isOpen={showConfirm} onClose={closeModal} showCloseButton={false} closeOnBackdrop={!deleteLoading}>
         <div className="p-5">
           <div className="mb-4 flex items-center gap-3">
             <span className="inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-[10px] bg-[rgba(239,68,68,0.1)] text-[var(--color-error)]">
@@ -149,7 +205,7 @@ export default function DeleteAccountPage() {
             </button>
           </div>
         </div>
-      </Modal>
-    </div>
+    </Modal>
+    </>
   );
 }

--- a/src/app/share/[shareId]/page.tsx
+++ b/src/app/share/[shareId]/page.tsx
@@ -10,6 +10,7 @@ import { Icon } from '@/components/ui/Icon';
 import { SolidButton, SolidPanel } from '@/components/redesign/SolidPage';
 import { useRewardedDownloadAd } from '@/components/ads/useRewardedDownloadAd';
 import { useAuth } from '@/hooks/use-auth';
+import { useIsMobileViewport } from '@/hooks/use-is-mobile-viewport';
 import { useToast } from '@/components/ui/toast';
 import { isBillingEnabled } from '@/lib/billing/feature';
 import { getRepository } from '@/lib/db';
@@ -118,6 +119,7 @@ export default function SharedDetailPage() {
   const params = useParams();
   const shareId = params.shareId as string;
   const { user, subscription, loading: authLoading } = useAuth();
+  const isMobileViewport = useIsMobileViewport();
   const { showToast } = useToast();
   const billingEnabled = isBillingEnabled();
   const {
@@ -580,13 +582,10 @@ export default function SharedDetailPage() {
         previewClearWordCount={SHARE_PREVIEW_CLEAR_WORD_COUNT}
         lockedCtaHref={loginRedirectHref}
         onToggleLike={() => void handleToggleLike()}
-        onToggleSelectMode={() => {
-          setSelectMode((current) => !current);
-          setSelectedWordIds(new Set());
-        }}
         onToggleWord={handleToggleSelect}
         onImport={() => void handleImport()}
         onClearSelection={() => setSelectedWordIds(new Set())}
+        onWordAction={setActionWord}
       />
       <div className="relative flex min-h-screen flex-col bg-[var(--color-background)] pb-[160px] font-[var(--font-body)] lg:hidden">
       <div className="flex items-center justify-between px-3.5 pb-2 pt-2">
@@ -855,11 +854,11 @@ export default function SharedDetailPage() {
       )}
       </div>
 
-      {/* 単語の「…」メニュー: 単語帳に追加 / 共有 */}
+      {/* 単語の「…」メニュー: 単語帳に追加 / 共有（デスクトップは中央モーダル） */}
       <Modal
         isOpen={actionWord !== null && !bookPickerOpen}
         onClose={() => setActionWord(null)}
-        variant="sheet"
+        variant={isMobileViewport ? 'sheet' : 'center'}
       >
         {actionWord && (
           <div className="px-4 pb-6 pt-5">
@@ -889,13 +888,13 @@ export default function SharedDetailPage() {
         )}
       </Modal>
 
-      {/* 「単語帳に追加」: 自分の単語帳一覧 */}
+      {/* 「単語帳に追加」: 自分の単語帳一覧（デスクトップは中央モーダル） */}
       <Modal
         isOpen={bookPickerOpen}
         onClose={() => {
           if (!addingToBookId) setBookPickerOpen(false);
         }}
-        variant="sheet"
+        variant={isMobileViewport ? 'sheet' : 'center'}
       >
         <div className="px-4 pb-6 pt-5">
           <p className="mb-3 px-3 font-display text-sm font-bold text-[var(--color-secondary-text)]">

--- a/src/app/shared/SharedPageClient.tsx
+++ b/src/app/shared/SharedPageClient.tsx
@@ -103,17 +103,6 @@ function buildDiscoverUrl(category: SharedDiscoverCategory, query: string, curso
   return `/api/shared-projects/discover?${params.toString()}`;
 }
 
-function mergeDiscoverPage(current: SharedDiscoverPayload, incoming: SharedDiscoverPayload): SharedDiscoverPayload {
-  const projectIds = new Set(current.projects.map((item) => item.project.id));
-  const userIds = new Set(current.users.map((item) => item.userId));
-
-  return {
-    ...incoming,
-    users: [...current.users, ...incoming.users.filter((item) => !userIds.has(item.userId))],
-    projects: [...current.projects, ...incoming.projects.filter((item) => !projectIds.has(item.project.id))],
-  };
-}
-
 function isDiscoverPayload(payload: DiscoverResponse | null): payload is SharedDiscoverPayload {
   return Boolean(payload && 'category' in payload && Array.isArray(payload.projects));
 }
@@ -140,7 +129,6 @@ export default function SharedPageClient({ initialDiscover }: SharedPageClientPr
   const [userResults, setUserResults] = useState<FollowSearchResult[]>([]);
   const [userLoading, setUserLoading] = useState(false);
   const [userError, setUserError] = useState<string | null>(null);
-  const [loadingMore, setLoadingMore] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [refreshNonce] = useState(0);
   const hasUsedInitialRef = useRef(false);
@@ -185,27 +173,6 @@ export default function SharedPageClient({ initialDiscover }: SharedPageClientPr
 
     return () => controller.abort();
   }, [category, initialDiscover, query, refreshNonce]);
-
-  async function handleLoadMore() {
-    if (category === 'all' || category === 'groups' || !discover.nextCursor || loadingMore) return;
-
-    setLoadingMore(true);
-    setError(null);
-
-    try {
-      const response = await fetch(buildDiscoverUrl(category, query, discover.nextCursor), { cache: 'no-store' });
-      const payload = await response.json().catch(() => null) as DiscoverResponse | null;
-      if (!response.ok || !isDiscoverPayload(payload)) {
-        throw new Error(payload && 'error' in payload ? payload.error : 'shared_discover_more_failed');
-      }
-      startTransition(() => setDiscover((current) => mergeDiscoverPage(current, payload)));
-    } catch (loadError) {
-      console.error('Failed to load more shared results:', loadError);
-      setError('追加の検索結果を読み込めませんでした。');
-    } finally {
-      setLoadingMore(false);
-    }
-  }
 
   function handleOpenShareSheet() {
     setChooserOpen(true);
@@ -281,7 +248,6 @@ export default function SharedPageClient({ initialDiscover }: SharedPageClientPr
         query={query}
         payload={discover}
         loading={loading}
-        loadingMore={loadingMore}
         error={error}
         joinedGroups={myGroups}
         groupQuery={groupQuery}
@@ -293,7 +259,6 @@ export default function SharedPageClient({ initialDiscover }: SharedPageClientPr
         onQueryChange={setQuery}
         onCategorySelect={handleSelectCategory}
         onBackToAll={handleBackToAll}
-        onLoadMore={() => void handleLoadMore()}
         onOpenShareSheet={handleOpenShareSheet}
         onProjectMissing={handleProjectMissing}
       />
@@ -412,19 +377,6 @@ export default function SharedPageClient({ initialDiscover }: SharedPageClientPr
             ) : (
               <>
                 {category === 'projects' && <ProjectSection projects={discover.projects} onProjectMissing={handleProjectMissing} />}
-                {discover.nextCursor && (
-                  <button
-                    type="button"
-                    onClick={() => void handleLoadMore()}
-                    disabled={loadingMore}
-                    className="rounded-xl border-2 border-[var(--solid-ink)] bg-white px-4 py-3 text-sm font-bold text-[var(--solid-ink)] disabled:opacity-60"
-                  >
-                    <span className="inline-flex items-center gap-2">
-                      <Icon name={loadingMore ? 'progress_activity' : 'expand_more'} size={18} className={loadingMore ? 'animate-spin' : undefined} />
-                      {loadingMore ? '読み込み中...' : 'もっと見る'}
-                    </span>
-                  </button>
-                )}
               </>
             )}
           </div>
@@ -502,18 +454,22 @@ function BrowseSection({
   );
 }
 
+type GenreResultsState = {
+  genre: WordbookGenre;
+  projects: SharedProjectCard[];
+  error: string | null;
+};
+
 function GenreResultsView({ genre, onBack }: { genre: WordbookGenre; onBack: () => void }) {
   const { showToast } = useToast();
-  const [projects, setProjects] = useState<SharedProjectCard[]>([]);
-  const [nextCursor, setNextCursor] = useState<string | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [loadingMore, setLoadingMore] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+  // ジャンルごとの取得結果を1つの state に持つ（loading はジャンル不一致で導出）。
+  const [result, setResult] = useState<GenreResultsState | null>(null);
+  const loading = result?.genre !== genre;
+  const projects = result?.genre === genre ? result.projects : [];
+  const error = result?.genre === genre ? result.error : null;
 
   useEffect(() => {
     const controller = new AbortController();
-    setLoading(true);
-    setError(null);
 
     fetch(buildDiscoverUrl('projects', genre.query), { cache: 'no-store', signal: controller.signal })
       .then(async (response) => {
@@ -521,46 +477,23 @@ function GenreResultsView({ genre, onBack }: { genre: WordbookGenre; onBack: () 
         if (!response.ok || !isDiscoverPayload(payload)) {
           throw new Error(payload && 'error' in payload ? payload.error : 'genre_discover_failed');
         }
-        setProjects(payload.projects);
-        setNextCursor(payload.nextCursor);
+        setResult({ genre, projects: payload.projects, error: null });
       })
       .catch((loadError) => {
         if (controller.signal.aborted) return;
         console.error('Failed to load genre wordbooks:', loadError);
-        setError('単語帳を読み込めませんでした。');
-      })
-      .finally(() => {
-        if (!controller.signal.aborted) setLoading(false);
+        setResult({ genre, projects: [], error: '単語帳を読み込めませんでした。' });
       });
 
     return () => controller.abort();
   }, [genre]);
 
-  async function handleLoadMore() {
-    if (!nextCursor || loadingMore) return;
-    setLoadingMore(true);
-    setError(null);
-    try {
-      const response = await fetch(buildDiscoverUrl('projects', genre.query, nextCursor), { cache: 'no-store' });
-      const payload = await response.json().catch(() => null) as DiscoverResponse | null;
-      if (!response.ok || !isDiscoverPayload(payload)) {
-        throw new Error(payload && 'error' in payload ? payload.error : 'genre_discover_more_failed');
-      }
-      setProjects((current) => {
-        const known = new Set(current.map((item) => item.project.id));
-        return [...current, ...payload.projects.filter((item) => !known.has(item.project.id))];
-      });
-      setNextCursor(payload.nextCursor);
-    } catch (loadError) {
-      console.error('Failed to load more genre wordbooks:', loadError);
-      setError('追加の検索結果を読み込めませんでした。');
-    } finally {
-      setLoadingMore(false);
-    }
-  }
-
   function handleProjectMissing(projectId: string) {
-    setProjects((current) => current.filter((item) => item.project.id !== projectId));
+    setResult((current) =>
+      current
+        ? { ...current, projects: current.projects.filter((item) => item.project.id !== projectId) }
+        : current,
+    );
     showToast({ message: 'この単語帳は共有が停止されています', type: 'warning' });
   }
 
@@ -594,22 +527,7 @@ function GenreResultsView({ genre, onBack }: { genre: WordbookGenre; onBack: () 
         ) : projects.length === 0 ? (
           <EmptyBox message="このジャンルの単語帳はまだありません" />
         ) : (
-          <>
-            <ProjectSection projects={projects} onProjectMissing={handleProjectMissing} />
-            {nextCursor && (
-              <button
-                type="button"
-                onClick={() => void handleLoadMore()}
-                disabled={loadingMore}
-                className="rounded-xl border-2 border-[var(--solid-ink)] bg-white px-4 py-3 text-sm font-bold text-[var(--solid-ink)] disabled:opacity-60"
-              >
-                <span className="inline-flex items-center gap-2">
-                  <Icon name={loadingMore ? 'progress_activity' : 'expand_more'} size={18} className={loadingMore ? 'animate-spin' : undefined} />
-                  {loadingMore ? '読み込み中...' : 'もっと見る'}
-                </span>
-              </button>
-            )}
-          </>
+          <ProjectSection projects={projects} onProjectMissing={handleProjectMissing} />
         )}
       </div>
     </>

--- a/src/components/desktop/DesktopAccount.tsx
+++ b/src/components/desktop/DesktopAccount.tsx
@@ -147,9 +147,13 @@ export function DesktopSettingsView({
             )}
           </div>
 
-          <StudyReminderSettings variant="desktop" />
-
-          <ExampleGenreSettings variant="desktop" />
+          {/* モバイルのカスタマイズページと同様、リマインダーと例文ジャンルは
+              同じセクションにまとめる */}
+          <div className="ds-set-group">
+            <div className="gh">カスタマイズ</div>
+            <StudyReminderSettings variant="desktop" embedded />
+            <ExampleGenreSettings variant="desktop" embedded />
+          </div>
 
           <div className="ds-set-group">
             <div className="gh">豆知識</div>

--- a/src/components/desktop/DesktopAccount.tsx
+++ b/src/components/desktop/DesktopAccount.tsx
@@ -166,6 +166,19 @@ export function DesktopSettingsView({
             <SettingsLink icon="storefront" label="特定商取引法に基づく表記" href="/tokusho" />
           </div>
 
+          {email && (
+            <div className="ds-set-group">
+              <div className="gh">データ</div>
+              <SettingsLink
+                icon="delete"
+                label="アカウント削除"
+                description="ログイン情報・クラウド上の学習データを完全に削除します"
+                href="/settings/account/delete"
+                tone="danger"
+              />
+            </div>
+          )}
+
           <div className="mono muted" style={{ fontSize: 11, textAlign: 'center', paddingBottom: 8 }}>Merken for Desktop · バージョン 2.4.0</div>
         </div>
       </div>
@@ -277,11 +290,29 @@ export function DesktopSubscriptionView({
   );
 }
 
-function SettingsLink({ icon, label, description, href }: { icon: string; label: string; description?: string; href: string }) {
+function SettingsLink({
+  icon,
+  label,
+  description,
+  href,
+  tone = 'default',
+}: {
+  icon: string;
+  label: string;
+  description?: string;
+  href: string;
+  tone?: 'default' | 'danger';
+}) {
+  const danger = tone === 'danger';
   return (
     <Link href={href} className="ds-set-row" style={{ color: 'inherit', textDecoration: 'none' }}>
-      <div className="ic"><Icon name={icon} /></div>
-      <div className="lab"><div className="t">{label}</div>{description && <div className="d">{description}</div>}</div>
+      <div className="ic" style={danger ? { background: 'var(--color-error-light)' } : undefined}>
+        <Icon name={icon} style={danger ? { color: 'var(--color-error)' } : undefined} />
+      </div>
+      <div className="lab">
+        <div className="t" style={danger ? { color: 'var(--color-error)' } : undefined}>{label}</div>
+        {description && <div className="d">{description}</div>}
+      </div>
       <Icon name="chevron_right" style={{ color: 'var(--color-muted)' }} />
     </Link>
   );

--- a/src/components/desktop/DesktopChrome.tsx
+++ b/src/components/desktop/DesktopChrome.tsx
@@ -2,9 +2,8 @@
 
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
-import { type InputHTMLAttributes, type ReactNode, useState } from 'react';
+import type { InputHTMLAttributes, ReactNode } from 'react';
 import { Icon } from '@/components/ui/Icon';
-import { DesktopWordSearchOverlay } from '@/components/desktop/DesktopWordSearchOverlay';
 import { useAuth } from '@/hooks/use-auth';
 import { useCoins } from '@/hooks/use-coins';
 import { cn } from '@/lib/utils';
@@ -17,7 +16,6 @@ const NAV_ITEMS: { key: NavKey; href: string; icon: string; label: string; count
   { key: 'reels', href: '/reels', icon: 'movie', label: 'リール' },
   { key: 'shared', href: '/shared', icon: 'group', label: '共有ライブラリ', count: 6 },
   { key: 'fav', href: '/favorites', icon: 'star', label: 'お気に入り', count: 21 },
-  { key: 'scan', href: '/scan', icon: 'photo_camera', label: 'スキャン' },
   { key: 'settings', href: '/settings', icon: 'settings', label: '設定' },
 ];
 
@@ -43,10 +41,8 @@ export function DesktopSidebar({
   const pathname = usePathname();
   const { user, isPro } = useAuth();
   const { enabled: coinsEnabled, balance: coinBalance } = useCoins();
-  const [searchOpen, setSearchOpen] = useState(false);
   const active = activeKeyForPath(pathname);
   const userInitial = user?.email?.charAt(0).toUpperCase() || 'R';
-  const isLoggedIn = Boolean(user);
 
   return (
     <aside className={cn('ds-side', collapsed && 'ds-side--collapsed')} aria-label="デスクトップナビゲーション">
@@ -104,23 +100,6 @@ export function DesktopSidebar({
             )}
           </Link>
         )}
-        {isLoggedIn && (
-          <button
-            type="button"
-            className="ds-word-search"
-            onClick={() => setSearchOpen(true)}
-            title={collapsed ? '単語を検索' : undefined}
-            aria-label="自分の単語帳から検索"
-          >
-            <Icon name="search" className="ico" />
-            {!collapsed && (
-              <div>
-                <div className="n">単語を検索</div>
-                <div className="l">自分の単語帳から探す</div>
-              </div>
-            )}
-          </button>
-        )}
         {!collapsed && (
           <div className="ds-user">
             <div className="ds-avatar">{userInitial}</div>
@@ -131,10 +110,6 @@ export function DesktopSidebar({
           </div>
         )}
       </div>
-      {/* 自分の単語帳内の単語検索。開くたびにマウントし直して状態を初期化する */}
-      {searchOpen && user && (
-        <DesktopWordSearchOverlay onClose={() => setSearchOpen(false)} userId={user.id} />
-      )}
     </aside>
   );
 }

--- a/src/components/desktop/DesktopHome.tsx
+++ b/src/components/desktop/DesktopHome.tsx
@@ -15,6 +15,8 @@ import {
   DesktopSearchBox,
   DesktopTopbar,
 } from '@/components/desktop/DesktopChrome';
+import { DesktopWordSearchOverlay } from '@/components/desktop/DesktopWordSearchOverlay';
+import { useAuth } from '@/hooks/use-auth';
 import { DesktopMediaCard, DesktopShelf } from '@/components/desktop/DesktopMediaShelf';
 import { DesktopStudySidebar } from '@/components/desktop/DesktopStudySidebar';
 import { JoinedGroupGrid } from '@/components/groups/JoinedGroupsSection';
@@ -91,6 +93,9 @@ export function DesktopHomeView({
   showUpgrade?: boolean;
   onDismissUpgrade?: () => void;
 }) {
+  const { user } = useAuth();
+  // 単語検索（旧サイドバー下部のボタンから移設）。開くたびに初期化する。
+  const [wordSearchOpen, setWordSearchOpen] = useState(false);
   const [query, setQuery] = useState('');
   const q = query.trim().toLowerCase();
   const filteredProjects = useMemo(
@@ -109,14 +114,27 @@ export function DesktopHomeView({
     <div className="hidden h-full min-h-0 flex-col lg:flex">
       <DesktopTopbar title="ホーム" crumb="HOME / ライブラリ">
         <DesktopSearchBox
-          placeholder="単語・単語帳を検索"
+          placeholder="単語帳を検索"
           value={query}
           onChange={(event) => setQuery(event.target.value)}
         />
+        {/* 自分の単語帳内の単語検索（サイドバー下部から移設） */}
+        {user && (
+          <DesktopButton
+            icon="manage_search"
+            onClick={() => setWordSearchOpen(true)}
+            title="自分の単語帳から単語を検索"
+          >
+            {''}
+          </DesktopButton>
+        )}
         <DesktopButton variant="accent" icon="add" onClick={onStartScan}>
           新規作成
         </DesktopButton>
       </DesktopTopbar>
+      {wordSearchOpen && user && (
+        <DesktopWordSearchOverlay onClose={() => setWordSearchOpen(false)} userId={user.id} />
+      )}
 
       <div className="ds-scroll" style={{ display: 'grid', gridTemplateColumns: '1fr 300px', gap: 24, alignItems: 'start' }}>
         <div style={{ minWidth: 0 }}>

--- a/src/components/desktop/DesktopHome.tsx
+++ b/src/components/desktop/DesktopHome.tsx
@@ -1,5 +1,12 @@
 'use client';
 
+/**
+ * デスクトップホーム（Spotify デスクトップ風の構成）。
+ * 上部: ショートカットグリッド（TODAY'S GOAL + 保存済み + 単語帳/グループ/おすすめ）
+ * 下部: 横スクロールのシェルフ（マイ単語帳 / おすすめの単語帳 / おすすめのリール）
+ * 右サイドの学習サイドバー・アップグレードカードはモバイルと違い維持する。
+ */
+
 import Link from 'next/link';
 import { useMemo, useState } from 'react';
 import { Icon } from '@/components/ui/Icon';
@@ -8,13 +15,17 @@ import {
   DesktopSearchBox,
   DesktopTopbar,
 } from '@/components/desktop/DesktopChrome';
+import { DesktopMediaCard, DesktopShelf } from '@/components/desktop/DesktopMediaShelf';
 import { DesktopStudySidebar } from '@/components/desktop/DesktopStudySidebar';
 import { JoinedGroupGrid } from '@/components/groups/JoinedGroupsSection';
+import { desktopThumbColor } from '@/components/desktop/desktop-data';
+import { buildHomeShortcutTiles, homeShortcutContentSlots } from '@/lib/home/shortcut-tiles';
 import {
-  desktopSourceLabel,
-  desktopThumbColor,
-  desktopUpdatedLabel,
-} from '@/components/desktop/desktop-data';
+  prefetchGroupOverview,
+  seedGroupSummary,
+} from '@/lib/shared-projects/group-overview-cache';
+import { prefetchReelFeed } from '@/hooks/use-reel-feed';
+import type { HomeRecommendedBook, HomeReelPreviewItem } from '@/lib/home/recommendations-types';
 import type { Project } from '@/types';
 import type { StudyGroupSummary } from '@/lib/shared-projects/types';
 
@@ -35,7 +46,13 @@ type DesktopHomeStats = {
   activeW: number;
   review: number;
   newW: number;
+  favoriteCount: number;
   hasReviewSchedule: boolean;
+};
+
+type DesktopHomeGoal = {
+  state: 'review' | 'learn' | 'empty' | 'start' | 'done';
+  count: number;
 };
 
 type DesktopPendingScan = {
@@ -51,6 +68,10 @@ export function DesktopHomeView({
   error,
   pendingScans,
   joinedGroups = [],
+  goal,
+  recommendedBooks = [],
+  recommendedReels = [],
+  recommendationsLoading = false,
   onStartScan,
   showUpgrade = false,
   onDismissUpgrade,
@@ -61,23 +82,24 @@ export function DesktopHomeView({
   error: string | null;
   pendingScans: DesktopPendingScan[];
   joinedGroups?: StudyGroupSummary[];
+  goal: DesktopHomeGoal;
+  recommendedBooks?: HomeRecommendedBook[];
+  recommendedReels?: HomeReelPreviewItem[];
+  recommendationsLoading?: boolean;
   onStartScan: () => void;
   showUpgrade?: boolean;
   onDismissUpgrade?: () => void;
 }) {
-  const [view, setView] = useState<'grid' | 'list'>('grid');
   const [query, setQuery] = useState('');
   const q = query.trim().toLowerCase();
   const filteredProjects = useMemo(
     () => (q ? projects.filter((project) => project.title.toLowerCase().includes(q)) : projects),
     [projects, q],
   );
-  const firstProject = projects[0];
-  const hasVisibleBooks = pendingScans.length > 0 || filteredProjects.length > 0;
 
   return (
     <div className="hidden h-full min-h-0 flex-col lg:flex">
-      <DesktopTopbar title="マイ単語帳" crumb="HOME / ライブラリ">
+      <DesktopTopbar title="ホーム" crumb="HOME / ライブラリ">
         <DesktopSearchBox
           placeholder="単語・単語帳を検索"
           value={query}
@@ -89,119 +111,67 @@ export function DesktopHomeView({
       </DesktopTopbar>
 
       <div className="ds-scroll" style={{ display: 'grid', gridTemplateColumns: '1fr 300px', gap: 24, alignItems: 'start' }}>
-        <div>
+        <div style={{ minWidth: 0 }}>
           {error && (
             <div className="ds-card" style={{ padding: 14, marginBottom: 18, color: 'var(--color-error)', borderColor: 'var(--color-error)' }}>
               {error}
             </div>
           )}
 
-          <div className="ds-sec-head" style={{ marginBottom: 14 }}>
-            <div style={{ display: 'flex', alignItems: 'baseline', gap: 10 }}>
-              <h2>本棚</h2>
-              <span className="mono muted" style={{ fontSize: 12 }}>
-                {projects.length + pendingScans.length} 冊 · {stats.totalWords} 語
-              </span>
-            </div>
-            <div style={{ display: 'flex', gap: 4 }}>
-              <button
-                type="button"
-                className="ds-btn ghost sm"
-                onClick={() => setView('grid')}
-                style={view === 'grid' ? { background: 'rgba(26,26,26,0.06)' } : undefined}
-                aria-label="グリッド表示"
-              >
-                <Icon name="grid_view" />
-              </button>
-              <button
-                type="button"
-                className="ds-btn ghost sm"
-                onClick={() => setView('list')}
-                style={view === 'list' ? { background: 'rgba(26,26,26,0.06)' } : undefined}
-                aria-label="リスト表示"
-              >
-                <Icon name="view_list" />
-              </button>
-            </div>
-          </div>
+          {/* Spotify風ショートカットグリッド */}
+          <DesktopShortcutGrid
+            goal={goal}
+            favoriteCount={stats.favoriteCount}
+            projects={projects}
+            groups={joinedGroups}
+            recommendations={loading ? [] : recommendedBooks}
+            onStartScan={onStartScan}
+          />
 
-          {loading && projects.length === 0 ? (
-            <div className="ds-card" style={{ padding: 42, textAlign: 'center', color: 'var(--color-muted)' }}>
-              <Icon name="progress_activity" className="animate-spin" />
-              <span style={{ marginLeft: 8 }}>読み込み中...</span>
-            </div>
-          ) : !hasVisibleBooks ? (
-            <button
-              type="button"
-              onClick={onStartScan}
-              className="ds-book"
-              style={{
-                width: 220,
-                background: '#fff',
-                color: 'var(--color-muted)',
-                border: '1.5px dashed var(--solid-ink)',
-                boxShadow: 'none',
-                alignItems: 'center',
-                justifyContent: 'center',
-                gap: 8,
-              }}
-            >
-              <Icon name="add" style={{ fontSize: 30, color: 'var(--color-ink)' }} />
-              <div style={{ fontFamily: 'var(--font-display)', fontWeight: 700, fontSize: 14, color: 'var(--color-ink)' }}>
-                新しい単語帳
-              </div>
-              <div className="mono" style={{ fontSize: 10, textAlign: 'center' }}>
-                写真を撮るだけ
-              </div>
-            </button>
-          ) : view === 'grid' ? (
-            <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3, minmax(0, 1fr))', gap: 18 }}>
-              {pendingScans.map((scan) => (
-                <DesktopGeneratingBookTile key={scan.id} scan={scan} />
-              ))}
-              {filteredProjects.map((project) => (
-                <DesktopBookTile key={project.id} project={project} />
-              ))}
-              <button
-                type="button"
-                onClick={onStartScan}
-                className="ds-book"
-                style={{
-                  background: '#fff',
-                  color: 'var(--color-muted)',
-                  border: '1.5px dashed var(--solid-ink)',
-                  boxShadow: 'none',
-                  alignItems: 'center',
-                  justifyContent: 'center',
-                  gap: 8,
-                }}
-              >
-                <Icon name="add" style={{ fontSize: 30, color: 'var(--color-ink)' }} />
-                <div style={{ fontFamily: 'var(--font-display)', fontWeight: 700, fontSize: 14, color: 'var(--color-ink)' }}>
-                  新しい単語帳
-                </div>
-                <div className="mono" style={{ fontSize: 10, textAlign: 'center' }}>
-                  写真を撮るだけ
-                </div>
-              </button>
-            </div>
-          ) : (
-            <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
-              {pendingScans.map((scan) => (
-                <DesktopGeneratingProjectRow key={scan.id} scan={scan} />
-              ))}
-              {filteredProjects.map((project) => (
-                <DesktopProjectRow key={project.id} project={project} />
-              ))}
-            </div>
-          )}
+          {/* マイ単語帳（横スクロールのメディアカード） */}
+          <DesktopShelf
+            title="マイ単語帳"
+            count={projects.length + pendingScans.length}
+            seeAllHref="/projects"
+          >
+            {pendingScans.map((scan) => (
+              <DesktopGeneratingMediaCard key={scan.id} scan={scan} />
+            ))}
+            {loading && filteredProjects.length === 0 && pendingScans.length === 0
+              ? [0, 1, 2, 3].map((slot) => <DesktopMediaCardSkeleton key={slot} />)
+              : filteredProjects.map((project) => (
+                  <DesktopHomeBookCard key={project.id} project={project} />
+                ))}
+            {!q && !loading && <DesktopNewBookCard onClick={onStartScan} />}
+          </DesktopShelf>
 
-          {/* 参加中のグループ（マイ単語帳の下・/shared から移設） */}
-          <div style={{ marginTop: 26 }}>
+          {/* 参加中のグループ */}
+          <div style={{ marginTop: 28 }}>
             <JoinedGroupGrid groups={joinedGroups} columns={3} />
           </div>
+
+          {/* おすすめの単語帳（英検級ベースの共有単語帳） */}
+          {recommendedBooks.length > 0 && (
+            <DesktopShelf title="おすすめの単語帳" seeAllHref="/shared">
+              {recommendedBooks.map((book) => (
+                <DesktopRecommendedBookCard key={book.shareId} book={book} />
+              ))}
+            </DesktopShelf>
+          )}
+
+          {/* おすすめのリール（語源がある単語限定） */}
+          {(recommendationsLoading || recommendedReels.length > 0) && (
+            <DesktopShelf title="おすすめのリール" seeAllHref="/reels">
+              {recommendationsLoading && recommendedReels.length === 0
+                ? [0, 1, 2].map((slot) => <DesktopMediaCardSkeleton key={slot} />)
+                : recommendedReels.map((item) => (
+                    <DesktopReelPreviewCard key={item.id} item={item} />
+                  ))}
+            </DesktopShelf>
+          )}
         </div>
 
+        {/* 右サイド（モバイルと違い維持） */}
         <div style={{ display: 'flex', flexDirection: 'column', gap: 18, position: 'sticky', top: 0 }}>
           {showUpgrade && <DesktopUpgradeCard onDismiss={onDismissUpgrade} />}
           <DesktopStudySidebar
@@ -214,6 +184,370 @@ export function DesktopHomeView({
     </div>
   );
 }
+
+/* ============ ショートカットグリッド（Spotify のクイックアクセス風） ============ */
+
+function DesktopShortcutGrid({
+  goal,
+  favoriteCount,
+  projects,
+  groups,
+  recommendations,
+  onStartScan,
+}: {
+  goal: DesktopHomeGoal;
+  favoriteCount: number;
+  projects: DesktopHomeProject[];
+  groups: StudyGroupSummary[];
+  recommendations: HomeRecommendedBook[];
+  onStartScan: () => void;
+}) {
+  const showSavedTile = favoriteCount > 0;
+  const tiles = buildHomeShortcutTiles({
+    projects,
+    groups,
+    recommendations,
+    slots: homeShortcutContentSlots(showSavedTile),
+  });
+
+  return (
+    <div className="ds-shortcut-grid">
+      <DesktopGoalTile goal={goal} onStartScan={onStartScan} />
+      {showSavedTile && (
+        <ShortcutTile
+          href="/favorites"
+          artStyle={{ background: 'var(--color-accent)' }}
+          artChildren={<Icon name="bookmark" size={20} filled />}
+          title="保存済み単語"
+          sub={`${favoriteCount}語`}
+        />
+      )}
+      {tiles.map((tile) => {
+        if (tile.kind === 'project') {
+          const project = tile.project;
+          return (
+            <ShortcutTile
+              key={`p:${project.id}`}
+              href={`/project/${project.id}`}
+              artStyle={{
+                background: desktopThumbColor(project.id),
+                backgroundImage: project.iconImage ? `url(${project.iconImage})` : undefined,
+              }}
+              artChildren={!project.iconImage && project.title.charAt(0)}
+              title={project.title}
+              sub={`${project.totalWords}語`}
+            />
+          );
+        }
+        if (tile.kind === 'group') {
+          const group = tile.group;
+          return (
+            <ShortcutTile
+              key={`g:${group.id}`}
+              href={`/groups/${group.id}`}
+              onPress={() => {
+                // タップ時点で概要をシード+先読みして、グループページの
+                // ヘッダーを即描画できるようにする（遷移の体感短縮）。
+                seedGroupSummary(group);
+                prefetchGroupOverview(group.id);
+              }}
+              artStyle={{ background: desktopThumbColor(group.id) }}
+              artChildren={group.name.charAt(0)}
+              title={group.name}
+              sub={`グループ · ${group.memberCount}人`}
+            />
+          );
+        }
+        const book = tile.book;
+        return (
+          <ShortcutTile
+            key={`b:${book.shareId}`}
+            href={`/share/${book.shareId}`}
+            artStyle={{
+              background: desktopThumbColor(book.shareId),
+              backgroundImage: book.iconImage ? `url(${book.iconImage})` : undefined,
+            }}
+            artChildren={!book.iconImage && book.title.charAt(0)}
+            title={book.title}
+            sub={book.eikenLevelTag ? `おすすめ · ${book.eikenLevelTag}` : 'おすすめ'}
+            subAccent
+          />
+        );
+      })}
+    </div>
+  );
+}
+
+function DesktopGoalTile({ goal, onStartScan }: { goal: DesktopHomeGoal; onStartScan: () => void }) {
+  if (goal.state === 'empty') {
+    return (
+      <ShortcutTile
+        onClick={onStartScan}
+        artStyle={{ background: 'var(--color-accent)' }}
+        artChildren={<Icon name="photo_camera" size={20} filled />}
+        title="最初のスキャン"
+        sub="クリックして開始"
+        subAccent
+      />
+    );
+  }
+  if (goal.state === 'done') {
+    return (
+      <ShortcutTile
+        artStyle={{ background: 'var(--color-success)' }}
+        artChildren={<Icon name="check_circle" size={20} filled />}
+        title="復習完了"
+        sub="今日はおつかれさま"
+      />
+    );
+  }
+  if (goal.state === 'review') {
+    return (
+      <ShortcutTile
+        href="/quiz/all?review=1&from=/"
+        artStyle={{ background: 'var(--color-accent)' }}
+        artChildren={<Icon name="replay" size={20} filled />}
+        title="今日の復習"
+        sub={`${goal.count}語 →`}
+        subAccent
+      />
+    );
+  }
+  // 'learn' | 'start'
+  return (
+    <ShortcutTile
+      href="/quiz/all?learn=1&from=/"
+      artStyle={{ background: 'var(--color-accent)' }}
+      artChildren={<Icon name="school" size={20} filled />}
+      title={goal.state === 'start' ? '学習を始める' : '今日の学習'}
+      sub={`${goal.count}語 →`}
+      subAccent
+    />
+  );
+}
+
+function ShortcutTile({
+  href,
+  onClick,
+  onPress,
+  artStyle,
+  artChildren,
+  title,
+  sub,
+  subAccent = false,
+}: {
+  href?: string;
+  onClick?: () => void;
+  /** クリック時に発火（先読みなど） */
+  onPress?: () => void;
+  artStyle?: React.CSSProperties;
+  artChildren?: React.ReactNode;
+  title: string;
+  sub?: string;
+  subAccent?: boolean;
+}) {
+  const inner = (
+    <>
+      <div className="art" style={artStyle}>{artChildren}</div>
+      <div className="body">
+        <div className="t">{title}</div>
+        {sub && <div className={subAccent ? 's accent' : 's'}>{sub}</div>}
+      </div>
+    </>
+  );
+
+  if (href) {
+    return (
+      <Link href={href} className="ds-shortcut" onClick={onPress}>
+        {inner}
+      </Link>
+    );
+  }
+  if (onClick) {
+    return (
+      <button type="button" className="ds-shortcut" onClick={onClick}>
+        {inner}
+      </button>
+    );
+  }
+  return <div className="ds-shortcut" style={{ cursor: 'default' }}>{inner}</div>;
+}
+
+/* ============ シェルフのカード ============ */
+
+function DesktopHomeBookCard({ project }: { project: DesktopHomeProject }) {
+  const pct = project.totalWords > 0 ? Math.round((project.masteredWords / project.totalWords) * 100) : 0;
+  return (
+    <DesktopMediaCard
+      href={`/project/${project.id}`}
+      artStyle={{
+        background: desktopThumbColor(project.id),
+        backgroundImage: project.iconImage ? `url(${project.iconImage})` : undefined,
+      }}
+      artChildren={!project.iconImage && project.title.charAt(0)}
+      title={project.title}
+      subtitle={`${project.totalWords}語 · 習得 ${pct}%`}
+      playHref={project.totalWords > 0 ? `/quiz/${project.id}?from=/` : undefined}
+      playLabel={`${project.title}のクイズを開始`}
+    />
+  );
+}
+
+function DesktopGeneratingMediaCard({ scan }: { scan: DesktopPendingScan }) {
+  return (
+    <div
+      className="ds-media-card"
+      role="status"
+      aria-live="polite"
+      aria-busy="true"
+      aria-label={`${scan.project_title} を生成中`}
+      style={{ cursor: 'default' }}
+    >
+      <div
+        className="art"
+        style={{
+          background: scan.iconDataUrl
+            ? `linear-gradient(rgba(26,26,26,0.42), rgba(26,26,26,0.42)), center / cover url(${scan.iconDataUrl})`
+            : 'linear-gradient(135deg, #137FEC 0%, #3DA1B8 52%, #228B22 100%)',
+        }}
+      >
+        <div
+          className="scanvocab-generating-spin"
+          style={{
+            width: 34,
+            height: 34,
+            border: '3px solid rgba(255,255,255,0.35)',
+            borderTopColor: '#fff',
+            borderRadius: 999,
+          }}
+          aria-hidden="true"
+        />
+      </div>
+      <div className="meta">
+        <div className="t">{scan.project_title}</div>
+        <div className="s">単語を抽出中...</div>
+      </div>
+    </div>
+  );
+}
+
+function DesktopNewBookCard({ onClick }: { onClick: () => void }) {
+  return (
+    <button type="button" onClick={onClick} className="ds-media-card">
+      <div
+        className="art"
+        style={{
+          background: '#fff',
+          border: '1.5px dashed var(--solid-ink)',
+          boxShadow: 'none',
+          color: 'var(--color-ink)',
+        }}
+      >
+        <Icon name="add" style={{ fontSize: 34 }} />
+      </div>
+      <div className="meta">
+        <div className="t">新しい単語帳</div>
+        <div className="s">写真を撮るだけ</div>
+      </div>
+    </button>
+  );
+}
+
+function DesktopMediaCardSkeleton() {
+  return (
+    <div className="ds-media-card" style={{ cursor: 'default' }} aria-hidden="true">
+      <div className="art ds-shimmer" style={{ boxShadow: 'none', borderColor: 'var(--color-border)' }} />
+      <div className="meta">
+        <div className="ds-shimmer" style={{ height: 13, borderRadius: 6, width: '80%' }} />
+        <div className="ds-shimmer" style={{ height: 10, borderRadius: 6, width: '55%', marginTop: 6 }} />
+      </div>
+    </div>
+  );
+}
+
+function DesktopRecommendedBookCard({ book }: { book: HomeRecommendedBook }) {
+  return (
+    <DesktopMediaCard
+      href={`/share/${book.shareId}`}
+      artStyle={{
+        background: desktopThumbColor(book.shareId),
+        backgroundImage: book.iconImage ? `url(${book.iconImage})` : undefined,
+      }}
+      artChildren={!book.iconImage && book.title.charAt(0)}
+      title={book.title}
+      subtitle={
+        <>
+          <span style={{ color: 'var(--color-accent)', fontWeight: 700 }}>おすすめ</span>
+          {book.eikenLevelTag && <span>· {book.eikenLevelTag}</span>}
+        </>
+      }
+    />
+  );
+}
+
+const REEL_MAX_FORMULA_PARTS = 3;
+
+function DesktopReelPreviewCard({ item }: { item: HomeReelPreviewItem }) {
+  const parts = item.morphology.formula.slice(0, REEL_MAX_FORMULA_PARTS);
+  return (
+    <DesktopMediaCard
+      href={`/reels?pin=${encodeURIComponent(item.id)}`}
+      // クリック時点でフィード取得を先行開始（この単語を先頭に固定）。
+      onClick={() => prefetchReelFeed(item.id)}
+      artStyle={{ background: `linear-gradient(165deg, ${desktopThumbColor(item.id)} 0%, #1a1a1a 170%)` }}
+      artChildren={
+        <div
+          style={{
+            position: 'absolute',
+            inset: 0,
+            padding: 12,
+            display: 'flex',
+            flexDirection: 'column',
+            justifyContent: 'space-between',
+            textAlign: 'left',
+          }}
+        >
+          <span
+            className="mono"
+            style={{
+              alignSelf: 'flex-start',
+              borderRadius: 999,
+              background: 'rgba(255,255,255,0.2)',
+              padding: '2px 8px',
+              fontSize: 9,
+              fontWeight: 700,
+              letterSpacing: '0.04em',
+            }}
+          >
+            語源
+          </span>
+          <div style={{ minWidth: 0 }}>
+            <div style={{ fontSize: 20, fontWeight: 800, lineHeight: 1.15, wordBreak: 'break-word' }}>
+              {item.english}
+            </div>
+            <div style={{ display: 'flex', flexWrap: 'wrap', alignItems: 'center', gap: 4, marginTop: 8 }}>
+              {parts.map((part, index) => (
+                <span key={`${part.text}-${index}`} style={{ display: 'inline-flex', alignItems: 'center', gap: 4 }}>
+                  {index > 0 && <span style={{ fontSize: 10, fontWeight: 700, color: 'rgba(255,255,255,0.6)' }}>+</span>}
+                  <span
+                    className="mono"
+                    style={{ borderRadius: 6, background: 'rgba(255,255,255,0.2)', padding: '2px 6px', fontSize: 10, fontWeight: 700 }}
+                  >
+                    {part.text}
+                  </span>
+                </span>
+              ))}
+            </div>
+          </div>
+        </div>
+      }
+      title={item.japanese}
+      subtitle={item.bookTitle}
+    />
+  );
+}
+
+/* ============ 右サイド ============ */
 
 function DesktopUpgradeCard({ onDismiss }: { onDismiss?: () => void }) {
   return (
@@ -286,155 +620,6 @@ function DesktopUpgradeCard({ onDismiss }: { onDismiss?: () => void }) {
         Proプランを見る
       </div>
     </Link>
-    </div>
-  );
-}
-
-function DesktopGeneratingBookTile({ scan }: { scan: DesktopPendingScan }) {
-  return (
-    <div
-      className="ds-book"
-      role="status"
-      aria-live="polite"
-      aria-busy="true"
-      aria-label={`${scan.project_title} を生成中`}
-      style={{
-        background: scan.iconDataUrl
-          ? `linear-gradient(rgba(26,26,26,0.42), rgba(26,26,26,0.42)), center / cover url(${scan.iconDataUrl})`
-          : 'linear-gradient(135deg, #137FEC 0%, #3DA1B8 52%, #228B22 100%)',
-        cursor: 'default',
-        pointerEvents: 'none',
-      }}
-    >
-      <div className="bk-spine" />
-      <div style={{ display: 'flex', justifyContent: 'space-between', gap: 12 }}>
-        <div style={{ minWidth: 0 }}>
-          <div className="bk-title" style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
-            {scan.project_title}
-          </div>
-          <div className="bk-foot mono">単語を抽出中...</div>
-        </div>
-        <div
-          className="scanvocab-generating-spin"
-          style={{
-            width: 30,
-            height: 30,
-            border: '3px solid rgba(255,255,255,0.35)',
-            borderTopColor: '#fff',
-            borderRadius: 999,
-            flexShrink: 0,
-          }}
-          aria-hidden="true"
-        />
-      </div>
-      <div>
-        <div className="bk-n">AI<span className="u">解析</span></div>
-        <div style={{ display: 'flex', gap: 7, marginTop: 12 }}>
-          <span className="scanvocab-generating-pulse" style={{ height: 9, flex: 1, borderRadius: 999, background: 'rgba(255,255,255,0.78)' }} />
-          <span className="scanvocab-generating-pulse" style={{ height: 9, flex: 1, borderRadius: 999, background: 'rgba(255,255,255,0.58)', animationDelay: '0.16s' }} />
-          <span className="scanvocab-generating-pulse" style={{ height: 9, flex: 1, borderRadius: 999, background: 'rgba(255,255,255,0.38)', animationDelay: '0.32s' }} />
-        </div>
-      </div>
-    </div>
-  );
-}
-
-function DesktopBookTile({ project }: { project: DesktopHomeProject }) {
-  const pct = project.totalWords > 0 ? Math.round((project.masteredWords / project.totalWords) * 100) : 0;
-  const bg = project.iconImage ? undefined : desktopThumbColor(project.id);
-  return (
-    <Link
-      href={`/project/${project.id}`}
-      className="ds-book"
-      style={{
-        background: bg,
-        backgroundImage: project.iconImage ? `url(${project.iconImage})` : undefined,
-        backgroundSize: 'cover',
-        backgroundPosition: 'center',
-      }}
-    >
-      <div className="bk-spine" />
-      <div>
-        <div className="bk-title">{project.title}</div>
-        <div className="bk-foot mono">{desktopSourceLabel(project)}</div>
-      </div>
-      <div>
-        <div className="bk-n">{project.totalWords}<span className="u">語</span></div>
-        <div className="bk-bar"><i style={{ width: `${pct}%` }} /></div>
-        <div className="bk-foot">習得 {pct}% · 更新 {desktopUpdatedLabel(project.lastUsedAt ?? project.createdAt)}</div>
-      </div>
-    </Link>
-  );
-}
-
-function DesktopGeneratingProjectRow({ scan }: { scan: DesktopPendingScan }) {
-  return (
-    <div className="ds-prow" role="status" aria-live="polite" aria-busy="true" style={{ cursor: 'default', pointerEvents: 'none' }}>
-      <div
-        className="tn"
-        style={{
-          background: scan.iconDataUrl
-            ? `center / cover url(${scan.iconDataUrl})`
-            : 'linear-gradient(135deg, #137FEC, #3DA1B8)',
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'center',
-        }}
-      >
-        <div
-          className="scanvocab-generating-spin"
-          style={{
-            width: 25,
-            height: 25,
-            border: '3px solid rgba(255,255,255,0.35)',
-            borderTopColor: '#fff',
-            borderRadius: 999,
-          }}
-          aria-hidden="true"
-        />
-      </div>
-      <div className="body">
-        <div className="ttl">{scan.project_title}</div>
-        <div className="sub">AI が単語を抽出しています</div>
-      </div>
-      <div className="count" style={{ fontSize: 18 }}>生成中</div>
-    </div>
-  );
-}
-
-function DesktopProjectRow({ project }: { project: DesktopHomeProject }) {
-  const hasWords = project.totalWords > 0;
-  return (
-    <div className="ds-prow">
-      <Link href={`/project/${project.id}`} className="ds-prow-main">
-        <div
-          className="tn"
-          style={{
-            background: desktopThumbColor(project.id),
-            backgroundImage: project.iconImage ? `url(${project.iconImage})` : undefined,
-            backgroundSize: 'cover',
-            backgroundPosition: 'center',
-          }}
-        >
-          {!project.iconImage && project.title.charAt(0)}
-        </div>
-        <div className="body">
-          <div className="ttl">{project.title}</div>
-          <div className="sub">{desktopSourceLabel(project)} · 更新 {desktopUpdatedLabel(project.lastUsedAt ?? project.createdAt)}</div>
-        </div>
-        <div className="count">{project.totalWords}<span className="u">語</span></div>
-      </Link>
-      {hasWords && (
-        <Link
-          href={`/quiz/${project.id}?from=/`}
-          className="ds-prow-play"
-          aria-label={`${project.title}のクイズを開始`}
-          title="クイズを開始"
-        >
-          <Icon name="play_arrow" size={20} filled />
-        </Link>
-      )}
-      <Icon name="chevron_right" style={{ color: 'var(--color-muted)' }} />
     </div>
   );
 }

--- a/src/components/desktop/DesktopHome.tsx
+++ b/src/components/desktop/DesktopHome.tsx
@@ -25,6 +25,7 @@ import {
   seedGroupSummary,
 } from '@/lib/shared-projects/group-overview-cache';
 import { prefetchReelFeed } from '@/hooks/use-reel-feed';
+import { seedPinnedReelPreview } from '@/lib/reels/pinned-preview';
 import type { HomeRecommendedBook, HomeReelPreviewItem } from '@/lib/home/recommendations-types';
 import type { Project } from '@/types';
 import type { StudyGroupSummary } from '@/lib/shared-projects/types';
@@ -96,6 +97,13 @@ export function DesktopHomeView({
     () => (q ? projects.filter((project) => project.title.toLowerCase().includes(q)) : projects),
     [projects, q],
   );
+  // 上部ショートカットグリッドに載った単語帳は下のシェルフから除外し、
+  // 溢れた分だけを表示する（検索中は全件から検索）。
+  const gridProjectCount = Math.min(
+    projects.length,
+    homeShortcutContentSlots(stats.favoriteCount > 0),
+  );
+  const shelfProjects = q ? filteredProjects : projects.slice(gridProjectCount);
 
   return (
     <div className="hidden h-full min-h-0 flex-col lg:flex">
@@ -137,9 +145,9 @@ export function DesktopHomeView({
             {pendingScans.map((scan) => (
               <DesktopGeneratingMediaCard key={scan.id} scan={scan} />
             ))}
-            {loading && filteredProjects.length === 0 && pendingScans.length === 0
+            {loading && shelfProjects.length === 0 && pendingScans.length === 0
               ? [0, 1, 2, 3].map((slot) => <DesktopMediaCardSkeleton key={slot} />)
-              : filteredProjects.map((project) => (
+              : shelfProjects.map((project) => (
                   <DesktopHomeBookCard key={project.id} project={project} />
                 ))}
             {!q && !loading && <DesktopNewBookCard onClick={onStartScan} />}
@@ -492,8 +500,12 @@ function DesktopReelPreviewCard({ item }: { item: HomeReelPreviewItem }) {
   return (
     <DesktopMediaCard
       href={`/reels?pin=${encodeURIComponent(item.id)}`}
-      // クリック時点でフィード取得を先行開始（この単語を先頭に固定）。
-      onClick={() => prefetchReelFeed(item.id)}
+      // クリック時点でフィード取得を先行開始（この単語を先頭に固定）し、
+      // /reels 側で即時表示できるよう表示データもシードする。
+      onClick={() => {
+        prefetchReelFeed(item.id);
+        seedPinnedReelPreview(item);
+      }}
       artStyle={{ background: `linear-gradient(165deg, ${desktopThumbColor(item.id)} 0%, #1a1a1a 170%)` }}
       artChildren={
         <div

--- a/src/components/desktop/DesktopMediaShelf.tsx
+++ b/src/components/desktop/DesktopMediaShelf.tsx
@@ -1,0 +1,94 @@
+'use client';
+
+/**
+ * デスクトップ Spotify 風の共通部品。
+ * - DesktopShelf: セクション見出し（タイトル + すべて表示）と横スクロール列
+ * - DesktopMediaCard: 正方形アートワーク + タイトル + サブタイトルのカード。
+ *   ホームのマイ単語帳と共有ライブラリの共有単語帳で同じカードを使う。
+ */
+
+import Link from 'next/link';
+import type { CSSProperties, MouseEvent, ReactNode } from 'react';
+import { Icon } from '@/components/ui/Icon';
+
+export function DesktopShelf({
+  title,
+  count,
+  seeAllHref,
+  onSeeAll,
+  children,
+}: {
+  title: string;
+  count?: number;
+  seeAllHref?: string;
+  onSeeAll?: () => void;
+  children: ReactNode;
+}) {
+  return (
+    <section className="ds-shelf">
+      <div className="ds-shelf-head">
+        <div style={{ display: 'flex', alignItems: 'baseline', gap: 8, minWidth: 0 }}>
+          <h2>{title}</h2>
+          {typeof count === 'number' && (
+            <span className="mono muted" style={{ fontSize: 12 }}>{count}</span>
+          )}
+        </div>
+        {seeAllHref ? (
+          <Link href={seeAllHref} className="see-all">
+            すべて表示
+            <Icon name="chevron_right" style={{ fontSize: 15 }} />
+          </Link>
+        ) : onSeeAll ? (
+          <button type="button" className="see-all" onClick={onSeeAll}>
+            すべて表示
+            <Icon name="chevron_right" style={{ fontSize: 15 }} />
+          </button>
+        ) : null}
+      </div>
+      <div className="ds-shelf-row">{children}</div>
+    </section>
+  );
+}
+
+export function DesktopMediaCard({
+  href,
+  onClick,
+  artStyle,
+  artChildren,
+  title,
+  subtitle,
+  playHref,
+  playLabel,
+}: {
+  href?: string;
+  /** stretch リンクのクリック時に呼ばれる（preventDefault + 独自遷移も可） */
+  onClick?: (event: MouseEvent<HTMLAnchorElement>) => void;
+  artStyle?: CSSProperties;
+  artChildren?: ReactNode;
+  title: string;
+  subtitle?: ReactNode;
+  /** ホバー時に出す再生ボタンの遷移先（例: クイズ開始） */
+  playHref?: string;
+  playLabel?: string;
+}) {
+  return (
+    <div className="ds-media-card">
+      <div className="art" style={artStyle}>
+        {artChildren}
+        {playHref && (
+          <Link href={playHref} className="play" aria-label={playLabel ?? `${title}を再生`}>
+            <Icon name="play_arrow" size={22} filled />
+          </Link>
+        )}
+      </div>
+      <div className="meta">
+        <div className="t">{title}</div>
+        {subtitle != null && <div className="s">{subtitle}</div>}
+      </div>
+      {href && (
+        // カード全面を覆うリンク（play ボタンは z-index で上に重なる）
+        <Link href={href} className="stretch" aria-label={title} onClick={onClick} />
+      )}
+    </div>
+  );
+}

--- a/src/components/desktop/DesktopProjectDetail.tsx
+++ b/src/components/desktop/DesktopProjectDetail.tsx
@@ -218,45 +218,7 @@ export function DesktopProjectDetailView({
 
   return (
     <div className="hidden h-full min-h-0 flex-col lg:flex">
-      <DesktopTopbar title={project.title} crumb="単語帳 / 一覧">
-        <DesktopButton href={`/quiz/${projectId}`} variant="accent" icon="school" title="クイズ">{''}</DesktopButton>
-        <DesktopButton href={`/flashcard/${projectId}`} icon="style" title="カード">{''}</DesktopButton>
-        <DesktopButton onClick={onRename} icon="edit" title="名称変更">{''}</DesktopButton>
-        <div ref={addMenuRef} style={{ position: 'relative' }}>
-          <DesktopButton onClick={() => setAddMenuOpen((v) => !v)} icon="add" title="単語を追加">{''}</DesktopButton>
-          {addMenuOpen && (
-            <>
-              <button
-                type="button"
-                className="fixed inset-0 z-40 cursor-default bg-transparent"
-                aria-label="メニューを閉じる"
-                onClick={() => setAddMenuOpen(false)}
-              />
-              <div
-                className="absolute right-0 top-[calc(100%+6px)] z-50 w-[180px] overflow-hidden rounded-[12px] border-2 border-[var(--solid-ink)] bg-white"
-                style={{ boxShadow: '2px 3px 0 var(--solid-ink)' }}
-              >
-                <button
-                  type="button"
-                  className="flex w-full items-center gap-2 px-4 py-3 text-left text-[13px] font-bold transition-colors hover:bg-[var(--color-surface-secondary)]"
-                  onClick={() => { setAddMenuOpen(false); onScan(); }}
-                >
-                  <Icon name="photo_camera" style={{ fontSize: 18 }} />
-                  スキャンで追加
-                </button>
-                <button
-                  type="button"
-                  className="flex w-full items-center gap-2 px-4 py-3 text-left text-[13px] font-bold transition-colors hover:bg-[var(--color-surface-secondary)]"
-                  onClick={() => { setAddMenuOpen(false); onManualAdd(); }}
-                >
-                  <Icon name="edit" style={{ fontSize: 18 }} />
-                  手動で追加
-                </button>
-              </div>
-            </>
-          )}
-        </div>
-      </DesktopTopbar>
+      <DesktopTopbar title={project.title} crumb="単語帳 / 一覧" />
 
       <div className={`ds-scroll ds-project-detail-grid${railCollapsed ? ' ds-project-detail-grid--rail-collapsed' : ''}`}>
         <div style={{ minWidth: 0 }}>
@@ -293,41 +255,45 @@ export function DesktopProjectDetailView({
           </div>
 
           <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 14, flexShrink: 0 }}>
+            {/* 旧トップバー右上のアクション（クイズ/カード/名称変更/追加） */}
             <div style={{ display: 'flex', gap: 8 }}>
-              <button
-                type="button"
-                className={'ds-btn sm' + (filterActive ? ' dark' : '')}
-                onClick={onOpenFilterSheet}
-                aria-pressed={filterActive}
-              >
-                <Icon name="filter_list" />
-              </button>
-              <button
-                type="button"
-                className={'ds-btn sm' + (sortActive ? ' dark' : '')}
-                onClick={onOpenSortSheet}
-                aria-pressed={sortActive}
-              >
-                <Icon name="swap_vert" />
-              </button>
-              <button
-                type="button"
-                className={'ds-btn sm' + (selectMode ? ' dark' : '')}
-                onClick={onToggleSelectMode}
-                aria-pressed={selectMode}
-              >
-                <Icon name="check_box" />
-              </button>
-              {selectMode && selectedWordIds.size > 0 && (
-                <button
-                  type="button"
-                  className="ds-btn sm"
-                  onClick={onBulkDelete}
-                  style={{ color: 'var(--color-error, #cc4d59)' }}
-                >
-                  <Icon name="delete" />{selectedWordIds.size}語を削除
-                </button>
-              )}
+              <DesktopButton href={`/quiz/${projectId}`} variant="accent" icon="school" title="クイズ">{''}</DesktopButton>
+              <DesktopButton href={`/flashcard/${projectId}`} icon="style" title="カード">{''}</DesktopButton>
+              <DesktopButton onClick={onRename} icon="edit" title="名称変更">{''}</DesktopButton>
+              <div ref={addMenuRef} style={{ position: 'relative' }}>
+                <DesktopButton onClick={() => setAddMenuOpen((v) => !v)} icon="add" title="単語を追加">{''}</DesktopButton>
+                {addMenuOpen && (
+                  <>
+                    <button
+                      type="button"
+                      className="fixed inset-0 z-40 cursor-default bg-transparent"
+                      aria-label="メニューを閉じる"
+                      onClick={() => setAddMenuOpen(false)}
+                    />
+                    <div
+                      className="absolute left-0 top-[calc(100%+6px)] z-50 w-[180px] overflow-hidden rounded-[12px] border-2 border-[var(--solid-ink)] bg-white"
+                      style={{ boxShadow: '2px 3px 0 var(--solid-ink)' }}
+                    >
+                      <button
+                        type="button"
+                        className="flex w-full items-center gap-2 px-4 py-3 text-left text-[13px] font-bold transition-colors hover:bg-[var(--color-surface-secondary)]"
+                        onClick={() => { setAddMenuOpen(false); onScan(); }}
+                      >
+                        <Icon name="photo_camera" style={{ fontSize: 18 }} />
+                        スキャンで追加
+                      </button>
+                      <button
+                        type="button"
+                        className="flex w-full items-center gap-2 px-4 py-3 text-left text-[13px] font-bold transition-colors hover:bg-[var(--color-surface-secondary)]"
+                        onClick={() => { setAddMenuOpen(false); onManualAdd(); }}
+                      >
+                        <Icon name="edit" style={{ fontSize: 18 }} />
+                        手動で追加
+                      </button>
+                    </div>
+                  </>
+                )}
+              </div>
             </div>
             {hiddenCols.size > 0 && (
               <div style={{ display: 'flex', gap: 6, alignItems: 'center' }}>
@@ -349,6 +315,49 @@ export function DesktopProjectDetailView({
               </span>
             )}
             <div style={{ flex: 1 }} />
+            {/* フィルタ・ソート・選択（正方形）は検索窓の左に配置 */}
+            <div style={{ display: 'flex', gap: 8 }}>
+              {selectMode && selectedWordIds.size > 0 && (
+                <button
+                  type="button"
+                  className="ds-btn sm"
+                  onClick={onBulkDelete}
+                  style={{ color: 'var(--color-error, #cc4d59)' }}
+                >
+                  <Icon name="delete" />{selectedWordIds.size}語を削除
+                </button>
+              )}
+              <button
+                type="button"
+                className={'ds-btn sm' + (filterActive ? ' dark' : '')}
+                style={{ width: 36, height: 36, padding: 0 }}
+                onClick={onOpenFilterSheet}
+                aria-pressed={filterActive}
+                aria-label="フィルタ"
+              >
+                <Icon name="filter_list" />
+              </button>
+              <button
+                type="button"
+                className={'ds-btn sm' + (sortActive ? ' dark' : '')}
+                style={{ width: 36, height: 36, padding: 0 }}
+                onClick={onOpenSortSheet}
+                aria-pressed={sortActive}
+                aria-label="並べ替え"
+              >
+                <Icon name="swap_vert" />
+              </button>
+              <button
+                type="button"
+                className={'ds-btn sm' + (selectMode ? ' dark' : '')}
+                style={{ width: 36, height: 36, padding: 0 }}
+                onClick={onToggleSelectMode}
+                aria-pressed={selectMode}
+                aria-label="選択"
+              >
+                <Icon name="check_box" />
+              </button>
+            </div>
             <DesktopSearchBox
               placeholder="英単語・日本語を検索"
               value={query}

--- a/src/components/desktop/DesktopProjectDetail.tsx
+++ b/src/components/desktop/DesktopProjectDetail.tsx
@@ -218,7 +218,51 @@ export function DesktopProjectDetailView({
 
   return (
     <div className="hidden h-full min-h-0 flex-col lg:flex">
-      <DesktopTopbar title={project.title} crumb="単語帳 / 一覧" />
+      <DesktopTopbar title={project.title} crumb="単語帳 / 一覧">
+        {/* 「...」メニュー: 単語の追加 / 名称変更 */}
+        <div ref={addMenuRef} style={{ position: 'relative' }}>
+          <DesktopButton onClick={() => setAddMenuOpen((v) => !v)} icon="more_horiz" title="その他の操作">{''}</DesktopButton>
+          {addMenuOpen && (
+            <>
+              <button
+                type="button"
+                className="fixed inset-0 z-40 cursor-default bg-transparent"
+                aria-label="メニューを閉じる"
+                onClick={() => setAddMenuOpen(false)}
+              />
+              <div
+                className="absolute right-0 top-[calc(100%+6px)] z-50 w-[180px] overflow-hidden rounded-[12px] border-2 border-[var(--solid-ink)] bg-white"
+                style={{ boxShadow: '2px 3px 0 var(--solid-ink)' }}
+              >
+                <button
+                  type="button"
+                  className="flex w-full items-center gap-2 px-4 py-3 text-left text-[13px] font-bold transition-colors hover:bg-[var(--color-surface-secondary)]"
+                  onClick={() => { setAddMenuOpen(false); onScan(); }}
+                >
+                  <Icon name="photo_camera" style={{ fontSize: 18 }} />
+                  スキャンで追加
+                </button>
+                <button
+                  type="button"
+                  className="flex w-full items-center gap-2 px-4 py-3 text-left text-[13px] font-bold transition-colors hover:bg-[var(--color-surface-secondary)]"
+                  onClick={() => { setAddMenuOpen(false); onManualAdd(); }}
+                >
+                  <Icon name="edit" style={{ fontSize: 18 }} />
+                  手動で追加
+                </button>
+                <button
+                  type="button"
+                  className="flex w-full items-center gap-2 px-4 py-3 text-left text-[13px] font-bold transition-colors hover:bg-[var(--color-surface-secondary)]"
+                  onClick={() => { setAddMenuOpen(false); onRename(); }}
+                >
+                  <Icon name="drive_file_rename_outline" style={{ fontSize: 18 }} />
+                  名称変更
+                </button>
+              </div>
+            </>
+          )}
+        </div>
+      </DesktopTopbar>
 
       <div className={`ds-scroll ds-project-detail-grid${railCollapsed ? ' ds-project-detail-grid--rail-collapsed' : ''}`}>
         <div style={{ minWidth: 0 }}>
@@ -255,45 +299,11 @@ export function DesktopProjectDetailView({
           </div>
 
           <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 14, flexShrink: 0 }}>
-            {/* 旧トップバー右上のアクション（クイズ/カード/名称変更/追加） */}
+            {/* クイズ（再生）とフラッシュカード。カードは緑（アクセント）の次に
+                目を引く dark 配色にする */}
             <div style={{ display: 'flex', gap: 8 }}>
-              <DesktopButton href={`/quiz/${projectId}`} variant="accent" icon="school" title="クイズ">{''}</DesktopButton>
-              <DesktopButton href={`/flashcard/${projectId}`} icon="style" title="カード">{''}</DesktopButton>
-              <DesktopButton onClick={onRename} icon="edit" title="名称変更">{''}</DesktopButton>
-              <div ref={addMenuRef} style={{ position: 'relative' }}>
-                <DesktopButton onClick={() => setAddMenuOpen((v) => !v)} icon="add" title="単語を追加">{''}</DesktopButton>
-                {addMenuOpen && (
-                  <>
-                    <button
-                      type="button"
-                      className="fixed inset-0 z-40 cursor-default bg-transparent"
-                      aria-label="メニューを閉じる"
-                      onClick={() => setAddMenuOpen(false)}
-                    />
-                    <div
-                      className="absolute left-0 top-[calc(100%+6px)] z-50 w-[180px] overflow-hidden rounded-[12px] border-2 border-[var(--solid-ink)] bg-white"
-                      style={{ boxShadow: '2px 3px 0 var(--solid-ink)' }}
-                    >
-                      <button
-                        type="button"
-                        className="flex w-full items-center gap-2 px-4 py-3 text-left text-[13px] font-bold transition-colors hover:bg-[var(--color-surface-secondary)]"
-                        onClick={() => { setAddMenuOpen(false); onScan(); }}
-                      >
-                        <Icon name="photo_camera" style={{ fontSize: 18 }} />
-                        スキャンで追加
-                      </button>
-                      <button
-                        type="button"
-                        className="flex w-full items-center gap-2 px-4 py-3 text-left text-[13px] font-bold transition-colors hover:bg-[var(--color-surface-secondary)]"
-                        onClick={() => { setAddMenuOpen(false); onManualAdd(); }}
-                      >
-                        <Icon name="edit" style={{ fontSize: 18 }} />
-                        手動で追加
-                      </button>
-                    </div>
-                  </>
-                )}
-              </div>
+              <DesktopButton href={`/quiz/${projectId}`} variant="accent" icon="play_arrow" title="クイズを開始">{''}</DesktopButton>
+              <DesktopButton href={`/flashcard/${projectId}`} variant="dark" icon="style" title="フラッシュカード">{''}</DesktopButton>
             </div>
             {hiddenCols.size > 0 && (
               <div style={{ display: 'flex', gap: 6, alignItems: 'center' }}>

--- a/src/components/desktop/DesktopShared.tsx
+++ b/src/components/desktop/DesktopShared.tsx
@@ -391,13 +391,6 @@ function DiscoverFeed({
           ))}
         </div>
       )}
-
-      {feed.nextCursor && (
-        <button type="button" onClick={feed.loadMore} disabled={feed.loadingMore} className="ds-btn" style={{ marginTop: 16 }}>
-          <Icon name={feed.loadingMore ? 'progress_activity' : 'expand_more'} className={feed.loadingMore ? 'animate-spin' : undefined} />
-          {feed.loadingMore ? '読み込み中...' : 'もっと見る'}
-        </button>
-      )}
     </section>
   );
 }

--- a/src/components/desktop/DesktopShared.tsx
+++ b/src/components/desktop/DesktopShared.tsx
@@ -37,7 +37,6 @@ export function DesktopSharedView({
   query,
   payload,
   loading,
-  loadingMore,
   error,
   joinedGroups,
   groupQuery,
@@ -49,7 +48,6 @@ export function DesktopSharedView({
   onQueryChange,
   onCategorySelect,
   onBackToAll,
-  onLoadMore,
   onOpenShareSheet,
   onProjectMissing,
 }: {
@@ -57,7 +55,6 @@ export function DesktopSharedView({
   query: string;
   payload: SharedDiscoverPayload;
   loading: boolean;
-  loadingMore: boolean;
   error: string | null;
   joinedGroups: StudyGroupSummary[];
   groupQuery: string;
@@ -69,7 +66,6 @@ export function DesktopSharedView({
   onQueryChange: (value: string) => void;
   onCategorySelect: (category: DesktopSharedCategory) => void;
   onBackToAll: () => void;
-  onLoadMore: () => void;
   onOpenShareSheet: () => void;
   onProjectMissing: (projectId: string) => void;
 }) {
@@ -205,8 +201,6 @@ export function DesktopSharedView({
                 <CategoryResults
                   category={category as Exclude<SharedDiscoverCategory, 'all'>}
                   payload={payload}
-                  onLoadMore={onLoadMore}
-                  loadingMore={loadingMore}
                   onProjectMissing={onProjectMissing}
                 />
               ) : hasQuery ? (
@@ -843,26 +837,16 @@ function GroupSearchResults({
 function CategoryResults({
   category,
   payload,
-  loadingMore,
-  onLoadMore,
   onProjectMissing,
 }: {
   category: Exclude<SharedDiscoverCategory, 'all'>;
   payload: SharedDiscoverPayload;
-  loadingMore: boolean;
-  onLoadMore: () => void;
   onProjectMissing: (projectId: string) => void;
 }) {
   return (
     <>
       {category === 'users' && <UserGrid users={payload.users} />}
       {category === 'projects' && <ProjectGrid projects={payload.projects} onProjectMissing={onProjectMissing} />}
-      {payload.nextCursor && (
-        <button type="button" onClick={onLoadMore} disabled={loadingMore} className="ds-btn" style={{ marginTop: 18 }}>
-          <Icon name={loadingMore ? 'progress_activity' : 'expand_more'} className={loadingMore ? 'animate-spin' : undefined} />
-          {loadingMore ? '読み込み中...' : 'もっと見る'}
-        </button>
-      )}
     </>
   );
 }

--- a/src/components/desktop/DesktopShared.tsx
+++ b/src/components/desktop/DesktopShared.tsx
@@ -5,6 +5,7 @@ import { useEffect, useRef, useState } from 'react';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { DesktopButton, DesktopSearchBox } from '@/components/desktop/DesktopChrome';
+import { DesktopMediaCard } from '@/components/desktop/DesktopMediaShelf';
 import { FollowNotificationsButton } from '@/components/notifications/FollowNotificationsButton';
 import { desktopThumbColor } from '@/components/desktop/desktop-data';
 import { Icon } from '@/components/ui/Icon';
@@ -145,8 +146,6 @@ export function DesktopSharedView({
                 {error}
               </div>
             )}
-
-            <CategoryChipRow onCategorySelect={onCategorySelect} onQueryChange={onQueryChange} />
 
             <DiscoverFeed
               feed={feed}
@@ -357,40 +356,6 @@ function usePublicGroupsPreview(enabled: boolean) {
 
 // ============ Dashboard: main column ============
 
-function CategoryChipRow({
-  onCategorySelect,
-  onQueryChange,
-}: {
-  onCategorySelect: (category: DesktopSharedCategory) => void;
-  onQueryChange: (value: string) => void;
-}) {
-  return (
-    <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8, marginBottom: 22 }}>
-      {(Object.keys(CATEGORY_META) as DesktopSharedCategory[]).map((key) => (
-        <button
-          key={key}
-          type="button"
-          className="ds-chip"
-          onClick={() => onCategorySelect(key)}
-          title={CATEGORY_META[key].description}
-        >
-          <Icon name={CATEGORY_META[key].icon} style={{ fontSize: 16 }} />
-          {CATEGORY_META[key].label}
-        </button>
-      ))}
-      <button
-        type="button"
-        className="ds-chip"
-        onClick={() => { onCategorySelect('projects'); onQueryChange('英検'); }}
-        title="英検対策の単語帳を探す"
-      >
-        <Icon name="school" style={{ fontSize: 16 }} />
-        英検
-      </button>
-    </div>
-  );
-}
-
 function DiscoverFeed({
   feed,
   onProjectMissing,
@@ -416,9 +381,9 @@ function DiscoverFeed({
       ) : feed.projects.length === 0 && !feed.error ? (
         <EmptyCard label="公開されている単語帳はまだありません" />
       ) : (
-        <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
+        <div className="ds-media-grid">
           {feed.projects.map((project) => (
-            <FeedProjectRow
+            <SharedWordbookCard
               key={project.project.id}
               project={project}
               onProjectMissing={onProjectMissing}
@@ -434,73 +399,6 @@ function DiscoverFeed({
         </button>
       )}
     </section>
-  );
-}
-
-function FeedProjectRow({
-  project,
-  onProjectMissing,
-}: {
-  project: SharedProjectCard;
-  onProjectMissing: (projectId: string) => void;
-}) {
-  const router = useRouter();
-  const href = project.project.shareId ? `/share/${project.project.shareId}` : '/shared';
-  const ownerLabel = sharedOwnerLabel(project);
-
-  const handleClick = async (event: MouseEvent<HTMLAnchorElement>) => {
-    const shareId = project.project.shareId;
-    if (!shareId) return;
-
-    event.preventDefault();
-    const exists = await sharedProjectStillExists(shareId);
-    if (exists === false) {
-      onProjectMissing(project.project.id);
-      return;
-    }
-    router.push(href);
-  };
-
-  return (
-    <Link
-      href={href}
-      onClick={(event) => void handleClick(event)}
-      className="ds-card"
-      style={{ padding: 16, display: 'flex', alignItems: 'center', gap: 14, color: 'inherit', textDecoration: 'none' }}
-    >
-      <div
-        className="ds-project-icon ds-project-icon--lg"
-        style={{
-          background: desktopThumbColor(project.project.id),
-          backgroundImage: project.project.iconImage ? `url(${project.project.iconImage})` : undefined,
-          flexShrink: 0,
-        }}
-      >
-        {!project.project.iconImage && project.project.title.charAt(0)}
-      </div>
-      <div style={{ flex: 1, minWidth: 0 }}>
-        <div style={{ fontFamily: 'var(--font-display)', fontWeight: 700, fontSize: 15, lineHeight: 1.3, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
-          {project.project.title}
-        </div>
-        <div className="muted" style={{ marginTop: 4, fontSize: 12, display: 'flex', alignItems: 'center', gap: 10, minWidth: 0 }}>
-          <span className="mono" style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{ownerLabel}</span>
-          <span style={{ display: 'inline-flex', alignItems: 'center', gap: 3, flexShrink: 0 }}>
-            <Icon name="menu_book" style={{ fontSize: 14 }} />{project.wordCount ?? 0} 語
-          </span>
-          <span style={{ display: 'inline-flex', alignItems: 'center', gap: 3, flexShrink: 0 }}>
-            <Icon name="thumb_up" style={{ fontSize: 14 }} />{project.likeCount ?? 0}
-          </span>
-        </div>
-        {(project.project.sharedTags ?? []).length > 0 && (
-          <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6, marginTop: 8 }}>
-            {project.project.sharedTags!.slice(0, 4).map((tag) => (
-              <span key={tag} className="ds-tag accent">{formatSharedTag(tag)}</span>
-            ))}
-          </div>
-        )}
-      </div>
-      <Icon name="chevron_right" style={{ fontSize: 20, color: 'var(--color-muted)', flexShrink: 0 }} />
-    </Link>
   );
 }
 
@@ -557,7 +455,7 @@ function PopularWordbooksRail({ projects }: { projects: SharedProjectCard[] }) {
               href={href}
               style={{
                 display: 'grid',
-                gridTemplateColumns: '20px minmax(0, 1fr) auto',
+                gridTemplateColumns: '18px 34px minmax(0, 1fr) auto',
                 alignItems: 'center',
                 gap: 10,
                 padding: '9px 0',
@@ -569,13 +467,17 @@ function PopularWordbooksRail({ projects }: { projects: SharedProjectCard[] }) {
               <span className="mono" style={{ fontSize: 13, fontWeight: 800, color: index < 3 ? 'var(--color-accent-ink)' : 'var(--color-muted)' }}>
                 {index + 1}
               </span>
-              <div style={{ minWidth: 0 }}>
-                <div style={{ fontSize: 13, fontWeight: 700, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
-                  {item.project.title}
-                </div>
-                <div className="muted" style={{ marginTop: 2, fontSize: 11, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
-                  {sharedOwnerLabel(item)} · {item.wordCount ?? 0} 語
-                </div>
+              <div
+                className="ds-project-icon ds-project-icon--sm"
+                style={{
+                  background: desktopThumbColor(item.project.id),
+                  backgroundImage: item.project.iconImage ? `url(${item.project.iconImage})` : undefined,
+                }}
+              >
+                {!item.project.iconImage && item.project.title.charAt(0)}
+              </div>
+              <div style={{ fontSize: 13, fontWeight: 700, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                {item.project.title}
               </div>
               <span className="muted" style={{ fontSize: 11.5, display: 'inline-flex', alignItems: 'center', gap: 3 }}>
                 <Icon name="thumb_up" style={{ fontSize: 14 }} />{item.likeCount ?? 0}
@@ -1060,9 +962,9 @@ function ProjectGrid({
     <section>
       <SectionTitle count={projects.length}>単語帳</SectionTitle>
       {projects.length === 0 ? <EmptyCard label="該当する単語帳はありません" /> : (
-        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3,1fr)', gap: 16 }}>
+        <div className="ds-media-grid">
           {projects.map((project) => (
-            <DesktopSharedCard
+            <SharedWordbookCard
               key={project.project.id}
               project={project}
               onProjectMissing={onProjectMissing}
@@ -1074,7 +976,8 @@ function ProjectGrid({
   );
 }
 
-function DesktopSharedCard({
+// 共有単語帳カード。ホームのマイ単語帳と同じ DesktopMediaCard を使う。
+function SharedWordbookCard({
   project,
   onProjectMissing,
 }: {
@@ -1099,37 +1002,24 @@ function DesktopSharedCard({
   };
 
   return (
-    <Link href={href} onClick={(event) => void handleClick(event)} className="ds-card" style={{ padding: 18, display: 'flex', flexDirection: 'column', gap: 14, color: 'inherit', textDecoration: 'none' }}>
-      <div style={{ display: 'flex', gap: 14 }}>
-        <div
-          className="ds-project-icon ds-project-icon--lg"
-          style={{
-            background: desktopThumbColor(project.project.id),
-            backgroundImage: project.project.iconImage ? `url(${project.project.iconImage})` : undefined,
-          }}
-        >
-          {!project.project.iconImage && project.project.title.charAt(0)}
-        </div>
-        <div style={{ flex: 1, minWidth: 0 }}>
-          <div style={{ fontFamily: 'var(--font-display)', fontWeight: 700, fontSize: 15, lineHeight: 1.25 }}>{project.project.title}</div>
-          <div className="mono muted" style={{ fontSize: 11, marginTop: 4 }}>{ownerLabel}</div>
-        </div>
-        <span className="ds-tag plain">公開</span>
-      </div>
-      {(project.project.sharedTags ?? []).length > 0 && (
-        <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6 }}>
-          {project.project.sharedTags!.slice(0, 4).map((tag) => <span key={tag} className="ds-tag accent">{formatSharedTag(tag)}</span>)}
-        </div>
-      )}
-      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
-        <span style={{ fontFamily: 'var(--font-display)', fontWeight: 800, fontSize: 18 }}>
-          {project.wordCount ?? 0}<span style={{ fontSize: 12, color: 'var(--color-secondary-text)' }}> 語</span>
-        </span>
-        <span className="muted" style={{ fontSize: 11.5, display: 'inline-flex', alignItems: 'center', gap: 4 }}>
-          <Icon name="thumb_up" style={{ fontSize: 15 }} />{project.likeCount ?? 0}
-        </span>
-      </div>
-    </Link>
+    <DesktopMediaCard
+      href={href}
+      onClick={(event) => void handleClick(event)}
+      artStyle={{
+        background: desktopThumbColor(project.project.id),
+        backgroundImage: project.project.iconImage ? `url(${project.project.iconImage})` : undefined,
+      }}
+      artChildren={!project.project.iconImage && project.project.title.charAt(0)}
+      title={project.project.title}
+      subtitle={
+        <>
+          <span className="mono" style={{ overflow: 'hidden', textOverflow: 'ellipsis' }}>{ownerLabel}</span>
+          <span style={{ display: 'inline-flex', alignItems: 'center', gap: 3, flexShrink: 0 }}>
+            <Icon name="thumb_up" style={{ fontSize: 13 }} />{project.likeCount ?? 0}
+          </span>
+        </>
+      }
+    />
   );
 }
 

--- a/src/components/desktop/DesktopSharedDetail.tsx
+++ b/src/components/desktop/DesktopSharedDetail.tsx
@@ -23,10 +23,10 @@ export function DesktopSharedDetailView({
   previewClearWordCount = 5,
   lockedCtaHref = '/login',
   onToggleLike,
-  onToggleSelectMode,
   onToggleWord,
   onImport,
   onClearSelection,
+  onWordAction,
 }: {
   project: Project;
   words: Word[];
@@ -43,10 +43,11 @@ export function DesktopSharedDetailView({
   previewClearWordCount?: number;
   lockedCtaHref?: string;
   onToggleLike: () => void;
-  onToggleSelectMode: () => void;
   onToggleWord: (wordId: string) => void;
   onImport: () => void;
   onClearSelection: () => void;
+  /** 行の「…」から単語単位のアクション（単語帳に追加 / 共有）を開く */
+  onWordAction?: (word: Word) => void;
 }) {
   const [ap, setAp] = useState<'all' | 'active' | 'passive'>('all');
   const [query, setQuery] = useState('');
@@ -75,13 +76,9 @@ export function DesktopSharedDetailView({
         <DesktopButton variant="ghost" icon="thumb_up" onClick={onToggleLike}>
           {liked ? 'いいね済み' : 'いいね'} {likeCount > 0 ? likeCount : ''}
         </DesktopButton>
-        {isPreviewLocked ? (
+        {isPreviewLocked && (
           <DesktopButton href={lockedCtaHref} variant="dark" icon="login">
             ログインして単語を見る
-          </DesktopButton>
-        ) : (
-          <DesktopButton variant={selectMode ? 'dark' : undefined} icon="checklist" onClick={onToggleSelectMode}>
-            {selectMode ? '選択を終了' : '選択して追加'}
           </DesktopButton>
         )}
       </DesktopTopbar>
@@ -151,6 +148,7 @@ export function DesktopSharedDetailView({
                 <th style={{ width: 90 }}>品詞</th>
                 <th>訳</th>
                 <th style={{ width: 70 }}>CEFR</th>
+                {onWordAction && !isPreviewLocked && <th style={{ width: 52 }} />}
               </tr>
             </thead>
             <tbody>
@@ -179,6 +177,22 @@ export function DesktopSharedDetailView({
                     <td className="pos"><span style={textStyle}>{desktopPosLabel(word.partOfSpeechTags)}</span></td>
                     <td className="ja"><span style={textStyle}><TranslationDisplay word={word} compact /></span></td>
                     <td className="cefr"><span className="cefr-pill" style={textStyle}>{word.cefrLevel || '-'}</span></td>
+                    {onWordAction && !isPreviewLocked && (
+                      <td style={{ textAlign: 'center' }}>
+                        <button
+                          type="button"
+                          className="ds-iconbtn"
+                          aria-label={`${word.english}のアクション`}
+                          title="単語帳に追加 / 共有"
+                          onClick={(event) => {
+                            event.stopPropagation();
+                            onWordAction(word);
+                          }}
+                        >
+                          <Icon name="more_horiz" style={{ fontSize: 18 }} />
+                        </button>
+                      </td>
+                    )}
                   </tr>
                 );
               })}

--- a/src/components/desktop/DesktopStats.tsx
+++ b/src/components/desktop/DesktopStats.tsx
@@ -31,7 +31,9 @@ export function DesktopStatsView({
   const masteryPercent = totalWords > 0 ? Math.round((mastered / totalWords) * 100) : 0;
   const summaryStats: DesktopStudySummaryStats = stats
     ? {
-        dueCount: stats.reviewWords,
+        // ホームの「今日の目標」と同じ SM-2 due 語数（getWordsDueForReview）。
+        // 縮退時（dueCount=null）のみ従来どおり学習中の語数で代替する。
+        dueCount: stats.dueCount ?? stats.reviewWords,
         completedToday: stats.quizStats.todayCount,
         streakDays: stats.quizStats.streakDays,
         totalWords,

--- a/src/components/desktop/DesktopStats.tsx
+++ b/src/components/desktop/DesktopStats.tsx
@@ -104,7 +104,6 @@ export function DesktopStatsView({
               <div className="ds-card ds-kpi"><div className="l" style={{ marginBottom: 2 }}>定着中</div><div className="v" style={{ color: '#1d4ed8' }}>{activeW}</div><div className="mono muted" style={{ fontSize: 11 }}>もう少し</div></div>
               <div className="ds-card ds-kpi"><div className="l" style={{ marginBottom: 2 }}>復習中</div><div className="v" style={{ color: '#92400e' }}>{review}</div><div className="mono muted" style={{ fontSize: 11 }}>要レビュー</div></div>
               <div className="ds-card ds-kpi"><div className="l" style={{ marginBottom: 2 }}>未学習</div><div className="v muted">{newWords}</div><div className="mono muted" style={{ fontSize: 11 }}>これから</div></div>
-              <div className="ds-card ds-kpi"><div className="l" style={{ marginBottom: 2 }}>間違えた問題</div><div className="v" style={{ color: 'var(--color-error)' }}>{stats.wrongAnswersCount}</div><div className="mono muted" style={{ fontSize: 11 }}>復習推奨</div></div>
             </div>
 
             <div className="ds-card" style={{ marginTop: 18, padding: '22px 26px', display: 'flex', alignItems: 'center', gap: 26 }}>

--- a/src/components/groups/JoinedGroupsSection.tsx
+++ b/src/components/groups/JoinedGroupsSection.tsx
@@ -157,7 +157,10 @@ export function JoinedGroupCard({ group, className }: { group: StudyGroupSummary
   );
 }
 
-/** デスクトップ向けカードグリッド（元 DesktopShared のローカル実装）。 */
+/**
+ * デスクトップ向けグリッド。モバイルの新UI（JoinedGroupCard: 今週のランキング
+ * 上位3人つきのリッチカード）をそのままグリッドで並べる。
+ */
 export function JoinedGroupGrid({
   groups,
   columns = 3,
@@ -191,38 +194,9 @@ export function JoinedGroupGrid({
           {groups.length}
         </span>
       </div>
-      <div style={{ display: 'grid', gridTemplateColumns: `repeat(${columns}, minmax(0, 1fr))`, gap: 16 }}>
+      <div style={{ display: 'grid', gridTemplateColumns: `repeat(${columns}, minmax(0, 1fr))`, gap: 16, alignItems: 'stretch' }}>
         {groups.map((group) => (
-          <Link
-            key={group.id}
-            href={`/groups/${encodeURIComponent(group.id)}`}
-            className="ds-card"
-            style={{ padding: 18, display: 'flex', alignItems: 'center', gap: 14, color: 'inherit', textDecoration: 'none' }}
-          >
-            <div
-              className="ds-project-icon ds-project-icon--lg"
-              style={{ background: thumbColor(group.id) }}
-            >
-              {group.name.charAt(0)}
-            </div>
-            <div style={{ flex: 1, minWidth: 0 }}>
-              <div style={{ display: 'flex', alignItems: 'center', gap: 6, minWidth: 0 }}>
-                <span style={{ fontFamily: 'var(--font-display)', fontWeight: 700, fontSize: 15, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
-                  {group.name}
-                </span>
-                {group.role === 'owner' && <span className="ds-tag plain">owner</span>}
-              </div>
-              <div className="muted" style={{ marginTop: 4, fontSize: 12, display: 'flex', alignItems: 'center', gap: 10 }}>
-                <span style={{ display: 'inline-flex', alignItems: 'center', gap: 3 }}>
-                  <Icon name="group" style={{ fontSize: 14 }} />{group.memberCount}人
-                </span>
-                <span style={{ display: 'inline-flex', alignItems: 'center', gap: 3 }}>
-                  <Icon name="menu_book" style={{ fontSize: 14 }} />{group.projectCount}冊
-                </span>
-              </div>
-            </div>
-            <Icon name="chevron_right" style={{ fontSize: 20, color: 'var(--color-muted)', flexShrink: 0 }} />
-          </Link>
+          <JoinedGroupCard key={group.id} group={group} className="h-full [&>div]:h-full" />
         ))}
       </div>
     </section>

--- a/src/components/home/CreateWordbookSheet.tsx
+++ b/src/components/home/CreateWordbookSheet.tsx
@@ -29,6 +29,11 @@ const METHODS: MethodOption[] = [
 interface CreateWordbookSheetProps {
   isOpen: boolean;
   onClose: () => void;
+  /**
+   * 'sheet'（既定）はモバイル向けボトムシート。'modal' はデスクトップ向けの
+   * 中央モーダル（下から出る UI を使わない）。中身のフローは共通。
+   */
+  variant?: 'sheet' | 'modal';
 }
 
 /**
@@ -38,7 +43,7 @@ interface CreateWordbookSheetProps {
  * modal. The optional name is carried into the scan flow as the new project
  * title, and is required for blank creation.
  */
-export function CreateWordbookSheet({ isOpen, onClose }: CreateWordbookSheetProps) {
+export function CreateWordbookSheet({ isOpen, onClose, variant = 'sheet' }: CreateWordbookSheetProps) {
   const router = useRouter();
   const { user, subscription, isPro } = useAuth();
   const [step, setStep] = useState<'method' | 'scan'>('method');
@@ -123,25 +128,46 @@ export function CreateWordbookSheet({ isOpen, onClose }: CreateWordbookSheetProp
         onClick={submitting ? undefined : onClose}
       />
 
-      {/* Bottom sheet — centered, max 480px */}
-      <div className="absolute bottom-0 left-0 right-0 flex justify-center">
+      {/* variant='sheet': ボトムシート / variant='modal': 中央モーダル（デスクトップ） */}
+      <div
+        className={
+          variant === 'modal'
+            ? 'absolute inset-0 flex items-center justify-center p-6'
+            : 'absolute bottom-0 left-0 right-0 flex justify-center'
+        }
+      >
         <div
-          className="w-full animate-fade-in-up"
-          style={{
-            maxWidth: 480,
-            background: '#faf7f1',
-            border: '2px solid var(--solid-ink)',
-            borderBottomWidth: 0,
-            borderTopLeftRadius: 20,
-            borderTopRightRadius: 20,
-            padding: '14px 18px max(28px, env(safe-area-inset-bottom))',
-            boxShadow: '0 -8px 24px rgba(26,26,26,0.18)',
-          }}
+          className={variant === 'modal' ? 'w-full animate-fade-in' : 'w-full animate-fade-in-up'}
+          style={
+            variant === 'modal'
+              ? {
+                  maxWidth: 480,
+                  maxHeight: '100%',
+                  overflowY: 'auto',
+                  background: '#faf7f1',
+                  border: '2px solid var(--solid-ink)',
+                  borderRadius: 20,
+                  padding: '18px 20px 22px',
+                  boxShadow: '6px 8px 0 var(--solid-ink)',
+                }
+              : {
+                  maxWidth: 480,
+                  background: '#faf7f1',
+                  border: '2px solid var(--solid-ink)',
+                  borderBottomWidth: 0,
+                  borderTopLeftRadius: 20,
+                  borderTopRightRadius: 20,
+                  padding: '14px 18px max(28px, env(safe-area-inset-bottom))',
+                  boxShadow: '0 -8px 24px rgba(26,26,26,0.18)',
+                }
+          }
         >
-          {/* Drag handle */}
-          <div className="mb-2.5 flex justify-center">
-            <div className="h-1 w-10 rounded-full bg-[rgba(26,26,26,0.2)]" />
-          </div>
+          {/* Drag handle（ボトムシートのみ） */}
+          {variant === 'sheet' && (
+            <div className="mb-2.5 flex justify-center">
+              <div className="h-1 w-10 rounded-full bg-[rgba(26,26,26,0.2)]" />
+            </div>
+          )}
 
           {/* Title row */}
           <div className="mb-3.5 flex items-center justify-between">

--- a/src/components/home/HomeReelRail.tsx
+++ b/src/components/home/HomeReelRail.tsx
@@ -9,6 +9,7 @@
 import Link from 'next/link';
 import { Icon } from '@/components/ui/Icon';
 import { prefetchReelFeed } from '@/hooks/use-reel-feed';
+import { seedPinnedReelPreview } from '@/lib/reels/pinned-preview';
 import { triggerHaptic } from '@/lib/haptics';
 import type { HomeReelPreviewItem } from '@/lib/home/recommendations-types';
 
@@ -68,8 +69,10 @@ function ReelPreviewCard({ item }: { item: HomeReelPreviewItem }) {
       href={`/reels?pin=${encodeURIComponent(item.id)}`}
       onPointerDown={() => {
         triggerHaptic();
-        // タップ時点でフィード取得を先行開始（この単語を先頭に固定）。
+        // タップ時点でフィード取得を先行開始（この単語を先頭に固定）し、
+        // /reels 側で即時表示できるよう表示データもシードする。
         prefetchReelFeed(item.id);
+        seedPinnedReelPreview(item);
       }}
       aria-label={`リールで${item.english}を見る`}
       className="relative flex h-[190px] w-[140px] shrink-0 snap-start flex-col overflow-hidden rounded-[14px] border-2 border-[var(--solid-ink)] p-3 text-white transition-all duration-100 active:translate-x-px active:translate-y-px"

--- a/src/components/home/ScanCaptureModal.tsx
+++ b/src/components/home/ScanCaptureModal.tsx
@@ -62,23 +62,11 @@ export function ScanCaptureModal({
         onClick={onClose}
       />
 
-      {/* Bottom sheet — centered, max 480px */}
-      <div className="absolute bottom-0 left-0 right-0 flex justify-center">
-        <div
-          className="w-full animate-fade-in-up"
-          style={{
-            maxWidth: 480,
-            background: '#faf7f1',
-            border: '2px solid var(--solid-ink)',
-            borderBottomWidth: 0,
-            borderTopLeftRadius: 20,
-            borderTopRightRadius: 20,
-            padding: '14px 18px max(28px, env(safe-area-inset-bottom))',
-            boxShadow: '0 -8px 24px rgba(26,26,26,0.18)',
-          }}
-        >
-          {/* Drag handle */}
-          <div className="mb-2.5 flex justify-center">
+      {/* モバイル: ボトムシート / デスクトップ(lg): ホームの新規作成と同じ中央モーダル */}
+      <div className="absolute bottom-0 left-0 right-0 flex justify-center lg:inset-0 lg:items-center lg:p-6">
+        <div className="w-full max-w-[480px] animate-fade-in-up rounded-t-[20px] border-2 border-b-0 border-[var(--solid-ink)] bg-[#faf7f1] px-[18px] pb-[max(28px,env(safe-area-inset-bottom))] pt-[14px] shadow-[0_-8px_24px_rgba(26,26,26,0.18)] lg:max-h-full lg:animate-fade-in lg:overflow-y-auto lg:rounded-[20px] lg:border-b-2 lg:pb-[22px] lg:shadow-[6px_8px_0_var(--solid-ink)]">
+          {/* Drag handle（ボトムシートのみ） */}
+          <div className="mb-2.5 flex justify-center lg:hidden">
             <div className="h-1 w-10 rounded-full bg-[rgba(26,26,26,0.2)]" />
           </div>
 

--- a/src/components/reel/ReelCard.tsx
+++ b/src/components/reel/ReelCard.tsx
@@ -26,7 +26,8 @@ type ReelCardProps = {
 
 const SWIPE_THRESHOLD = 80;
 
-function speak(english: string) {
+/** リール単語の読み上げ（カード内レールとデスクトップの外側レールで共用）。 */
+export function speakReelWord(english: string) {
   if (typeof window === 'undefined' || !('speechSynthesis' in window)) return;
   window.speechSynthesis.cancel();
   const utterance = new SpeechSynthesisUtterance(english);
@@ -215,14 +216,14 @@ export function ReelCard({
       </div>
       )}
 
-      {/* Right action rail */}
-      <div className="pointer-events-none absolute inset-y-0 right-3 flex items-center">
+      {/* Right action rail（デスクトップはカード外のレールを使うため非表示） */}
+      <div className="pointer-events-none absolute inset-y-0 right-3 flex items-center lg:hidden">
         <div className="pointer-events-auto">
           <ReelActionRail
             item={item}
             onLike={onLike}
             onSave={onSave}
-            onSpeak={() => speak(item.english)}
+            onSpeak={() => speakReelWord(item.english)}
             onComment={() => setCommentsOpen(true)}
             onShare={onShare}
             onMore={() => setMoreOpen(true)}

--- a/src/components/reel/ReelFeed.tsx
+++ b/src/components/reel/ReelFeed.tsx
@@ -22,6 +22,8 @@ type ReelFeedProps = {
   onShare: (item: ReelItem) => void;
   onFeedback: (item: ReelItem, feedback: ReelFeedback) => void;
   onCommentCountChange: (item: ReelItem, delta: number) => void;
+  /** アクティブなカードの単語が変わったとき（デスクトップの外側レール用） */
+  onActiveItemChange?: (item: ReelFeedItem | null) => void;
 };
 
 const RENDER_WINDOW = 2;
@@ -46,6 +48,7 @@ export function ReelFeed({
   onShare,
   onFeedback,
   onCommentCountChange,
+  onActiveItemChange,
 }: ReelFeedProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const [activeIndex, setActiveIndex] = useState(0);
@@ -92,6 +95,12 @@ export function ReelFeed({
       onLoadMore();
     }
   }, [activeIndex, hasMore, entries.length, onLoadMore]);
+
+  useEffect(() => {
+    if (!onActiveItemChange) return;
+    const entry = entries[activeIndex];
+    onActiveItemChange(entry && entry.kind === 'item' ? entry.item : null);
+  }, [activeIndex, entries, onActiveItemChange]);
 
   return (
     <div

--- a/src/components/reel/ReelStatusCards.tsx
+++ b/src/components/reel/ReelStatusCards.tsx
@@ -2,6 +2,7 @@
 
 import Link from 'next/link';
 import { Icon } from '@/components/ui/Icon';
+import type { HomeReelPreviewItem } from '@/lib/home/recommendations-types';
 
 function StatusShell({ children }: { children: React.ReactNode }) {
   return (
@@ -81,6 +82,69 @@ export function ReelSkeleton() {
       <div className="h-10 w-52 animate-pulse rounded-lg bg-[var(--color-surface-secondary)]" />
       <div className="h-5 w-32 animate-pulse rounded-lg bg-[var(--color-surface-secondary)]" />
       <div className="mt-8 h-16 w-full max-w-sm animate-pulse rounded-[var(--solid-radius-sm)] bg-[var(--color-surface-secondary)]" />
+    </div>
+  );
+}
+
+/**
+ * ホームのリールカードから遷移した直後、フィードAPIの応答を待つ間に
+ * pin された単語（英単語・訳・語源）を即時表示するプレビュー。
+ * レイアウトは ReelEtymologyPanel の統合面と揃えている。
+ */
+export function ReelPinnedPreviewCard({ item }: { item: HomeReelPreviewItem }) {
+  return (
+    <div className="flex h-full w-full flex-col items-center justify-center gap-4 px-8 text-center">
+      <div className="flex flex-col items-center gap-1">
+        <p className="font-display text-3xl font-bold text-[var(--color-foreground)]">
+          {item.english}
+        </p>
+        {item.pronunciation && (
+          <p className="font-mono text-base text-[var(--color-secondary-text)]">
+            {item.pronunciation}
+          </p>
+        )}
+      </div>
+
+      <div className="text-2xl font-bold leading-snug text-[var(--color-foreground)]">
+        {item.japanese}
+      </div>
+
+      {!item.morphology.none && item.morphology.formula.length > 0 && (
+        <div className="flex w-full max-w-md flex-col items-center gap-3 border-t border-[var(--color-border)] pt-4">
+          <p className="font-mono text-[10px] font-bold uppercase tracking-[0.14em] text-[var(--color-muted)]">
+            語源
+          </p>
+          <div className="flex flex-wrap items-center justify-center gap-x-1.5 gap-y-2">
+            {item.morphology.formula.map((part, index) => (
+              <span key={`${part.text}-${index}`} className="flex items-center gap-1.5">
+                {index > 0 && (
+                  <span className="text-base font-bold text-[var(--color-muted)]">＋</span>
+                )}
+                <span
+                  className={`rounded-full border px-3 py-1 text-sm font-bold ${
+                    part.kind === 'root'
+                      ? 'border-[var(--color-border)] bg-[var(--color-surface-secondary)] text-[var(--color-foreground)]'
+                      : 'border-[var(--color-accent)] bg-[var(--color-accent-light)] text-[var(--color-accent-ink)]'
+                  }`}
+                >
+                  {part.text}
+                  <span className="ml-1 text-xs font-semibold opacity-80">({part.meaningJa})</span>
+                </span>
+              </span>
+            ))}
+          </div>
+          {item.morphology.explanation && (
+            <p className="whitespace-pre-line text-base leading-relaxed text-[var(--color-secondary-text)]">
+              {item.morphology.explanation}
+            </p>
+          )}
+        </div>
+      )}
+
+      <div className="mt-2 flex items-center gap-2 text-xs font-semibold text-[var(--color-muted)]">
+        <Icon name="progress_activity" size={14} className="animate-spin" />
+        フィードを読み込み中...
+      </div>
     </div>
   );
 }

--- a/src/components/settings/ExampleGenreSettings.tsx
+++ b/src/components/settings/ExampleGenreSettings.tsx
@@ -12,9 +12,11 @@ import {
 
 type ExampleGenreSettingsProps = {
   variant?: 'mobile' | 'desktop';
+  /** desktop のみ: 親の ds-set-group に組み込む（外枠と見出しを描画しない） */
+  embedded?: boolean;
 };
 
-export function ExampleGenreSettings({ variant = 'mobile' }: ExampleGenreSettingsProps) {
+export function ExampleGenreSettings({ variant = 'mobile', embedded = false }: ExampleGenreSettingsProps) {
   const { isAuthenticated } = useAuth();
   const { showToast } = useToast();
   const { exampleGenres, loading, saving, setExampleGenres } = useUserPreferences();
@@ -190,9 +192,8 @@ export function ExampleGenreSettings({ variant = 'mobile' }: ExampleGenreSetting
   );
 
   if (variant === 'desktop') {
-    return (
-      <div className="ds-set-group">
-        <div className="gh">例文のパーソナライズ</div>
+    const desktopContent = (
+      <>
         <div className="ds-set-row">
           <div className="ic">
             <Icon
@@ -206,6 +207,15 @@ export function ExampleGenreSettings({ variant = 'mobile' }: ExampleGenreSetting
           </div>
         </div>
         {body}
+      </>
+    );
+
+    // embedded: 親側の ds-set-group（例: カスタマイズ）に組み込む
+    if (embedded) return desktopContent;
+    return (
+      <div className="ds-set-group">
+        <div className="gh">例文のパーソナライズ</div>
+        {desktopContent}
       </div>
     );
   }

--- a/src/components/settings/StudyReminderSettings.tsx
+++ b/src/components/settings/StudyReminderSettings.tsx
@@ -17,6 +17,8 @@ import { cn } from '@/lib/utils';
 
 type StudyReminderSettingsProps = {
   variant?: 'mobile' | 'desktop';
+  /** desktop のみ: 親の ds-set-group に組み込む（外枠と見出しを描画しない） */
+  embedded?: boolean;
 };
 
 const ADD_TIME_CANDIDATES = ['12:00', '21:00', '10:00', '19:00', '07:00', '22:00', '14:00'];
@@ -57,7 +59,7 @@ function getSetupErrorMessage(result: PushSubscriptionSetupResult): string {
   }
 }
 
-export function StudyReminderSettings({ variant = 'mobile' }: StudyReminderSettingsProps) {
+export function StudyReminderSettings({ variant = 'mobile', embedded = false }: StudyReminderSettingsProps) {
   const { user, isAuthenticated } = useAuth();
   const { showToast } = useToast();
   const {
@@ -210,9 +212,8 @@ export function StudyReminderSettings({ variant = 'mobile' }: StudyReminderSetti
   };
 
   if (variant === 'desktop') {
-    return (
-      <div className="ds-set-group">
-        <div className="gh">通知</div>
+    const desktopContent = (
+      <>
         <div className="ds-set-row">
           <div className="ic">
             <Icon
@@ -257,6 +258,15 @@ export function StudyReminderSettings({ variant = 'mobile' }: StudyReminderSetti
           </button>
         </div>
         {error && <div className="ds-notif-error">{error}</div>}
+      </>
+    );
+
+    // embedded: 親側の ds-set-group（例: カスタマイズ）に組み込む
+    if (embedded) return desktopContent;
+    return (
+      <div className="ds-set-group">
+        <div className="gh">通知</div>
+        {desktopContent}
       </div>
     );
   }

--- a/src/lib/profile/stats-server.ts
+++ b/src/lib/profile/stats-server.ts
@@ -109,6 +109,9 @@ export async function getPublicUserStats(
       reviewWords: s.review_words ?? 0,
       newWords: s.new_words ?? 0,
       favoriteWords: s.favorite_words ?? 0,
+      // サーバー側集計は単語ごとの nextReviewAt を持たないため算出不可（null）。
+      // 表示側は reviewWords に代替する。
+      dueCount: null,
       wrongAnswersCount: 0,
       quizStats: {
         todayCount: todayRow?.quiz_count ?? 0,

--- a/src/lib/reels/pinned-preview.ts
+++ b/src/lib/reels/pinned-preview.ts
@@ -1,0 +1,26 @@
+import type { HomeReelPreviewItem } from '@/lib/home/recommendations-types';
+
+/**
+ * ホームのリールカードは表示に必要な情報（英単語・訳・語源）を既に持っている。
+ * タップ時にここへシードしておき、/reels 側はフィードAPIの応答を待つ間、
+ * 固定（pin）単語のカードを即時レンダリングする（体感遅延の解消）。
+ */
+const PINNED_PREVIEW_TTL_MS = 30_000;
+
+let entry: { item: HomeReelPreviewItem; storedAt: number } | null = null;
+
+/** リールカードのタップ時に呼ぶ。 */
+export function seedPinnedReelPreview(item: HomeReelPreviewItem): void {
+  entry = { item, storedAt: Date.now() };
+}
+
+/** /reels 側で pin に一致するシードがあれば返す（TTL内のみ）。 */
+export function getPinnedReelPreview(pin: string): HomeReelPreviewItem | null {
+  if (!entry) return null;
+  if (entry.item.id !== pin) return null;
+  if (Date.now() - entry.storedAt >= PINNED_PREVIEW_TTL_MS) {
+    entry = null;
+    return null;
+  }
+  return entry.item;
+}

--- a/src/lib/stats-cache.ts
+++ b/src/lib/stats-cache.ts
@@ -19,6 +19,7 @@ import {
 } from '@/lib/utils';
 import { getCachedProjects, getCachedProjectWords, getHasLoaded } from '@/lib/home-cache';
 import { isRemoteStatsSyncEnabled } from '@/lib/stats-sync-config';
+import { getWordsDueForReview } from '@/lib/spaced-repetition';
 import { summarizeWordMemory } from '@/lib/words/memory';
 import type { SubscriptionStatus, Word } from '@/types';
 
@@ -30,6 +31,13 @@ export interface CachedStats {
   reviewWords: number;
   newWords: number;
   favoriteWords: number;
+  /**
+   * 今日の復習対象語数（SM-2 で nextReviewAt が到来している語数）。
+   * ホームの「今日の目標」と同一ロジック（getWordsDueForReview）で算出し、
+   * 統計ページとホームの復習語数を一致させる。完全な単語データを取得できない
+   * 縮退フォールバック時のみ null（表示側は reviewWords に代替）。
+   */
+  dueCount: number | null;
   wrongAnswersCount: number;
   quizStats: {
     todayCount: number;
@@ -420,6 +428,9 @@ async function fetchStatsData(
       favoriteWords: number;
     };
     let allWords: Word[] = [];
+    // ホームの「今日の目標」と同一ロジックの復習対象語数。完全な単語データが
+    // 手に入らない縮退経路では null のまま（表示側で reviewWords に代替）。
+    let dueCount: number | null = null;
 
     if (hasRemoteData) {
       wordStats = await fetchStatsViaRpc(userId);
@@ -430,6 +441,7 @@ async function fetchStatsData(
         const allWordsArrays = await Promise.all(projects.map((project) => repository.getWords(project.id)));
         allWords = allWordsArrays.flat();
         const memorySummary = summarizeWordMemory(allWords);
+        dueCount = getWordsDueForReview(allWords).length;
         wordStats = {
           totalProjects: projects.length,
           totalWords: memorySummary.total,
@@ -466,6 +478,7 @@ async function fetchStatsData(
         const { allWords: words, ...stats } = cached;
         wordStats = stats;
         allWords = words;
+        dueCount = getWordsDueForReview(allWords).length;
       } else {
         // Fallback: home-cache not ready yet, use repository
         const { getRepository } = await import('@/lib/db');
@@ -483,6 +496,7 @@ async function fetchStatsData(
         }
 
         const memorySummary = summarizeWordMemory(allWords);
+        dueCount = getWordsDueForReview(allWords).length;
         wordStats = {
           totalProjects: projects.length,
           totalWords: memorySummary.total,
@@ -545,6 +559,7 @@ async function fetchStatsData(
 
     const stats: CachedStats = {
       ...wordStats,
+      dueCount,
       wrongAnswersCount,
       weeklyStats,
       activityHistory,


### PR DESCRIPTION
# 概要

デスクトップの主要画面を一括で改善します。ホームは PR #395（モバイル）に続き Spotify デスクトップ風の構成に刷新し、共有ライブラリ・グループ・設定・フラッシュカード・クイズ・リールのデスクトップ対応を拡充。あわせてリール表示の高速化、復習語数の不一致修正、CEFR ベースのおすすめ導出も行います。

## ホーム（デスクトップ・Spotify風刷新）

- **ショートカットグリッド（4列×2段）**: TODAY'S GOAL（5状態）+ 保存済み単語 + 単語帳→グループ→おすすめの優先順（モバイルと同じ `buildHomeShortcutTiles` を再利用）
- **横スクロールのシェルフ**: マイ単語帳（上部グリッドに載り切らなかった単語帳のみ表示、ホバーでクイズ再生ボタン）／おすすめの単語帳／おすすめのリール
- **右サイドは維持**: 学習サイドバー・アップグレードカード
- 新規作成はページ遷移なしの中央モーダル（`CreateWordbookSheet variant="modal"`、ボトムシート不使用）
- サイドバー下部の単語検索ボタンをホーム右上（新規作成の左）へ移設。サイドバーのスキャン項目は削除

## 共通部品

- `DesktopShelf` / `DesktopMediaCard` を新設し、共有ページの共有単語帳もホームと同じカードに統一

## 共有ライブラリ / 共有単語帳

- 検索上部のカテゴリチップ（ユーザー/単語帳/グループ検索/英検）を削除
- 人気の単語帳: ID・語数を削除しアイコン表示（順位+アイコン+タイトル+👍）
- 「もっと見る」ボタンを全て削除（デスクトップ/モバイル）
- **/share/[shareId] デスクトップ**: 行の「…」から単語単位で自分の単語帳へ追加（モバイル機能の移植・中央モーダル）。「選択して追加」ボタンは削除

## グループ

- デスクトップのグループ表示をモバイルの新UI（今週のランキング上位3人つきリッチカード）に統一
- グループページ: 共有ライブラリ遷移ボタンと上部3統計タイルを削除、招待シェアシートをデスクトップは中央モーダル化、設定ページの左寄せズレを修正

## /project/*（デスクトップ）

- 名称変更/単語追加は右上の「…」メニューへ。単語一覧上はクイズ（再生ボタン・accent）とフラッシュカード（dark）
- フィルタ/ソート/選択は正方形アイコンボタンで検索窓の左に配置（モバイルも正方形化）

## リール

- **表示高速化**: タグ類似度埋め込みのサーバー内キャッシュ、`reel_seen_words` upsert の `after()` 化、語源結合とエンリッチの並走化、タップ時シードによる pin 単語の即時表示（`ReelPinnedPreviewCard`）
- **デスクトップは右側アクションレールをカードの外に配置**（アクティブカード追随、コメント/フィードバックシート対応）

## フラッシュカード（デスクトップ）

- 裏面に語源（morphology）を表示、モバイルと同じアクションチップ（英辞郎/発音/ステータス/お気に入り/削除）を追加

## 設定・統計・その他

- デスクトップ設定: アカウント削除導線（デスクトップ削除ページ新設）、リマインダー+例文ジャンルを「カスタマイズ」1セクションに統合
- 学習の推移: 「間違えた問題」カードを削除
- **復習語数の統一**: `CachedStats` に SM-2 due の `dueCount` を追加し、統計ページの「今日の目標」もホームと同じ `getWordsDueForReview` 起点に（縮退時のみ従来値にフォールバック）
- **おすすめ単語帳の導出**: 単語帳内サンプル語の CEFR × 志望英検級の CEFR バンド比較で levelFit を実測（`cefrFitForBand`）。CEFR が引けない場合は英検タグ推定にフォールバック
- クイズ2・即答チャレンジの完了画面にデスクトップ表示を追加（4択は既存）
- 単語詳細モーダルの背景シャドウがサイドバーに掛からない問題を修正（fixed 化）

## テスト

- `npx tsc --noEmit` ✅ / `npm run lint` ✅（既存の `gcp-budget-guard/` 5件のみ）
- `npm test` 958 pass / 2 fail — 失敗2件（`otp.contract` / `words/create`）はベースコミットでも再現する既存問題
- `npm run build` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HagiPzb4iZggw6pZjFHf9r