### PR TITLE
Merge duplicate polysemous headwords in highlighted response conversion

### DIFF
--- a/src/lib/ai/extract-highlighted-words.test.ts
+++ b/src/lib/ai/extract-highlighted-words.test.ts
@@ -2,6 +2,7 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 
 import { extractHighlightedWordsFromImage } from '@/lib/ai/extract-highlighted-words';
+import { HighlightedResponseSchema, convertToStandardFormat } from '@/lib/schemas/highlighted-response';
 import type { AIProvider } from '@/lib/ai/providers';
 
 function createProvider(generate: AIProvider['generate']): AIProvider {
@@ -367,4 +368,48 @@ test('extractHighlightedWordsFromImage uses relaxed fallback when strict candida
     assert.equal(result.data.words.length, 1);
     assert.equal(result.data.words[0].english, 'recoverable-word');
   }
+});
+
+test('convertToStandardFormat merges duplicate polysemous headwords into one word with combined translations', () => {
+  const highlighted = HighlightedResponseSchema.parse({
+    words: [
+      {
+        english: 'spare',
+        japanese: '余分な',
+        japaneseSource: 'scan',
+        partOfSpeechTags: ['adjective'],
+        confidence: 0.95,
+      },
+      {
+        english: 'spare',
+        japanese: '割く',
+        japaneseSource: 'scan',
+        partOfSpeechTags: ['verb'],
+        confidence: 0.9,
+      },
+      {
+        english: 'spare time',
+        japanese: '余暇',
+        japaneseSource: 'scan',
+        partOfSpeechTags: ['idiom'],
+        confidence: 0.9,
+      },
+    ],
+    sourceLabels: [],
+  });
+
+  const standard = convertToStandardFormat(highlighted);
+
+  assert.deepEqual(
+    standard.words.map((word) => word.english),
+    ['spare', 'spare time'],
+  );
+
+  const spare = standard.words[0];
+  assert.equal(spare.japanese, '余分な');
+  assert.deepEqual(spare.partOfSpeechTags, ['adjective', 'verb']);
+  assert.deepEqual(
+    spare.translations?.map((translation) => translation.translationJa),
+    ['余分な', '割く'],
+  );
 });

--- a/src/lib/schemas/highlighted-response.ts
+++ b/src/lib/schemas/highlighted-response.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 import { normalizeSourceLabels } from '../../../shared/source-labels';
 import { normalizeWordTranslationPayload } from '../../../shared/word-translations';
-import type { ValidatedAIResponse } from './ai-response';
+import { mergeDuplicateHeadwords, type ValidatedAIResponse } from './ai-response';
 
 // Schema for highlighted word extraction with enhanced detection features
 // Based on research findings for Gemini 2.5 Flash capabilities
@@ -128,7 +128,7 @@ export function filterByConfidence(
 // This ensures compatibility with existing app infrastructure
 export function convertToStandardFormat(highlighted: HighlightedResponse): ValidatedAIResponse {
   return {
-    words: highlighted.words.map((word) => {
+    words: mergeDuplicateHeadwords(highlighted.words.map((word) => {
       const translationPayload = normalizeWordTranslationPayload({
         translations: word.translations,
         japanese: word.japanese,
@@ -154,7 +154,7 @@ export function convertToStandardFormat(highlighted: HighlightedResponse): Valid
           ? { japaneseSource: translationPayload.japaneseSource }
           : {}),
       };
-    }),
+    })),
     sourceLabels: normalizeSourceLabels(highlighted.sourceLabels),
   };
 }


### PR DESCRIPTION
## Summary
Adds deduplication logic to `convertToStandardFormat()` to merge duplicate English headwords (polysemous words with multiple senses) into a single word entry with combined translations and part-of-speech tags.

## Changes
- **Import `mergeDuplicateHeadwords`** from `ai-response` schema in `highlighted-response.ts`
- **Apply deduplication** in `convertToStandardFormat()` by wrapping the mapped words array with `mergeDuplicateHeadwords()`
- **Add test case** verifying that duplicate headwords are merged:
  - Two entries for "spare" (adjective + verb senses) merge into one word
  - Part-of-speech tags are combined (`['adjective', 'verb']`)
  - Translations array includes both Japanese translations
  - Phrase entries like "spare time" remain separate

## Implementation Details
The `mergeDuplicateHeadwords()` function (defined in `ai-response.ts`) consolidates words with identical English headwords by:
1. Grouping words by their `english` field
2. Combining `partOfSpeechTags` arrays
3. Preserving the first occurrence's primary `japanese` translation
4. Aggregating all translations into the `translations` array

This ensures the standard format output properly handles polysemous words extracted from highlighted text, improving data consistency for downstream quiz generation and word storage.

https://claude.ai/code/session_01XFzqx2JhQk9TGpr7mjbZRd