### PR TITLE
ニュースフィード（学習タイムライン）をデスクトップ対応

### DIFF
--- a/src/app/friends/page.tsx
+++ b/src/app/friends/page.tsx
@@ -186,6 +186,35 @@ export default function FriendsPage() {
     });
   };
 
+  const renderFeedEntries = () => (
+    <>
+      {feedEntries.map((entry) => (
+        entry.kind === 'quiz'
+          ? (
+            <TimelineItem
+              key={`quiz-${entry.session.id}`}
+              session={entry.session}
+              expanded={expandedSessions.has(entry.session.id)}
+              onToggle={() => toggleSession(entry.session.id)}
+            />
+          )
+          : <GroupEventItem key={`group-${entry.event.id}`} event={entry.event} />
+      ))}
+
+      {timelineLoading && (
+        <div className="flex items-center justify-center py-10 text-[var(--color-muted)]">
+          <Icon name="progress_activity" className="animate-spin" size={20} />
+        </div>
+      )}
+
+      {!timelineLoading && feedEntries.length === 0 && (
+        <div className="px-[18px] py-16 text-center text-[13px] font-bold text-[var(--color-muted)]">
+          まだ学習セッションがありません。クイズを始めると、ここにフィードが表示されます。
+        </div>
+      )}
+    </>
+  );
+
   const renderContent = () => {
     if (authLoading || loading) {
       return (
@@ -231,30 +260,7 @@ export default function FriendsPage() {
           </div>
         )}
 
-        {feedEntries.map((entry) => (
-          entry.kind === 'quiz'
-            ? (
-              <TimelineItem
-                key={`quiz-${entry.session.id}`}
-                session={entry.session}
-                expanded={expandedSessions.has(entry.session.id)}
-                onToggle={() => toggleSession(entry.session.id)}
-              />
-            )
-            : <GroupEventItem key={`group-${entry.event.id}`} event={entry.event} />
-        ))}
-
-        {timelineLoading && (
-          <div className="flex items-center justify-center py-10 text-[var(--color-muted)]">
-            <Icon name="progress_activity" className="animate-spin" size={20} />
-          </div>
-        )}
-
-        {!timelineLoading && feedEntries.length === 0 && (
-          <div className="px-[18px] py-16 text-center text-[13px] font-bold text-[var(--color-muted)]">
-            まだ学習セッションがありません。クイズを始めると、ここにフィードが表示されます。
-          </div>
-        )}
+        {renderFeedEntries()}
 
         {home.friends.length > 0 && (
           <div className="mx-[18px] mt-6 border-t border-[var(--color-border)] pt-5 pb-4">
@@ -269,14 +275,91 @@ export default function FriendsPage() {
     );
   };
 
+  const renderDesktopContent = () => {
+    if (authLoading || loading) {
+      return (
+        <div className="flex items-center justify-center py-20 text-[var(--color-muted)]">
+          <Icon name="progress_activity" className="animate-spin" />
+          <span className="ml-2 text-sm font-bold">読み込み中...</span>
+        </div>
+      );
+    }
+
+    if (!isAuthenticated) {
+      return (
+        <div className="flex justify-center py-20">
+          <div className="ds-card" style={{ padding: '32px 44px', textAlign: 'center' }}>
+            <Icon name="lock" size={28} className="mx-auto text-[var(--color-muted)]" />
+            <div className="mt-3 font-display text-lg font-bold text-[var(--solid-ink)]">ログインが必要です</div>
+            <Link href="/login" className="ds-btn dark" style={{ marginTop: 16 }}>
+              ログイン
+            </Link>
+          </div>
+        </div>
+      );
+    }
+
+    return (
+      <div style={{ display: 'grid', gridTemplateColumns: 'minmax(0, 1fr) 300px', gap: 24, alignItems: 'start' }}>
+        <div style={{ maxWidth: 760, minWidth: 0 }}>
+          {error && (
+            <div className="mb-4 flex items-center justify-between rounded-[12px] border border-[var(--color-error)] bg-[var(--color-error-light)] px-4 py-3 text-[13px] font-bold text-[var(--color-error)]">
+              <span>{error}</span>
+              <button type="button" onClick={() => void refreshAll()} className="ml-3 underline">再試行</button>
+            </div>
+          )}
+          <div className="ds-card" style={{ overflow: 'hidden' }}>
+            <div className="[&>article:last-child]:border-b-0">
+              {renderFeedEntries()}
+            </div>
+          </div>
+        </div>
+
+        <aside style={{ display: 'flex', flexDirection: 'column', gap: 16, position: 'sticky', top: 0 }}>
+          {hasRequests && (
+            <div className="ds-card" style={{ padding: 16 }}>
+              <SectionTitle icon="mark_email_unread" label="申請" count={home.incoming.length + home.outgoing.length} />
+              <div className="mt-2 flex flex-col gap-1.5">
+                <RequestRows
+                  incoming={home.incoming}
+                  outgoing={home.outgoing}
+                  actionLoading={actionLoading}
+                  onRespondRequest={respondRequest}
+                  onRemoveFriend={removeFriend}
+                />
+              </div>
+            </div>
+          )}
+          <div className="ds-card" style={{ padding: 16 }}>
+            <SectionTitle icon="groups" label="フレンド" count={home.friends.length} />
+            {home.friends.length > 0 ? (
+              <div className="mt-2 flex flex-col gap-1.5">
+                <FriendRows
+                  friends={home.friends}
+                  actionLoading={actionLoading}
+                  onRemoveFriend={removeFriend}
+                />
+              </div>
+            ) : (
+              <p className="mt-2 text-[12px] font-bold leading-relaxed text-[var(--color-muted)]">
+                まだフレンドがいません。
+              </p>
+            )}
+          </div>
+        </aside>
+      </div>
+    );
+  };
+
   return (
     <>
       <div className="hidden h-full min-h-0 flex-col lg:flex">
         <DesktopTopbar title="フィード" crumb="学習タイムライン">
+          <DesktopButton onClick={() => void refreshAll()} icon="refresh" variant="ghost" title="フィードを更新">更新</DesktopButton>
           <DesktopButton href="/shared" icon="hub" variant="ghost">共有ライブラリ</DesktopButton>
         </DesktopTopbar>
         <div className="ds-scroll">
-          {renderContent()}
+          {renderDesktopContent()}
         </div>
       </div>
 
@@ -291,6 +374,61 @@ export default function FriendsPage() {
         </div>
         {renderContent()}
       </div>
+    </>
+  );
+}
+
+function RequestRows({
+  incoming,
+  outgoing,
+  actionLoading,
+  onRespondRequest,
+  onRemoveFriend,
+}: {
+  incoming: FriendshipSummary[];
+  outgoing: FriendshipSummary[];
+  actionLoading: string | null;
+  onRespondRequest: (friendshipId: string, action: 'accept' | 'decline') => void;
+  onRemoveFriend: (friendshipId: string) => void;
+}) {
+  return (
+    <>
+      {incoming.map((item) => (
+        <FriendRow key={item.id} friendship={item}>
+          <button
+            type="button"
+            onClick={() => onRespondRequest(item.id, 'accept')}
+            disabled={Boolean(actionLoading)}
+            className="inline-flex h-7 w-7 items-center justify-center rounded-[7px] border-2 border-[var(--color-accent-ink)] bg-[var(--color-accent)] text-white disabled:opacity-50"
+            aria-label="承認"
+          >
+            <Icon name={actionLoading === `accept:${item.id}` ? 'progress_activity' : 'check'} className={actionLoading === `accept:${item.id}` ? 'animate-spin' : ''} size={14} />
+          </button>
+          <button
+            type="button"
+            onClick={() => onRespondRequest(item.id, 'decline')}
+            disabled={Boolean(actionLoading)}
+            className="inline-flex h-7 w-7 items-center justify-center rounded-[7px] border border-[var(--color-border)] bg-white text-[var(--color-muted)] disabled:opacity-50"
+            aria-label="拒否"
+          >
+            <Icon name="close" size={14} />
+          </button>
+        </FriendRow>
+      ))}
+      {outgoing.map((item) => (
+        <FriendRow key={item.id} friendship={item}>
+          <StatusChip label="申請中" />
+          <button
+            type="button"
+            onClick={() => onRemoveFriend(item.id)}
+            disabled={Boolean(actionLoading)}
+            className="inline-flex h-7 w-7 items-center justify-center rounded-[7px] border border-[var(--color-border)] bg-white text-[var(--color-muted)] disabled:opacity-50"
+            aria-label="申請を取り消す"
+          >
+            <Icon name="close" size={14} />
+          </button>
+        </FriendRow>
+      ))}
     </>
   );
 }
@@ -312,44 +450,43 @@ function RequestsSection({
     <SolidPanel className="!rounded-[14px]" faceClassName="!p-3">
       <SectionTitle icon="mark_email_unread" label="申請" count={incoming.length + outgoing.length} />
       <div className="mt-2 flex flex-col gap-1.5">
-        {incoming.map((item) => (
-          <FriendRow key={item.id} friendship={item}>
-            <button
-              type="button"
-              onClick={() => onRespondRequest(item.id, 'accept')}
-              disabled={Boolean(actionLoading)}
-              className="inline-flex h-7 w-7 items-center justify-center rounded-[7px] border-2 border-[var(--color-accent-ink)] bg-[var(--color-accent)] text-white disabled:opacity-50"
-              aria-label="承認"
-            >
-              <Icon name={actionLoading === `accept:${item.id}` ? 'progress_activity' : 'check'} className={actionLoading === `accept:${item.id}` ? 'animate-spin' : ''} size={14} />
-            </button>
-            <button
-              type="button"
-              onClick={() => onRespondRequest(item.id, 'decline')}
-              disabled={Boolean(actionLoading)}
-              className="inline-flex h-7 w-7 items-center justify-center rounded-[7px] border border-[var(--color-border)] bg-white text-[var(--color-muted)] disabled:opacity-50"
-              aria-label="拒否"
-            >
-              <Icon name="close" size={14} />
-            </button>
-          </FriendRow>
-        ))}
-        {outgoing.map((item) => (
-          <FriendRow key={item.id} friendship={item}>
-            <StatusChip label="申請中" />
-            <button
-              type="button"
-              onClick={() => onRemoveFriend(item.id)}
-              disabled={Boolean(actionLoading)}
-              className="inline-flex h-7 w-7 items-center justify-center rounded-[7px] border border-[var(--color-border)] bg-white text-[var(--color-muted)] disabled:opacity-50"
-              aria-label="申請を取り消す"
-            >
-              <Icon name="close" size={14} />
-            </button>
-          </FriendRow>
-        ))}
+        <RequestRows
+          incoming={incoming}
+          outgoing={outgoing}
+          actionLoading={actionLoading}
+          onRespondRequest={onRespondRequest}
+          onRemoveFriend={onRemoveFriend}
+        />
       </div>
     </SolidPanel>
+  );
+}
+
+function FriendRows({
+  friends,
+  actionLoading,
+  onRemoveFriend,
+}: {
+  friends: FriendshipSummary[];
+  actionLoading: string | null;
+  onRemoveFriend: (friendshipId: string) => void;
+}) {
+  return (
+    <>
+      {friends.map((friend) => (
+        <FriendRow key={friend.id} friendship={friend}>
+          <button
+            type="button"
+            onClick={() => onRemoveFriend(friend.id)}
+            disabled={Boolean(actionLoading)}
+            className="inline-flex h-7 w-7 items-center justify-center rounded-[7px] border border-[var(--color-border)] bg-white text-[var(--color-muted)] disabled:opacity-50"
+            aria-label="フレンド解除"
+          >
+            <Icon name={actionLoading === `delete:${friend.id}` ? 'progress_activity' : 'person_remove'} className={actionLoading === `delete:${friend.id}` ? 'animate-spin' : ''} size={14} />
+          </button>
+        </FriendRow>
+      ))}
+    </>
   );
 }
 
@@ -366,19 +503,7 @@ function FriendsSection({
     <>
       <SectionTitle icon="groups" label="フレンド" count={friends.length} />
       <div className="mt-2 flex flex-col gap-1.5">
-        {friends.map((friend) => (
-          <FriendRow key={friend.id} friendship={friend}>
-            <button
-              type="button"
-              onClick={() => onRemoveFriend(friend.id)}
-              disabled={Boolean(actionLoading)}
-              className="inline-flex h-7 w-7 items-center justify-center rounded-[7px] border border-[var(--color-border)] bg-white text-[var(--color-muted)] disabled:opacity-50"
-              aria-label="フレンド解除"
-            >
-              <Icon name={actionLoading === `delete:${friend.id}` ? 'progress_activity' : 'person_remove'} className={actionLoading === `delete:${friend.id}` ? 'animate-spin' : ''} size={14} />
-            </button>
-          </FriendRow>
-        ))}
+        <FriendRows friends={friends} actionLoading={actionLoading} onRemoveFriend={onRemoveFriend} />
       </div>
     </>
   );

--- a/src/components/desktop/DesktopChrome.tsx
+++ b/src/components/desktop/DesktopChrome.tsx
@@ -8,12 +8,13 @@ import { useAuth } from '@/hooks/use-auth';
 import { useCoins } from '@/hooks/use-coins';
 import { cn } from '@/lib/utils';
 
-type NavKey = 'home' | 'books' | 'stats' | 'reels' | 'shared' | 'fav' | 'scan' | 'settings';
+type NavKey = 'home' | 'books' | 'stats' | 'reels' | 'feed' | 'shared' | 'fav' | 'scan' | 'settings';
 
 const NAV_ITEMS: { key: NavKey; href: string; icon: string; label: string; count?: number }[] = [
   { key: 'home', href: '/', icon: 'home', label: 'ホーム' },
   { key: 'stats', href: '/stats', icon: 'bar_chart', label: '統計' },
   { key: 'reels', href: '/reels', icon: 'movie', label: 'リール' },
+  { key: 'feed', href: '/friends', icon: 'dynamic_feed', label: 'フィード' },
   { key: 'shared', href: '/shared', icon: 'group', label: '共有ライブラリ', count: 6 },
   { key: 'fav', href: '/favorites', icon: 'star', label: 'お気に入り', count: 21 },
   { key: 'settings', href: '/settings', icon: 'settings', label: '設定' },
@@ -24,6 +25,7 @@ function activeKeyForPath(pathname: string): NavKey {
   if (pathname === '/projects' || pathname.startsWith('/project/') || pathname.startsWith('/word/')) return 'books';
   if (pathname === '/stats') return 'stats';
   if (pathname === '/reels') return 'reels';
+  if (pathname === '/friends' || pathname === '/follows' || pathname.startsWith('/profile')) return 'feed';
   if (pathname === '/shared' || pathname.startsWith('/share/') || pathname.startsWith('/groups/')) return 'shared';
   if (pathname === '/favorites' || pathname.startsWith('/collections')) return 'fav';
   if (pathname.startsWith('/scan')) return 'scan';


### PR DESCRIPTION
## 概要

ニュースフィード（`/friends` の学習タイムライン）をデスクトップに対応させました。これまでデスクトップではサイドバーからフィードに到達する手段がなく、ページ自体もモバイル向けリストが画面幅いっぱいに引き伸ばされるだけの表示でした。

## 変更内容

### デスクトップサイドバー（`src/components/desktop/DesktopChrome.tsx`）
- ナビに「フィード」項目を追加（リールと共有ライブラリの間、アイコン `dynamic_feed`）
- `/friends`・`/follows`・`/profile` 配下でフィードナビをアクティブ表示

### フィードページ（`src/app/friends/page.tsx`）
- デスクトップ（`lg:` 以上）を2カラムレイアウトに刷新
  - 中央: タイムライン（クイズセッション + グループイベント）を `ds-card` に集約（最大幅 760px）
  - 右レール（300px・sticky）: フレンド申請カードとフレンド一覧カード
- トップバーに「更新」ボタンを追加（フィード + フレンド情報を再取得）
- デスクトップ用のログイン誘導・読み込み中・エラー表示を追加
- 申請・フレンドの行UIを `RequestRows` / `FriendRows` に切り出し、モバイル（`SolidPanel`）とデスクトップ（`ds-card`）で共用
- **モバイル表示は変更なし**（既存の `renderContent()` の構成を維持）

## 確認

- `npx tsc --noEmit`: 本変更に起因するエラーなし（既存の `translation-targets.test.ts` のエラーのみ）
- `npm run lint`: 変更ファイルにエラー・警告なし（既存の `gcp-budget-guard/` のエラーのみ）
- `npm run build`: 成功
- Playwright（1440×900 / 390×844）で表示確認: デスクトップはサイドバー「フィード」+ 2カラムシェルが描画され、モバイルは従来どおり

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HfqZJgD44av1bxmooSCcdq

---
_Generated by [Claude Code](https://claude.ai/code/session_01HfqZJgD44av1bxmooSCcdq)_