### PR TITLE
ホームの棚を横スクロールに戻す + おすすめも本棚タイル化 + リール拡大 + 「お気に入り」→「保存」

### DIFF
--- a/src/app/desktop.css
+++ b/src/app/desktop.css
@@ -287,11 +287,14 @@
   font-family: inherit; font-size: 13px; font-weight: 700; color: var(--color-accent);
   text-decoration: none; background: none; border: none; padding: 0; cursor: pointer;
 }
-/* 1 行あたり最大 10 枚。10 枚を超えたカードは次の行に折り返す。 */
+/* 横スクロールの棚。カード幅は --shelf-card-w で棚ごとに調整できる。 */
 .ds-shelf-row {
-  display: grid; grid-template-columns: repeat(10, minmax(0, 1fr)); gap: 16px;
-  padding: 4px 4px 12px; margin: -4px -4px 0;
+  display: grid; grid-auto-flow: column; grid-auto-columns: var(--shelf-card-w, 190px); gap: 16px;
+  overflow-x: auto; padding: 4px 4px 12px; margin: -4px -4px 0;
+  scroll-snap-type: x proximity; scrollbar-width: none;
 }
+.ds-shelf-row::-webkit-scrollbar { display: none; }
+.ds-shelf-row > * { scroll-snap-align: start; }
 
 /* Media card: square artwork on top, title + subtitle below.
    ホームのマイ単語帳と共有ライブラリの共有単語帳で共用する。 */

--- a/src/app/flashcard/[projectId]/page.tsx
+++ b/src/app/flashcard/[projectId]/page.tsx
@@ -413,7 +413,7 @@ export default function FlashcardPage() {
           <span className="ds-qcount">{currentIndex + 1} <span className="muted" style={{ fontWeight: 500 }}>/ {total}</span></span>
         </div>
         <div className="mono muted" style={{ fontSize: 12, marginTop: 6, marginBottom: 4 }}>
-          {favoritesOnly ? 'お気に入り' : collectionId ? 'コレクション' : '単語帳'} · フラッシュカード
+          {favoritesOnly ? '保存済み' : collectionId ? 'コレクション' : '単語帳'} · フラッシュカード
         </div>
 
         <div className="ds-fc-scene">
@@ -422,7 +422,7 @@ export default function FlashcardPage() {
               <button
                 type="button"
                 onClick={(event) => { event.stopPropagation(); handleToggleFavorite(); }}
-                aria-label="お気に入り"
+                aria-label="保存"
                 style={{ position: 'absolute', top: 18, right: 18, color: currentWord?.isFavorite ? 'var(--color-accent)' : 'var(--color-muted)' }}
               >
                 <Icon name="bookmark" filled={currentWord?.isFavorite} />
@@ -501,7 +501,7 @@ export default function FlashcardPage() {
           />
           <ActionChip
             icon="bookmark"
-            label="お気に入り"
+            label="保存"
             tint={currentWord?.isFavorite ? 'var(--color-accent)' : 'var(--solid-ink)'}
             filled={currentWord?.isFavorite}
             onClick={handleToggleFavorite}
@@ -688,7 +688,7 @@ export default function FlashcardPage() {
           onClick={handleCycleStatus}
         />
         <ActionChip
-          icon="bookmark" label="お気に入り"
+          icon="bookmark" label="保存"
           tint={currentWord?.isFavorite ? 'var(--color-accent)' : 'var(--solid-ink)'}
           filled={currentWord?.isFavorite}
           onClick={handleToggleFavorite}

--- a/src/app/project/[id]/page.tsx
+++ b/src/app/project/[id]/page.tsx
@@ -508,8 +508,8 @@ export default function ProjectPage() {
       invalidateHomeCache();
       showToast({
         message: nextValue
-          ? `${targets.length}語をお気に入りに追加しました`
-          : `${targets.length}語をお気に入りから外しました`,
+          ? `${targets.length}語を保存しました`
+          : `${targets.length}語の保存を解除しました`,
         type: 'success',
       });
     } catch (favoriteError) {
@@ -518,7 +518,7 @@ export default function ProjectPage() {
         const original = targets.find((t) => t.id === w.id);
         return original ? { ...w, isFavorite: original.isFavorite } : w;
       }));
-      showToast({ message: 'お気に入り更新に失敗しました', type: 'error' });
+      showToast({ message: '保存の更新に失敗しました', type: 'error' });
     } finally {
       setBulkFavoriteLoading(false);
     }
@@ -2327,7 +2327,7 @@ function WordRow({
           type="button"
           onClick={onToggleFavorite}
           className="inline-flex h-[26px] w-[26px] shrink-0 items-center justify-center text-[var(--color-accent)]"
-          aria-label="お気に入りを切り替え"
+          aria-label="保存を切り替え"
         >
           <Icon name="bookmark" size={22} filled={word.isFavorite} />
         </button>

--- a/src/components/desktop/DesktopChrome.tsx
+++ b/src/components/desktop/DesktopChrome.tsx
@@ -15,7 +15,7 @@ const NAV_ITEMS: { key: NavKey; href: string; icon: string; label: string; count
   { key: 'stats', href: '/stats', icon: 'bar_chart', label: '統計' },
   { key: 'reels', href: '/reels', icon: 'movie', label: 'リール' },
   { key: 'shared', href: '/shared', icon: 'group', label: '共有ライブラリ', count: 6 },
-  { key: 'fav', href: '/favorites', icon: 'star', label: 'お気に入り', count: 21 },
+  { key: 'fav', href: '/favorites', icon: 'star', label: '保存', count: 21 },
   { key: 'settings', href: '/settings', icon: 'settings', label: '設定' },
 ];
 

--- a/src/components/desktop/DesktopFavorites.tsx
+++ b/src/components/desktop/DesktopFavorites.tsx
@@ -66,7 +66,7 @@ export function DesktopFavoritesView({
 
   return (
     <div className="hidden h-full min-h-0 flex-col lg:flex">
-      <DesktopTopbar title="お気に入り" crumb="コレクション">
+      <DesktopTopbar title="保存" crumb="コレクション">
         <DesktopButton href={isPro ? `/quiz/all?favorites=1&count=10&from=${returnPath}` : '/subscription'} variant="accent" icon="school">
           クイズ
         </DesktopButton>
@@ -79,7 +79,7 @@ export function DesktopFavoritesView({
         <div style={{ display: 'flex', alignItems: 'center', gap: 12, marginBottom: 16 }}>
           <Icon name="star" filled style={{ color: 'var(--color-warning)', fontSize: 22 }} />
           <span style={{ fontFamily: 'var(--font-display)', fontWeight: 800, fontSize: 20 }}>{favorites.length} <span style={{ fontSize: 13 }}>語</span></span>
-          <span className="muted" style={{ fontSize: 13 }}>をお気に入り登録中</span>
+          <span className="muted" style={{ fontSize: 13 }}>を保存中</span>
           <div style={{ display: 'flex', gap: 12, marginLeft: 8 }}>
             <span className="ds-status mastered"><span className="ds-sdot c-mastered" />習得 {counts.mastered}</span>
             <span className="ds-status active"><span className="ds-sdot c-active" />定着中 {counts.active}</span>
@@ -88,7 +88,7 @@ export function DesktopFavoritesView({
           </div>
           <div style={{ flex: 1 }} />
           <DesktopSearchBox
-            placeholder="お気に入りを検索"
+            placeholder="保存した単語を検索"
             value={query}
             onChange={(event) => setQuery(event.target.value)}
             style={{ minWidth: 220 }}

--- a/src/components/desktop/DesktopHome.tsx
+++ b/src/components/desktop/DesktopHome.tsx
@@ -214,7 +214,8 @@ export function DesktopHomeView({
                 </div>
               </button>
             ) : view === 'grid' ? (
-              <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3, minmax(0, 1fr))', gap: 18 }}>
+              /* 横スクロールの棚に従来の本棚タイルを並べる */
+              <div className="ds-shelf-row" style={{ '--shelf-card-w': '210px' } as React.CSSProperties}>
                 {pendingScans.map((scan) => (
                   <DesktopGeneratingBookTile key={scan.id} scan={scan} />
                 ))}
@@ -261,18 +262,19 @@ export function DesktopHomeView({
             <JoinedGroupGrid groups={joinedGroups} columns={3} />
           </div>
 
-          {/* おすすめの単語帳（英検級ベースの共有単語帳） */}
+          {/* おすすめの単語帳（マイ単語帳と同じ本棚タイルで表示） */}
           {recommendedBooks.length > 0 && (
-            <DesktopShelf title="おすすめの単語帳" seeAllHref="/shared">
+            <DesktopShelf title="おすすめの単語帳" seeAllHref="/shared" cardWidth={210}>
               {recommendedBooks.map((book) => (
-                <DesktopRecommendedBookCard key={book.shareId} book={book} />
+                <DesktopRecommendedBookTile key={book.shareId} book={book} />
               ))}
             </DesktopShelf>
           )}
 
-          {/* おすすめのリール（語源がある単語限定） */}
+          {/* おすすめのリール（語源がある単語限定）。デスクトップで小さくなり
+              すぎないようカード幅を広めに取る */}
           {(recommendationsLoading || recommendedReels.length > 0) && (
-            <DesktopShelf title="おすすめのリール" seeAllHref="/reels">
+            <DesktopShelf title="おすすめのリール" seeAllHref="/reels" cardWidth={210}>
               {recommendationsLoading && recommendedReels.length === 0
                 ? [0, 1, 2].map((slot) => <DesktopMediaCardSkeleton key={slot} />)
                 : recommendedReels.map((item) => (
@@ -647,23 +649,35 @@ function DesktopMediaCardSkeleton() {
   );
 }
 
-function DesktopRecommendedBookCard({ book }: { book: HomeRecommendedBook }) {
+// おすすめの共有単語帳。マイ単語帳と同じ本棚タイル（ds-book）で表示する。
+function DesktopRecommendedBookTile({ book }: { book: HomeRecommendedBook }) {
+  const bg = book.iconImage ? undefined : desktopThumbColor(book.shareId);
   return (
-    <DesktopMediaCard
+    <Link
       href={`/share/${book.shareId}`}
-      artStyle={{
-        background: desktopThumbColor(book.shareId),
+      className="ds-book"
+      style={{
+        background: bg,
         backgroundImage: book.iconImage ? `url(${book.iconImage})` : undefined,
+        backgroundSize: 'cover',
+        backgroundPosition: 'center',
       }}
-      artChildren={!book.iconImage && book.title.charAt(0)}
-      title={book.title}
-      subtitle={
-        <>
-          <span style={{ color: 'var(--color-accent)', fontWeight: 700 }}>おすすめ</span>
-          {book.eikenLevelTag && <span>· {book.eikenLevelTag}</span>}
-        </>
-      }
-    />
+    >
+      <div className="bk-spine" />
+      <div>
+        <div className="bk-title">{book.title}</div>
+        <div className="bk-foot mono">
+          {book.eikenLevelTag ? `おすすめ · ${book.eikenLevelTag}` : 'おすすめ'}
+        </div>
+      </div>
+      <div>
+        <div className="bk-n">{book.wordCount}<span className="u">語</span></div>
+        <div className="bk-foot" style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
+          <Icon name="thumb_up" style={{ fontSize: 13 }} />
+          {book.likeCount}
+        </div>
+      </div>
+    </Link>
   );
 }
 

--- a/src/components/desktop/DesktopMediaShelf.tsx
+++ b/src/components/desktop/DesktopMediaShelf.tsx
@@ -2,9 +2,9 @@
 
 /**
  * デスクトップ Spotify 風の共通部品。
- * - DesktopShelf: セクション見出し（タイトル + すべて表示）と 1 行 10 枚で折り返すカードグリッド
+ * - DesktopShelf: セクション見出し（タイトル + すべて表示）と横スクロールのカード列
  * - DesktopMediaCard: 正方形アートワーク + タイトル + サブタイトルのカード。
- *   ホームのマイ単語帳と共有ライブラリの共有単語帳で同じカードを使う。
+ *   共有ライブラリの共有単語帳などで使う。
  */
 
 import Link from 'next/link';
@@ -16,12 +16,15 @@ export function DesktopShelf({
   count,
   seeAllHref,
   onSeeAll,
+  cardWidth,
   children,
 }: {
   title: string;
   count?: number;
   seeAllHref?: string;
   onSeeAll?: () => void;
+  /** 1 カードの幅(px)。省略時は CSS の既定値（190px） */
+  cardWidth?: number;
   children: ReactNode;
 }) {
   return (
@@ -45,7 +48,12 @@ export function DesktopShelf({
           </button>
         ) : null}
       </div>
-      <div className="ds-shelf-row">{children}</div>
+      <div
+        className="ds-shelf-row"
+        style={cardWidth ? ({ '--shelf-card-w': `${cardWidth}px` } as CSSProperties) : undefined}
+      >
+        {children}
+      </div>
     </section>
   );
 }

--- a/src/components/desktop/DesktopProjects.tsx
+++ b/src/components/desktop/DesktopProjects.tsx
@@ -74,7 +74,7 @@ export function DesktopProjectsView({
               すべて <span className="tnum" style={{ opacity: 0.7 }}>{projects.length}</span>
             </button>
             <button type="button" className={'ds-chip' + (filter === 'fav' ? ' active' : '')} onClick={() => setFilter('fav')}>
-              <Icon name="star" filled style={{ fontSize: 15 }} />お気に入り
+              <Icon name="star" filled style={{ fontSize: 15 }} />保存
             </button>
             <button type="button" className={'ds-chip' + (sort === 'newest' ? ' active' : '')} onClick={() => onSortChange('newest')}>
               <Icon name="schedule" style={{ fontSize: 15 }} />新しい順

--- a/src/components/desktop/DesktopWordDetailModal.tsx
+++ b/src/components/desktop/DesktopWordDetailModal.tsx
@@ -53,7 +53,7 @@ export function DesktopWordDetailModal({
           <div>
             <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
               <div className="word-en">{word.english}</div>
-              <button type="button" className="ds-btn ghost sm" onClick={onToggleFavorite} aria-label="お気に入り">
+              <button type="button" className="ds-btn ghost sm" onClick={onToggleFavorite} aria-label="保存">
                 <Icon
                   name={word.isFavorite ? 'star' : 'star_border'}
                   filled={word.isFavorite}

--- a/src/components/project/ProjectDetailSheet.tsx
+++ b/src/components/project/ProjectDetailSheet.tsx
@@ -147,7 +147,7 @@ function WordRow({ word, onCycleStatus, onCycleVocabularyType, onToggleFavorite 
             </div>
           </Link>
           <VocabularyTypeButton vocabularyType={word.vocabularyType} onClick={onCycleVocabularyType} className="shrink-0" />
-          <button type="button" onClick={onToggleFavorite} className="inline-flex text-[var(--color-accent)]" aria-label="お気に入りを切り替え">
+          <button type="button" onClick={onToggleFavorite} className="inline-flex text-[var(--color-accent)]" aria-label="保存を切り替え">
             <Icon name="bookmark" size={18} filled={word.isFavorite} />
           </button>
         </div>

--- a/src/lib/marketing/content.ts
+++ b/src/lib/marketing/content.ts
@@ -159,7 +159,7 @@ export const progressFeatures: ProgressFeature[] = [
   { icon: 'check_circle', text: '習得済み・復習中・未学習を自動で分類' },
   { icon: 'bar_chart', text: '今日の学習量と正答率をリアルタイム表示' },
   { icon: 'local_fire_department', text: '連続学習日数で継続をサポート' },
-  { icon: 'star', text: '苦手単語をお気に入り登録して重点復習' },
+  { icon: 'star', text: '苦手単語を保存して重点復習' },
 ];
 
 /* ===== Pricing page ===== */


### PR DESCRIPTION
# 概要

PR #405 のフォローアップです。

## ホーム（デスクトップ）

- **横スクロール仕様を復活**: `.ds-shelf-row` を横スクロール（スナップ付き）に戻し、カード幅は `--shelf-card-w` で棚ごとに調整できるようにしました（#404 の1行10枚折り返しグリッドを置き換え）
- **マイ単語帳**: 従来の本棚タイル（`ds-book`）のまま、横スクロールの棚で表示（カード幅 210px）。リスト表示切替・生成中タイル・新規作成タイルは維持
- **おすすめの単語帳**: マイ単語帳と同じ本棚タイル（`ds-book`）に統一（タイトル + おすすめ·英検級タグ + 語数 + いいね数）
- **おすすめのリール**: 10枚折り返しで極小化していたカードを 210px 幅に拡大

## 文言変更

- UI 上の「お気に入り」を「保存」に統一:
  - デスクトップサイドバーのナビ / 保存ページ（旧お気に入りページ）のタイトル・検索プレースホルダ
  - 単語帳一覧のフィルタチップ、単語詳細モーダル
  - フラッシュカードのアクションチップ・パンくず
  - 単語一覧の一括保存トースト（保存しました / 保存を解除しました）
  - LP の機能説明文

## テスト

- `npx tsc --noEmit` ✅（既存の `translation-targets.test.ts` 1件のみ、ベースでも再現）
- `npm run lint` ✅（警告2件はベースでも再現する既存分）
- `npm run build` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HagiPzb4iZggw6pZjFHf9r

---
_Generated by [Claude Code](https://claude.ai/code/session_01HagiPzb4iZggw6pZjFHf9r)_