### PR TITLE
デスクトップ: 単語詳細の領域外クリックで閉じる + カスタマイズをページ遷移に変更

### DIFF
--- a/src/app/settings/customize/page.tsx
+++ b/src/app/settings/customize/page.tsx
@@ -9,27 +9,53 @@ export default function CustomizePage() {
   const router = useRouter();
 
   return (
-    <div className="relative min-h-screen bg-[var(--color-background)] pb-[110px] pt-3 font-[var(--font-body)] lg:hidden">
-      <div className="px-[18px] pb-[14px] pt-1">
-        <button
-          type="button"
-          onClick={() => router.push('/settings')}
-          aria-label="設定へ戻る"
-          className="mb-2 flex h-[38px] w-[38px] items-center justify-center rounded-[19px] border-2 border-[var(--solid-ink)] bg-white text-[var(--solid-ink)] transition-all duration-100 active:translate-x-px active:translate-y-px"
-        >
-          <Icon name="chevron_left" size={20} />
-        </button>
-        <div className="font-mono text-[10px] font-bold uppercase tracking-[0.08em] text-[var(--color-muted)]">CUSTOMIZE</div>
-        <div className="mt-0.5 font-display text-[26px] font-extrabold leading-[1.1] tracking-[-0.02em] text-[var(--solid-ink)]">カスタマイズ</div>
+    <>
+      <div className="hidden h-full min-h-0 flex-col lg:flex">
+        <div className="ds-top">
+          <button
+            type="button"
+            className="ds-iconbtn"
+            onClick={() => router.push('/settings')}
+            style={{ width: 38, height: 38 }}
+            aria-label="設定へ戻る"
+          >
+            <Icon name="arrow_back" />
+          </button>
+          <div style={{ flex: 1, minWidth: 0 }}>
+            <div className="crumb">設定 / カスタマイズ</div>
+            <h1>カスタマイズ</h1>
+          </div>
+        </div>
+        <div className="ds-scroll">
+          <div style={{ width: 'min(100%, 720px)', margin: '0 auto', display: 'flex', flexDirection: 'column', gap: 20 }}>
+            <StudyReminderSettings variant="desktop" />
+            <ExampleGenreSettings variant="desktop" />
+          </div>
+        </div>
       </div>
 
-      <div className="px-[18px] pb-3">
-        <StudyReminderSettings variant="mobile" />
-      </div>
+      <div className="relative min-h-screen bg-[var(--color-background)] pb-[110px] pt-3 font-[var(--font-body)] lg:hidden">
+        <div className="px-[18px] pb-[14px] pt-1">
+          <button
+            type="button"
+            onClick={() => router.push('/settings')}
+            aria-label="設定へ戻る"
+            className="mb-2 flex h-[38px] w-[38px] items-center justify-center rounded-[19px] border-2 border-[var(--solid-ink)] bg-white text-[var(--solid-ink)] transition-all duration-100 active:translate-x-px active:translate-y-px"
+          >
+            <Icon name="chevron_left" size={20} />
+          </button>
+          <div className="font-mono text-[10px] font-bold uppercase tracking-[0.08em] text-[var(--color-muted)]">CUSTOMIZE</div>
+          <div className="mt-0.5 font-display text-[26px] font-extrabold leading-[1.1] tracking-[-0.02em] text-[var(--solid-ink)]">カスタマイズ</div>
+        </div>
 
-      <div className="px-[18px] pb-3">
-        <ExampleGenreSettings variant="mobile" />
+        <div className="px-[18px] pb-3">
+          <StudyReminderSettings variant="mobile" />
+        </div>
+
+        <div className="px-[18px] pb-3">
+          <ExampleGenreSettings variant="mobile" />
+        </div>
       </div>
-    </div>
+    </>
   );
 }

--- a/src/components/desktop/DesktopAccount.tsx
+++ b/src/components/desktop/DesktopAccount.tsx
@@ -4,8 +4,6 @@ import { useState } from 'react';
 import Link from 'next/link';
 import { Icon } from '@/components/ui/Icon';
 import { DesktopButton, DesktopTopbar } from '@/components/desktop/DesktopChrome';
-import { StudyReminderSettings } from '@/components/settings/StudyReminderSettings';
-import { ExampleGenreSettings } from '@/components/settings/ExampleGenreSettings';
 import { isBillingEnabled } from '@/lib/billing/feature';
 import { useCoins } from '@/hooks/use-coins';
 
@@ -147,12 +145,9 @@ export function DesktopSettingsView({
             )}
           </div>
 
-          {/* モバイルのカスタマイズページと同様、リマインダーと例文ジャンルは
-              同じセクションにまとめる */}
           <div className="ds-set-group">
             <div className="gh">カスタマイズ</div>
-            <StudyReminderSettings variant="desktop" embedded />
-            <ExampleGenreSettings variant="desktop" embedded />
+            <SettingsLink icon="tune" label="通知・パーソナライズ" description="学習リマインダー、例文ジャンル" href="/settings/customize" />
           </div>
 
           <div className="ds-set-group">

--- a/src/components/desktop/DesktopChrome.tsx
+++ b/src/components/desktop/DesktopChrome.tsx
@@ -27,7 +27,7 @@ function activeKeyForPath(pathname: string): NavKey {
   if (pathname === '/shared' || pathname.startsWith('/share/') || pathname.startsWith('/groups/')) return 'shared';
   if (pathname === '/favorites' || pathname.startsWith('/collections')) return 'fav';
   if (pathname.startsWith('/scan')) return 'scan';
-  if (pathname === '/settings' || pathname.startsWith('/subscription')) return 'settings';
+  if (pathname === '/settings' || pathname.startsWith('/settings/') || pathname.startsWith('/subscription')) return 'settings';
   return 'home';
 }
 

--- a/src/components/desktop/DesktopWordDetailModal.tsx
+++ b/src/components/desktop/DesktopWordDetailModal.tsx
@@ -24,8 +24,8 @@ export function DesktopWordDetailModal({
   onNav: (dir: -1 | 1) => void;
 }) {
   return (
-    <div className="ds-overlay">
-      <div className="ds-modal">
+    <div className="ds-overlay" onClick={onClose}>
+      <div className="ds-modal" onClick={(event) => event.stopPropagation()}>
         <div className="ds-modal-head">
           <div className="lab">単語の詳細</div>
           <div className="nav">


### PR DESCRIPTION
## 概要

デスクトップの挙動をモバイルに揃える2つの変更です。

### 1. 単語詳細モーダルを領域外クリックで閉じる

- `DesktopWordDetailModal` のオーバーレイ（`.ds-overlay`）クリックで `onClose` を呼ぶようにし、モーダル本体（`.ds-modal`）には `stopPropagation` を追加
- 既存の `DesktopWordSearchOverlay` と同じパターン（背景クリックで閉じる・ダイアログ内クリックは伝播停止）

### 2. 設定のカスタマイズを `/settings/customize` への遷移に変更

- `DesktopSettingsView`: リマインダー・例文ジャンルのインライン表示をやめ、モバイルと同じ「通知・パーソナライズ」リンク行（`/settings/customize` へ遷移）に変更
- `/settings/customize` ページにデスクトップ用ビューを追加（従来は `lg:hidden` のみでデスクトップでは空白だった）。戻るボタン付きトップバー + `StudyReminderSettings` / `ExampleGenreSettings` のデスクトップ版（各自の `ds-set-group` 付き）を表示
- サイドバーのアクティブ判定（`activeKeyForPath`）に `/settings/` 配下を追加し、カスタマイズページでも「設定」がハイライトされるように

## 検証

- `npx eslint`（変更4ファイル）: エラーなし
- `npm test`: 958/960 pass — 失敗2件（`otp.contract.test.ts`, `words/create/route.test.ts`)は変更前のコードでも失敗する既存の問題で、本変更とは無関係
- `npm run build`: 成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JfdCN3rV4ZPjuYid9H7ttt

---
_Generated by [Claude Code](https://claude.ai/code/session_01JfdCN3rV4ZPjuYid9H7ttt)_