### PR TITLE
ホームの棚は1行4枚固定で表示

### DIFF
--- a/src/app/desktop.css
+++ b/src/app/desktop.css
@@ -287,9 +287,14 @@
   font-family: inherit; font-size: 13px; font-weight: 700; color: var(--color-accent);
   text-decoration: none; background: none; border: none; padding: 0; cursor: pointer;
 }
-/* 横スクロールの棚。カード幅は --shelf-card-w で棚ごとに調整できる。 */
+/* 横スクロールの棚。1行に表示する枚数は --shelf-cols で固定（既定4枚）。
+   カード幅は表示領域から自動算出されるため、画面幅が変わっても枚数は一定。 */
 .ds-shelf-row {
-  display: grid; grid-auto-flow: column; grid-auto-columns: var(--shelf-card-w, 190px); gap: 16px;
+  --shelf-cols: 4;
+  --shelf-gap: 16px;
+  display: grid; grid-auto-flow: column;
+  grid-auto-columns: calc((100% - (var(--shelf-cols) - 1) * var(--shelf-gap)) / var(--shelf-cols));
+  gap: var(--shelf-gap);
   overflow-x: auto; padding: 4px 4px 12px; margin: -4px -4px 0;
   scroll-snap-type: x proximity; scrollbar-width: none;
 }

--- a/src/components/desktop/DesktopHome.tsx
+++ b/src/components/desktop/DesktopHome.tsx
@@ -215,7 +215,7 @@ export function DesktopHomeView({
               </button>
             ) : view === 'grid' ? (
               /* 横スクロールの棚に従来の本棚タイルを並べる */
-              <div className="ds-shelf-row" style={{ '--shelf-card-w': '210px' } as React.CSSProperties}>
+              <div className="ds-shelf-row">
                 {pendingScans.map((scan) => (
                   <DesktopGeneratingBookTile key={scan.id} scan={scan} />
                 ))}
@@ -264,7 +264,7 @@ export function DesktopHomeView({
 
           {/* おすすめの単語帳（マイ単語帳と同じ本棚タイルで表示） */}
           {recommendedBooks.length > 0 && (
-            <DesktopShelf title="おすすめの単語帳" seeAllHref="/shared" cardWidth={210}>
+            <DesktopShelf title="おすすめの単語帳" seeAllHref="/shared" >
               {recommendedBooks.map((book) => (
                 <DesktopRecommendedBookTile key={book.shareId} book={book} />
               ))}
@@ -274,7 +274,7 @@ export function DesktopHomeView({
           {/* おすすめのリール（語源がある単語限定）。デスクトップで小さくなり
               すぎないようカード幅を広めに取る */}
           {(recommendationsLoading || recommendedReels.length > 0) && (
-            <DesktopShelf title="おすすめのリール" seeAllHref="/reels" cardWidth={210}>
+            <DesktopShelf title="おすすめのリール" seeAllHref="/reels" >
               {recommendationsLoading && recommendedReels.length === 0
                 ? [0, 1, 2].map((slot) => <DesktopMediaCardSkeleton key={slot} />)
                 : recommendedReels.map((item) => (

--- a/src/components/desktop/DesktopMediaShelf.tsx
+++ b/src/components/desktop/DesktopMediaShelf.tsx
@@ -16,15 +16,15 @@ export function DesktopShelf({
   count,
   seeAllHref,
   onSeeAll,
-  cardWidth,
+  columns,
   children,
 }: {
   title: string;
   count?: number;
   seeAllHref?: string;
   onSeeAll?: () => void;
-  /** 1 カードの幅(px)。省略時は CSS の既定値（190px） */
-  cardWidth?: number;
+  /** 1 行に表示する枚数。省略時は CSS の既定値（4枚） */
+  columns?: number;
   children: ReactNode;
 }) {
   return (
@@ -50,7 +50,7 @@ export function DesktopShelf({
       </div>
       <div
         className="ds-shelf-row"
-        style={cardWidth ? ({ '--shelf-card-w': `${cardWidth}px` } as CSSProperties) : undefined}
+        style={columns ? ({ '--shelf-cols': columns } as CSSProperties) : undefined}
       >
         {children}
       </div>


### PR DESCRIPTION
# 概要

PR #407 のフォローアップです。デスクトップホームの横スクロールの棚（マイ単語帳・おすすめの単語帳・おすすめのリール）で、1行に表示する単語帳の枚数を **4枚固定** にします。

## 変更内容

- `.ds-shelf-row` のカードサイズ指定を固定幅（`--shelf-card-w: 210px`）から **1行あたりの枚数指定**（`--shelf-cols`、既定4枚）に変更
  - カード幅は表示領域から `calc((100% - 3 * gap) / 4)` で自動算出されるため、画面幅が変わっても常にちょうど4枚が並び、5枚目以降は横スクロールで表示
- `DesktopShelf` の `cardWidth` prop を `columns`（1行の枚数）に置換。棚ごとに枚数を変えたい場合に指定できます（現状は全棚とも既定の4枚）

## テスト

- `npx tsc --noEmit` ✅ / `npm run lint` ✅ / `npm run build` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HagiPzb4iZggw6pZjFHf9r

---
_Generated by [Claude Code](https://claude.ai/code/session_01HagiPzb4iZggw6pZjFHf9r)_