### PR TITLE
モバイル: グループページに固定ヘッダー + 本棚のタップアニメ/影を廃止 + 検索をオーバーレイ化

### DIFF
--- a/src/app/groups/[groupId]/page.tsx
+++ b/src/app/groups/[groupId]/page.tsx
@@ -168,15 +168,46 @@ export default function GroupPage() {
           paddingBottom: 'max(2rem, env(safe-area-inset-bottom))',
         }}
       >
+        {/* スクロールしても上部に固定されるヘッダー。top はノッチ下端に合わせ、
+            ノッチ帯は全体共通の StatusBarCover がすりガラスで覆う。 */}
+        <header
+          className="sticky z-40 flex items-center gap-2.5 border-b-2 border-[var(--solid-ink)] bg-[var(--color-background)]/95 px-[14px] py-2.5 backdrop-blur-md"
+          style={{ top: 'env(safe-area-inset-top, 0px)' }}
+        >
+          <button
+            type="button"
+            onClick={() => router.back()}
+            aria-label="戻る"
+            className="inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-full border-2 border-[var(--solid-ink)] bg-white text-[var(--solid-ink)] transition-all duration-100 active:translate-x-px active:translate-y-px"
+          >
+            <Icon name="arrow_back" size={16} />
+          </button>
+          <div className="min-w-0 flex-1">
+            <div className="font-mono text-[9px] font-bold uppercase tracking-[0.08em] text-[var(--color-muted)]">
+              STUDY GROUP
+            </div>
+            <div className="truncate font-display text-[15px] font-extrabold leading-tight text-[var(--solid-ink)]">
+              {group?.name ?? 'グループ'}
+            </div>
+          </div>
+          {group && (
+            <Link
+              href={settingsHref}
+              aria-label="グループ設定"
+              onClick={() => triggerHaptic()}
+              className="inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-full border-2 border-[var(--solid-ink)] bg-white text-[var(--solid-ink)] transition-all duration-100 active:translate-x-px active:translate-y-px"
+            >
+              <Icon name="settings" size={16} />
+            </Link>
+          )}
+        </header>
         {stateView ?? (group && (
-          <div className="flex flex-col gap-4 px-[14px]">
+          <div className="flex flex-col gap-4 px-[14px] pt-3">
             <GroupHeader
               group={group}
               totalQuiz={totalQuiz}
-              onBack={() => router.back()}
               onCopyInvite={() => void copyInvite()}
               onShare={() => { triggerHaptic(); setInviteShareOpen(true); }}
-              settingsHref={settingsHref}
             />
             {loading ? (
               <LoadingState />
@@ -210,46 +241,19 @@ export default function GroupPage() {
 function GroupHeader({
   group,
   totalQuiz,
-  onBack,
   onCopyInvite,
   onShare,
-  settingsHref,
 }: {
   group: StudyGroupSummary;
   totalQuiz: number;
-  /** 履歴で1つ戻る（ホーム/共有どちらから来ても元の画面に返す） */
-  onBack: () => void;
   onCopyInvite: () => void;
   onShare: () => void;
-  settingsHref: string;
 }) {
   return (
     <section
       className="relative overflow-hidden rounded-[18px] border-2 border-[var(--solid-ink)] p-4 text-white"
       style={{ background: `linear-gradient(135deg, ${thumbColor(group.id)} 0%, var(--solid-ink) 160%)` }}
     >
-      <div className="mb-3 flex items-center gap-2">
-        <button
-          type="button"
-          onClick={onBack}
-          aria-label="戻る"
-          className="inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-full border-2 border-white/50 bg-white/15 text-white backdrop-blur-sm transition-all duration-100 active:translate-x-px active:translate-y-px"
-        >
-          <Icon name="arrow_back" size={16} />
-        </button>
-        <div className="font-mono text-[10px] font-bold tracking-[0.08em] text-white/70">
-          STUDY GROUP
-        </div>
-        <Link
-          href={settingsHref}
-          aria-label="グループ設定"
-          onClick={() => triggerHaptic()}
-          className="ml-auto inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-full border-2 border-white/50 bg-white/15 text-white backdrop-blur-sm transition-all duration-100 active:translate-x-px active:translate-y-px"
-        >
-          <Icon name="settings" size={16} />
-        </Link>
-      </div>
-
       <div className="flex items-start gap-3">
         <div
           className="flex h-14 w-14 shrink-0 items-center justify-center rounded-[14px] border-2 border-white/70 bg-white/15 font-display text-[26px] font-extrabold backdrop-blur-sm"
@@ -511,7 +515,7 @@ function BookshelfSection({ groupId, projects }: { groupId: string; projects: Sh
       href={`/groups/${encodeURIComponent(groupId)}/bookshelf`}
       onClick={() => triggerHaptic()}
       aria-label="本棚をひらく"
-      className="relative block overflow-hidden rounded-[18px] border-2 border-[var(--solid-ink)] p-4 shadow-[4px_4px_0_var(--solid-ink)] transition-all duration-100 active:translate-x-[4px] active:translate-y-[4px] active:shadow-none"
+      className="relative block overflow-hidden rounded-[18px] border-2 border-[var(--solid-ink)] p-4"
       style={{ background: 'linear-gradient(150deg, #FFF6DE 0%, #FFE7BC 100%)' }}
     >
       <div className="flex items-center gap-2.5">

--- a/src/components/home/HomeWordSearchSheet.tsx
+++ b/src/components/home/HomeWordSearchSheet.tsx
@@ -2,6 +2,8 @@
 
 /**
  * ホームの検索ボタンから開く、自分の単語帳内の単語検索オーバーレイ。
+ * デスクトップの DesktopWordSearchOverlay と同様、ページ遷移せず現在の
+ * ページの上にダイアログとして重ねる（背景は暗転し、タップで閉じる）。
  * 検索対象は自分が持つ単語帳の単語のみ（共有ライブラリは対象外）。
  * データはホームが同期済みの IndexedDB（localRepository）から読む。
  */
@@ -36,88 +38,115 @@ export function HomeWordSearchSheet({
   }, []);
 
   return (
-    <div className="fixed inset-0 z-[90] flex flex-col bg-[var(--color-background)]" style={{ fontFamily: 'var(--font-body)' }}>
-      <div className="flex items-center gap-2 px-[14px] pb-2 pt-[max(12px,env(safe-area-inset-top))]">
-        <div className="flex h-[42px] min-w-0 flex-1 items-center gap-2 rounded-[12px] border-2 border-[var(--solid-ink)] bg-white px-3">
-          <Icon name="search" size={16} className="shrink-0 text-[var(--color-muted)]" />
-          <input
-            ref={inputRef}
-            value={query}
-            onChange={(event) => setQuery(event.target.value)}
-            placeholder="自分の単語帳から検索"
-            className="min-w-0 flex-1 bg-transparent text-[14px] font-bold text-[var(--solid-ink)] outline-none placeholder:font-semibold placeholder:text-[var(--color-muted)]"
-          />
-          {query && (
+    <div className="fixed inset-0 z-[90]" style={{ fontFamily: 'var(--font-body)' }}>
+      <div
+        className="absolute inset-0"
+        style={{ background: 'rgba(26,26,26,0.45)', backdropFilter: 'blur(3px)' }}
+        onClick={onClose}
+      />
+      {/* キーボードが下半分を占めるので、ダイアログは上寄せで出す。
+          maxHeight は dvh 基準なのでキーボード表示時は自動で縮む。 */}
+      <div
+        className="absolute inset-0 flex justify-center px-4 pb-10"
+        style={{ paddingTop: 'max(16px, calc(env(safe-area-inset-top) + 8px))' }}
+        onClick={onClose}
+      >
+        <div
+          role="dialog"
+          aria-modal="true"
+          aria-label="自分の単語帳から検索"
+          className="flex w-full flex-col overflow-hidden"
+          onClick={(event) => event.stopPropagation()}
+          style={{
+            maxWidth: 560,
+            maxHeight: '62dvh',
+            height: 'fit-content',
+            background: '#faf7f1',
+            border: '2px solid var(--solid-ink)',
+            borderRadius: 18,
+          }}
+        >
+          <div className="flex items-center gap-2 border-b border-[var(--color-border)] px-3.5 py-2.5">
+            <Icon name="search" size={16} className="shrink-0 text-[var(--color-muted)]" />
+            <input
+              ref={inputRef}
+              value={query}
+              onChange={(event) => setQuery(event.target.value)}
+              placeholder="自分の単語帳から検索"
+              className="min-w-0 flex-1 bg-transparent text-[14px] font-bold text-[var(--solid-ink)] outline-none placeholder:font-semibold placeholder:text-[var(--color-muted)]"
+            />
+            {query && (
+              <button
+                type="button"
+                onClick={() => setQuery('')}
+                aria-label="入力をクリア"
+                className="shrink-0 text-[var(--color-muted)]"
+              >
+                <Icon name="close" size={15} />
+              </button>
+            )}
             <button
               type="button"
-              onClick={() => setQuery('')}
-              aria-label="入力をクリア"
-              className="shrink-0 text-[var(--color-muted)]"
+              onClick={onClose}
+              className="ml-1 shrink-0 text-[13px] font-bold text-[var(--solid-ink)]"
             >
-              <Icon name="close" size={15} />
+              キャンセル
             </button>
-          )}
-        </div>
-        <button
-          type="button"
-          onClick={onClose}
-          className="shrink-0 text-[13px] font-bold text-[var(--solid-ink)]"
-        >
-          キャンセル
-        </button>
-      </div>
+          </div>
 
-      <div className="min-h-0 flex-1 overflow-y-auto overscroll-contain px-4 pb-[max(24px,env(safe-area-inset-bottom))]">
-        {query.trim() === '' ? (
-          <div className="px-2 py-10 text-center text-sm text-[var(--color-muted)]">
-            単語（英語・日本語）で検索できます
-          </div>
-        ) : entries === null ? (
-          <div className="flex items-center justify-center py-10 text-[var(--color-muted)]">
-            <Icon name="progress_activity" size={18} className="animate-spin" />
-            <span className="ml-2 text-sm">読み込み中...</span>
-          </div>
-        ) : results.length === 0 ? (
-          <div className="px-2 py-10 text-center text-sm text-[var(--color-muted)]">
-            一致する単語がありません
-          </div>
-        ) : (
-          <div className="divide-y divide-[var(--color-border)]">
-            {results.map(({ word, projectTitle }) => {
-              const pos = word.partOfSpeechTags?.[0] ?? null;
-              return (
-                <button
-                  key={word.id}
-                  type="button"
-                  onClick={() => setSelectedWord(word)}
-                  className="block w-full px-1 py-2.5 text-left"
-                >
-                  <div className="flex items-center gap-2.5">
-                    <div className="min-w-0 flex-1">
-                      <div className="truncate font-display text-[15px] font-bold text-[var(--solid-ink)]">
-                        {word.english}
-                      </div>
-                      <div className="mt-px flex items-center gap-1 text-[11px] text-[var(--color-muted)]">
-                        {pos && (
-                          <span className="shrink-0 font-mono text-[9px]">
-                            ({getPartOfSpeechLabel(pos).charAt(0)})
-                          </span>
-                        )}
-                        <span className="truncate">
-                          <TranslationDisplay word={word} compact />
+          <div className="min-h-0 flex-1 overflow-y-auto overscroll-contain px-4">
+            {query.trim() === '' ? (
+              <div className="px-2 py-8 text-center text-sm text-[var(--color-muted)]">
+                単語（英語・日本語）で検索できます
+              </div>
+            ) : entries === null ? (
+              <div className="flex items-center justify-center py-8 text-[var(--color-muted)]">
+                <Icon name="progress_activity" size={18} className="animate-spin" />
+                <span className="ml-2 text-sm">読み込み中...</span>
+              </div>
+            ) : results.length === 0 ? (
+              <div className="px-2 py-8 text-center text-sm text-[var(--color-muted)]">
+                一致する単語がありません
+              </div>
+            ) : (
+              <div className="divide-y divide-[var(--color-border)] pb-2">
+                {results.map(({ word, projectTitle }) => {
+                  const pos = word.partOfSpeechTags?.[0] ?? null;
+                  return (
+                    <button
+                      key={word.id}
+                      type="button"
+                      onClick={() => setSelectedWord(word)}
+                      className="block w-full px-1 py-2.5 text-left"
+                    >
+                      <div className="flex items-center gap-2.5">
+                        <div className="min-w-0 flex-1">
+                          <div className="truncate font-display text-[15px] font-bold text-[var(--solid-ink)]">
+                            {word.english}
+                          </div>
+                          <div className="mt-px flex items-center gap-1 text-[11px] text-[var(--color-muted)]">
+                            {pos && (
+                              <span className="shrink-0 font-mono text-[9px]">
+                                ({getPartOfSpeechLabel(pos).charAt(0)})
+                              </span>
+                            )}
+                            <span className="truncate">
+                              <TranslationDisplay word={word} compact />
+                            </span>
+                          </div>
+                        </div>
+                        <span className="max-w-[96px] shrink-0 truncate text-[9px] font-bold text-[var(--color-muted)]">
+                          {projectTitle}
                         </span>
+                        <Icon name="chevron_right" size={14} className="shrink-0 text-[var(--color-muted)]" />
                       </div>
-                    </div>
-                    <span className="max-w-[96px] shrink-0 truncate text-[9px] font-bold text-[var(--color-muted)]">
-                      {projectTitle}
-                    </span>
-                    <Icon name="chevron_right" size={14} className="shrink-0 text-[var(--color-muted)]" />
-                  </div>
-                </button>
-              );
-            })}
+                    </button>
+                  );
+                })}
+              </div>
+            )}
           </div>
-        )}
+        </div>
       </div>
 
       {selectedWord && (


### PR DESCRIPTION
## 変更内容

### 1. モバイルのグループページにスティッキーヘッダーを追加
- `src/app/groups/[groupId]/page.tsx` のモバイル表示に、スクロールしても上部に固定表示されるヘッダー（戻るボタン・グループ名・設定ボタン）を追加
- `position: sticky` + `top: env(safe-area-inset-top)` でノッチ下端に固定し、ノッチ帯は既存の全体共通 `StatusBarCover` がすりガラスで覆う構成
- ヘッダーはローディング中・エラー時・未ログイン時にも表示されるため、どの状態でも戻る操作が可能
- グラデーションカード（`GroupHeader`）内で重複していた戻る/設定ボタンと「STUDY GROUP」ラベルの行は削除し、固定ヘッダー側へ移動

### 2. 本棚カードのタップアニメーションと影を削除
- グループページの本棚（`BookshelfSection`）カードから、タップ時の押し込みアニメーション（`active:translate-x/y` + `transition-all`）とオフセット影（`shadow-[4px_4px_0_var(--solid-ink)]`）を削除

### 3. モバイルの単語検索をデスクトップ同様のオーバーレイに変更
- `HomeWordSearchSheet` を全画面の不透明シート（ページ遷移風）から、デスクトップの `DesktopWordSearchOverlay` と同じく現在のページの上に重なるダイアログに変更
- 背景は暗転＋ブラーで現在のページが透けて見え、背景タップまたは「キャンセル」で閉じる
- キーボードが下半分を占めるため、ダイアログは上寄せで配置。`maxHeight: 62dvh` によりキーボード表示時は自動で縮む
- 検索ロジック・単語詳細モーダル・呼び出し側（`home-client.tsx`）のインターフェースは変更なし

## 動作確認
- `npm run lint`: 今回の変更ファイルにエラーなし（既存の `gcp-budget-guard/` の5エラーは変更前から存在）
- `npm test`: 958/960 pass（失敗2件はベースコミットでも失敗する既存のAPIテストで、本変更とは無関係なことを確認済み）
- `npm run build`: 成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X9zzwn6P4fjKGrqqJaudBf

---
_Generated by [Claude Code](https://claude.ai/code/session_01X9zzwn6P4fjKGrqqJaudBf)_