### PR TITLE
リール復習/ヒント表示削除 + フィード一覧化 + 共有単語帳のA/P・CEFR削除 + 保存UIをブックマーク化

### DIFF
--- a/src/app/desktop.css
+++ b/src/app/desktop.css
@@ -133,6 +133,9 @@
   padding: 18px 34px; border-bottom: 1px solid var(--color-border);
   background: rgba(246,245,241,0.86); backdrop-filter: blur(8px);
   flex-shrink: 0;
+  /* トップバーの「...」ドロップダウンがスクロール領域内の sticky 要素
+     （復習レール等）の下に潜らないよう前面に出す */
+  position: relative; z-index: 30;
 }
 .ds-top h1 { font-size: 24px; margin: 0; }
 .ds-top .crumb { font-size: 13px; color: var(--color-muted); font-family: var(--font-mono); }
@@ -942,6 +945,7 @@ button.ds-tile { appearance: none; }
   display: grid; grid-template-columns: minmax(0, 1fr) 316px;
   gap: 24px; align-items: start;
 }
+.ds-feed-grid.single { grid-template-columns: minmax(0, 1fr); }
 .ds-feed-main { display: flex; flex-direction: column; gap: 14px; min-width: 0; }
 .ds-feed-side { display: flex; flex-direction: column; gap: 16px; position: sticky; top: 0; min-width: 0; }
 @media (max-width: 1240px) {
@@ -966,6 +970,14 @@ button.ds-tile { appearance: none; }
   border-radius: var(--solid-radius); box-shadow: 3px 4px 0 var(--solid-ink);
   overflow: hidden;
 }
+/* タイムラインは単語一覧と同じく1枚のリストに連結し、薄い線で区切る */
+.ds-feed-list {
+  background: #fff; border: 1.5px solid var(--solid-ink);
+  border-radius: var(--solid-radius); box-shadow: 3px 4px 0 var(--solid-ink);
+  overflow: hidden;
+}
+.ds-feed-list .ds-feed-card { border: none; border-radius: 0; box-shadow: none; }
+.ds-feed-list .ds-feed-card + .ds-feed-card { border-top: 1px solid var(--color-border); }
 .ds-feed-card .fc-row { display: flex; align-items: flex-start; gap: 14px; padding: 16px 18px; }
 .ds-feed-card .fc-link { color: inherit; text-decoration: none; transition: background var(--dur-fast); }
 .ds-feed-card .fc-link:hover { background: var(--color-surface-secondary); }

--- a/src/app/friends/page.tsx
+++ b/src/app/friends/page.tsx
@@ -164,18 +164,22 @@ export default function FriendsPage() {
 
   const renderFeedEntries = () => (
     <>
-      {feedEntries.map((entry) => (
-        entry.kind === 'quiz'
-          ? (
-            <TimelineItem
-              key={`quiz-${entry.session.id}`}
-              session={entry.session}
-              expanded={expandedSessions.has(entry.session.id)}
-              onToggle={() => toggleSession(entry.session.id)}
-            />
-          )
-          : <GroupEventItem key={`group-${entry.event.id}`} event={entry.event} />
-      ))}
+      {feedEntries.length > 0 && (
+        <div className="divide-y divide-[var(--color-border)]">
+          {feedEntries.map((entry) => (
+            entry.kind === 'quiz'
+              ? (
+                <TimelineItem
+                  key={`quiz-${entry.session.id}`}
+                  session={entry.session}
+                  expanded={expandedSessions.has(entry.session.id)}
+                  onToggle={() => toggleSession(entry.session.id)}
+                />
+              )
+              : <GroupEventItem key={`group-${entry.event.id}`} event={entry.event} />
+          ))}
+        </div>
+      )}
 
       {timelineLoading && (
         <div className="flex items-center justify-center py-10 text-[var(--color-muted)]">
@@ -237,16 +241,6 @@ export default function FriendsPage() {
         )}
 
         {renderFeedEntries()}
-
-        {home.friends.length > 0 && (
-          <div className="mx-[18px] mt-6 border-t border-[var(--color-border)] pt-5 pb-4">
-            <FriendsSection
-              friends={home.friends}
-              actionLoading={actionLoading}
-              onRemoveFriend={removeFriend}
-            />
-          </div>
-        )}
       </>
     );
   };
@@ -369,53 +363,6 @@ function RequestsSection({
   );
 }
 
-function FriendRows({
-  friends,
-  actionLoading,
-  onRemoveFriend,
-}: {
-  friends: FriendshipSummary[];
-  actionLoading: string | null;
-  onRemoveFriend: (friendshipId: string) => void;
-}) {
-  return (
-    <>
-      {friends.map((friend) => (
-        <FriendRow key={friend.id} friendship={friend}>
-          <button
-            type="button"
-            onClick={() => onRemoveFriend(friend.id)}
-            disabled={Boolean(actionLoading)}
-            className="inline-flex h-7 w-7 items-center justify-center rounded-[7px] border border-[var(--color-border)] bg-white text-[var(--color-muted)] disabled:opacity-50"
-            aria-label="フレンド解除"
-          >
-            <Icon name={actionLoading === `delete:${friend.id}` ? 'progress_activity' : 'person_remove'} className={actionLoading === `delete:${friend.id}` ? 'animate-spin' : ''} size={14} />
-          </button>
-        </FriendRow>
-      ))}
-    </>
-  );
-}
-
-function FriendsSection({
-  friends,
-  actionLoading,
-  onRemoveFriend,
-}: {
-  friends: FriendshipSummary[];
-  actionLoading: string | null;
-  onRemoveFriend: (friendshipId: string) => void;
-}) {
-  return (
-    <>
-      <SectionTitle icon="groups" label="フレンド" count={friends.length} />
-      <div className="mt-2 flex flex-col gap-1.5">
-        <FriendRows friends={friends} actionLoading={actionLoading} onRemoveFriend={onRemoveFriend} />
-      </div>
-    </>
-  );
-}
-
 function TimelineItem({
   session,
   expanded,
@@ -427,7 +374,7 @@ function TimelineItem({
 }) {
   const profileHref = `/profile/${encodeURIComponent(session.profile.accountId)}`;
   return (
-    <article className="border-b border-[var(--color-border)] transition-colors hover:bg-[var(--color-surface-secondary)]">
+    <article className="transition-colors hover:bg-[var(--color-surface-secondary)]">
       <div className="flex items-start gap-3.5 px-[18px] py-4">
         <Link href={profileHref} aria-label={`${displayName(session.profile)}のプロフィール`} className="shrink-0">
           <Avatar profile={session.profile} />
@@ -485,7 +432,7 @@ function TimelineItem({
 
 function GroupEventItem({ event }: { event: StudyGroupFeedEvent }) {
   return (
-    <article className="border-b border-[var(--color-border)]">
+    <article>
       <Link href={`/groups/${event.groupId}`} className="flex items-start gap-3.5 px-[18px] py-4 transition-colors active:bg-[var(--color-surface-secondary)]">
         <div
           className="flex h-11 w-11 shrink-0 items-center justify-center rounded-[11px] border-2 border-[var(--solid-ink)] text-white"

--- a/src/app/groups/[groupId]/join/page.tsx
+++ b/src/app/groups/[groupId]/join/page.tsx
@@ -243,7 +243,7 @@ export default function GroupJoinPage() {
           <DesktopButton href="/shared" icon="arrow_back" variant="ghost">共有ライブラリ</DesktopButton>
         </div>
         <div className="ds-scroll">
-          <div style={{ maxWidth: 560 }}>
+          <div style={{ maxWidth: 560, width: '100%', margin: '0 auto' }}>
             {stateView ?? joinContent}
           </div>
         </div>

--- a/src/app/project/[id]/page.tsx
+++ b/src/app/project/[id]/page.tsx
@@ -1201,7 +1201,6 @@ export default function ProjectPage() {
         onToggleFavorite={(word) => void handleToggleFavorite(word)}
         onCycleVocabularyType={(word) => void handleCycleVocabularyType(word)}
         onDeleteWord={handleOpenDeleteWord}
-        onBulkDelete={() => setBulkDeleteModalOpen(true)}
         onScan={() => setShowScanCaptureModal(true)}
         onManualAdd={openManualWordModal}
       />

--- a/src/components/desktop/DesktopChrome.tsx
+++ b/src/components/desktop/DesktopChrome.tsx
@@ -16,7 +16,7 @@ const NAV_ITEMS: { key: NavKey; href: string; icon: string; label: string; count
   { key: 'reels', href: '/reels', icon: 'movie', label: 'リール' },
   { key: 'feed', href: '/friends', icon: 'dynamic_feed', label: 'フィード' },
   { key: 'shared', href: '/shared', icon: 'group', label: '共有ライブラリ', count: 6 },
-  { key: 'fav', href: '/favorites', icon: 'star', label: '保存', count: 21 },
+  { key: 'fav', href: '/favorites', icon: 'bookmark', label: '保存', count: 21 },
   { key: 'settings', href: '/settings', icon: 'settings', label: '設定' },
 ];
 

--- a/src/components/desktop/DesktopFavorites.tsx
+++ b/src/components/desktop/DesktopFavorites.tsx
@@ -77,7 +77,7 @@ export function DesktopFavoritesView({
 
       <div className="ds-scroll">
         <div style={{ display: 'flex', alignItems: 'center', gap: 12, marginBottom: 16 }}>
-          <Icon name="star" filled style={{ color: 'var(--color-warning)', fontSize: 22 }} />
+          <Icon name="bookmark" filled style={{ color: 'var(--color-accent)', fontSize: 22 }} />
           <span style={{ fontFamily: 'var(--font-display)', fontWeight: 800, fontSize: 20 }}>{favorites.length} <span style={{ fontSize: 13 }}>語</span></span>
           <span className="muted" style={{ fontSize: 13 }}>を保存中</span>
           <div style={{ display: 'flex', gap: 12, marginLeft: 8 }}>
@@ -127,7 +127,7 @@ export function DesktopFavoritesView({
                       onToggleFavorite(word);
                     }}
                   >
-                    <Icon name="star" filled style={{ color: 'var(--color-warning)' }} />
+                    <Icon name="bookmark" filled style={{ color: 'var(--color-accent)' }} />
                   </td>
                   <td className="en">{word.english}</td>
                   <td className="pos">{desktopPosShort(word.partOfSpeechTags)}</td>

--- a/src/components/desktop/DesktopFeed.tsx
+++ b/src/components/desktop/DesktopFeed.tsx
@@ -2,8 +2,8 @@
 
 /**
  * デスクトップ版フィード（/friends）。
- * 中央寄せの2カラム構成: 左=学習タイムライン、右=申請・フレンド管理。
- * レイアウトとカードのスタイルは desktop.css の .ds-feed-* を参照。
+ * 学習タイムラインを1枚のリストに連結して表示し、フレンド申請があるときだけ
+ * 右カラムに申請パネルを出す。スタイルは desktop.css の .ds-feed-* を参照。
  */
 
 import Link from 'next/link';
@@ -75,19 +75,23 @@ export function DesktopFeed({
                   <button type="button" onClick={onRefresh}>再試行</button>
                 </div>
               )}
-              <div className="ds-feed-grid">
+              <div className={`ds-feed-grid${home.incoming.length > 0 || home.outgoing.length > 0 ? '' : ' single'}`}>
                 <div className="ds-feed-main">
-                  {entries.map((entry) =>
-                    entry.kind === 'quiz' ? (
-                      <QuizEntryCard
-                        key={`quiz-${entry.session.id}`}
-                        session={entry.session}
-                        expanded={expandedSessions.has(entry.session.id)}
-                        onToggle={() => onToggleSession(entry.session.id)}
-                      />
-                    ) : (
-                      <GroupEntryCard key={`group-${entry.event.id}`} event={entry.event} />
-                    ),
+                  {entries.length > 0 && (
+                    <div className="ds-feed-list">
+                      {entries.map((entry) =>
+                        entry.kind === 'quiz' ? (
+                          <QuizEntryCard
+                            key={`quiz-${entry.session.id}`}
+                            session={entry.session}
+                            expanded={expandedSessions.has(entry.session.id)}
+                            onToggle={() => onToggleSession(entry.session.id)}
+                          />
+                        ) : (
+                          <GroupEntryCard key={`group-${entry.event.id}`} event={entry.event} />
+                        ),
+                      )}
+                    </div>
                   )}
                   {timelineLoading && (
                     <div className="ds-feed-loadrow">
@@ -97,8 +101,8 @@ export function DesktopFeed({
                   {!timelineLoading && entries.length === 0 && <FeedEmptyCard />}
                 </div>
 
-                <aside className="ds-feed-side">
-                  {(home.incoming.length > 0 || home.outgoing.length > 0) && (
+                {(home.incoming.length > 0 || home.outgoing.length > 0) && (
+                  <aside className="ds-feed-side">
                     <RequestsPanel
                       incoming={home.incoming}
                       outgoing={home.outgoing}
@@ -106,13 +110,8 @@ export function DesktopFeed({
                       onRespondRequest={onRespondRequest}
                       onRemoveFriend={onRemoveFriend}
                     />
-                  )}
-                  <FriendsPanel
-                    friends={home.friends}
-                    actionLoading={actionLoading}
-                    onRemoveFriend={onRemoveFriend}
-                  />
-                </aside>
+                  </aside>
+                )}
               </div>
             </>
           )}
@@ -295,49 +294,6 @@ function RequestsPanel({
   );
 }
 
-function FriendsPanel({
-  friends,
-  actionLoading,
-  onRemoveFriend,
-}: {
-  friends: FriendshipSummary[];
-  actionLoading: string | null;
-  onRemoveFriend: (friendshipId: string) => void;
-}) {
-  return (
-    <section className="ds-feed-panel">
-      <header className="ph">
-        <Icon name="groups" size={16} />
-        <span className="t">フレンド</span>
-        <span className="ct">{friends.length}</span>
-      </header>
-      {friends.length > 0 ? (
-        <div className="pb">
-          {friends.map((friend) => (
-            <SideRow key={friend.id} profile={friend.profile}>
-              <button
-                type="button"
-                className="ds-feed-act"
-                onClick={() => onRemoveFriend(friend.id)}
-                disabled={Boolean(actionLoading)}
-                aria-label="フレンド解除"
-              >
-                <Icon
-                  name={actionLoading === `delete:${friend.id}` ? 'progress_activity' : 'person_remove'}
-                  className={actionLoading === `delete:${friend.id}` ? 'animate-spin' : ''}
-                  size={15}
-                />
-              </button>
-            </SideRow>
-          ))}
-        </div>
-      ) : (
-        <p className="pe">まだフレンドがいません。プロフィールページから申請を送ってみましょう。</p>
-      )}
-    </section>
-  );
-}
-
 function SideRow({
   profile,
   children,
@@ -406,7 +362,7 @@ function FeedLoginCard() {
 
 function FeedSkeleton() {
   return (
-    <div className="ds-feed-grid" aria-hidden="true">
+    <div className="ds-feed-grid single" aria-hidden="true">
       <div className="ds-feed-main">
         {[0, 1, 2].map((index) => (
           <div key={index} className="ds-feed-skel">
@@ -418,15 +374,6 @@ function FeedSkeleton() {
           </div>
         ))}
       </div>
-      <aside className="ds-feed-side">
-        <div className="ds-feed-skel">
-          <div className="body">
-            <div className="ds-shimmer ln w40" />
-            <div className="ds-shimmer ln w70" />
-            <div className="ds-shimmer ln w70" />
-          </div>
-        </div>
-      </aside>
     </div>
   );
 }

--- a/src/components/desktop/DesktopProjectDetail.tsx
+++ b/src/components/desktop/DesktopProjectDetail.tsx
@@ -66,7 +66,6 @@ export function DesktopProjectDetailView({
   onToggleFavorite,
   onCycleVocabularyType,
   onDeleteWord,
-  onBulkDelete,
   onScan,
   onManualAdd,
 }: {
@@ -90,7 +89,6 @@ export function DesktopProjectDetailView({
   onToggleFavorite: (word: Word) => void;
   onCycleVocabularyType: (word: Word) => void;
   onDeleteWord: (wordId: string) => void;
-  onBulkDelete: () => void;
   onScan: () => void;
   onManualAdd: () => void;
 }) {
@@ -327,16 +325,6 @@ export function DesktopProjectDetailView({
             <div style={{ flex: 1 }} />
             {/* フィルタ・ソート・選択（正方形）は検索窓の左に配置 */}
             <div style={{ display: 'flex', gap: 8 }}>
-              {selectMode && selectedWordIds.size > 0 && (
-                <button
-                  type="button"
-                  className="ds-btn sm"
-                  onClick={onBulkDelete}
-                  style={{ color: 'var(--color-error, #cc4d59)' }}
-                >
-                  <Icon name="delete" />{selectedWordIds.size}語を削除
-                </button>
-              )}
               <button
                 type="button"
                 className={'ds-btn sm' + (filterActive ? ' dark' : '')}
@@ -439,9 +427,9 @@ export function DesktopProjectDetailView({
                         </span>
                       ) : (
                         <Icon
-                          name={word.isFavorite ? 'star' : 'star_border'}
+                          name="bookmark"
                           filled={word.isFavorite}
-                          style={word.isFavorite ? { color: 'var(--color-warning)' } : undefined}
+                          style={word.isFavorite ? { color: 'var(--color-accent)' } : undefined}
                         />
                       )}
                     </td>

--- a/src/components/desktop/DesktopProjects.tsx
+++ b/src/components/desktop/DesktopProjects.tsx
@@ -74,7 +74,7 @@ export function DesktopProjectsView({
               すべて <span className="tnum" style={{ opacity: 0.7 }}>{projects.length}</span>
             </button>
             <button type="button" className={'ds-chip' + (filter === 'fav' ? ' active' : '')} onClick={() => setFilter('fav')}>
-              <Icon name="star" filled style={{ fontSize: 15 }} />保存
+              <Icon name="bookmark" filled style={{ fontSize: 15 }} />保存
             </button>
             <button type="button" className={'ds-chip' + (sort === 'newest' ? ' active' : '')} onClick={() => onSortChange('newest')}>
               <Icon name="schedule" style={{ fontSize: 15 }} />新しい順
@@ -140,7 +140,7 @@ function DesktopProjectTableRow({ project }: { project: DesktopProjectRow }) {
   return (
     <tr>
       <td className="star">
-        <Icon name={project.isFavorite ? 'star' : 'star_border'} filled={project.isFavorite} style={project.isFavorite ? { color: 'var(--color-warning)' } : undefined} />
+        <Icon name="bookmark" filled={project.isFavorite} style={project.isFavorite ? { color: 'var(--color-accent)' } : undefined} />
       </td>
       <td>
         <Link href={`/project/${project.id}`} style={{ display: 'flex', alignItems: 'center', gap: 12, textDecoration: 'none', color: 'inherit' }}>

--- a/src/components/desktop/DesktopSharedDetail.tsx
+++ b/src/components/desktop/DesktopSharedDetail.tsx
@@ -49,7 +49,6 @@ export function DesktopSharedDetailView({
   /** 行の「…」から単語単位のアクション（単語帳に追加 / 共有）を開く */
   onWordAction?: (word: Word) => void;
 }) {
-  const [ap, setAp] = useState<'all' | 'active' | 'passive'>('all');
   const [query, setQuery] = useState('');
   const q = query.trim().toLowerCase();
   const bg = project.iconImage ? undefined : desktopThumbColor(project.id);
@@ -62,12 +61,11 @@ export function DesktopSharedDetailView({
     () => {
       if (isPreviewLocked) return words;
       return words.filter((word) => {
-        if (ap !== 'all' && (word.vocabularyType || 'none') !== ap) return false;
         if (!q) return true;
         return word.english.toLowerCase().includes(q) || formatJapaneseForDisplay(word).toLowerCase().includes(q);
       });
     },
-    [ap, isPreviewLocked, q, words],
+    [isPreviewLocked, q, words],
   );
 
   return (
@@ -123,18 +121,7 @@ export function DesktopSharedDetailView({
           </div>
           <div style={{ flex: 1 }} />
           {!isPreviewLocked && (
-            <>
-              <div style={{ display: 'flex', gap: 6 }}>
-                {([
-                  ['all', 'すべて'],
-                  ['active', 'アクティブ'],
-                  ['passive', 'パッシブ'],
-                ] as const).map(([value, label]) => (
-                  <button key={value} type="button" className={'ds-chip' + (ap === value ? ' active' : '')} onClick={() => setAp(value)}>{label}</button>
-                ))}
-              </div>
-              <DesktopSearchBox placeholder="単語を検索" value={query} onChange={(event) => setQuery(event.target.value)} style={{ minWidth: 200 }} />
-            </>
+            <DesktopSearchBox placeholder="単語を検索" value={query} onChange={(event) => setQuery(event.target.value)} style={{ minWidth: 200 }} />
           )}
         </div>
 
@@ -144,10 +131,8 @@ export function DesktopSharedDetailView({
               <tr>
                 {selectMode && <th style={{ width: 44 }} />}
                 <th style={{ minWidth: 150 }}>単語</th>
-                <th style={{ width: 56, textAlign: 'center' }}>A/P</th>
                 <th style={{ width: 90 }}>品詞</th>
                 <th>訳</th>
-                <th style={{ width: 70 }}>CEFR</th>
                 {onWordAction && !isPreviewLocked && <th style={{ width: 52 }} />}
               </tr>
             </thead>
@@ -173,10 +158,8 @@ export function DesktopSharedDetailView({
                       <span style={textStyle}>{word.english}</span>
                       {locked && <Icon name="lock" style={{ marginLeft: 6, fontSize: 14, color: 'var(--color-muted)' }} />}
                     </td>
-                    <td style={{ textAlign: 'center' }}><span style={textStyle}><ApBadge value={word.vocabularyType} /></span></td>
                     <td className="pos"><span style={textStyle}>{desktopPosLabel(word.partOfSpeechTags)}</span></td>
                     <td className="ja"><span style={textStyle}><TranslationDisplay word={word} compact /></span></td>
-                    <td className="cefr"><span className="cefr-pill" style={textStyle}>{word.cefrLevel || '-'}</span></td>
                     {onWordAction && !isPreviewLocked && (
                       <td style={{ textAlign: 'center' }}>
                         <button
@@ -238,6 +221,3 @@ export function DesktopSharedDetailView({
   );
 }
 
-function ApBadge({ value }: { value?: Word['vocabularyType'] }) {
-  return <span className={'ds-ap ' + (value || 'none')}>{value === 'active' ? 'A' : value === 'passive' ? 'P' : '-'}</span>;
-}

--- a/src/components/desktop/DesktopWordDetailModal.tsx
+++ b/src/components/desktop/DesktopWordDetailModal.tsx
@@ -55,9 +55,9 @@ export function DesktopWordDetailModal({
               <div className="word-en">{word.english}</div>
               <button type="button" className="ds-btn ghost sm" onClick={onToggleFavorite} aria-label="保存">
                 <Icon
-                  name={word.isFavorite ? 'star' : 'star_border'}
+                  name="bookmark"
                   filled={word.isFavorite}
-                  style={{ color: word.isFavorite ? 'var(--color-warning)' : 'var(--color-muted)' }}
+                  style={{ color: word.isFavorite ? 'var(--color-accent)' : 'var(--color-muted)' }}
                 />
               </button>
             </div>

--- a/src/components/reel/ReelCard.tsx
+++ b/src/components/reel/ReelCard.tsx
@@ -158,13 +158,8 @@ export function ReelCard({
             className="flex h-full flex-col items-center justify-center gap-4 px-8 text-center"
             style={{ width: `${faceWidth}%` }}
           >
-            {(item.partOfSpeechTags.length > 0 || item.isRecycled) && (
+            {item.partOfSpeechTags.length > 0 && (
               <div className="flex flex-wrap justify-center gap-1.5">
-                {item.isRecycled && (
-                  <span className="rounded-full border border-[var(--color-accent)] bg-[var(--color-accent-light)] px-2.5 py-0.5 text-xs font-bold text-[var(--color-accent-ink)]">
-                    復習
-                  </span>
-                )}
                 {item.partOfSpeechTags.slice(0, 3).map((tag) => (
                   <span
                     key={tag}
@@ -178,9 +173,6 @@ export function ReelCard({
             <p className="t-word-display break-words">{item.english}</p>
             <p className="font-mono text-base text-[var(--color-secondary-text)]">
               {item.pronunciation || ' '}
-            </p>
-            <p className="mt-4 text-xs text-[var(--color-muted)]">
-              ← スワイプ / タップで意味を表示
             </p>
           </div>
           {/* Back: Japanese meaning */}

--- a/src/components/reel/ReelEtymologyPanel.tsx
+++ b/src/components/reel/ReelEtymologyPanel.tsx
@@ -16,13 +16,8 @@ export function ReelEtymologyPanel({ item }: { item: ReelItem }) {
 
   return (
     <div className="flex h-full w-full flex-col items-center justify-center gap-4 px-8 text-center">
-      {(item.partOfSpeechTags.length > 0 || item.isRecycled) && (
+      {item.partOfSpeechTags.length > 0 && (
         <div className="flex flex-wrap justify-center gap-1.5">
-          {item.isRecycled && (
-            <span className="rounded-full border border-[var(--color-accent)] bg-[var(--color-accent-light)] px-2.5 py-0.5 text-xs font-bold text-[var(--color-accent-ink)]">
-              復習
-            </span>
-          )}
           {item.partOfSpeechTags.slice(0, 3).map((tag) => (
             <span
               key={tag}


### PR DESCRIPTION
## 概要

リール・フィード・共有単語帳・単語帳ページのUI調整をまとめて行いました。

## 変更内容

### リール
- 「復習」バッジ表示を削除（`ReelCard` / `ReelEtymologyPanel`）
- 「← スワイプ / タップで意味を表示」のヒントテキストを削除（スワイプ/タップの操作自体は維持）

### フィードページ（/friends）
- タイムラインの各エントリを独立カードではなく、単語一覧と同様に**1枚のリストに連結し薄線で区切る**表示に変更（デスクトップ: `.ds-feed-list`、モバイル: `divide-y`）
- フレンド欄（フレンド一覧パネル/セクション）を削除。申請パネルは申請があるときのみ表示し、無いときはタイムラインを全幅表示

### グループ参加ページ
- デスクトップ表示で参加カードが左に寄っていた問題を修正（`max-width: 560px` のコンテンツを中央寄せ）

### 共有単語帳（デスクトップ）
- 単語一覧テーブルから **A/P列** と **CEFR列** を削除
- **アクティブ/パッシブフィルター**チップを削除

### 保存UI
- スターアイコンをブックマークアイコンに統一（モバイルの単語一覧と揃える）
  - 単語詳細モーダル / 単語帳詳細テーブル / 保存ページ / デスクトップサイドバー / 単語帳一覧の保存フィルター・行

### 単語帳ページ（デスクトップ）
- トップバーの「…」メニューがスクロール領域内の sticky 要素（復習レール等）の下に埋もれる問題を修正（`.ds-top` に `position: relative; z-index: 30` を付与）
- 選択モード時の「N語を削除」ボタンを削除（下部バルクバーの「削除」ボタンに一本化）

## テスト
- `npx tsc --noEmit`: 変更ファイル起因のエラーなし（既存の `translation-targets.test.ts` のエラーのみ）
- `npm run lint`: 変更ファイル起因のエラー/警告なし（既存の `gcp-budget-guard/` エラーのみ）
- `npm test`: 958/960 pass。失敗2件（`otp.contract.test.ts` / `words/create/route.test.ts`）はベースコミットでも失敗する既存の問題であることを確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WjePpRi4RJ8wctv82g8idJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01WjePpRi4RJ8wctv82g8idJ)_