### PR TITLE
Fix review quiz count growing mid-session and quiz restarting after 終了

### DIFF
--- a/src/app/quiz/[projectId]/page.tsx
+++ b/src/app/quiz/[projectId]/page.tsx
@@ -603,6 +603,10 @@ export default function QuizPage() {
   const vocabularyMergeFromLocalAppliedRef = useRef(false);
   const currentIndexRef = useRef(0);
   const wordOrderGenerationRunRef = useRef(0);
+  // True once the user has answered (or skipped) any question in the current
+  // quiz run. Late-arriving background word-order quizzes must not grow the
+  // question list after this point.
+  const hasAnsweredRef = useRef(false);
   const storageKey = reminderMode
     ? 'quiz_state_reminder'
     : wrongMode
@@ -667,7 +671,10 @@ export default function QuizPage() {
     const cnt = Math.max(1, Math.min(questionCount ?? DEFAULT_QUESTION_COUNT, MAX_NORMAL_QUIZ_QUESTION_COUNT));
     const modeParam = learnMode ? 'learn=1' : 'review=1';
     const url = `${pathname}?${modeParam}&count=${cnt}${fromQ}&_rs=${Date.now()}`;
-    window.location.assign(url);
+    // replace() instead of assign(): each round must not add a history entry,
+    // otherwise 終了する (router.back) lands on the previous round's quiz URL
+    // and starts a brand-new quiz instead of leaving.
+    window.location.replace(url);
   }, [clearQuizState, returnPath, questionCount, pathname, learnMode]);
 
   useEffect(() => {
@@ -767,6 +774,8 @@ export default function QuizPage() {
           prev,
           updatedSelected,
           currentIndexRef.current,
+          undefined,
+          { allowInsert: !hasAnsweredRef.current, maxQuestions: count },
         ));
       })();
     }
@@ -845,6 +854,7 @@ export default function QuizPage() {
         setQuestionCount(restoredCount);
         setQuizDirection(state.quizDirection);
         setAllWords(restoredQuestions.map(q => q.word));
+        hasAnsweredRef.current = (state.results?.total ?? 0) > 0 || state.currentIndex > 0;
         restoredFromStorage.current = true;
         setLoading(false);
         return true;
@@ -1092,6 +1102,7 @@ export default function QuizPage() {
   }, [currentIndex, isTypeInMode, isRevealed, focusTypeInField]);
 
   const applyAnswerOutcome = async (word: Word, isCorrect: boolean, marker?: QuizAnswerResult) => {
+    hasAnsweredRef.current = true;
     playAnswerFeedbackSound(isCorrect);
     setResults((prev) => ({ correct: prev.correct + (isCorrect ? 1 : 0), total: prev.total + 1 }));
     setAnswerResults((prev) => {
@@ -1254,6 +1265,7 @@ export default function QuizPage() {
 
   const handleRestart = async () => {
     clearQuizState();
+    hasAnsweredRef.current = false;
     const targetCount = getQuizTargetCount(allWords, { primaryOnly: !isPro });
     const count = Math.max(1, Math.min(questionCount ?? targetCount ?? DEFAULT_QUESTION_COUNT, targetCount || DEFAULT_QUESTION_COUNT, MAX_NORMAL_QUIZ_QUESTION_COUNT));
     if (allWords.some((w) => needsDistractors(w) || needsWordOrderQuiz(w))) await startQuizWithDistractors(allWords, count);
@@ -1266,6 +1278,7 @@ export default function QuizPage() {
 
   const handleSelectCount = async (count: number) => {
     setQuestionCount(count);
+    hasAnsweredRef.current = false;
     if (allWords.length > 0) {
       setCurrentIndex(0); setSelectedIndex(null); setWordOrderSelectedTokens([]); setWordOrderResult(null); setIsRevealed(false);
       setTypeInAnswer(''); setTypeInResult(null);

--- a/src/lib/quiz/quiz-state.test.ts
+++ b/src/lib/quiz/quiz-state.test.ts
@@ -495,6 +495,166 @@ test('applyWordOrderQuestionsToPendingQuiz inserts newly generated word-order qu
   assert.deepEqual(nextQuestions[0]?.options, ['take', 'care', 'hold', 'keep', 'watch']);
 });
 
+test('applyWordOrderQuestionsToPendingQuiz never grows the quiz when inserts are disallowed', () => {
+  const answeredQuestion = {
+    word: createWord({
+      id: 'word-1',
+      english: 'take care',
+      japanese: '世話をする',
+      distractors: ['守る', '持つ', '作る'],
+    }),
+    options: ['世話をする', '守る', '持つ', '作る'],
+    correctIndex: 0,
+  };
+
+  const questions = [answeredQuestion];
+  const nextQuestions = applyWordOrderQuestionsToPendingQuiz(
+    questions,
+    [
+      createWord({
+        id: 'word-1',
+        english: 'take care',
+        japanese: '世話をする',
+        wordOrderQuiz: {
+          version: WORD_ORDER_CACHE_VERSION,
+          sourceEnglish: 'take care',
+          sourceJapanese: '世話をする',
+          sentenceTokens: [WORD_ORDER_BLANK_TOKEN, WORD_ORDER_BLANK_TOKEN],
+          answerTokens: ['take', 'care'],
+          decoyTokens: ['hold', 'keep', 'watch'],
+          generatedAt: '2026-05-09T00:00:00.000Z',
+        },
+      }),
+      createWord({
+        id: 'word-2',
+        english: 'look up',
+        japanese: '調べる',
+        wordOrderQuiz: {
+          version: WORD_ORDER_CACHE_VERSION,
+          sourceEnglish: 'look up',
+          sourceJapanese: '調べる',
+          sentenceTokens: [WORD_ORDER_BLANK_TOKEN, WORD_ORDER_BLANK_TOKEN],
+          answerTokens: ['look', 'up'],
+          decoyTokens: ['see', 'find', 'check'],
+          generatedAt: '2026-05-09T00:00:00.000Z',
+        },
+      }),
+    ],
+    0,
+    identityShuffle,
+    { allowInsert: false },
+  );
+
+  assert.equal(nextQuestions, questions);
+  assert.equal(nextQuestions.length, 1);
+});
+
+test('applyWordOrderQuestionsToPendingQuiz still replaces pending questions when inserts are disallowed', () => {
+  const answeredQuestion = {
+    word: createWord({
+      id: 'word-2',
+      english: 'look up',
+      japanese: '調べる',
+      distractors: ['見る', '上げる', '探す'],
+    }),
+    options: ['調べる', '見る', '上げる', '探す'],
+    correctIndex: 0,
+  };
+
+  const pendingQuestion = {
+    word: createWord({
+      id: 'word-1',
+      english: 'take care',
+      japanese: '世話をする',
+      distractors: ['守る', '持つ', '作る'],
+    }),
+    options: ['世話をする', '守る', '持つ', '作る'],
+    correctIndex: 0,
+  };
+
+  const nextQuestions = applyWordOrderQuestionsToPendingQuiz(
+    [answeredQuestion, pendingQuestion],
+    [
+      createWord({
+        id: 'word-1',
+        english: 'take care',
+        japanese: '世話をする',
+        wordOrderQuiz: {
+          version: WORD_ORDER_CACHE_VERSION,
+          sourceEnglish: 'take care',
+          sourceJapanese: '世話をする',
+          sentenceTokens: [WORD_ORDER_BLANK_TOKEN, WORD_ORDER_BLANK_TOKEN],
+          answerTokens: ['take', 'care'],
+          decoyTokens: ['hold', 'keep', 'watch'],
+          generatedAt: '2026-05-09T00:00:00.000Z',
+        },
+      }),
+    ],
+    0,
+    identityShuffle,
+    { allowInsert: false },
+  );
+
+  assert.equal(nextQuestions.length, 2);
+  assert.notEqual(nextQuestions[0]?.type, 'word-order');
+  assert.equal(nextQuestions[1]?.type, 'word-order');
+});
+
+test('applyWordOrderQuestionsToPendingQuiz caps insertions at maxQuestions', () => {
+  const answeredQuestion = {
+    word: createWord({
+      id: 'word-1',
+      english: 'take care',
+      japanese: '世話をする',
+      distractors: ['守る', '持つ', '作る'],
+    }),
+    options: ['世話をする', '守る', '持つ', '作る'],
+    correctIndex: 0,
+  };
+
+  const nextQuestions = applyWordOrderQuestionsToPendingQuiz(
+    [answeredQuestion],
+    [
+      createWord({
+        id: 'word-1',
+        english: 'take care',
+        japanese: '世話をする',
+        wordOrderQuiz: {
+          version: WORD_ORDER_CACHE_VERSION,
+          sourceEnglish: 'take care',
+          sourceJapanese: '世話をする',
+          sentenceTokens: [WORD_ORDER_BLANK_TOKEN, WORD_ORDER_BLANK_TOKEN],
+          answerTokens: ['take', 'care'],
+          decoyTokens: ['hold', 'keep', 'watch'],
+          generatedAt: '2026-05-09T00:00:00.000Z',
+        },
+      }),
+      createWord({
+        id: 'word-2',
+        english: 'look up',
+        japanese: '調べる',
+        wordOrderQuiz: {
+          version: WORD_ORDER_CACHE_VERSION,
+          sourceEnglish: 'look up',
+          sourceJapanese: '調べる',
+          sentenceTokens: [WORD_ORDER_BLANK_TOKEN, WORD_ORDER_BLANK_TOKEN],
+          answerTokens: ['look', 'up'],
+          decoyTokens: ['see', 'find', 'check'],
+          generatedAt: '2026-05-09T00:00:00.000Z',
+        },
+      }),
+    ],
+    0,
+    identityShuffle,
+    { maxQuestions: 2 },
+  );
+
+  assert.equal(nextQuestions.length, 2);
+  assert.notEqual(nextQuestions[0]?.type, 'word-order');
+  assert.equal(nextQuestions[1]?.type, 'word-order');
+  assert.equal(nextQuestions[1]?.word.id, 'word-1');
+});
+
 test('applyWordOrderQuestionsToPendingQuiz does not replace active multi-word questions', () => {
   const currentQuestion = {
     word: createWord({

--- a/src/lib/quiz/quiz-state.ts
+++ b/src/lib/quiz/quiz-state.ts
@@ -187,7 +187,12 @@ export function applyWordOrderQuestionsToPendingQuiz(
   words: Word[],
   currentIndex: number,
   shuffle: <T>(items: T[]) => T[] = shuffleArray,
+  options: { allowInsert?: boolean; maxQuestions?: number } = {},
 ): QuizQuestion[] {
+  // allowInsert=false: the quiz is already underway, so late-arriving word-order
+  // quizzes may only replace pending questions — growing the list mid-session
+  // would move the finish line under the user.
+  const { allowInsert = true, maxQuestions } = options;
   const wordByTargetKey = new Map(
     expandWordsForQuizTargets(words).map((word) => [getQuizTargetKey(word), word]),
   );
@@ -230,7 +235,7 @@ export function applyWordOrderQuestionsToPendingQuiz(
     }
 
     if (index <= currentIndex) {
-      if (!wordOrderQuestionWordIds.has(questionTargetKey)) {
+      if (allowInsert && !wordOrderQuestionWordIds.has(questionTargetKey)) {
         insertAfterCurrent.push(wordOrderQuestion);
         wordOrderQuestionWordIds.add(questionTargetKey);
         questionTargetKeys.add(questionTargetKey);
@@ -245,29 +250,36 @@ export function applyWordOrderQuestionsToPendingQuiz(
     return wordOrderQuestion;
   });
 
-  for (const updatedWord of wordByTargetKey.values()) {
-    const targetKey = getQuizTargetKey(updatedWord);
-    if (questionTargetKeys.has(targetKey)) continue;
-    if (isActiveQuizWord(updatedWord)) continue;
-    if (isTranslationQuizTarget(updatedWord)) continue;
+  if (allowInsert) {
+    for (const updatedWord of wordByTargetKey.values()) {
+      const targetKey = getQuizTargetKey(updatedWord);
+      if (questionTargetKeys.has(targetKey)) continue;
+      if (isActiveQuizWord(updatedWord)) continue;
+      if (isTranslationQuizTarget(updatedWord)) continue;
 
-    const wordOrderQuestion = buildWordOrderQuestion(updatedWord, shuffle);
-    if (!wordOrderQuestion) continue;
+      const wordOrderQuestion = buildWordOrderQuestion(updatedWord, shuffle);
+      if (!wordOrderQuestion) continue;
 
-    insertAfterCurrent.push(wordOrderQuestion);
-    wordOrderQuestionWordIds.add(targetKey);
-    questionTargetKeys.add(targetKey);
-    changed = true;
+      insertAfterCurrent.push(wordOrderQuestion);
+      wordOrderQuestionWordIds.add(targetKey);
+      questionTargetKeys.add(targetKey);
+      changed = true;
+    }
   }
 
-  if (insertAfterCurrent.length === 0) {
+  const insertBudget = maxQuestions === undefined
+    ? insertAfterCurrent.length
+    : Math.max(0, maxQuestions - nextQuestions.length);
+  const insertions = insertAfterCurrent.slice(0, insertBudget);
+
+  if (insertions.length === 0) {
     return changed ? nextQuestions : questions;
   }
 
   const insertAt = Math.min(Math.max(currentIndex + 1, 0), nextQuestions.length);
   return [
     ...nextQuestions.slice(0, insertAt),
-    ...insertAfterCurrent,
+    ...insertions,
     ...nextQuestions.slice(insertAt),
   ];
 }


### PR DESCRIPTION
## 問題

1. **復習クイズを全て解き終わった後、問題数が増えることがある**
   クイズ開始時にバックグラウンドで語順クイズをAPI生成しており、生成完了時に `applyWordOrderQuestionsToPendingQuiz` が現在の問題の後ろに新しい問題を挿入していた。生成が遅れると、解答中(または最後の問題を解き終わった直後)に合計問題数が 10 → 12 などに増え、終わったはずのクイズが続いてしまう。

2. **完了画面で「次へ」を押して次のラウンドを解いた後、「終了する」を押すとクイズが再度始まる**
   「次へ」(`goToNextReviewQuiz`)が `window.location.assign` を使っていたため、ラウンドごとにブラウザ履歴が積まれていた。「終了する」は `router.back()` なので、1つ前の履歴 = 前ラウンドのクイズURLに戻ってしまい、そこで新しいクイズが開始されていた。

## 修正内容

- `applyWordOrderQuestionsToPendingQuiz` に `allowInsert` / `maxQuestions` オプションを追加(`src/lib/quiz/quiz-state.ts`)
  - `allowInsert: false`(1問でも解答済み)の場合、遅れて届いた語順クイズは**未出題の問題の置き換えのみ**行い、問題リストを伸ばさない
  - 挿入が許可される場合(クイズ開始直後)でも、`maxQuestions`(選択した問題数)を超える挿入は行わない
  - クイズ画面側は解答有無を `hasAnsweredRef` で追跡し、復元時・リスタート時・問題数選択時に適切にセット/リセット
- `goToNextReviewQuiz` を `window.location.assign` → `window.location.replace` に変更(`src/app/quiz/[projectId]/page.tsx`)。ラウンドが履歴に積まれなくなり、「終了する」で元のページ(ホーム等)に正しく戻る

## テスト

- `src/lib/quiz/quiz-state.test.ts` に3ケース追加(挿入禁止時にリストが伸びない / 挿入禁止時でも置き換えは行う / `maxQuestions` で挿入を打ち切る)
- `npx tsx --test src/lib/quiz/*.test.ts` → 38/38 pass
- `npm test` → 961/963 pass(失敗2件は `otp.contract.test.ts` / `words/create/route.test.ts` で、本修正前の main でも同様に失敗する既存の問題)
- ESLint(変更ファイル)pass。`tsc --noEmit` のエラー1件は未変更ファイル `translation-targets.test.ts` の既存エラー

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011W9o5iJauoBFg2ipcGcyZp

---
_Generated by [Claude Code](https://claude.ai/code/session_011W9o5iJauoBFg2ipcGcyZp)_