### PR TITLE
リールにページドット追加 + フィードは行タップで展開 + 共有単語帳の戻る矢印削除 + グループページ刷新

### DIFF
--- a/src/app/desktop.css
+++ b/src/app/desktop.css
@@ -981,6 +981,9 @@ button.ds-tile { appearance: none; }
 .ds-feed-card .fc-row { display: flex; align-items: flex-start; gap: 14px; padding: 16px 18px; }
 .ds-feed-card .fc-link { color: inherit; text-decoration: none; transition: background var(--dur-fast); }
 .ds-feed-card .fc-link:hover { background: var(--color-surface-secondary); }
+/* クイズエントリは行全体クリックで開閉（展開ボタンなし） */
+.ds-feed-card .fc-toggle { cursor: pointer; transition: background var(--dur-fast); }
+.ds-feed-card .fc-toggle:hover { background: var(--color-surface-secondary); }
 .ds-feed-card .fc-body { flex: 1; min-width: 0; }
 .ds-feed-card .fc-text { margin: 0; font-size: 14.5px; font-weight: 600; line-height: 1.55; color: var(--color-ink); }
 .ds-feed-card .fc-text a,

--- a/src/app/friends/page.tsx
+++ b/src/app/friends/page.tsx
@@ -375,13 +375,36 @@ function TimelineItem({
   const profileHref = `/profile/${encodeURIComponent(session.profile.accountId)}`;
   return (
     <article className="transition-colors hover:bg-[var(--color-surface-secondary)]">
-      <div className="flex items-start gap-3.5 px-[18px] py-4">
-        <Link href={profileHref} aria-label={`${displayName(session.profile)}のプロフィール`} className="shrink-0">
+      {/* 行全体をタップで学習内容を開閉する（展開ボタンは置かない） */}
+      <div
+        role="button"
+        tabIndex={0}
+        aria-expanded={expanded}
+        aria-label={expanded ? '学習内容を閉じる' : '学習内容を開く'}
+        onClick={onToggle}
+        onKeyDown={(event) => {
+          if (event.key === 'Enter' || event.key === ' ') {
+            event.preventDefault();
+            onToggle();
+          }
+        }}
+        className="flex cursor-pointer items-start gap-3.5 px-[18px] py-4"
+      >
+        <Link
+          href={profileHref}
+          aria-label={`${displayName(session.profile)}のプロフィール`}
+          className="shrink-0"
+          onClick={(event) => event.stopPropagation()}
+        >
           <Avatar profile={session.profile} />
         </Link>
         <div className="min-w-0 flex-1">
           <p className="text-[15px] font-bold leading-snug text-[var(--solid-ink)]">
-            <Link href={profileHref} className="font-display font-extrabold hover:underline">
+            <Link
+              href={profileHref}
+              className="font-display font-extrabold hover:underline"
+              onClick={(event) => event.stopPropagation()}
+            >
               {displayName(session.profile)}
             </Link>
             さんが{session.answerCount}問クイズを解きました！
@@ -396,15 +419,6 @@ function TimelineItem({
             <MetricChip icon="check_circle" label={`${session.masteredCount}語 習得`} variant="mastered" />
           </div>
         </div>
-        <button
-          type="button"
-          onClick={onToggle}
-          aria-expanded={expanded}
-          aria-label={expanded ? '学習内容を閉じる' : '学習内容を開く'}
-          className="mt-1 inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-full text-[var(--color-muted)]"
-        >
-          <Icon name={expanded ? 'expand_less' : 'expand_more'} size={20} />
-        </button>
       </div>
       {expanded && (
         <div className="border-t border-[var(--color-border)] bg-[var(--color-surface-secondary)] px-[18px] py-4">

--- a/src/app/groups/[groupId]/page.tsx
+++ b/src/app/groups/[groupId]/page.tsx
@@ -141,15 +141,15 @@ export default function GroupPage() {
                 <LoadingState />
               ) : (
                 <div style={{ display: 'grid', gridTemplateColumns: 'minmax(0, 1.55fr) minmax(320px, 1fr)', gap: 20, alignItems: 'start' }}>
+                  <GroupWordbooksSection groupId={groupId} projects={projects} />
                   <div className="flex flex-col gap-5">
-                    <BookshelfSection groupId={groupId} projects={projects} />
+                    <LeaderboardSection leaderboard={leaderboard} />
                     <MissedWordsSection
                       groupId={groupId}
                       missedWords={missedWords}
                       totalCount={missedWordsTotalCount}
                     />
                   </div>
-                  <LeaderboardSection leaderboard={leaderboard} />
                 </div>
               )}
             </>
@@ -497,6 +497,78 @@ function MissedWordsSection({
         </>
       )}
     </SectionCard>
+  );
+}
+
+// デスクトップ用: 本棚ティザーに格納せず、グループの単語帳をそのまま
+// グリッドで表示する。共有・解除の管理は従来どおり本棚ページで行う。
+function GroupWordbooksSection({ groupId, projects }: { groupId: string; projects: SharedProjectCard[] }) {
+  return (
+    <section className="rounded-[18px] border-2 border-[var(--solid-ink)] bg-white p-4">
+      <div className="mb-3 flex items-center gap-2.5">
+        <span className="inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-[10px] border-2 border-[var(--solid-ink)] bg-[#F5A623] text-white">
+          <Icon name="auto_stories" size={18} />
+        </span>
+        <div className="min-w-0 flex-1">
+          <h2 className="font-display text-[16px] font-extrabold leading-tight text-[var(--solid-ink)]">単語帳</h2>
+          <div className="text-[11px] font-bold text-[var(--color-muted)]">
+            {projects.length > 0 ? `みんなの単語帳 ${projects.length}冊` : 'みんなの単語帳が並ぶ場所'}
+          </div>
+        </div>
+        <Link
+          href={`/groups/${encodeURIComponent(groupId)}/bookshelf`}
+          className="inline-flex shrink-0 items-center gap-1 rounded-full border-2 border-[var(--solid-ink)] bg-white px-3 py-1.5 font-display text-[12px] font-extrabold text-[var(--solid-ink)] transition-all duration-100 active:translate-x-px active:translate-y-px"
+        >
+          共有・管理
+          <Icon name="chevron_right" size={14} />
+        </Link>
+      </div>
+      {projects.length === 0 ? (
+        <EmptyRow message="まだ単語帳がありません。最初の1冊を共有しよう！" />
+      ) : (
+        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(150px, 1fr))', gap: 12 }}>
+          {projects.map((card) => (
+            <GroupBookTile key={card.project.id} card={card} />
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}
+
+function GroupBookTile({ card }: { card: SharedProjectCard }) {
+  const href = card.project.shareId ? `/share/${card.project.shareId}` : '#';
+  return (
+    <Link
+      href={href}
+      onClick={() => triggerHaptic()}
+      className="block overflow-hidden rounded-[14px] border-2 border-[var(--solid-ink)] bg-white transition-all duration-100 hover:-translate-y-0.5 active:translate-y-0"
+    >
+      <div
+        className="relative flex h-[92px] items-center justify-center bg-cover bg-center"
+        style={{
+          backgroundColor: thumbColor(card.project.id),
+          backgroundImage: card.project.iconImage ? `url(${card.project.iconImage})` : undefined,
+        }}
+      >
+        {!card.project.iconImage && (
+          <span className="font-display text-[30px] font-extrabold text-white drop-shadow-[2px_2px_0_rgba(0,0,0,0.25)]">
+            {card.project.title.charAt(0)}
+          </span>
+        )}
+        <span className="absolute bottom-1.5 right-1.5 rounded-full border-2 border-[var(--solid-ink)] bg-white px-2 py-0.5 font-mono text-[10px] font-extrabold tabular-nums text-[var(--solid-ink)]">
+          {card.wordCount ?? 0}語
+        </span>
+      </div>
+      <div className="border-t-2 border-[var(--solid-ink)] p-2.5">
+        <div className="line-clamp-2 font-display text-[13px] font-extrabold leading-snug text-[var(--solid-ink)]">
+          {card.project.title}
+        </div>
+        <div className="mt-1 truncate text-[10px] font-bold text-[var(--color-muted)]">
+          {card.ownerUsername ? `@${card.ownerUsername}` : '共有ユーザー'}
+        </div>
+      </div>
+    </Link>
   );
 }
 

--- a/src/app/share/[shareId]/page.tsx
+++ b/src/app/share/[shareId]/page.tsx
@@ -588,10 +588,7 @@ export default function SharedDetailPage() {
         onWordAction={setActionWord}
       />
       <div className="relative flex min-h-screen flex-col bg-[var(--color-background)] pb-[160px] font-[var(--font-body)] lg:hidden">
-      <div className="flex items-center justify-between px-3.5 pb-2 pt-2">
-        <SharedHeaderBtn onClick={() => router.back()} aria-label="戻る">
-          <Icon name="chevron_left" size={16} />
-        </SharedHeaderBtn>
+      <div className="flex items-center justify-end px-3.5 pb-2 pt-2">
         <div className="flex gap-2">
           <SharedHeaderBtn
             onClick={handleToggleLike}

--- a/src/components/desktop/DesktopFeed.tsx
+++ b/src/components/desktop/DesktopFeed.tsx
@@ -135,18 +135,35 @@ function QuizEntryCard({
   const profileHref = `/profile/${encodeURIComponent(session.profile.accountId)}`;
   return (
     <article className="ds-feed-card fade-in">
-      <div className="fc-row">
+      {/* 行全体をクリックで学習内容を開閉する（展開ボタンは置かない） */}
+      <div
+        className="fc-row fc-toggle"
+        role="button"
+        tabIndex={0}
+        aria-expanded={expanded}
+        aria-label={expanded ? '学習内容を閉じる' : '学習内容を開く'}
+        onClick={onToggle}
+        onKeyDown={(event) => {
+          if (event.key === 'Enter' || event.key === ' ') {
+            event.preventDefault();
+            onToggle();
+          }
+        }}
+      >
         <Link
           href={profileHref}
           className="ds-feed-avatar md"
           style={{ backgroundColor: avatarColor(session.profile.accountId) }}
           aria-label={`${displayName(session.profile)}のプロフィール`}
+          onClick={(event) => event.stopPropagation()}
         >
           {(session.profile.username || session.profile.accountId || '?').charAt(0).toUpperCase()}
         </Link>
         <div className="fc-body">
           <p className="fc-text">
-            <Link href={profileHref}>{displayName(session.profile)}</Link>
+            <Link href={profileHref} onClick={(event) => event.stopPropagation()}>
+              {displayName(session.profile)}
+            </Link>
             さんが{session.answerCount}問クイズを解きました
           </p>
           <div className="fc-meta">
@@ -165,15 +182,6 @@ function QuizEntryCard({
             </span>
           </div>
         </div>
-        <button
-          type="button"
-          className="ds-iconbtn"
-          onClick={onToggle}
-          aria-expanded={expanded}
-          aria-label={expanded ? '学習内容を閉じる' : '学習内容を開く'}
-        >
-          <Icon name={expanded ? 'expand_less' : 'expand_more'} size={18} />
-        </button>
       </div>
       {expanded && (
         <div className="fc-words">

--- a/src/components/reel/ReelCard.tsx
+++ b/src/components/reel/ReelCard.tsx
@@ -138,7 +138,7 @@ export function ReelCard({
       ) : (
       /* Swipeable face track: front(English) then back(meaning) */
       <div
-        className="min-h-0 flex-1"
+        className="relative min-h-0 flex-1"
         style={{ touchAction: 'pan-y' }}
         onTouchStart={handleTouchStart}
         onTouchMove={handleTouchMove}
@@ -179,6 +179,19 @@ export function ReelCard({
           <div className="h-full" style={{ width: `${faceWidth}%` }}>
             <ReelMeaningPanel item={item} />
           </div>
+        </div>
+        {/* ページドット: もう1面あることを示し、スワイプ/タップを誘う */}
+        <div className="pointer-events-none absolute bottom-3 left-0 right-0 flex justify-center gap-1.5">
+          {Array.from({ length: faces }, (_, index) => (
+            <span
+              key={index}
+              className={`h-1.5 rounded-full transition-all duration-200 ${
+                index === page
+                  ? 'w-5 bg-[var(--solid-ink)]'
+                  : 'w-1.5 bg-[var(--color-border)]'
+              }`}
+            />
+          ))}
         </div>
       </div>
       )}


### PR DESCRIPTION
## 概要

リール・フィード・共有単語帳・グループページのUI調整の続き(#412 の続編)です。

## 変更内容

### リール
- 2面カード(英語⇄意味)の下部に**ページドット**を追加。もう1面あることを視覚的に示し、スワイプ/タップを誘導します(現在の面は横長ドットで強調)

### モバイル共有単語帳
- ヘッダー左の**戻る(左矢印)ボタンを削除**。いいねボタンは右側に維持

### フィード
- クイズエントリの**下矢印(展開)ボタンを削除**し、**行全体のタップ/クリックで学習内容を開閉**するように変更(モバイル/デスクトップ両方)
- プロフィールへのリンクは `stopPropagation` で従来どおり遷移。キーボード操作(Enter/Space)にも対応

### デスクトップグループページ
- **本棚ティザーコンポーネントを廃止**し、グループの単語帳をカードグリッドで**直接表示**
- **「みんなが苦戦中」セクションを右カラム**(ランキングの下)へ移動
- 共有・解除の管理はセクションヘッダーの「共有・管理」リンクから従来の本棚ページで行えます
- モバイルの本棚ティザーは変更なし

## テスト
- `npx tsc --noEmit`: 変更ファイル起因のエラーなし(既存の `translation-targets.test.ts` のみ)
- `npm test`: 958/960 pass。失敗2件はベースでも失敗する既存の問題

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WjePpRi4RJ8wctv82g8idJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01WjePpRi4RJ8wctv82g8idJ)_