### PR TITLE
グループの単語帳共有シートをデスクトップ対応（中央モーダル化）

### DIFF
--- a/src/app/groups/[groupId]/share-to-group-sheet.tsx
+++ b/src/app/groups/[groupId]/share-to-group-sheet.tsx
@@ -88,23 +88,13 @@ export function ShareToGroupSheet({
   return (
     <div className="fixed inset-0 z-[100]" style={{ fontFamily: 'var(--font-body)' }}>
       <button type="button" aria-label="閉じる" onClick={onClose} className="absolute inset-0 cursor-default" style={{ background: 'rgba(26,26,26,0.45)', backdropFilter: 'blur(3px)' }} />
-      <div className="absolute inset-x-0 bottom-0 flex justify-center">
+      {/* モバイル: ボトムシート / デスクトップ(lg): 中央モーダル */}
+      <div className="absolute inset-x-0 bottom-0 flex justify-center lg:inset-0 lg:items-center lg:p-6">
         <div
-          className="w-full animate-fade-in-up"
-          style={{
-            maxWidth: 520,
-            background: '#faf7f1',
-            border: '2px solid var(--solid-ink)',
-            borderBottomWidth: 0,
-            borderTopLeftRadius: 20,
-            borderTopRightRadius: 20,
-            padding: '14px 18px max(28px, env(safe-area-inset-bottom))',
-            boxShadow: '0 -8px 24px rgba(26,26,26,0.18)',
-            maxHeight: 'min(82vh, 680px)',
-            overflowY: 'auto',
-          }}
+          className="w-full max-w-[520px] animate-fade-in-up overflow-y-auto rounded-t-[20px] border-2 border-b-0 border-[var(--solid-ink)] bg-[#faf7f1] px-[18px] pb-[max(28px,env(safe-area-inset-bottom))] pt-[14px] shadow-[0_-8px_24px_rgba(26,26,26,0.18)] lg:animate-fade-in lg:rounded-[20px] lg:border-b-2 lg:pb-[22px] lg:shadow-[6px_8px_0_var(--solid-ink)]"
+          style={{ maxHeight: 'min(82vh, 680px)' }}
         >
-          <div className="mb-2.5 flex justify-center">
+          <div className="mb-2.5 flex justify-center lg:hidden">
             <div className="h-1 w-10 rounded-full bg-[rgba(26,26,26,0.2)]" />
           </div>
           <div className="mb-3 flex items-center justify-between gap-3">


### PR DESCRIPTION
## 概要

グループ本棚の「単語帳を共有」シート（`ShareToGroupSheet`）が、デスクトップでも画面下端に張り付くモバイル用ボトムシートのまま表示されていたため、デスクトップ対応しました。

## 変更内容

- `src/app/groups/[groupId]/share-to-group-sheet.tsx`
  - 招待シェアシート（`GroupInviteShareSheet`）で確立済みのパターンに統一:
    - モバイル: 従来どおり画面下からスライドインするボトムシート
    - デスクトップ（`lg` 以上）: 画面中央のモーダル（角丸4辺・オフセットシャドウ・フェードイン）
  - ドラッグハンドルはデスクトップでは非表示
  - インラインスタイルで持っていたシートの見た目を Tailwind クラスに移行（挙動・配色は既存のまま）

## 確認

- `npm run lint`: 本変更起因のエラーなし（既存の `gcp-budget-guard/` の require エラー5件のみ）
- `npm run build`: 成功
- `npm test`: 958/960 pass（失敗2件は base コミットでも失敗する既存の API コントラクトテストで、本変更とは無関係なことを確認済み）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GuHGV7XtKawcpMAyjZGdub

---
_Generated by [Claude Code](https://claude.ai/code/session_01GuHGV7XtKawcpMAyjZGdub)_