### PR TITLE
スキャン失敗理由の即時表示+通知反映 / リールのすべて見る削除 / モバイル固定ヘッダ / 空単語帳の手動追加自動表示+日本語任意化 / 共有選択のデスクトップ対応

### DIFF
--- a/src/app/api/scan-jobs/process/route.contract.test.ts
+++ b/src/app/api/scan-jobs/process/route.contract.test.ts
@@ -1293,6 +1293,8 @@ test('server_cloud words insert failure rolls back only the newly created projec
       projectTitle: 'Scan Result',
       status: 'failed',
       wordCount: 0,
+      // 失敗理由は通知本文にも載せる
+      errorMessage: '単語の抽出はできましたが、単語帳の保存に失敗しました。時間をおいてもう一度お試しください。',
     },
   ]);
   assert.deepEqual(apnsNotifications, pushNotifications);
@@ -1391,6 +1393,8 @@ test('server_cloud existing project words insert failure does not delete the pro
       projectTitle: 'Scan Result',
       status: 'failed',
       wordCount: 0,
+      // 失敗理由は通知本文にも載せる
+      errorMessage: '単語の抽出はできましたが、単語帳の保存に失敗しました。時間をおいてもう一度お試しください。',
     },
   ]);
   assert.deepEqual(apnsNotifications, pushNotifications);
@@ -1414,7 +1418,7 @@ test('process route refunds coins after both total-failure paths', async () => {
 
   for (const anchor of [
     "error_message: errorMessage,",
-    "error_message: toUserFacingScanErrorMessage(processingError),",
+    "error_message: failureMessage,",
   ]) {
     const anchorIndex = source.indexOf(anchor);
     assert.ok(anchorIndex >= 0, `missing anchor: ${anchor}`);

--- a/src/app/api/scan-jobs/process/route.ts
+++ b/src/app/api/scan-jobs/process/route.ts
@@ -1077,6 +1077,7 @@ export async function processJobById(jobId: string, processDeps?: ProcessJobDeps
           userId: job.user_id,
           jobId,
           projectTitle: job.project_title,
+          errorMessage,
         });
         await sendScanJobNotifications({
           supabaseAdmin,
@@ -1875,13 +1876,15 @@ export async function processJobById(jobId: string, processDeps?: ProcessJobDeps
 
         timing.totalMs = Date.now() - processingStartedAt;
 
+        // error_message はホーム画面・プッシュ通知にそのまま表示されるため、
+        // 内部エラーの英語メッセージではなく理由の伝わる日本語文言に変換する。
+        const failureMessage = toUserFacingScanErrorMessage(processingError);
+
         await supabaseAdmin
           .from('scan_jobs')
           .update({
             status: 'failed',
-            // error_message はホーム画面にそのまま表示されるため、内部エラーの
-            // 英語メッセージではなく理由の伝わる日本語文言に変換して書き込む。
-            error_message: toUserFacingScanErrorMessage(processingError),
+            error_message: failureMessage,
             updated_at: new Date().toISOString(),
           })
           .eq('id', jobId);
@@ -1898,6 +1901,7 @@ export async function processJobById(jobId: string, processDeps?: ProcessJobDeps
           userId: job.user_id,
           jobId,
           projectTitle: job.project_title,
+          errorMessage: failureMessage,
         });
         await sendScanJobNotifications({
           supabaseAdmin,

--- a/src/app/api/words/enrich-manual/route.ts
+++ b/src/app/api/words/enrich-manual/route.ts
@@ -49,6 +49,7 @@ const partOfSpeechTagsSchema = z.preprocess((value) => {
 }, z.array(z.string()).default([]));
 
 const aiResponseSchema = z.object({
+  japanese: z.string().optional().default(''),
   pronunciation: z.string().optional().default(''),
   partOfSpeechTags: partOfSpeechTagsSchema,
   exampleSentence: z.string().optional().default(''),
@@ -56,6 +57,7 @@ const aiResponseSchema = z.object({
 });
 
 const SYSTEM_PROMPT = `英単語の補助情報をJSON形式で返せ。
+japanese: 単語帳向けの簡潔な日本語訳(訳語のみ・説明不要)
 pronunciation: IPA発音記号を"/.../"形式で返す
 partOfSpeechTags: [noun/verb/adjective/adverb/idiom/phrasal_verb/other]から1つ
 exampleSentence: 10〜15語の実用的な英文(中高レベル)
@@ -134,14 +136,16 @@ export async function POST(request: NextRequest) {
     const filledExampleJa = input.exampleSentenceJa?.trim() ?? '';
     const filledPosTags = normalizePartOfSpeechTags(input.partOfSpeechTags ?? []);
 
+    const needsJapanese = filledJapanese.length === 0;
     const needsPronunciation = filledPronunciation.length === 0;
     const needsPos = filledPosTags.length === 0;
     const needsExample = filledExample.length === 0 || filledExampleJa.length === 0;
 
-    if (!needsPronunciation && !needsPos && !needsExample) {
+    if (!needsJapanese && !needsPronunciation && !needsPos && !needsExample) {
       return NextResponse.json({
         success: true,
         enriched: {
+          japanese: filledJapanese,
           pronunciation: filledPronunciation,
           partOfSpeechTags: filledPosTags,
           exampleSentence: filledExample,
@@ -173,6 +177,7 @@ export async function POST(request: NextRequest) {
       master = null;
     }
 
+    const masterJapanese = needsJapanese ? (master?.japanese ?? '') : '';
     const masterPronunciation = needsPronunciation ? (master?.pronunciation ?? '') : '';
     const masterPosTags = needsPos
       ? normalizePartOfSpeechTags(master?.partOfSpeechTags ?? [])
@@ -180,10 +185,11 @@ export async function POST(request: NextRequest) {
     const masterExample = needsExample ? (master?.exampleSentence ?? '') : '';
     const masterExampleJa = needsExample ? (master?.exampleSentenceJa ?? '') : '';
 
+    const aiNeedsJapanese = needsJapanese && !masterJapanese;
     const aiNeedsPronunciation = needsPronunciation && !masterPronunciation;
     const aiNeedsPos = needsPos && masterPosTags.length === 0;
     const aiNeedsExample = needsExample && !(masterExample && masterExampleJa);
-    const needsAi = aiNeedsPronunciation || aiNeedsPos || aiNeedsExample;
+    const needsAi = aiNeedsJapanese || aiNeedsPronunciation || aiNeedsPos || aiNeedsExample;
 
     // 2c. マスターで埋まらなかったフィールドのみAI生成を開始 (auth 完了を待たない)
     let aiPromise: Promise<import('@/lib/ai/providers').AIResponse> | null = null;
@@ -191,6 +197,7 @@ export async function POST(request: NextRequest) {
       try {
         const { provider, config } = getEnrichProvider();
         const prompt = buildManualEnrichPrompt(englishTrimmed, filledJapanese, {
+          japanese: aiNeedsJapanese,
           pronunciation: aiNeedsPronunciation,
           pos: aiNeedsPos,
           example: aiNeedsExample,
@@ -224,6 +231,7 @@ export async function POST(request: NextRequest) {
     //    マスターで全フィールドが埋まった場合はAIコール自体が無い。
     const aiStart = Date.now();
     let parsedAi: z.infer<typeof aiResponseSchema> = {
+      japanese: '',
       pronunciation: '',
       partOfSpeechTags: [],
       exampleSentence: '',
@@ -270,6 +278,10 @@ export async function POST(request: NextRequest) {
 
     // 6. ユーザ入力 > マスター > AI の優先順で埋める
     const generatedFields: string[] = [];
+
+    const aiJapanese = (parsedAi.japanese || '').trim();
+    const finalJapanese = needsJapanese ? (masterJapanese || aiJapanese) : filledJapanese;
+    if (needsJapanese && finalJapanese) generatedFields.push('japanese');
 
     const aiPronunciation = (parsedAi.pronunciation || '').trim();
     const finalPronunciation = needsPronunciation
@@ -346,6 +358,7 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({
       success: true,
       enriched: {
+        japanese: finalJapanese,
         pronunciation: finalPronunciation,
         partOfSpeechTags: finalPosTags,
         exampleSentence: finalExample,

--- a/src/app/home-client.tsx
+++ b/src/app/home-client.tsx
@@ -260,6 +260,12 @@ export function HomeClient() {
   const [pendingScans, setPendingScans] = useState<HomePendingScan[]>([]);
   const [recentScanJobs, setRecentScanJobs] = useState<RecentScanJob[]>([]);
   const [pendingGeneratingWordbook, setPendingGeneratingWordbook] = useState<HomeGeneratingWordbookPayload | null>(null);
+  // スキャン失敗の理由表示。loadHome() が setError(null) するため error とは
+  // 別に持ち、リロードせずポーリング検出の時点で即表示する。
+  const [scanFailureNotice, setScanFailureNotice] = useState<string | null>(null);
+  // 直前のポーリングで実行中(pending/processing)だったジョブID。次のポーリングで
+  // failed に変わったものを検出して失敗理由を即表示するために使う。
+  const watchedActiveJobIdsRef = useRef<Set<string>>(new Set());
 
   const [vocabScanOpen, setVocabScanOpen] = useState(false);
   const [createSheetOpen, setCreateSheetOpen] = useState(false);
@@ -275,6 +281,7 @@ export function HomeClient() {
   const showHomeGeneratingWordbook = useCallback((payload: HomeGeneratingWordbookPayload) => {
     // 新しいスキャンを開始したら、前回の失敗メッセージが残っていても消す。
     setError(null);
+    setScanFailureNotice(null);
     setPendingGeneratingWordbook(withHomeGeneratingFallbackId(payload));
   }, []);
 
@@ -397,6 +404,19 @@ export function HomeClient() {
         const active = jobs.filter((j) => j.status === 'pending' || j.status === 'processing');
         setRecentScanJobs(jobs);
         setPendingScans(active.map((j) => ({ id: j.id, project_title: j.project_title })));
+
+        // 実行中として見えていたジョブが failed に変わった瞬間に理由を表示する。
+        // （以前は「生成中」カードが理由も出さず消えるだけで、リロードするまで
+        // 失敗に気づけなかった。）
+        const newlyFailed = jobs.find(
+          (j) => j.status === 'failed' && watchedActiveJobIdsRef.current.has(j.id),
+        );
+        if (newlyFailed) {
+          setScanFailureNotice(
+            `「${newlyFailed.project_title}」を作成できませんでした：${newlyFailed.error_message?.trim() || SCAN_JOB_FAILED_FALLBACK_MESSAGE}`,
+          );
+        }
+        watchedActiveJobIdsRef.current = new Set(active.map((j) => j.id));
         if (active.length === 0) {
           if (hadActiveRef.current) {
             hadActiveRef.current = false;
@@ -441,8 +461,11 @@ export function HomeClient() {
 
     // 失敗（単語ゼロなど）した場合、以前は「生成中」カードが理由も出さず
     // 消えるだけでユーザーが困っていた。サーバーが記録した理由を必ず表示する。
+    // （ポーリングで実行中を経ずに最初から failed で見えた高速失敗ケース。）
     if (linkedJob.status === 'failed') {
-      setError(linkedJob.error_message?.trim() || SCAN_JOB_FAILED_FALLBACK_MESSAGE);
+      setScanFailureNotice(
+        `「${linkedJob.project_title}」を作成できませんでした：${linkedJob.error_message?.trim() || SCAN_JOB_FAILED_FALLBACK_MESSAGE}`,
+      );
     }
   }, [pendingGeneratingWordbook?.linkedJobId, recentScanJobs]);
 
@@ -591,6 +614,27 @@ export function HomeClient() {
         <div className="px-[18px] pb-3">
           <SolidPanel className="!rounded-[12px] border-[var(--color-error)]" faceClassName="!p-3 text-xs font-bold text-[var(--color-error)]">
             {error}
+          </SolidPanel>
+        </div>
+      )}
+
+      {/* スキャン失敗の理由。ポーリング検出時に即表示し、リロード不要にする */}
+      {scanFailureNotice && (
+        <div className="px-[18px] pb-3">
+          <SolidPanel className="!rounded-[12px] border-[var(--color-error)]" faceClassName="!p-3">
+            <div className="flex items-start gap-2">
+              <p className="min-w-0 flex-1 text-xs font-bold leading-[1.5] text-[var(--color-error)]">
+                {scanFailureNotice}
+              </p>
+              <button
+                type="button"
+                onClick={() => setScanFailureNotice(null)}
+                aria-label="失敗メッセージを閉じる"
+                className="inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-full text-[var(--color-error)]"
+              >
+                <Icon name="close" size={14} />
+              </button>
+            </div>
           </SolidPanel>
         </div>
       )}

--- a/src/app/project/[id]/page.tsx
+++ b/src/app/project/[id]/page.tsx
@@ -22,6 +22,7 @@ import { useWordCount } from '@/hooks/use-word-count';
 import { getRepository, hybridRepository } from '@/lib/db';
 import { remoteRepository } from '@/lib/db/remote-repository';
 import { scheduleWordStatusWrite } from '@/lib/db/debounced-status-write';
+import { consumeManualAddIntent } from '@/lib/home/home-session-storage';
 import { invalidateHomeCache } from '@/lib/home-cache';
 import { markProjectVisited } from '@/lib/project-visit';
 import { saveProjectSharedTags } from '@/lib/shared-projects/client';
@@ -278,6 +279,19 @@ export default function ProjectPage() {
   useEffect(() => {
     if (project?.id) markProjectVisited(project.id);
   }, [project?.id]);
+
+  // 空の単語帳を作成して遷移してきた直後は、手動追加モーダルを自動で開く
+  // （CreateWordbookSheet が sessionStorage 経由で projectId を渡してくる）。
+  useEffect(() => {
+    try {
+      if (consumeManualAddIntent(sessionStorage) === projectId) {
+        setManualWordAddedCount(0);
+        setShowManualWordModal(true);
+      }
+    } catch {
+      // sessionStorage が使えない環境では自動オープンだけ諦める
+    }
+  }, [projectId]);
 
   useEffect(() => {
     if (!wordsLoaded || recommendationsLoaded || !project || words.length > 0) return;
@@ -1034,8 +1048,9 @@ export default function ProjectPage() {
 
   const handleSaveManualWord = async () => {
     const english = manualWordEnglish.trim();
-    const japanese = manualWordJapanese.trim();
-    if (!english || !japanese || !project) return;
+    // 日本語訳は任意入力。未入力なら enrich API（マスター/AI）が補完する。
+    const japaneseInput = manualWordJapanese.trim();
+    if (!english || !project) return;
 
     const { canAdd, wouldExceed } = canAddWords(1);
     if (!canAdd || wouldExceed) {
@@ -1049,6 +1064,7 @@ export default function ProjectPage() {
     setManualWordSaving(true);
     setManualWordSavingMessage('情報を生成中...');
 
+    let japanese = japaneseInput;
     let enrichedPronunciation = '';
     let enrichedPartOfSpeechTags: string[] = userPos ? [userPos] : [];
     let enrichedExampleSentence = userExample;
@@ -1061,7 +1077,7 @@ export default function ProjectPage() {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           english,
-          japanese,
+          ...(japaneseInput ? { japanese: japaneseInput } : {}),
           ...(userPos ? { partOfSpeechTags: [userPos] } : {}),
           ...(userExample ? { exampleSentence: userExample } : {}),
         }),
@@ -1071,6 +1087,7 @@ export default function ProjectPage() {
         const data = (await enrichResponse.json()) as {
           success?: boolean;
           enriched?: {
+            japanese?: string;
             pronunciation?: string;
             partOfSpeechTags?: string[];
             exampleSentence?: string;
@@ -1079,6 +1096,9 @@ export default function ProjectPage() {
           morphology?: Word['morphology'];
         };
         if (data.success && data.enriched) {
+          if (!japanese && data.enriched.japanese) {
+            japanese = data.enriched.japanese.trim();
+          }
           enrichedPronunciation = data.enriched.pronunciation ?? '';
           if (data.enriched.partOfSpeechTags && data.enriched.partOfSpeechTags.length > 0) {
             enrichedPartOfSpeechTags = data.enriched.partOfSpeechTags;
@@ -1092,6 +1112,15 @@ export default function ProjectPage() {
       }
     } catch (enrichError) {
       console.warn('[manual-word] enrich error:', enrichError);
+    }
+
+    // 日本語訳が入力されず自動補完もできなかった場合だけ入力をお願いする
+    // （意味が空の単語はクイズ・カードで使いものにならないため保存しない）。
+    if (!japanese) {
+      setManualWordSaving(false);
+      setManualWordSavingMessage(undefined);
+      showToast({ message: '日本語訳を自動生成できませんでした。日本語訳を入力してください', type: 'error' });
+      return;
     }
 
     const optimisticWord: Word = {
@@ -1205,39 +1234,59 @@ export default function ProjectPage() {
         onManualAdd={openManualWordModal}
       />
       <div className="relative flex min-h-screen flex-col bg-[var(--color-background)] font-[var(--font-body)] lg:hidden">
-      <div className="sticky top-0 z-10 flex items-center justify-between bg-[var(--color-background)] px-4 pb-2 pt-3 lg:hidden">
+      {/* スクロールしても上部に固定されるヘッダー（グループページと同じパターン）。
+          top はノッチ下端に合わせ、ノッチ帯は全体共通の StatusBarCover が覆う。 */}
+      <header
+        className="sticky z-40 flex items-center gap-2.5 border-b-2 border-[var(--solid-ink)] bg-[var(--color-background)]/95 px-[14px] py-2.5 backdrop-blur-md lg:hidden"
+        style={{ top: 'env(safe-area-inset-top, 0px)' }}
+      >
         <HeaderBtn onClick={() => router.replace('/')} aria-label="ホームへ戻る">
-          <Icon name="chevron_left" size={16} />
+          <Icon name="arrow_back" size={16} />
         </HeaderBtn>
-        <div className="relative flex gap-2">
+        <div className="min-w-0 flex-1">
+          <div className="font-mono text-[9px] font-bold uppercase tracking-[0.08em] text-[var(--color-muted)]">
+            BOOK
+          </div>
+          <div className="truncate font-display text-[15px] font-extrabold leading-tight text-[var(--solid-ink)]">
+            {project.title}
+          </div>
+        </div>
+        <div className="flex shrink-0 gap-2">
           <HeaderBtn aria-label="共有" onClick={handleOpenShareSheet}>
             <Icon name="ios_share" size={16} />
           </HeaderBtn>
           <HeaderBtn aria-label="メニュー" onClick={() => setMenuOpen((open) => !open)}>
             <Icon name="more_horiz" size={16} />
           </HeaderBtn>
-          {menuOpen && (
-            <>
-              <button
-                type="button"
-                className="fixed inset-0 z-20 cursor-default bg-transparent"
-                aria-label="メニューを閉じる"
-                onClick={() => setMenuOpen(false)}
-              />
-              <div className="absolute right-0 top-11 z-30 w-[170px] overflow-hidden rounded-[14px] border-2 border-[var(--solid-ink)] bg-white">
-                <MenuButton icon="edit" label="名称変更" onClick={handleOpenRename} />
-                <MenuButton icon="image" label="画像設定" onClick={handleOpenImagePicker} />
-                <MenuButton
-                  icon="delete"
-                  label="削除"
-                  destructive
-                  onClick={() => { setMenuOpen(false); setDeleteModalOpen(true); }}
-                />
-              </div>
-            </>
-          )}
         </div>
-      </div>
+      </header>
+
+      {/* ヘッダの「…」メニュー。ヘッダは backdrop-blur を持ち fixed 配置の基準に
+          なってしまうため、全画面の閉じオーバーレイとポップオーバーはヘッダの
+          外に置き、常にヘッダ直下（右端）へ固定表示する。 */}
+      {menuOpen && (
+        <>
+          <button
+            type="button"
+            className="fixed inset-0 z-50 cursor-default bg-transparent"
+            aria-label="メニューを閉じる"
+            onClick={() => setMenuOpen(false)}
+          />
+          <div
+            className="fixed z-[60] w-[170px] overflow-hidden rounded-[14px] border-2 border-[var(--solid-ink)] bg-white lg:hidden"
+            style={{ top: 'calc(env(safe-area-inset-top, 0px) + 62px)', right: 14 }}
+          >
+            <MenuButton icon="edit" label="名称変更" onClick={handleOpenRename} />
+            <MenuButton icon="image" label="画像設定" onClick={handleOpenImagePicker} />
+            <MenuButton
+              icon="delete"
+              label="削除"
+              destructive
+              onClick={() => { setMenuOpen(false); setDeleteModalOpen(true); }}
+            />
+          </div>
+        </>
+      )}
 
       <div className="flex items-start gap-3.5 px-5 pb-2.5 pt-[18px] lg:pt-8">
         <div
@@ -1957,7 +2006,8 @@ function ManualWordModal({
   }, [loading, open]);
 
   if (!open) return null;
-  const canSubmit = english.trim().length > 0 && japanese.trim().length > 0 && !loading;
+  // 日本語訳は任意（未入力ならマスター/AI が補完する）。英単語だけ必須。
+  const canSubmit = english.trim().length > 0 && !loading;
 
   return (
     <div className="fixed inset-0 z-[100]" style={{ fontFamily: 'var(--font-body)' }}>
@@ -1981,7 +2031,7 @@ function ManualWordModal({
             単語を追加
           </h2>
           <p className="mt-1 text-[11px] leading-[1.5] text-[var(--color-muted)]">
-            続けて何語でも入力できます。品詞・例文・発音記号は AI が自動で補完します。
+            続けて何語でも入力できます。日本語訳・品詞・例文・発音記号は未入力でも AI が自動で補完します。
           </p>
           {addedCount > 0 && (
             <div className="mt-2 inline-flex items-center gap-1 rounded-full border border-[var(--solid-ink)] bg-[var(--color-accent-light)] px-2.5 py-1 font-mono text-[10px] font-bold text-[var(--color-accent-ink)]">
@@ -2010,14 +2060,14 @@ function ManualWordModal({
             </div>
             <div>
               <label className="mb-1 block font-mono text-[10px] font-bold uppercase tracking-[0.06em] text-[var(--color-muted)]">
-                日本語訳
+                日本語訳（任意）
               </label>
               <input
                 type="text"
                 value={japanese}
                 onChange={(e) => onJapaneseChange(e.target.value)}
                 onKeyDown={(e) => { if (e.key === 'Enter' && canSubmit) onConfirm(); }}
-                placeholder="例: 美しい"
+                placeholder="例: 美しい（未入力なら自動補完）"
                 disabled={loading}
                 maxLength={100}
                 className="w-full rounded-[10px] border-2 border-[var(--solid-ink)] bg-white px-3 py-2.5 font-display text-[15px] font-bold text-[var(--solid-ink)] outline-none disabled:opacity-60"

--- a/src/app/share/[shareId]/page.tsx
+++ b/src/app/share/[shareId]/page.tsx
@@ -588,24 +588,40 @@ export default function SharedDetailPage() {
         onWordAction={setActionWord}
       />
       <div className="relative flex min-h-screen flex-col bg-[var(--color-background)] pb-[160px] font-[var(--font-body)] lg:hidden">
-      <div className="flex items-center justify-between px-3.5 pb-2 pt-2">
-        <SharedHeaderBtn onClick={() => router.back()} aria-label="戻る">
-          <Icon name="chevron_left" size={16} />
-        </SharedHeaderBtn>
-        <div className="flex gap-2">
-          <SharedHeaderBtn
-            onClick={handleToggleLike}
-            aria-label={liked ? 'いいねを取り消す' : 'いいね'}
-          >
-            <div className="flex items-center gap-1">
-              <Icon name="thumb_up" size={14} filled={liked} />
-              {likeCount > 0 && <span className="font-mono text-[9px] font-bold">{likeCount}</span>}
-            </div>
-          </SharedHeaderBtn>
+      {/* スクロールしても上部に固定されるヘッダー（グループページと同じパターン）。
+          top はノッチ下端に合わせ、ノッチ帯は全体共通の StatusBarCover が覆う。 */}
+      <header
+        className="sticky z-40 flex items-center gap-2.5 border-b-2 border-[var(--solid-ink)] bg-[var(--color-background)]/95 px-[14px] py-2.5 backdrop-blur-md"
+        style={{ top: 'env(safe-area-inset-top, 0px)' }}
+      >
+        <button
+          type="button"
+          onClick={() => router.back()}
+          aria-label="戻る"
+          className="inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-full border-2 border-[var(--solid-ink)] bg-white text-[var(--solid-ink)] transition-all duration-100 active:translate-x-px active:translate-y-px"
+        >
+          <Icon name="arrow_back" size={16} />
+        </button>
+        <div className="min-w-0 flex-1">
+          <div className="font-mono text-[9px] font-bold uppercase tracking-[0.08em] text-[var(--color-muted)]">
+            SHARED
+          </div>
+          <div className="truncate font-display text-[15px] font-extrabold leading-tight text-[var(--solid-ink)]">
+            {project.title}
+          </div>
         </div>
-      </div>
+        <SharedHeaderBtn
+          onClick={handleToggleLike}
+          aria-label={liked ? 'いいねを取り消す' : 'いいね'}
+        >
+          <div className="flex items-center gap-1">
+            <Icon name="thumb_up" size={14} filled={liked} />
+            {likeCount > 0 && <span className="font-mono text-[9px] font-bold">{likeCount}</span>}
+          </div>
+        </SharedHeaderBtn>
+      </header>
 
-      <div className="px-[18px] pb-3.5 pt-1">
+      <div className="px-[18px] pb-3.5 pt-3">
         <SolidPanel
           className="!rounded-[16px] overflow-hidden"
           faceClassName="!p-4 relative [background:linear-gradient(135deg,oklch(0.94_0.04_14),#fff)]"

--- a/src/app/shared/SharedPageClient.tsx
+++ b/src/app/shared/SharedPageClient.tsx
@@ -263,46 +263,45 @@ export default function SharedPageClient({ initialDiscover }: SharedPageClientPr
         onProjectMissing={handleProjectMissing}
       />
 
-      <div className="flex min-h-screen flex-col bg-[var(--color-background)] pb-[110px] pt-3 font-[var(--font-body)] lg:hidden">
-        <div className="px-[18px] pb-2 pt-1">
-          <div className="flex items-start justify-between gap-3">
-            <div className="flex min-w-0 items-center gap-2.5">
-              <button
-                type="button"
-                onClick={() => {
-                  if (typeof window !== 'undefined' && window.history.length > 1) {
-                    router.back();
-                  } else {
-                    router.push('/');
-                  }
-                }}
-                aria-label="戻る"
-                className="flex h-[38px] w-[38px] shrink-0 items-center justify-center rounded-[19px] border-2 border-[var(--solid-ink)] bg-white text-[var(--solid-ink)] transition-all duration-100 active:translate-x-px active:translate-y-px"
-              >
-                <Icon name="chevron_left" size={18} />
-              </button>
-              <div className="min-w-0">
-                <div className="font-mono text-[10px] font-bold tracking-[0.08em] text-[var(--color-muted)]">
-                  COMMUNITY
-                </div>
-                <div className="mt-0.5 font-display text-[26px] font-extrabold leading-[1.1] text-[var(--solid-ink)]">
-                  共有単語帳
-                </div>
-              </div>
+      <div className="flex min-h-screen flex-col bg-[var(--color-background)] pb-[110px] font-[var(--font-body)] lg:hidden">
+        {/* スクロールしても上部に固定されるヘッダー（グループページと同じパターン）。
+            top はノッチ下端に合わせ、ノッチ帯は全体共通の StatusBarCover が覆う。 */}
+        <header
+          className="sticky z-40 flex items-center gap-2.5 border-b-2 border-[var(--solid-ink)] bg-[var(--color-background)]/95 px-[14px] py-2.5 backdrop-blur-md"
+          style={{ top: 'env(safe-area-inset-top, 0px)' }}
+        >
+          <button
+            type="button"
+            onClick={() => {
+              if (typeof window !== 'undefined' && window.history.length > 1) {
+                router.back();
+              } else {
+                router.push('/');
+              }
+            }}
+            aria-label="戻る"
+            className="inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-full border-2 border-[var(--solid-ink)] bg-white text-[var(--solid-ink)] transition-all duration-100 active:translate-x-px active:translate-y-px"
+          >
+            <Icon name="arrow_back" size={16} />
+          </button>
+          <div className="min-w-0 flex-1">
+            <div className="font-mono text-[9px] font-bold uppercase tracking-[0.08em] text-[var(--color-muted)]">
+              COMMUNITY
             </div>
-            <div className="flex shrink-0 items-center gap-2">
-              <FollowNotificationsButton variant="mobile" />
-              <button
-                type="button"
-                onClick={handleOpenShareSheet}
-                aria-label="単語帳を共有"
-                className="inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-[12px] border-2 border-[var(--solid-ink)] bg-[var(--solid-ink)] text-white transition-all duration-100 active:translate-x-px active:translate-y-px"
-              >
-                <Icon name="add" size={20} />
-              </button>
+            <div className="truncate font-display text-[15px] font-extrabold leading-tight text-[var(--solid-ink)]">
+              共有単語帳
             </div>
           </div>
-        </div>
+          <FollowNotificationsButton variant="mobile" />
+          <button
+            type="button"
+            onClick={handleOpenShareSheet}
+            aria-label="単語帳を共有"
+            className="inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-full border-2 border-[var(--solid-ink)] bg-[var(--solid-ink)] text-white transition-all duration-100 active:translate-x-px active:translate-y-px"
+          >
+            <Icon name="add" size={18} />
+          </button>
+        </header>
 
         {selectedGenre ? (
           <GenreResultsView genre={selectedGenre} onBack={() => setSelectedGenre(null)} />

--- a/src/app/shared/share-wordbook/ShareWordbookClient.tsx
+++ b/src/app/shared/share-wordbook/ShareWordbookClient.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useRouter } from 'next/navigation';
+import { DesktopSidebar } from '@/components/desktop/DesktopChrome';
 import { Icon } from '@/components/ui';
 import { useAuth } from '@/hooks/use-auth';
 import { useToast } from '@/components/ui/toast';
@@ -142,149 +143,215 @@ export default function ShareWordbookClient() {
     }
   };
 
+  // ===== モバイル/デスクトップで共有する表示ブロック =====
+
+  const sharedSection = user && isPro && sharedWordbooks.length > 0 ? (
+    <div>
+      <div className="mb-2 flex items-center gap-1.5 px-1 font-mono text-[10px] font-bold uppercase tracking-[0.08em] text-[var(--color-muted)]">
+        <Icon name="public" size={13} />
+        共有中の単語帳
+        <span className="tabular-nums">{sharedWordbooks.length}</span>
+      </div>
+      <div className="flex flex-col gap-2">
+        {sharedWordbooks.map((card) => (
+          <SharedWordbookRow
+            key={card.project.id}
+            card={card}
+            confirming={confirmingStopId === card.project.id}
+            stopping={stoppingId === card.project.id}
+            onStop={() => void handleStopShare(card)}
+            onCancel={() => setConfirmingStopId(null)}
+          />
+        ))}
+      </div>
+    </div>
+  ) : null;
+
+  // ログイン/Pro/読込などのゲート状態。null なら選択リストを表示できる。
+  const gateState = authLoading ? (
+    <CenterState icon="progress_activity" spin message="確認中..." />
+  ) : !user ? (
+    <ActionState
+      icon="login"
+      message="ログインすると単語帳を共有できます。"
+      actionLabel="ログイン"
+      onAction={() => router.push('/login?redirect=/shared/share-wordbook')}
+    />
+  ) : !isPro ? (
+    <ActionState
+      icon="auto_awesome"
+      message="単語帳の共有はProプラン限定です。"
+      actionLabel="Proを見る"
+      onAction={() => router.push('/subscription')}
+    />
+  ) : loading ? (
+    <CenterState icon="progress_activity" spin message="読み込み中..." />
+  ) : loadError ? (
+    <div className="px-[18px] pt-6">
+      <div className="rounded-[12px] border-2 border-red-700 bg-red-50 px-4 py-3 text-sm font-bold text-red-700">
+        {loadError}
+        <button type="button" className="ml-2 underline" onClick={() => void loadProjects()}>再読み込み</button>
+      </div>
+    </div>
+  ) : projects.length === 0 ? (
+    <div className="px-[18px] pt-10 text-center text-sm font-bold text-[var(--color-muted)]">
+      共有できる単語帳がありません
+    </div>
+  ) : null;
+
+  const selectionList = gateState === null ? (
+    <div className="flex flex-col gap-2.5">
+      {sharedWordbooks.length > 0 && (
+        <div className="flex items-center gap-1.5 px-1 font-mono text-[10px] font-bold uppercase tracking-[0.08em] text-[var(--color-muted)]">
+          <Icon name="add" size={13} />
+          新しく共有する
+        </div>
+      )}
+      {projects.map((project) => {
+        const selected = selectedId === project.id;
+        return (
+          <button
+            key={project.id}
+            type="button"
+            onClick={() => setSelectedId(project.id)}
+            className="flex items-center gap-3 rounded-[14px] border-2 bg-white px-3 py-3 text-left transition-all duration-100 active:translate-x-px active:translate-y-px"
+            style={{ borderColor: selected ? 'var(--color-accent)' : 'var(--solid-ink)' }}
+          >
+            <span
+              className="flex h-[46px] w-[46px] shrink-0 items-center justify-center rounded-[11px] border-2 border-[var(--solid-ink)] bg-cover bg-center font-display text-[20px] font-extrabold text-white"
+              style={{
+                background: project.iconImage ? undefined : thumbColor(project.id),
+                backgroundImage: project.iconImage ? `url(${project.iconImage})` : undefined,
+              }}
+            >
+              {!project.iconImage && project.title.charAt(0)}
+            </span>
+            <span className="min-w-0 flex-1">
+              <span className="block truncate font-display text-[15px] font-bold text-[var(--solid-ink)]">{project.title}</span>
+              {project.description && (
+                <span className="mt-0.5 block truncate text-[11px] text-[var(--color-muted)]">{project.description}</span>
+              )}
+            </span>
+            <span
+              className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full border-2"
+              style={{
+                borderColor: selected ? 'var(--color-accent)' : 'var(--color-border)',
+                background: selected ? 'var(--color-accent)' : 'transparent',
+              }}
+            >
+              {selected && <Icon name="check" size={14} className="text-white" />}
+            </span>
+          </button>
+        );
+      })}
+    </div>
+  ) : null;
+
+  const publishForm = (
+    <>
+      <div className="mb-2 flex items-center gap-1.5 font-mono text-[9px] font-bold uppercase tracking-[0.08em] text-[var(--color-muted)]">
+        <Icon name="sell" size={11} />
+        タグ（任意）
+      </div>
+      <input
+        value={tagDraft}
+        onChange={(event) => setTagDraft(event.target.value)}
+        placeholder="例: #TOEIC, #熟語, #高校英語"
+        className="mb-2.5 w-full rounded-[10px] border-2 border-[var(--solid-ink)] bg-white px-3 py-2.5 text-[13px] font-bold text-[var(--solid-ink)] outline-none"
+      />
+      <button
+        type="button"
+        onClick={() => void handlePublish()}
+        disabled={!selectedProject || saving}
+        className="flex w-full items-center justify-center gap-2 rounded-[12px] border-2 border-[var(--solid-ink)] bg-[var(--solid-ink)] px-4 py-3 text-[15px] font-extrabold text-white disabled:opacity-45"
+      >
+        <Icon name={saving ? 'progress_activity' : 'ios_share'} size={17} className={saving ? 'animate-spin' : undefined} />
+        {saving ? '共有中...' : selectedProject ? `「${selectedProject.title}」を共有` : '単語帳を選択'}
+      </button>
+    </>
+  );
+
+  const showPublishPanel = user && isPro && projects.length > 0 && gateState === null;
+
   return (
-    <div className="flex min-h-screen flex-col bg-[var(--color-background)] pb-[150px] font-[var(--font-body)]">
-      <div className="flex items-center gap-3 px-[18px] pb-2 pt-3">
-        <button
-          type="button"
-          onClick={() => router.back()}
-          aria-label="戻る"
-          className="inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-full border-2 border-[var(--solid-ink)] bg-white text-[var(--solid-ink)]"
-        >
-          <Icon name="chevron_left" size={18} />
-        </button>
-        <div className="min-w-0">
-          <div className="font-mono text-[10px] font-bold tracking-[0.08em] text-[var(--color-muted)]">SHARE</div>
-          <div className="font-display text-[20px] font-extrabold leading-[1.1] text-[var(--solid-ink)]">共有する単語帳を選ぶ</div>
+    <>
+      {/* Desktop: サイドバー付きの標準シェル。公開フォームは右カラムに常設 */}
+      <div className="hidden h-screen lg:block">
+        <div className="ds-app">
+          <DesktopSidebar />
+          <div className="ds-main">
+            <div className="ds-top">
+              <button
+                type="button"
+                className="ds-iconbtn"
+                onClick={() => router.back()}
+                style={{ width: 38, height: 38 }}
+                aria-label="戻る"
+              >
+                <Icon name="arrow_back" />
+              </button>
+              <div style={{ flex: 1, minWidth: 0 }}>
+                <div className="crumb">共有ライブラリ / 共有</div>
+                <h1>共有する単語帳を選ぶ</h1>
+              </div>
+            </div>
+            <div
+              className="ds-scroll"
+              style={{
+                display: 'grid',
+                gridTemplateColumns: showPublishPanel ? 'minmax(0, 1fr) 300px' : 'minmax(0, 1fr)',
+                gap: 26,
+                alignItems: 'start',
+                width: 'min(100%, 940px)',
+                margin: '0 auto',
+              }}
+            >
+              <div className="flex flex-col gap-5">
+                {sharedSection}
+                {gateState}
+                {selectionList}
+              </div>
+              {showPublishPanel && (
+                <div className="ds-card" style={{ position: 'sticky', top: 0, padding: '18px 20px' }}>
+                  {publishForm}
+                </div>
+              )}
+            </div>
+          </div>
         </div>
       </div>
 
-      {user && isPro && sharedWordbooks.length > 0 && (
-        <div className="px-[14px] pt-2">
-          <div className="mb-2 flex items-center gap-1.5 px-1 font-mono text-[10px] font-bold uppercase tracking-[0.08em] text-[var(--color-muted)]">
-            <Icon name="public" size={13} />
-            共有中の単語帳
-            <span className="tabular-nums">{sharedWordbooks.length}</span>
-          </div>
-          <div className="flex flex-col gap-2">
-            {sharedWordbooks.map((card) => (
-              <SharedWordbookRow
-                key={card.project.id}
-                card={card}
-                confirming={confirmingStopId === card.project.id}
-                stopping={stoppingId === card.project.id}
-                onStop={() => void handleStopShare(card)}
-                onCancel={() => setConfirmingStopId(null)}
-              />
-            ))}
-          </div>
-        </div>
-      )}
-
-      {authLoading ? (
-        <CenterState icon="progress_activity" spin message="確認中..." />
-      ) : !user ? (
-        <ActionState
-          icon="login"
-          message="ログインすると単語帳を共有できます。"
-          actionLabel="ログイン"
-          onAction={() => router.push('/login?redirect=/shared/share-wordbook')}
-        />
-      ) : !isPro ? (
-        <ActionState
-          icon="auto_awesome"
-          message="単語帳の共有はProプラン限定です。"
-          actionLabel="Proを見る"
-          onAction={() => router.push('/subscription')}
-        />
-      ) : loading ? (
-        <CenterState icon="progress_activity" spin message="読み込み中..." />
-      ) : loadError ? (
-        <div className="px-[18px] pt-6">
-          <div className="rounded-[12px] border-2 border-red-700 bg-red-50 px-4 py-3 text-sm font-bold text-red-700">
-            {loadError}
-            <button type="button" className="ml-2 underline" onClick={() => void loadProjects()}>再読み込み</button>
-          </div>
-        </div>
-      ) : projects.length === 0 ? (
-        <div className="px-[18px] pt-10 text-center text-sm font-bold text-[var(--color-muted)]">
-          共有できる単語帳がありません
-        </div>
-      ) : (
-        <div className="flex flex-col gap-2.5 px-[14px] pt-3">
-          {sharedWordbooks.length > 0 && (
-            <div className="flex items-center gap-1.5 px-1 font-mono text-[10px] font-bold uppercase tracking-[0.08em] text-[var(--color-muted)]">
-              <Icon name="add" size={13} />
-              新しく共有する
-            </div>
-          )}
-          {projects.map((project) => {
-            const selected = selectedId === project.id;
-            return (
-              <button
-                key={project.id}
-                type="button"
-                onClick={() => setSelectedId(project.id)}
-                className="flex items-center gap-3 rounded-[14px] border-2 bg-white px-3 py-3 text-left transition-all duration-100 active:translate-x-px active:translate-y-px"
-                style={{ borderColor: selected ? 'var(--color-accent)' : 'var(--solid-ink)' }}
-              >
-                <span
-                  className="flex h-[46px] w-[46px] shrink-0 items-center justify-center rounded-[11px] border-2 border-[var(--solid-ink)] bg-cover bg-center font-display text-[20px] font-extrabold text-white"
-                  style={{
-                    background: project.iconImage ? undefined : thumbColor(project.id),
-                    backgroundImage: project.iconImage ? `url(${project.iconImage})` : undefined,
-                  }}
-                >
-                  {!project.iconImage && project.title.charAt(0)}
-                </span>
-                <span className="min-w-0 flex-1">
-                  <span className="block truncate font-display text-[15px] font-bold text-[var(--solid-ink)]">{project.title}</span>
-                  {project.description && (
-                    <span className="mt-0.5 block truncate text-[11px] text-[var(--color-muted)]">{project.description}</span>
-                  )}
-                </span>
-                <span
-                  className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full border-2"
-                  style={{
-                    borderColor: selected ? 'var(--color-accent)' : 'var(--color-border)',
-                    background: selected ? 'var(--color-accent)' : 'transparent',
-                  }}
-                >
-                  {selected && <Icon name="check" size={14} className="text-white" />}
-                </span>
-              </button>
-            );
-          })}
-        </div>
-      )}
-
-      {user && isPro && projects.length > 0 && (
-        <div
-          className="fixed bottom-0 left-0 right-0 z-30 border-t-2 border-[var(--solid-ink)] bg-[#faf7f1] px-4 pt-3"
-          style={{ paddingBottom: 'max(1.25rem, env(safe-area-inset-bottom))' }}
-        >
-          <div className="mb-2 flex items-center gap-1.5 font-mono text-[9px] font-bold uppercase tracking-[0.08em] text-[var(--color-muted)]">
-            <Icon name="sell" size={11} />
-            タグ（任意）
-          </div>
-          <input
-            value={tagDraft}
-            onChange={(event) => setTagDraft(event.target.value)}
-            placeholder="例: #TOEIC, #熟語, #高校英語"
-            className="mb-2.5 w-full rounded-[10px] border-2 border-[var(--solid-ink)] bg-white px-3 py-2.5 text-[13px] font-bold text-[var(--solid-ink)] outline-none"
-          />
+      {/* Mobile */}
+      <div className="flex min-h-screen flex-col bg-[var(--color-background)] pb-[150px] font-[var(--font-body)] lg:hidden">
+        <div className="flex items-center gap-3 px-[18px] pb-2 pt-3">
           <button
             type="button"
-            onClick={() => void handlePublish()}
-            disabled={!selectedProject || saving}
-            className="flex w-full items-center justify-center gap-2 rounded-[12px] border-2 border-[var(--solid-ink)] bg-[var(--solid-ink)] px-4 py-3 text-[15px] font-extrabold text-white disabled:opacity-45"
+            onClick={() => router.back()}
+            aria-label="戻る"
+            className="inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-full border-2 border-[var(--solid-ink)] bg-white text-[var(--solid-ink)]"
           >
-            <Icon name={saving ? 'progress_activity' : 'ios_share'} size={17} className={saving ? 'animate-spin' : undefined} />
-            {saving ? '共有中...' : selectedProject ? `「${selectedProject.title}」を共有` : '単語帳を選択'}
+            <Icon name="chevron_left" size={18} />
           </button>
+          <div className="min-w-0">
+            <div className="font-mono text-[10px] font-bold tracking-[0.08em] text-[var(--color-muted)]">SHARE</div>
+            <div className="font-display text-[20px] font-extrabold leading-[1.1] text-[var(--solid-ink)]">共有する単語帳を選ぶ</div>
+          </div>
         </div>
-      )}
-    </div>
+
+        {sharedSection && <div className="px-[14px] pt-2">{sharedSection}</div>}
+        {gateState}
+        {selectionList && <div className="px-[14px] pt-3">{selectionList}</div>}
+
+        {showPublishPanel && (
+          <div
+            className="fixed bottom-0 left-0 right-0 z-30 border-t-2 border-[var(--solid-ink)] bg-[#faf7f1] px-4 pt-3"
+            style={{ paddingBottom: 'max(1.25rem, env(safe-area-inset-bottom))' }}
+          >
+            {publishForm}
+          </div>
+        )}
+      </div>
+    </>
   );
 }
 

--- a/src/components/home/CreateWordbookSheet.tsx
+++ b/src/components/home/CreateWordbookSheet.tsx
@@ -7,6 +7,7 @@ import { SolidButton } from '@/components/redesign/SolidPage';
 import { ScanCapturePanel } from '@/components/home/ScanCapturePanel';
 import { useAuth } from '@/hooks/use-auth';
 import { getRepository } from '@/lib/db';
+import { saveManualAddIntent } from '@/lib/home/home-session-storage';
 import { getGuestUserId, FREE_WORDBOOK_LIMIT } from '@/lib/utils';
 import type { SubscriptionStatus } from '@/types';
 
@@ -110,6 +111,12 @@ export function CreateWordbookSheet({ isOpen, onClose, variant = 'sheet' }: Crea
         }
       }
       const project = await repository.createProject({ userId, title: trimmedName });
+      // 空の単語帳は単語ゼロで始まるので、遷移先で手動追加モーダルを自動で開く
+      try {
+        saveManualAddIntent(sessionStorage, project.id);
+      } catch {
+        // sessionStorage が使えない環境では自動オープンだけ諦める
+      }
       onClose();
       router.push(`/project/${project.id}`);
     } catch (error) {

--- a/src/components/home/HomeReelRail.tsx
+++ b/src/components/home/HomeReelRail.tsx
@@ -28,22 +28,13 @@ export function HomeReelRail({ items, loading }: { items: HomeReelPreviewItem[];
 
   return (
     <div className="pb-2 pt-4">
-      <div className="flex items-baseline justify-between px-5 pb-2.5">
-        <div>
-          <div className="font-mono text-[10px] font-semibold tracking-[0.06em] text-[var(--color-muted)]">
-            REELS
-          </div>
-          <h2 className="font-display text-[19px] font-extrabold tracking-[-0.01em] text-[var(--solid-ink)]">
-            おすすめのリール
-          </h2>
+      <div className="px-5 pb-2.5">
+        <div className="font-mono text-[10px] font-semibold tracking-[0.06em] text-[var(--color-muted)]">
+          REELS
         </div>
-        <Link
-          href="/reels"
-          className="flex items-center gap-[3px] text-[13px] font-semibold text-[var(--color-accent)]"
-        >
-          すべて見る
-          <Icon name="chevron_right" size={11} />
-        </Link>
+        <h2 className="font-display text-[19px] font-extrabold tracking-[-0.01em] text-[var(--solid-ink)]">
+          おすすめのリール
+        </h2>
       </div>
 
       {/* scroll-pl はスナップ位置を左パディング分内側に寄せるため必須

--- a/src/components/notifications/FollowNotificationsButton.tsx
+++ b/src/components/notifications/FollowNotificationsButton.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
+import { createPortal } from 'react-dom';
 import Link from 'next/link';
 import { Icon } from '@/components/ui/Icon';
 import { useAuth } from '@/hooks/use-auth';
@@ -47,6 +48,8 @@ function formatNotificationTime(value: string) {
 export function FollowNotificationsButton({ variant = 'desktop' }: FollowNotificationsButtonProps) {
   const { isAuthenticated, loading: authLoading } = useAuth();
   const rootRef = useRef<HTMLDivElement | null>(null);
+  // モバイルパネルは portal で body 直下に出すため、外側クリック判定に別 ref が要る
+  const panelRef = useRef<HTMLDivElement | null>(null);
   const pushSetupRequestedRef = useRef(false);
   const [open, setOpen] = useState(false);
   const [notifications, setNotifications] = useState<FollowNotification[]>([]);
@@ -138,7 +141,10 @@ export function FollowNotificationsButton({ variant = 'desktop' }: FollowNotific
     if (!open) return;
 
     const handlePointerDown = (event: PointerEvent) => {
-      if (!rootRef.current?.contains(event.target as Node)) setOpen(false);
+      const target = event.target as Node;
+      if (!rootRef.current?.contains(target) && !panelRef.current?.contains(target)) {
+        setOpen(false);
+      }
     };
 
     document.addEventListener('pointerdown', handlePointerDown);
@@ -227,8 +233,9 @@ export function FollowNotificationsButton({ variant = 'desktop' }: FollowNotific
         )}
       </button>
 
-      {open && (
+      {open && renderPanel(
         <div
+          ref={panelRef}
           className={cn(
             'z-[120] w-[min(340px,calc(100vw-28px))] border-2 border-[var(--solid-ink)] bg-white shadow-[6px_6px_0_var(--solid-ink)]',
             isMobile ? 'fixed rounded-[14px]' : 'absolute right-0 top-[calc(100%+10px)] rounded-[12px]',
@@ -332,8 +339,18 @@ export function FollowNotificationsButton({ variant = 'desktop' }: FollowNotific
               </div>
             )}
           </div>
-        </div>
+        </div>,
       )}
     </div>
   );
+
+  // モバイルの通知パネルは viewport 基準の fixed 配置。backdrop-filter を持つ
+  // 固定ヘッダー内に置かれると fixed の基準がヘッダーになってしまうため、
+  // portal で body 直下に描画して常に viewport 基準にする。
+  function renderPanel(panel: ReactNode) {
+    if (isMobile && typeof document !== 'undefined') {
+      return createPortal(panel, document.body);
+    }
+    return panel;
+  }
 }

--- a/src/lib/home/home-session-storage.test.ts
+++ b/src/lib/home/home-session-storage.test.ts
@@ -6,9 +6,11 @@ import {
   clearHomeGeneratingWordbook,
   clearLegacyHomeProjectId,
   consumeHomeGeneratingWordbook,
+  consumeManualAddIntent,
   getHomeSelectedProjectId,
   saveHomeGeneratingWordbook,
   saveHomeSelectedProjectId,
+  saveManualAddIntent,
   type HomeSessionStorage,
 } from './home-session-storage';
 
@@ -125,6 +127,23 @@ test('clearHomeGeneratingWordbook removes only the generating wordbook key', () 
     [HOME_SESSION_STORAGE_KEYS.selectedProjectId]: 'project-1',
   });
   assert.deepEqual(storage.removedKeys, [HOME_SESSION_STORAGE_KEYS.generatingWordbook]);
+});
+
+test('consumeManualAddIntent returns the saved project id and removes it', () => {
+  const storage = new MemoryStorage();
+
+  saveManualAddIntent(storage, 'project-1');
+
+  assert.equal(consumeManualAddIntent(storage), 'project-1');
+  assert.equal(storage.getItem(HOME_SESSION_STORAGE_KEYS.manualAddProjectId), null);
+  assert.deepEqual(storage.removedKeys, [HOME_SESSION_STORAGE_KEYS.manualAddProjectId]);
+});
+
+test('consumeManualAddIntent returns null when no intent is stored', () => {
+  const storage = new MemoryStorage();
+
+  assert.equal(consumeManualAddIntent(storage), null);
+  assert.deepEqual(storage.removedKeys, []);
 });
 
 test('clearLegacyHomeProjectId removes only the legacy project id key', () => {

--- a/src/lib/home/home-session-storage.ts
+++ b/src/lib/home/home-session-storage.ts
@@ -8,6 +8,7 @@ export const HOME_SESSION_STORAGE_KEYS = {
   selectedProjectId: 'scanvocab_selected_project_id',
   generatingWordbook: 'scanvocab_generating_wordbook',
   legacyProjectId: 'scanvocab_project_id',
+  manualAddProjectId: 'scanvocab_manual_add_project_id',
 } as const;
 
 export interface HomeGeneratingWordbookPayload {
@@ -70,6 +71,22 @@ export function clearHomeGeneratingWordbook(storage: HomeSessionStorage): void {
 
 export function clearLegacyHomeProjectId(storage: HomeSessionStorage): void {
   storage.removeItem(HOME_SESSION_STORAGE_KEYS.legacyProjectId);
+}
+
+/**
+ * 空の単語帳を作成して単語帳ページへ遷移した直後に、手動追加モーダルを
+ * 自動で開くための受け渡し。作成元（CreateWordbookSheet）が projectId を
+ * 保存し、単語帳ページが consume して一致した場合のみモーダルを開く。
+ */
+export function saveManualAddIntent(storage: HomeSessionStorage, projectId: string): void {
+  storage.setItem(HOME_SESSION_STORAGE_KEYS.manualAddProjectId, projectId);
+}
+
+export function consumeManualAddIntent(storage: HomeSessionStorage): string | null {
+  const projectId = storage.getItem(HOME_SESSION_STORAGE_KEYS.manualAddProjectId);
+  if (projectId === null) return null;
+  storage.removeItem(HOME_SESSION_STORAGE_KEYS.manualAddProjectId);
+  return projectId;
 }
 
 function isGeneratingWordbookPayload(

--- a/src/lib/notifications/apns.ts
+++ b/src/lib/notifications/apns.ts
@@ -15,6 +15,7 @@ type ScanJobApnsParams = {
   projectTitle: string;
   status: 'completed' | 'failed' | 'warning';
   wordCount?: number;
+  errorMessage?: string;
 };
 
 async function getApnsClient(): Promise<InstanceType<typeof import('apns2').ApnsClient> | null> {
@@ -68,7 +69,7 @@ function buildNotificationContent(params: ScanJobApnsParams): {
     : 'スキャン完了';
 
   const body = params.status === 'failed'
-    ? `「${params.projectTitle}」のスキャンに失敗しました`
+    ? `「${params.projectTitle}」のスキャンに失敗しました${params.errorMessage ? `：${params.errorMessage}` : ''}`
     : params.status === 'warning'
     ? `「${params.projectTitle}」では文法抽出が見つかりませんでした`
     : `「${params.projectTitle}」に${params.wordCount ?? 0}語追加されました`;

--- a/src/lib/notifications/web-push.ts
+++ b/src/lib/notifications/web-push.ts
@@ -17,6 +17,7 @@ type ScanJobPushParams = {
   projectTitle: string;
   status: ScanJobPushStatus;
   wordCount?: number;
+  errorMessage?: string;
 };
 
 type SubscriptionRow = {
@@ -74,7 +75,7 @@ function createPayload(params: ScanJobPushParams): string {
     ? 'MERKEN: 文法抽出なし'
     : 'MERKEN: スキャン完了';
   const body = params.status === 'failed'
-    ? `「${params.projectTitle}」のスキャンに失敗しました`
+    ? `「${params.projectTitle}」のスキャンに失敗しました${params.errorMessage ? `：${params.errorMessage}` : ''}`
     : params.status === 'warning'
     ? `「${params.projectTitle}」では文法抽出が見つからなかったため、通常抽出に切り替えました`
     : `「${params.projectTitle}」に${params.wordCount ?? 0}語追加されました`;

--- a/src/lib/scan/job-side-effects.test.ts
+++ b/src/lib/scan/job-side-effects.test.ts
@@ -42,6 +42,24 @@ test('buildScanJobFailedNotificationParams fixes failed scan notification params
   );
 });
 
+test('buildScanJobFailedNotificationParams carries the failure reason into the notification', () => {
+  const params = buildScanJobFailedNotificationParams({
+    ...commonParams,
+    errorMessage: ' 画像から単語を読み取れませんでした。 ',
+  });
+
+  assert.equal(params.errorMessage, '画像から単語を読み取れませんでした。');
+});
+
+test('buildScanJobFailedNotificationParams omits errorMessage when the reason is blank', () => {
+  const params = buildScanJobFailedNotificationParams({
+    ...commonParams,
+    errorMessage: '   ',
+  });
+
+  assert.equal('errorMessage' in params, false);
+});
+
 test('buildScanJobCompletedNotificationParams fixes completed scan notification params', () => {
   assert.deepEqual(
     buildScanJobCompletedNotificationParams({

--- a/src/lib/scan/job-side-effects.ts
+++ b/src/lib/scan/job-side-effects.ts
@@ -10,6 +10,8 @@ export interface ScanJobNotificationParams {
   projectTitle: string;
   status: ScanJobNotificationStatus;
   wordCount?: number;
+  /** 失敗通知の本文にそのまま載せる、ユーザー向けの失敗理由（日本語） */
+  errorMessage?: string;
 }
 
 interface CommonNotificationParams {
@@ -31,8 +33,9 @@ export function buildScanJobWarningNotificationParams(
 }
 
 export function buildScanJobFailedNotificationParams(
-  params: CommonNotificationParams,
+  params: CommonNotificationParams & { errorMessage?: string },
 ): ScanJobNotificationParams {
+  const errorMessage = params.errorMessage?.trim();
   return {
     userId: params.userId,
     jobId: params.jobId,
@@ -40,6 +43,7 @@ export function buildScanJobFailedNotificationParams(
     projectTitle: params.projectTitle,
     status: 'failed',
     wordCount: 0,
+    ...(errorMessage ? { errorMessage } : {}),
   };
 }
 

--- a/src/lib/words/manual-enrichment.test.ts
+++ b/src/lib/words/manual-enrichment.test.ts
@@ -77,6 +77,19 @@ test('pickManualMasterEnrichment falls back to the most complete row without a h
   assert.equal(result.entryId, 'complete');
 });
 
+test('pickManualMasterEnrichment supplies a Japanese translation for empty manual input', () => {
+  const result = pickManualMasterEnrichment(
+    [
+      row({ id: 'entry-a', translation_ja: null, pronunciation: null }),
+      row({ id: 'entry-b', pos: 'noun', translation_ja: '経営', example_sentence: null, example_sentence_ja: null }),
+    ],
+    '',
+  );
+
+  assert.ok(result);
+  assert.equal(result.japanese, '経営');
+});
+
 test('buildManualEnrichPrompt lists only the fields the AI must generate', () => {
   const prompt = buildManualEnrichPrompt('run', '走る', {
     pronunciation: false,
@@ -84,8 +97,21 @@ test('buildManualEnrichPrompt lists only the fields the AI must generate', () =>
     example: true,
   });
 
+  assert.equal(prompt.includes('japanese'), false);
   assert.equal(prompt.includes('pronunciation'), false);
   assert.equal(prompt.includes('partOfSpeechTags'), true);
   assert.equal(prompt.includes('exampleSentence, exampleSentenceJa'), true);
   assert.equal(prompt.includes('"run" (走る)'), true);
+});
+
+test('buildManualEnrichPrompt asks for a Japanese translation when the user left it blank', () => {
+  const prompt = buildManualEnrichPrompt('run', '', {
+    japanese: true,
+    pronunciation: true,
+    pos: false,
+    example: false,
+  });
+
+  assert.equal(prompt.includes('japanese'), true);
+  assert.equal(prompt.includes('"run"\n'), true);
 });

--- a/src/lib/words/manual-enrichment.ts
+++ b/src/lib/words/manual-enrichment.ts
@@ -21,6 +21,8 @@ export interface ManualEnrichmentMasterRow {
 export interface ManualMasterEnrichment {
   /** 例文・発音の書き戻し先。マスターにエントリが無い場合は null。 */
   entryId: string | null;
+  /** 日本語訳が未入力のときの補完候補。マスターに無ければ空文字。 */
+  japanese: string;
   pronunciation: string;
   partOfSpeechTags: string[];
   exampleSentence: string;
@@ -64,12 +66,15 @@ export function pickManualMasterEnrichment(
 
   const pronunciation = normalizeText(best.pronunciation)
     || normalizeText(rows.find((row) => normalizeText(row.pronunciation))?.pronunciation);
+  const japanese = normalizeText(best.translation_ja)
+    || normalizeText(rows.find((row) => normalizeText(row.translation_ja))?.translation_ja);
   const exampleSentence = normalizeText(best.example_sentence);
   const exampleSentenceJa = normalizeText(best.example_sentence_ja);
   const pos = normalizeText(best.pos);
 
   return {
     entryId: best.id,
+    japanese,
     pronunciation,
     partOfSpeechTags: pos ? [pos] : [],
     // 例文は英日ペアが揃っている場合のみ採用する
@@ -109,6 +114,7 @@ export async function fetchManualEnrichmentFromMaster(
 }
 
 export interface ManualEnrichAiFields {
+  japanese?: boolean;
   pronunciation: boolean;
   pos: boolean;
   example: boolean;
@@ -125,6 +131,7 @@ export function buildManualEnrichPrompt(
   fields: ManualEnrichAiFields,
 ): string {
   const targets: string[] = [];
+  if (fields.japanese) targets.push('japanese');
   if (fields.pronunciation) targets.push('pronunciation');
   if (fields.pos) targets.push('partOfSpeechTags');
   if (fields.example) targets.push('exampleSentence', 'exampleSentenceJa');


### PR DESCRIPTION
## 概要

UX改善5件をまとめたPRです。

### 1. スキャン失敗理由の即時表示 + 通知文への理由追加
- **問題**: スキャン失敗時、「生成中」カードが理由も出さず消えるだけで、失敗理由の表示はリロードするまで出なかった。
- **修正**: ホームのポーリングで「実行中→failed」の遷移を検出し、`scanFailureNotice`（`loadHome()` の `setError(null)` に消されない独立 state）として即時表示。閉じるボタン付き。高速失敗（実行中を経ずに failed で初見）も従来の linkedJob 経路でカバー。
- **通知**: Web Push / APNs の失敗通知本文に `error_message`（ユーザー向け日本語文言）を追加。`buildScanJobFailedNotificationParams` に `errorMessage` を追加し、process ルートの両失敗経路（語ゼロ・処理例外）から渡す。

### 2. ホームのリール表示から「すべて見る」を削除
- `HomeReelRail` の `/reels` への「すべて見る」リンクを削除（マイ単語帳側の「すべて見る」は残置）。

### 3. モバイル: 共有 / 共有単語帳 / 単語帳ページに固定ヘッダ
- グループページ(#411)と同じ sticky ヘッダパターン（`top: env(safe-area-inset-top)` + `backdrop-blur`）を `/shared`・`/share/[shareId]`・`/project/[id]` に適用。
- 付随修正: `backdrop-filter` 付きヘッダ内の `fixed` 要素はヘッダが包含ブロックになるため、通知パネル（FollowNotificationsButton）は portal で body 直下に描画、単語帳ページの「…」メニューはヘッダ外の fixed 配置へ移動。

### 4. 空の単語帳作成後に手動追加UIを自動表示 + 日本語訳を任意に
- `CreateWordbookSheet` の空単語帳作成時に sessionStorage 経由で projectId を渡し、単語帳ページ到着時に手動追加モーダルを自動オープン。
- 手動追加の日本語訳を任意化。未入力時は `enrich-manual` API が lexicon マスター → AI の順で日本語訳を自動補完し、どちらも取れなかった場合のみ入力を促すトーストを表示（意味が空の単語は保存しない）。

### 5. 共有する単語帳を選ぶ画面のデスクトップ対応
- `/shared/share-wordbook` に標準デスクトップシェル（サイドバー + トップバー）を追加。選択リストを中央カラム、タグ入力+公開ボタンを右側 sticky カードに配置。モバイルは従来レイアウトを維持。

## テスト
- `npm test`: 964 pass / 2 fail — 失敗2件（`otp.contract.test.ts` / `words/create/route.test.ts`）は変更前の main でも失敗する既存の問題（stash して確認済み）。
- 追加テスト: 失敗通知の `errorMessage`（job-side-effects）、手動追加意図の save/consume（home-session-storage）、日本語訳のマスター補完・プロンプト生成（manual-enrichment）。contract テストは通知パラメータ・ソースアンカーを更新。
- `npm run lint`: 変更ファイルは新規エラー/警告なし（既存の gcp-budget-guard のエラー5件・未使用変数警告は変更前から存在）。
- `npm run build`: 成功。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mf8rbBRL295a5iUFYcXN3A

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mf8rbBRL295a5iUFYcXN3A)_