### PR TITLE
共有単語帳ページに無限スクロールを追加（下端到達で自動読み込み）

### DIFF
--- a/src/app/shared/SharedPageClient.tsx
+++ b/src/app/shared/SharedPageClient.tsx
@@ -7,11 +7,12 @@ import { DesktopSharedView } from '@/components/desktop/DesktopShared';
 import { FollowNotificationsButton } from '@/components/notifications/FollowNotificationsButton';
 import { Icon } from '@/components/ui';
 import { useAuth } from '@/hooks/use-auth';
+import { useInfiniteScrollSentinel, type LoadMoreState } from '@/hooks/use-infinite-scroll';
 import { useMyGroups } from '@/hooks/use-my-groups';
 import { useToast } from '@/components/ui/toast';
 import { ShareTypeChooser } from './ShareTypeChooser';
 import { triggerHaptic } from '@/lib/haptics';
-import { removeProjectFromDiscover } from './shared-page-utils';
+import { appendDiscoverPage, mergeUniqueProjectCards, removeProjectFromDiscover } from './shared-page-utils';
 import type {
   SharedDiscoverCategory,
   SharedDiscoverPayload,
@@ -132,11 +133,20 @@ export default function SharedPageClient({ initialDiscover }: SharedPageClientPr
   const [error, setError] = useState<string | null>(null);
   const [refreshNonce] = useState(0);
   const hasUsedInitialRef = useRef(false);
+  // 検索条件が変わるたびに増やし、古い追加読み込みの結果を捨てるための世代番号。
+  const discoverSeqRef = useRef(0);
+
+  // 追加読み込みの状態は検索条件キーに紐付けて持ち、条件が変わったら
+  // 自動的に idle へ戻す（effect での明示リセットを不要にする）。
+  const discoverKey = `${category}\n${query}\n${refreshNonce}`;
+  const [loadMore, setLoadMore] = useState<{ key: string; state: LoadMoreState } | null>(null);
+  const loadMoreState: LoadMoreState = loadMore?.key === discoverKey ? loadMore.state : 'idle';
 
   const [chooserOpen, setChooserOpen] = useState(false);
   const [selectedGenre, setSelectedGenre] = useState<WordbookGenre | null>(null);
 
   useEffect(() => {
+    discoverSeqRef.current += 1;
     if (category === 'groups') return;
 
     const canUseInitial = !hasUsedInitialRef.current && category === 'all' && !query.trim() && refreshNonce === 0;
@@ -176,6 +186,32 @@ export default function SharedPageClient({ initialDiscover }: SharedPageClientPr
 
   function handleOpenShareSheet() {
     setChooserOpen(true);
+  }
+
+  // 一覧の下端に達したら次ページを取得して追記する（カーソルが無ければ何もしない）。
+  function handleLoadMore() {
+    if (category === 'groups' || loading || loadMoreState === 'loading') return;
+    const cursor = discover.nextCursor;
+    if (!cursor) return;
+
+    const seq = discoverSeqRef.current;
+    const key = discoverKey;
+    setLoadMore({ key, state: 'loading' });
+    fetch(buildDiscoverUrl(category, query, cursor), { cache: 'no-store' })
+      .then(async (response) => {
+        const payload = await response.json().catch(() => null) as DiscoverResponse | null;
+        if (!response.ok || !isDiscoverPayload(payload)) {
+          throw new Error(payload && 'error' in payload ? payload.error : 'shared_discover_load_more_failed');
+        }
+        if (discoverSeqRef.current !== seq) return;
+        startTransition(() => setDiscover((current) => appendDiscoverPage(current, payload)));
+        setLoadMore({ key, state: 'idle' });
+      })
+      .catch((loadError) => {
+        if (discoverSeqRef.current !== seq) return;
+        console.error('Failed to load more shared projects:', loadError);
+        setLoadMore({ key, state: 'error' });
+      });
   }
 
   function handleProjectMissing(projectId: string) {
@@ -261,6 +297,8 @@ export default function SharedPageClient({ initialDiscover }: SharedPageClientPr
         onBackToAll={handleBackToAll}
         onOpenShareSheet={handleOpenShareSheet}
         onProjectMissing={handleProjectMissing}
+        loadMoreState={loadMoreState}
+        onLoadMore={handleLoadMore}
       />
 
       <div className="flex min-h-screen flex-col bg-[var(--color-background)] pb-[110px] pt-3 font-[var(--font-body)] lg:hidden">
@@ -379,6 +417,13 @@ export default function SharedPageClient({ initialDiscover }: SharedPageClientPr
                 {category === 'projects' && <ProjectSection projects={discover.projects} onProjectMissing={handleProjectMissing} />}
               </>
             )}
+            {!loading && !allEmpty && (
+              <LoadMoreSentinel
+                hasMore={Boolean(discover.nextCursor)}
+                state={loadMoreState}
+                onLoadMore={handleLoadMore}
+              />
+            )}
           </div>
         )}
         </>
@@ -458,15 +503,20 @@ type GenreResultsState = {
   genre: WordbookGenre;
   projects: SharedProjectCard[];
   error: string | null;
+  nextCursor: string | null;
 };
 
 function GenreResultsView({ genre, onBack }: { genre: WordbookGenre; onBack: () => void }) {
   const { showToast } = useToast();
   // ジャンルごとの取得結果を1つの state に持つ（loading はジャンル不一致で導出）。
   const [result, setResult] = useState<GenreResultsState | null>(null);
+  // 追加読み込み状態もジャンルに紐付けて持ち、切り替え時は自動で idle に戻る。
+  const [loadMore, setLoadMore] = useState<{ genre: WordbookGenre; state: LoadMoreState } | null>(null);
+  const loadMoreState: LoadMoreState = loadMore?.genre === genre ? loadMore.state : 'idle';
   const loading = result?.genre !== genre;
   const projects = result?.genre === genre ? result.projects : [];
   const error = result?.genre === genre ? result.error : null;
+  const nextCursor = result?.genre === genre ? result.nextCursor : null;
 
   useEffect(() => {
     const controller = new AbortController();
@@ -477,16 +527,43 @@ function GenreResultsView({ genre, onBack }: { genre: WordbookGenre; onBack: () 
         if (!response.ok || !isDiscoverPayload(payload)) {
           throw new Error(payload && 'error' in payload ? payload.error : 'genre_discover_failed');
         }
-        setResult({ genre, projects: payload.projects, error: null });
+        setResult({ genre, projects: payload.projects, error: null, nextCursor: payload.nextCursor });
       })
       .catch((loadError) => {
         if (controller.signal.aborted) return;
         console.error('Failed to load genre wordbooks:', loadError);
-        setResult({ genre, projects: [], error: '単語帳を読み込めませんでした。' });
+        setResult({ genre, projects: [], error: '単語帳を読み込めませんでした。', nextCursor: null });
       });
 
     return () => controller.abort();
   }, [genre]);
+
+  function handleLoadMore() {
+    if (loading || loadMoreState === 'loading' || !nextCursor) return;
+
+    setLoadMore({ genre, state: 'loading' });
+    fetch(buildDiscoverUrl('projects', genre.query, nextCursor), { cache: 'no-store' })
+      .then(async (response) => {
+        const payload = await response.json().catch(() => null) as DiscoverResponse | null;
+        if (!response.ok || !isDiscoverPayload(payload)) {
+          throw new Error(payload && 'error' in payload ? payload.error : 'genre_discover_load_more_failed');
+        }
+        setResult((current) =>
+          current && current.genre === genre
+            ? {
+              ...current,
+              projects: mergeUniqueProjectCards(current.projects, payload.projects),
+              nextCursor: payload.nextCursor,
+            }
+            : current,
+        );
+        setLoadMore({ genre, state: 'idle' });
+      })
+      .catch((loadError) => {
+        console.error('Failed to load more genre wordbooks:', loadError);
+        setLoadMore({ genre, state: 'error' });
+      });
+  }
 
   function handleProjectMissing(projectId: string) {
     setResult((current) =>
@@ -527,10 +604,58 @@ function GenreResultsView({ genre, onBack }: { genre: WordbookGenre; onBack: () 
         ) : projects.length === 0 ? (
           <EmptyBox message="このジャンルの単語帳はまだありません" />
         ) : (
-          <ProjectSection projects={projects} onProjectMissing={handleProjectMissing} />
+          <>
+            <ProjectSection projects={projects} onProjectMissing={handleProjectMissing} />
+            <LoadMoreSentinel
+              hasMore={Boolean(nextCursor)}
+              state={loadMoreState}
+              onLoadMore={handleLoadMore}
+            />
+          </>
         )}
       </div>
     </>
+  );
+}
+
+/**
+ * 一覧下端の無限スクロール用センチネル。表示領域に入ると自動で次ページを
+ * 読み込み、失敗したときだけ手動の再読み込みボタンに切り替える。
+ */
+function LoadMoreSentinel({
+  hasMore,
+  state,
+  onLoadMore,
+}: {
+  hasMore: boolean;
+  state: LoadMoreState;
+  onLoadMore: () => void;
+}) {
+  const sentinelRef = useInfiniteScrollSentinel({
+    enabled: hasMore && state === 'idle',
+    onLoadMore,
+  });
+
+  if (!hasMore) return null;
+
+  return (
+    <div ref={sentinelRef} className="flex items-center justify-center py-2">
+      {state === 'error' ? (
+        <button
+          type="button"
+          onClick={onLoadMore}
+          className="inline-flex h-9 items-center gap-1.5 rounded-[10px] border-2 border-[var(--solid-ink)] bg-white px-4 text-[12px] font-extrabold text-[var(--solid-ink)]"
+        >
+          <Icon name="refresh" size={14} />
+          再読み込み
+        </button>
+      ) : (
+        <span className="flex items-center gap-1.5 text-[12px] font-bold text-[var(--color-muted)]">
+          <Icon name="progress_activity" size={16} className="animate-spin" />
+          読み込み中...
+        </span>
+      )}
+    </div>
   );
 }
 

--- a/src/app/shared/shared-page-utils.test.ts
+++ b/src/app/shared/shared-page-utils.test.ts
@@ -1,8 +1,9 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 
-import type { SharedProjectCard } from '@/lib/shared-projects/types';
+import type { SharedProjectCard, SharedUserSummary } from '@/lib/shared-projects/types';
 import {
+  appendDiscoverPage,
   collectMetricProjectIds,
   mergeMetricsIntoCards,
   mergeUniqueProjectCards,
@@ -48,6 +49,59 @@ test('mergeMetricsIntoCards replaces placeholder counts', () => {
 
   assert.equal(merged[0]?.wordCount, 12);
   assert.equal(merged[0]?.collaboratorCount, 3);
+});
+
+function makeUser(userId: string): SharedUserSummary {
+  return {
+    userId,
+    username: `${userId}-name`,
+    accountId: `${userId}-account`,
+    projectCount: 1,
+    wordCount: 10,
+    likeCount: 0,
+  };
+}
+
+test('appendDiscoverPage appends unseen items and advances the cursor', () => {
+  const current = {
+    category: 'projects' as const,
+    users: [makeUser('user-1')],
+    projects: [makeCard('project-1')],
+    groups: [],
+    nextCursor: 'cursor-1',
+  };
+  const page = {
+    category: 'projects' as const,
+    users: [makeUser('user-1'), makeUser('user-2')],
+    projects: [makeCard('project-1'), makeCard('project-2')],
+    groups: [],
+    nextCursor: 'cursor-2',
+  };
+
+  const next = appendDiscoverPage(current, page);
+
+  assert.deepEqual(next.projects.map((card) => card.project.id), ['project-1', 'project-2']);
+  assert.deepEqual(next.users.map((user) => user.userId), ['user-1', 'user-2']);
+  assert.equal(next.nextCursor, 'cursor-2');
+});
+
+test('appendDiscoverPage clears the cursor on the last page', () => {
+  const current = {
+    category: 'projects' as const,
+    users: [],
+    projects: [makeCard('project-1')],
+    groups: [],
+    nextCursor: 'cursor-1',
+  };
+  const page = {
+    category: 'projects' as const,
+    users: [],
+    projects: [makeCard('project-2')],
+    groups: [],
+    nextCursor: null,
+  };
+
+  assert.equal(appendDiscoverPage(current, page).nextCursor, null);
 });
 
 test('removeProjectFromDiscover removes stale shared cards', () => {

--- a/src/app/shared/shared-page-utils.ts
+++ b/src/app/shared/shared-page-utils.ts
@@ -50,6 +50,23 @@ export function mergeMetricsIntoCards(
   return changed ? nextCards : cards;
 }
 
+/**
+ * 無限スクロールで取得した次ページを現在の一覧に追記する。ユーザー・単語帳
+ * とも既出の項目は落とし、nextCursor はページ側の値で置き換える。
+ */
+export function appendDiscoverPage(
+  current: SharedDiscoverPayload,
+  page: SharedDiscoverPayload,
+): SharedDiscoverPayload {
+  const seenUsers = new Set(current.users.map((user) => user.userId));
+  return {
+    ...current,
+    users: [...current.users, ...page.users.filter((user) => !seenUsers.has(user.userId))],
+    projects: mergeUniqueProjectCards(current.projects, page.projects),
+    nextCursor: page.nextCursor,
+  };
+}
+
 export function removeProjectFromDiscover(
   payload: SharedDiscoverPayload,
   projectId: string,

--- a/src/components/desktop/DesktopShared.tsx
+++ b/src/components/desktop/DesktopShared.tsx
@@ -9,6 +9,7 @@ import { DesktopMediaCard } from '@/components/desktop/DesktopMediaShelf';
 import { FollowNotificationsButton } from '@/components/notifications/FollowNotificationsButton';
 import { desktopThumbColor } from '@/components/desktop/desktop-data';
 import { Icon } from '@/components/ui/Icon';
+import { useInfiniteScrollSentinel, type LoadMoreState } from '@/hooks/use-infinite-scroll';
 import { formatSharedTag } from '../../../shared/shared-tags';
 import type {
   PublicStudyGroupSummary,
@@ -47,6 +48,8 @@ export function DesktopSharedView({
   onBackToAll,
   onOpenShareSheet,
   onProjectMissing,
+  loadMoreState,
+  onLoadMore,
 }: {
   category: SharedDiscoverCategory | 'groups';
   query: string;
@@ -65,6 +68,8 @@ export function DesktopSharedView({
   onBackToAll: () => void;
   onOpenShareSheet: () => void;
   onProjectMissing: (projectId: string) => void;
+  loadMoreState: LoadMoreState;
+  onLoadMore: () => void;
 }) {
   const isCategory = category !== 'all';
   const isGroups = category === 'groups';
@@ -209,11 +214,18 @@ export function DesktopSharedView({
                   検索中...
                 </div>
               ) : isCategory ? (
-                <CategoryResults
-                  category={category as Exclude<SharedDiscoverCategory, 'all'>}
-                  payload={payload}
-                  onProjectMissing={onProjectMissing}
-                />
+                <>
+                  <CategoryResults
+                    category={category as Exclude<SharedDiscoverCategory, 'all'>}
+                    payload={payload}
+                    onProjectMissing={onProjectMissing}
+                  />
+                  <DesktopLoadMore
+                    hasMore={Boolean(payload.nextCursor)}
+                    state={loadMoreState}
+                    onLoadMore={onLoadMore}
+                  />
+                </>
               ) : hasQuery ? (
                 <div style={{ display: 'flex', flexDirection: 'column', gap: 26 }}>
                   <UserGrid users={payload.users} />
@@ -386,17 +398,61 @@ function DiscoverFeed({
       ) : feed.projects.length === 0 && !feed.error ? (
         <EmptyCard label="公開されている単語帳はまだありません" />
       ) : (
-        <div className="ds-media-grid">
-          {feed.projects.map((project) => (
-            <SharedWordbookCard
-              key={project.project.id}
-              project={project}
-              onProjectMissing={onProjectMissing}
-            />
-          ))}
-        </div>
+        <>
+          <div className="ds-media-grid">
+            {feed.projects.map((project) => (
+              <SharedWordbookCard
+                key={project.project.id}
+                project={project}
+                onProjectMissing={onProjectMissing}
+              />
+            ))}
+          </div>
+          <DesktopLoadMore
+            hasMore={Boolean(feed.nextCursor)}
+            state={feed.loadingMore ? 'loading' : feed.error ? 'error' : 'idle'}
+            onLoadMore={feed.loadMore}
+          />
+        </>
       )}
     </section>
+  );
+}
+
+/**
+ * 一覧下端の無限スクロール用センチネル。表示領域に入ると自動で次ページを
+ * 読み込み、失敗したときだけ手動の再読み込みボタンに切り替える。
+ */
+function DesktopLoadMore({
+  hasMore,
+  state,
+  onLoadMore,
+}: {
+  hasMore: boolean;
+  state: LoadMoreState;
+  onLoadMore: () => void;
+}) {
+  const sentinelRef = useInfiniteScrollSentinel({
+    enabled: hasMore && state === 'idle',
+    onLoadMore,
+  });
+
+  if (!hasMore) return null;
+
+  return (
+    <div ref={sentinelRef} style={{ display: 'flex', justifyContent: 'center', padding: '18px 0' }}>
+      {state === 'error' ? (
+        <button type="button" className="ds-btn ghost sm" onClick={onLoadMore}>
+          <Icon name="refresh" />
+          再読み込み
+        </button>
+      ) : (
+        <span className="muted" style={{ display: 'inline-flex', alignItems: 'center', gap: 8, fontSize: 13 }}>
+          <Icon name="progress_activity" className="animate-spin" />
+          読み込み中...
+        </span>
+      )}
+    </div>
   );
 }
 

--- a/src/hooks/use-infinite-scroll.ts
+++ b/src/hooks/use-infinite-scroll.ts
@@ -1,0 +1,50 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+
+/** 追加読み込みの進行状態。error のときは自動読み込みを止めて手動再試行を待つ。 */
+export type LoadMoreState = 'idle' | 'loading' | 'error';
+
+type UseInfiniteScrollSentinelOptions = {
+  /** 続きがあり、かつ読み込み中・エラーでないときだけ true にする。 */
+  enabled: boolean;
+  /** センチネルが画面に入ったら呼ばれる。多重呼び出しガードは呼び出し側で持つ。 */
+  onLoadMore: () => void;
+  /** 下端に到達する少し手前から先読みを始めるための余白。 */
+  rootMargin?: string;
+};
+
+/**
+ * 一覧末尾に置いたセンチネル要素が表示領域に入ったら onLoadMore を呼ぶ。
+ * 返り値の ref コールバックをセンチネル要素に渡す。display:none の要素は
+ * 交差しないため、CSS で出し分けている複製ビュー側のセンチネルは発火しない。
+ */
+export function useInfiniteScrollSentinel({
+  enabled,
+  onLoadMore,
+  rootMargin = '240px',
+}: UseInfiniteScrollSentinelOptions) {
+  const [sentinel, setSentinel] = useState<HTMLElement | null>(null);
+  const onLoadMoreRef = useRef(onLoadMore);
+
+  useEffect(() => {
+    onLoadMoreRef.current = onLoadMore;
+  });
+
+  useEffect(() => {
+    if (!enabled || !sentinel) return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries.some((entry) => entry.isIntersecting)) {
+          onLoadMoreRef.current();
+        }
+      },
+      { rootMargin },
+    );
+    observer.observe(sentinel);
+    return () => observer.disconnect();
+  }, [enabled, sentinel, rootMargin]);
+
+  return setSentinel;
+}


### PR DESCRIPTION
## 概要

共有単語帳ページ（`/shared`）で、一覧の下端までスクロールしたら次のページを自動で読み込むようにしました。

これまで一覧は最初の12件しか表示されず、discover API が返す `nextCursor` はクライアント側で未使用でした。一覧末尾にセンチネル要素を置き、IntersectionObserver で下端到達（240px 手前で先読み）を検知して次ページを取得・追記します。

## 変更内容

- **`src/hooks/use-infinite-scroll.ts`（新規）**: センチネル要素の交差を監視して `onLoadMore` を呼ぶ `useInfiniteScrollSentinel` フック。`display:none` の要素は交差しないため、モバイル/デスクトップで CSS 出し分けしている複製ビュー側のセンチネルは発火しません。
- **モバイル（`SharedPageClient.tsx`）**:
  - 「単語帳」カテゴリ一覧と「英検」ジャンルビューに自動読み込みを配線
  - 追加読み込み状態は検索条件キー（カテゴリ・クエリ）に紐付けて保持し、条件変更時は自動で idle に戻る。世代番号（seq）で古いレスポンスの追記を破棄
- **デスクトップ（`DesktopShared.tsx`）**:
  - 定義済みだが未配線だったダッシュボード新着フィードの `feed.loadMore` をセンチネルで配線
  - カテゴリ検索結果（単語帳・ユーザー）にもセンチネルを追加
- **エラー時の挙動**: 追加読み込みが失敗したら自動リトライの無限ループを避けるため手動の「再読み込み」ボタンに切り替え
- **`shared-page-utils.ts`**: `appendDiscoverPage`（重複排除しつつページ追記・カーソル前進）を追加、テスト付き

## テスト・検証

- `shared-page-utils.test.ts` に `appendDiscoverPage` のテストを追加（8/8 pass。既存の unit テスト失敗2件は本変更前から存在）
- `npm run lint` / `npm run build` パス（残存エラーはすべて既存のもの）
- Playwright + モック API で実ブラウザ検証:
  - モバイル: 単語帳カテゴリで 12→24→36 件の自動読み込み、最終ページ後にセンチネル消滅
  - モバイル: 追加読み込み 500 エラー → 再読み込みボタン表示 → クリックで復帰
  - モバイル: 英検ジャンルビューで 12→24→36 件
  - デスクトップ: 新着フィードで `.ds-scroll` 下端到達時に 12→24→36 件

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UyF8aDuvNEfNGR4PeQKtZR

---
_Generated by [Claude Code](https://claude.ai/code/session_01UyF8aDuvNEfNGR4PeQKtZR)_