### PR TITLE
固定ヘッダの下線はスクロール中だけ表示 + 共有ページの戻るボタン削除

### DIFF
--- a/src/app/groups/[groupId]/page.tsx
+++ b/src/app/groups/[groupId]/page.tsx
@@ -7,6 +7,7 @@ import { useParams, useRouter } from 'next/navigation';
 import { DesktopButton } from '@/components/desktop/DesktopChrome';
 import { Icon } from '@/components/ui';
 import { useAuth } from '@/hooks/use-auth';
+import { usePageScrolled } from '@/hooks/use-page-scrolled';
 import { useToast } from '@/components/ui/toast';
 import { triggerHaptic } from '@/lib/haptics';
 import { getSeededGroupSummary, loadGroupOverview } from '@/lib/shared-projects/group-overview-cache';
@@ -29,6 +30,8 @@ const MEDALS = ['#FFC800', '#C3CDD6', '#E29C57'];
 
 export default function GroupPage() {
   const router = useRouter();
+  // ページ上端ではヘッダの下線を出さない（スクロールで表示）
+  const pageScrolled = usePageScrolled();
   const params = useParams<{ groupId: string }>();
   const groupId = params?.groupId ?? '';
   const { loading: authLoading, isAuthenticated } = useAuth();
@@ -169,9 +172,10 @@ export default function GroupPage() {
         }}
       >
         {/* スクロールしても上部に固定されるヘッダー。top はノッチ下端に合わせ、
-            ノッチ帯は全体共通の StatusBarCover がすりガラスで覆う。 */}
+            ノッチ帯は全体共通の StatusBarCover がすりガラスで覆う。
+            下線はコンテンツがヘッダの下に潜り込んだとき（スクロール中）だけ出す。 */}
         <header
-          className="sticky z-40 flex items-center gap-2.5 border-b-2 border-[var(--solid-ink)] bg-[var(--color-background)]/95 px-[14px] py-2.5 backdrop-blur-md"
+          className={`sticky z-40 flex items-center gap-2.5 border-b-2 bg-[var(--color-background)]/95 px-[14px] py-2.5 backdrop-blur-md ${pageScrolled ? 'border-[var(--solid-ink)]' : 'border-transparent'}`}
           style={{ top: 'env(safe-area-inset-top, 0px)' }}
         >
           <button

--- a/src/app/project/[id]/page.tsx
+++ b/src/app/project/[id]/page.tsx
@@ -16,6 +16,7 @@ import { WordDetailView } from '@/components/word/WordDetailView';
 import { TranslationDisplay } from '@/components/word/TranslationDisplay';
 import { useAuth } from '@/hooks/use-auth';
 import { useIsMobileViewport } from '@/hooks/use-is-mobile-viewport';
+import { usePageScrolled } from '@/hooks/use-page-scrolled';
 import { useTourSeen } from '@/hooks/use-tour-seen';
 import { useTutorialFlow } from '@/hooks/use-tutorial-flow';
 import { useWordCount } from '@/hooks/use-word-count';
@@ -136,6 +137,8 @@ export default function ProjectPage() {
   const { shouldRender: projectTourReady, markSeen: markProjectTourSeen } = useTourSeen('project-intro');
   const { stage: tutorialStage, setStage: setTutorialStage } = useTutorialFlow();
   const isMobileViewport = useIsMobileViewport();
+  // ページ上端ではヘッダの下線を出さない（スクロールで表示）
+  const pageScrolled = usePageScrolled();
 
   const [project, setProject] = useState<Project | null>(null);
   const [words, setWords] = useState<Word[]>([]);
@@ -1235,9 +1238,10 @@ export default function ProjectPage() {
       />
       <div className="relative flex min-h-screen flex-col bg-[var(--color-background)] font-[var(--font-body)] lg:hidden">
       {/* スクロールしても上部に固定されるヘッダー（グループページと同じパターン）。
-          top はノッチ下端に合わせ、ノッチ帯は全体共通の StatusBarCover が覆う。 */}
+          top はノッチ下端に合わせ、ノッチ帯は全体共通の StatusBarCover が覆う。
+          下線はコンテンツがヘッダの下に潜り込んだとき（スクロール中）だけ出す。 */}
       <header
-        className="sticky z-40 flex items-center gap-2.5 border-b-2 border-[var(--solid-ink)] bg-[var(--color-background)]/95 px-[14px] py-2.5 backdrop-blur-md lg:hidden"
+        className={`sticky z-40 flex items-center gap-2.5 border-b-2 bg-[var(--color-background)]/95 px-[14px] py-2.5 backdrop-blur-md lg:hidden ${pageScrolled ? 'border-[var(--solid-ink)]' : 'border-transparent'}`}
         style={{ top: 'env(safe-area-inset-top, 0px)' }}
       >
         <HeaderBtn onClick={() => router.replace('/')} aria-label="ホームへ戻る">

--- a/src/app/share/[shareId]/page.tsx
+++ b/src/app/share/[shareId]/page.tsx
@@ -11,6 +11,7 @@ import { SolidButton, SolidPanel } from '@/components/redesign/SolidPage';
 import { useRewardedDownloadAd } from '@/components/ads/useRewardedDownloadAd';
 import { useAuth } from '@/hooks/use-auth';
 import { useIsMobileViewport } from '@/hooks/use-is-mobile-viewport';
+import { usePageScrolled } from '@/hooks/use-page-scrolled';
 import { useToast } from '@/components/ui/toast';
 import { isBillingEnabled } from '@/lib/billing/feature';
 import { getRepository } from '@/lib/db';
@@ -120,6 +121,8 @@ export default function SharedDetailPage() {
   const shareId = params.shareId as string;
   const { user, subscription, loading: authLoading } = useAuth();
   const isMobileViewport = useIsMobileViewport();
+  // ページ上端ではヘッダの下線を出さない（スクロールで表示）
+  const pageScrolled = usePageScrolled();
   const { showToast } = useToast();
   const billingEnabled = isBillingEnabled();
   const {
@@ -589,9 +592,10 @@ export default function SharedDetailPage() {
       />
       <div className="relative flex min-h-screen flex-col bg-[var(--color-background)] pb-[160px] font-[var(--font-body)] lg:hidden">
       {/* スクロールしても上部に固定されるヘッダー（グループページと同じパターン）。
-          top はノッチ下端に合わせ、ノッチ帯は全体共通の StatusBarCover が覆う。 */}
+          top はノッチ下端に合わせ、ノッチ帯は全体共通の StatusBarCover が覆う。
+          下線はコンテンツがヘッダの下に潜り込んだとき（スクロール中）だけ出す。 */}
       <header
-        className="sticky z-40 flex items-center gap-2.5 border-b-2 border-[var(--solid-ink)] bg-[var(--color-background)]/95 px-[14px] py-2.5 backdrop-blur-md"
+        className={`sticky z-40 flex items-center gap-2.5 border-b-2 bg-[var(--color-background)]/95 px-[14px] py-2.5 backdrop-blur-md ${pageScrolled ? 'border-[var(--solid-ink)]' : 'border-transparent'}`}
         style={{ top: 'env(safe-area-inset-top, 0px)' }}
       >
         <button

--- a/src/app/shared/SharedPageClient.tsx
+++ b/src/app/shared/SharedPageClient.tsx
@@ -8,6 +8,7 @@ import { FollowNotificationsButton } from '@/components/notifications/FollowNoti
 import { Icon } from '@/components/ui';
 import { useAuth } from '@/hooks/use-auth';
 import { useMyGroups } from '@/hooks/use-my-groups';
+import { usePageScrolled } from '@/hooks/use-page-scrolled';
 import { useToast } from '@/components/ui/toast';
 import { ShareTypeChooser } from './ShareTypeChooser';
 import { triggerHaptic } from '@/lib/haptics';
@@ -124,6 +125,8 @@ export default function SharedPageClient({ initialDiscover }: SharedPageClientPr
   // 参加中のグループ。表示はホームへ移設済みだが、グループ検索の
   // 参加済みフィルタ（モバイル/デスクトップ両方）が引き続き使う。
   const { groups: myGroups } = useMyGroups();
+  // ページ上端ではヘッダの下線を出さない（スクロールで表示）
+  const pageScrolled = usePageScrolled();
 
   const [userQuery, setUserQuery] = useState('');
   const [userResults, setUserResults] = useState<FollowSearchResult[]>([]);
@@ -265,25 +268,12 @@ export default function SharedPageClient({ initialDiscover }: SharedPageClientPr
 
       <div className="flex min-h-screen flex-col bg-[var(--color-background)] pb-[110px] font-[var(--font-body)] lg:hidden">
         {/* スクロールしても上部に固定されるヘッダー（グループページと同じパターン）。
-            top はノッチ下端に合わせ、ノッチ帯は全体共通の StatusBarCover が覆う。 */}
+            top はノッチ下端に合わせ、ノッチ帯は全体共通の StatusBarCover が覆う。
+            下線はコンテンツがヘッダの下に潜り込んだとき（スクロール中）だけ出す。 */}
         <header
-          className="sticky z-40 flex items-center gap-2.5 border-b-2 border-[var(--solid-ink)] bg-[var(--color-background)]/95 px-[14px] py-2.5 backdrop-blur-md"
+          className={`sticky z-40 flex items-center gap-2.5 border-b-2 bg-[var(--color-background)]/95 px-[14px] py-2.5 backdrop-blur-md ${pageScrolled ? 'border-[var(--solid-ink)]' : 'border-transparent'}`}
           style={{ top: 'env(safe-area-inset-top, 0px)' }}
         >
-          <button
-            type="button"
-            onClick={() => {
-              if (typeof window !== 'undefined' && window.history.length > 1) {
-                router.back();
-              } else {
-                router.push('/');
-              }
-            }}
-            aria-label="戻る"
-            className="inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-full border-2 border-[var(--solid-ink)] bg-white text-[var(--solid-ink)] transition-all duration-100 active:translate-x-px active:translate-y-px"
-          >
-            <Icon name="arrow_back" size={16} />
-          </button>
           <div className="min-w-0 flex-1">
             <div className="font-mono text-[9px] font-bold uppercase tracking-[0.08em] text-[var(--color-muted)]">
               COMMUNITY

--- a/src/hooks/use-page-scrolled.ts
+++ b/src/hooks/use-page-scrolled.ts
@@ -1,0 +1,21 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+/**
+ * ページが上端からスクロールされているかを返す。
+ * 固定ヘッダの下線をページ上端では消し、コンテンツがヘッダの下に
+ * 潜り込んだときだけ表示するために使う。
+ */
+export function usePageScrolled(threshold = 4): boolean {
+  const [scrolled, setScrolled] = useState(false);
+
+  useEffect(() => {
+    const onScroll = () => setScrolled(window.scrollY > threshold);
+    onScroll();
+    window.addEventListener('scroll', onScroll, { passive: true });
+    return () => window.removeEventListener('scroll', onScroll);
+  }, [threshold]);
+
+  return scrolled;
+}


### PR DESCRIPTION
## 概要

### 1. 固定ヘッダの下線をスクロール中のみ表示
- 対象: グループページ / 共有ページ / 共有単語帳ページ / 単語帳ページ（モバイル固定ヘッダの4画面すべて）
- ページ上端にいる間は `border-b` を `border-transparent` にし、コンテンツがヘッダの下に潜り込むスクロール中だけ `--solid-ink` の下線を表示。
- `usePageScrolled` フックを新設（`window.scrollY > 4` を passive listener で監視）。border 幅は維持したまま色だけ切り替えるためレイアウトシフトなし。

### 2. 共有ページ（/shared）のヘッダから戻る矢印ボタンを削除
- 左端の戻るボタンを削除し、タイトル（COMMUNITY / 共有単語帳）が先頭に。通知・共有ボタンは右端のまま。
- 共有単語帳ページ・単語帳ページ・グループページの戻るボタンは残置。

## 検証
- ローカルで本番ビルドを起動し Playwright で確認: 上端で下線 `transparent` → スクロールで `rgb(26,26,26)` → 上端に戻すと再び `transparent`、/shared ヘッダに戻るボタンなし。
- 変更ファイルの ESLint 新規指摘なし、`npm run build` 成功。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mf8rbBRL295a5iUFYcXN3A

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mf8rbBRL295a5iUFYcXN3A)_