### PR TITLE
フィードを本文幅いっぱいのフルブリード表示にし、学習内容は浮き上がるモーダルで表示

### DIFF
--- a/src/app/desktop.css
+++ b/src/app/desktop.css
@@ -148,6 +148,8 @@
 .ds-search .material-symbols-outlined { font-size: 18px; }
 .ds-scroll { flex: 1; overflow-y: auto; padding: 30px 34px 40px; }
 .ds-scroll.tight { padding: 26px 34px 34px; }
+/* フルブリード表示（フィードなど、コンテンツを本文幅いっぱいに広げるページ用） */
+.ds-scroll.flush { padding: 0; }
 
 /* ── Solid button (desktop) ──────────────────────────────── */
 .ds-btn {
@@ -939,23 +941,27 @@ button.ds-tile { appearance: none; }
 @keyframes dsShimmer { 0% { background-position: 200% 0; } 100% { background-position: -200% 0; } }
 
 /* ── Feed page (friends timeline) ────────────────────────── */
-/* コンテンツ全体を中央寄せにする（左寄り防止）。 */
-.ds-feed-wrap { max-width: 1040px; margin: 0 auto; }
+/* タイムラインは本文幅いっぱいのフルブリード表示（.ds-scroll.flush 前提）。 */
+.ds-feed-wrap { width: 100%; }
 .ds-feed-grid {
   display: grid; grid-template-columns: minmax(0, 1fr) 316px;
-  gap: 24px; align-items: start;
+  align-items: start;
 }
 .ds-feed-grid.single { grid-template-columns: minmax(0, 1fr); }
-.ds-feed-main { display: flex; flex-direction: column; gap: 14px; min-width: 0; }
-.ds-feed-side { display: flex; flex-direction: column; gap: 16px; position: sticky; top: 0; min-width: 0; }
+.ds-feed-main { display: flex; flex-direction: column; min-width: 0; }
+.ds-feed-side {
+  display: flex; flex-direction: column; gap: 16px;
+  position: sticky; top: 0; min-width: 0;
+  padding: 26px 34px 26px 24px;
+}
 @media (max-width: 1240px) {
   .ds-feed-grid { grid-template-columns: minmax(0, 1fr); }
-  .ds-feed-side { position: static; }
+  .ds-feed-side { position: static; padding: 26px 34px; }
 }
 
 .ds-feed-error {
   display: flex; align-items: center; justify-content: space-between; gap: 12px;
-  margin-bottom: 16px; padding: 12px 16px; border-radius: 12px;
+  margin: 18px 34px 16px; padding: 12px 16px; border-radius: 12px;
   border: 1.5px solid var(--color-error); background: var(--color-error-light);
   color: var(--color-error); font-size: 13px; font-weight: 700;
 }
@@ -964,21 +970,22 @@ button.ds-tile { appearance: none; }
   color: inherit; font: inherit; text-decoration: underline;
 }
 
-/* timeline card */
+/* timeline card（空状態・ログイン誘導カードで使用） */
 .ds-feed-card {
   background: #fff; border: 1.5px solid var(--solid-ink);
   border-radius: var(--solid-radius); box-shadow: 3px 4px 0 var(--solid-ink);
   overflow: hidden;
 }
-/* タイムラインは単語一覧と同じく1枚のリストに連結し、薄い線で区切る */
+/* リスト外に直接置かれるカード（空状態など）はフルブリードにせず余白を持たせる */
+.ds-feed-main > .ds-feed-card { margin: 26px 34px 0; }
+/* タイムラインは枠なしで本文幅いっぱいに広げ、薄い線で区切る */
 .ds-feed-list {
-  background: #fff; border: 1.5px solid var(--solid-ink);
-  border-radius: var(--solid-radius); box-shadow: 3px 4px 0 var(--solid-ink);
-  overflow: hidden;
+  background: #fff;
+  border-bottom: 1px solid var(--color-border);
 }
-.ds-feed-list .ds-feed-card { border: none; border-radius: 0; box-shadow: none; }
+.ds-feed-list .ds-feed-card { border: none; border-radius: 0; box-shadow: none; margin: 0; }
 .ds-feed-list .ds-feed-card + .ds-feed-card { border-top: 1px solid var(--color-border); }
-.ds-feed-card .fc-row { display: flex; align-items: flex-start; gap: 14px; padding: 16px 18px; }
+.ds-feed-card .fc-row { display: flex; align-items: flex-start; gap: 14px; padding: 16px 34px; }
 .ds-feed-card .fc-link { color: inherit; text-decoration: none; transition: background var(--dur-fast); }
 .ds-feed-card .fc-link:hover { background: var(--color-surface-secondary); }
 /* クイズエントリは行全体クリックで開閉（展開ボタンなし） */
@@ -997,26 +1004,28 @@ button.ds-tile { appearance: none; }
 .ds-feed-card .fc-chips { display: flex; flex-wrap: wrap; gap: 8px; margin-top: 11px; }
 .ds-feed-card .fc-chev { color: var(--color-muted); align-self: center; flex-shrink: 0; }
 
+/* 解いた数・習得数のチップ。ソリッドスタイル（1.5px枠 + 角丸7px）で統一する */
 .ds-feed-chip {
   display: inline-flex; align-items: center; gap: 5px;
-  padding: 5px 11px; border-radius: 999px;
-  font-size: 11.5px; font-weight: 800; border: 1.5px solid;
+  padding: 4px 10px; border-radius: 7px;
+  font-size: 11px; font-weight: 700; border: 1.5px solid;
 }
-.ds-feed-chip.quiz { background: var(--color-accent-light); border-color: var(--color-accent); color: var(--color-accent-ink); }
-.ds-feed-chip.mastered { background: #fef3c7; border-color: #fbbf24; color: #92400e; }
+.ds-feed-chip .n { font-family: var(--font-display); font-weight: 800; font-size: 13.5px; line-height: 1; }
+.ds-feed-chip.quiz { background: var(--color-accent-light); border-color: var(--color-accent-ink); color: var(--color-accent-ink); }
+.ds-feed-chip.mastered { background: #fff; border-color: var(--solid-ink); color: var(--color-ink); }
 
-/* expanded mastered-word list */
-.ds-feed-card .fc-words { border-top: 1.5px solid var(--solid-ink); background: var(--color-surface-secondary); padding: 14px 18px 16px; }
-.ds-feed-card .fc-words .lab {
+/* session detail modal（ds-modal 内。単語詳細と同じ浮き上がり表示） */
+.ds-feed-detail-head { display: flex; align-items: flex-start; gap: 14px; }
+.ds-feed-detail-lab {
   display: flex; align-items: center; gap: 6px; margin-bottom: 10px;
   font-family: var(--font-mono); font-size: 10px; font-weight: 700;
   letter-spacing: 0.08em; text-transform: uppercase; color: var(--color-muted);
 }
-.ds-feed-card .fc-words-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(170px, 1fr)); gap: 8px; }
-.ds-feed-card .fc-word { background: #fff; border: 1.5px solid var(--color-border); border-radius: 10px; padding: 9px 12px; min-width: 0; }
-.ds-feed-card .fc-word .en { display: block; font-family: var(--font-display); font-weight: 700; font-size: 14px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.ds-feed-card .fc-word .ja { display: block; margin-top: 1px; font-size: 12px; color: var(--color-secondary-text); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.ds-feed-card .fc-words .none { margin: 0; font-size: 12.5px; font-weight: 600; color: var(--color-muted); }
+.ds-feed-detail-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(170px, 1fr)); gap: 8px; }
+.ds-feed-detail-word { background: #fff; border: 1.5px solid var(--color-border); border-radius: 10px; padding: 9px 12px; min-width: 0; }
+.ds-feed-detail-word .en { display: block; font-family: var(--font-display); font-weight: 700; font-size: 14px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.ds-feed-detail-word .ja { display: block; margin-top: 1px; font-size: 12px; color: var(--color-secondary-text); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.ds-feed-detail-none { margin: 0; font-size: 12.5px; font-weight: 600; color: var(--color-muted); }
 
 /* avatar */
 .ds-feed-avatar {
@@ -1091,10 +1100,10 @@ a.ds-feed-avatar:hover { transform: translateY(-1px); }
 
 .ds-feed-loadrow { display: flex; justify-content: center; padding: 18px 0; color: var(--color-muted); }
 
-/* skeleton */
+/* skeleton（フルブリードのリスト行と同じ見た目） */
 .ds-feed-skel {
-  display: flex; gap: 14px; padding: 16px 18px;
-  background: #fff; border: 1.5px solid var(--color-border); border-radius: var(--solid-radius);
+  display: flex; gap: 14px; padding: 16px 34px;
+  background: #fff; border-bottom: 1px solid var(--color-border);
 }
 .ds-feed-skel .av { width: 44px; height: 44px; border-radius: 12px; flex-shrink: 0; }
 .ds-feed-skel .body { flex: 1; display: flex; flex-direction: column; gap: 10px; padding-top: 4px; }

--- a/src/app/friends/page.tsx
+++ b/src/app/friends/page.tsx
@@ -53,7 +53,7 @@ export default function FriendsPage() {
   const [timelineLoading, setTimelineLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [actionLoading, setActionLoading] = useState<string | null>(null);
-  const [expandedSessions, setExpandedSessions] = useState<Set<string>>(new Set());
+  const [activeSession, setActiveSession] = useState<FriendTimelineSession | null>(null);
 
   const hasRequests = home.incoming.length > 0 || home.outgoing.length > 0;
 
@@ -153,27 +153,17 @@ export default function FriendsPage() {
     method: 'DELETE',
   }));
 
-  const toggleSession = (sessionId: string) => {
-    setExpandedSessions((current) => {
-      const next = new Set(current);
-      if (next.has(sessionId)) next.delete(sessionId);
-      else next.add(sessionId);
-      return next;
-    });
-  };
-
   const renderFeedEntries = () => (
     <>
       {feedEntries.length > 0 && (
-        <div className="divide-y divide-[var(--color-border)]">
+        <div className="divide-y divide-[var(--color-border)] border-y border-[var(--color-border)]">
           {feedEntries.map((entry) => (
             entry.kind === 'quiz'
               ? (
                 <TimelineItem
                   key={`quiz-${entry.session.id}`}
                   session={entry.session}
-                  expanded={expandedSessions.has(entry.session.id)}
-                  onToggle={() => toggleSession(entry.session.id)}
+                  onOpen={() => setActiveSession(entry.session)}
                 />
               )
               : <GroupEventItem key={`group-${entry.event.id}`} event={entry.event} />
@@ -256,8 +246,9 @@ export default function FriendsPage() {
           entries={feedEntries}
           home={home}
           actionLoading={actionLoading}
-          expandedSessions={expandedSessions}
-          onToggleSession={toggleSession}
+          activeSession={activeSession}
+          onOpenSession={setActiveSession}
+          onCloseSession={() => setActiveSession(null)}
           onRespondRequest={respondRequest}
           onRemoveFriend={removeFriend}
           onRefresh={() => void refreshAll()}
@@ -275,6 +266,10 @@ export default function FriendsPage() {
         </div>
         {renderContent()}
       </div>
+
+      {activeSession && (
+        <SessionDetailModal session={activeSession} onClose={() => setActiveSession(null)} />
+      )}
     </>
   );
 }
@@ -365,27 +360,25 @@ function RequestsSection({
 
 function TimelineItem({
   session,
-  expanded,
-  onToggle,
+  onOpen,
 }: {
   session: FriendTimelineSession;
-  expanded: boolean;
-  onToggle: () => void;
+  onOpen: () => void;
 }) {
   const profileHref = `/profile/${encodeURIComponent(session.profile.accountId)}`;
   return (
     <article className="transition-colors hover:bg-[var(--color-surface-secondary)]">
-      {/* 行全体をタップで学習内容を開閉する（展開ボタンは置かない） */}
+      {/* 行全体をタップで学習内容モーダルを開く（下方向への展開はしない） */}
       <div
         role="button"
         tabIndex={0}
-        aria-expanded={expanded}
-        aria-label={expanded ? '学習内容を閉じる' : '学習内容を開く'}
-        onClick={onToggle}
+        aria-haspopup="dialog"
+        aria-label="学習内容を見る"
+        onClick={onOpen}
         onKeyDown={(event) => {
           if (event.key === 'Enter' || event.key === ' ') {
             event.preventDefault();
-            onToggle();
+            onOpen();
           }
         }}
         className="flex cursor-pointer items-start gap-3.5 px-[18px] py-4"
@@ -415,32 +408,111 @@ function TimelineItem({
             <span>{formatSessionTime(session.lastAnsweredAt)}</span>
           </div>
           <div className="mt-2 flex flex-wrap gap-2">
-            <MetricChip icon="quiz" label={`${session.answerCount}問`} variant="quiz" />
-            <MetricChip icon="check_circle" label={`${session.masteredCount}語 習得`} variant="mastered" />
+            <MetricChip icon="quiz" value={session.answerCount} unit="問" variant="quiz" />
+            <MetricChip icon="check_circle" value={session.masteredCount} unit="語 習得" variant="mastered" />
+          </div>
+        </div>
+        <Icon name="chevron_right" size={20} className="mt-1 shrink-0 text-[var(--color-muted)]" />
+      </div>
+    </article>
+  );
+}
+
+/** 学習内容の詳細（モバイル）。単語詳細と同じく画面中央に浮き上がるモーダルで表示する。 */
+function SessionDetailModal({
+  session,
+  onClose,
+}: {
+  session: FriendTimelineSession;
+  onClose: () => void;
+}) {
+  const profileHref = `/profile/${encodeURIComponent(session.profile.accountId)}`;
+  return (
+    <div className="fixed inset-0 z-[80] lg:hidden" style={{ fontFamily: 'var(--font-body)' }}>
+      <div
+        className="animate-fade-in absolute inset-0"
+        style={{ background: 'rgba(26,26,26,0.45)', backdropFilter: 'blur(3px)' }}
+        onClick={onClose}
+      />
+      <div className="absolute inset-0 flex items-center justify-center px-4 py-10" onClick={onClose}>
+        <div
+          role="dialog"
+          aria-modal="true"
+          aria-label="学習の詳細"
+          className="animate-fade-in-up w-full overflow-y-auto overscroll-contain"
+          onClick={(event) => event.stopPropagation()}
+          style={{
+            maxWidth: 480,
+            maxHeight: '80dvh',
+            background: '#faf7f1',
+            border: '2px solid var(--solid-ink)',
+            borderRadius: 20,
+          }}
+        >
+          <div className="sticky top-0 z-[2] flex items-center justify-between border-b border-[var(--color-border)] bg-[#faf7f1] px-5 py-3.5">
+            <span className="font-mono text-[10px] font-bold uppercase tracking-[0.08em] text-[var(--color-muted)]">
+              学習の詳細
+            </span>
+            <button
+              type="button"
+              onClick={onClose}
+              aria-label="閉じる"
+              className="inline-flex h-8 w-8 items-center justify-center rounded-[9px] border border-[var(--color-border)] bg-white text-[var(--color-muted)]"
+            >
+              <Icon name="close" size={16} />
+            </button>
+          </div>
+          <div className="px-5 py-4">
+            <div className="flex items-start gap-3.5">
+              <Link
+                href={profileHref}
+                aria-label={`${displayName(session.profile)}のプロフィール`}
+                className="shrink-0"
+              >
+                <Avatar profile={session.profile} />
+              </Link>
+              <div className="min-w-0 flex-1">
+                <p className="text-[15px] font-bold leading-snug text-[var(--solid-ink)]">
+                  <Link href={profileHref} className="font-display font-extrabold hover:underline">
+                    {displayName(session.profile)}
+                  </Link>
+                  さんが{session.answerCount}問クイズを解きました！
+                </p>
+                <div className="mt-1 flex flex-wrap items-center gap-x-2 gap-y-0.5 text-[12px] font-bold text-[var(--color-muted)]">
+                  <span className="font-mono text-[11px]">@{session.profile.accountId}</span>
+                  <span className="text-[var(--color-border)]">·</span>
+                  <span>{formatSessionTime(session.lastAnsweredAt)}</span>
+                </div>
+                <div className="mt-2 flex flex-wrap gap-2">
+                  <MetricChip icon="quiz" value={session.answerCount} unit="問" variant="quiz" />
+                  <MetricChip icon="check_circle" value={session.masteredCount} unit="語 習得" variant="mastered" />
+                </div>
+              </div>
+            </div>
+            <div className="mt-4 border-t border-[var(--color-border)] pt-4">
+              <div className="flex items-center gap-1.5 font-mono text-[10px] font-bold uppercase tracking-[0.08em] text-[var(--color-muted)]">
+                <Icon name="school" size={13} />
+                習得した単語
+              </div>
+              {session.words.length > 0 ? (
+                <div className="mt-2.5 flex flex-col gap-2">
+                  {session.words.map((word) => (
+                    <div key={word.id} className="rounded-[12px] border border-[#bbf7d0] bg-[var(--color-accent-subtle)] px-4 py-3">
+                      <div className="font-display text-[15px] font-extrabold text-[var(--solid-ink)]">{word.english}</div>
+                      <div className="mt-0.5 text-[13px] font-bold text-[var(--color-muted)]">{word.japanese}</div>
+                    </div>
+                  ))}
+                </div>
+              ) : (
+                <div className="py-4 text-center text-[13px] font-bold text-[var(--color-muted)]">
+                  習得済みに変わった単語はありません
+                </div>
+              )}
+            </div>
           </div>
         </div>
       </div>
-      {expanded && (
-        <div className="border-t border-[var(--color-border)] bg-[var(--color-surface-secondary)] px-[18px] py-4">
-          <div className="pl-[52px]">
-            {session.words.length > 0 ? (
-              <div className="flex flex-col gap-2">
-                {session.words.map((word) => (
-                  <div key={word.id} className="rounded-[12px] border border-[#bbf7d0] bg-[var(--color-accent-subtle)] px-4 py-3">
-                    <div className="font-display text-[15px] font-extrabold text-[var(--solid-ink)]">{word.english}</div>
-                    <div className="mt-0.5 text-[13px] font-bold text-[var(--color-muted)]">{word.japanese}</div>
-                  </div>
-                ))}
-              </div>
-            ) : (
-              <div className="px-4 py-4 text-center text-[13px] font-bold text-[var(--color-muted)]">
-                習得済みに変わった単語はありません
-              </div>
-            )}
-          </div>
-        </div>
-      )}
-    </article>
+    </div>
   );
 }
 
@@ -538,24 +610,27 @@ function StatusChip({ label }: { label: string }) {
   );
 }
 
+/** 解いた数・習得数のチップ。ソリッドスタイル（インク/アクセントの1.5px枠 + 角丸7px）で統一する。 */
 function MetricChip({
   icon,
-  label,
-  variant = 'default',
+  value,
+  unit,
+  variant,
 }: {
   icon: string;
-  label: string;
-  variant?: 'quiz' | 'mastered' | 'default';
+  value: number;
+  unit: string;
+  variant: 'quiz' | 'mastered';
 }) {
   const styles = {
-    quiz: 'border-[#bbf7d0] bg-[var(--color-accent-light)] text-[var(--color-accent)]',
-    mastered: 'border-[#fde68a] bg-[#fef3c7] text-[#92400e]',
-    default: 'border-[var(--color-border)] bg-[var(--color-surface-secondary)] text-[var(--solid-ink)]',
+    quiz: 'border-[var(--color-accent-ink)] bg-[var(--color-accent-light)] text-[var(--color-accent-ink)]',
+    mastered: 'border-[var(--solid-ink)] bg-white text-[var(--solid-ink)]',
   };
   return (
-    <span className={`inline-flex items-center gap-1 rounded-full border px-2.5 py-1 text-[11px] font-extrabold ${styles[variant]}`}>
+    <span className={`inline-flex items-center gap-1 rounded-[7px] border-[1.5px] px-2 py-[3px] ${styles[variant]}`}>
       <Icon name={icon} size={13} />
-      {label}
+      <span className="font-display text-[13px] font-extrabold leading-none">{value}</span>
+      <span className="text-[10.5px] font-bold leading-none">{unit}</span>
     </span>
   );
 }

--- a/src/components/desktop/DesktopFeed.tsx
+++ b/src/components/desktop/DesktopFeed.tsx
@@ -2,8 +2,10 @@
 
 /**
  * デスクトップ版フィード（/friends）。
- * 学習タイムラインを1枚のリストに連結して表示し、フレンド申請があるときだけ
- * 右カラムに申請パネルを出す。スタイルは desktop.css の .ds-feed-* を参照。
+ * 学習タイムラインを本文幅いっぱいのフルブリードなリストで表示し、
+ * フレンド申請があるときだけ右カラムに申請パネルを出す。
+ * 行をクリックすると学習内容が単語詳細と同じモーダルで浮き上がる。
+ * スタイルは desktop.css の .ds-feed-* を参照。
  */
 
 import Link from 'next/link';
@@ -31,8 +33,9 @@ type DesktopFeedProps = {
   entries: FeedEntry[];
   home: FriendsHomePayload;
   actionLoading: string | null;
-  expandedSessions: Set<string>;
-  onToggleSession: (sessionId: string) => void;
+  activeSession: FriendTimelineSession | null;
+  onOpenSession: (session: FriendTimelineSession) => void;
+  onCloseSession: () => void;
   onRespondRequest: (friendshipId: string, action: 'accept' | 'decline') => void;
   onRemoveFriend: (friendshipId: string) => void;
   onRefresh: () => void;
@@ -46,8 +49,9 @@ export function DesktopFeed({
   entries,
   home,
   actionLoading,
-  expandedSessions,
-  onToggleSession,
+  activeSession,
+  onOpenSession,
+  onCloseSession,
   onRespondRequest,
   onRemoveFriend,
   onRefresh,
@@ -61,7 +65,7 @@ export function DesktopFeed({
           </DesktopButton>
         )}
       </DesktopTopbar>
-      <div className="ds-scroll">
+      <div className="ds-scroll flush">
         <div className="ds-feed-wrap">
           {loading ? (
             <FeedSkeleton />
@@ -84,8 +88,7 @@ export function DesktopFeed({
                           <QuizEntryCard
                             key={`quiz-${entry.session.id}`}
                             session={entry.session}
-                            expanded={expandedSessions.has(entry.session.id)}
-                            onToggle={() => onToggleSession(entry.session.id)}
+                            onOpen={() => onOpenSession(entry.session)}
                           />
                         ) : (
                           <GroupEntryCard key={`group-${entry.event.id}`} event={entry.event} />
@@ -117,6 +120,10 @@ export function DesktopFeed({
           )}
         </div>
       </div>
+
+      {activeSession && (
+        <SessionDetailModal session={activeSession} onClose={onCloseSession} />
+      )}
     </>
   );
 }
@@ -125,28 +132,26 @@ export function DesktopFeed({
 
 function QuizEntryCard({
   session,
-  expanded,
-  onToggle,
+  onOpen,
 }: {
   session: FriendTimelineSession;
-  expanded: boolean;
-  onToggle: () => void;
+  onOpen: () => void;
 }) {
   const profileHref = `/profile/${encodeURIComponent(session.profile.accountId)}`;
   return (
     <article className="ds-feed-card fade-in">
-      {/* 行全体をクリックで学習内容を開閉する（展開ボタンは置かない） */}
+      {/* 行全体をクリックで学習内容モーダルを開く（下方向への展開はしない） */}
       <div
         className="fc-row fc-toggle"
         role="button"
         tabIndex={0}
-        aria-expanded={expanded}
-        aria-label={expanded ? '学習内容を閉じる' : '学習内容を開く'}
-        onClick={onToggle}
+        aria-haspopup="dialog"
+        aria-label="学習内容を見る"
+        onClick={onOpen}
         onKeyDown={(event) => {
           if (event.key === 'Enter' || event.key === ' ') {
             event.preventDefault();
-            onToggle();
+            onOpen();
           }
         }}
       >
@@ -174,36 +179,104 @@ function QuizEntryCard({
           <div className="fc-chips">
             <span className="ds-feed-chip quiz">
               <Icon name="quiz" size={14} />
-              {session.answerCount}問
+              <span className="n">{session.answerCount}</span>問
             </span>
             <span className="ds-feed-chip mastered">
               <Icon name="check_circle" size={14} />
-              {session.masteredCount}語 習得
+              <span className="n">{session.masteredCount}</span>語 習得
             </span>
           </div>
         </div>
+        <Icon name="chevron_right" size={20} className="fc-chev" />
       </div>
-      {expanded && (
-        <div className="fc-words">
-          <div className="lab">
-            <Icon name="school" size={13} />
-            習得した単語
-          </div>
-          {session.words.length > 0 ? (
-            <div className="fc-words-grid">
-              {session.words.map((word) => (
-                <div key={word.id} className="fc-word">
-                  <span className="en">{word.english}</span>
-                  <span className="ja">{word.japanese}</span>
-                </div>
-              ))}
-            </div>
-          ) : (
-            <p className="none">習得済みに変わった単語はありません</p>
-          )}
-        </div>
-      )}
     </article>
+  );
+}
+
+/** 学習内容の詳細。単語詳細（ds-modal）と同じく浮き上がるモーダルで表示する。 */
+function SessionDetailModal({
+  session,
+  onClose,
+}: {
+  session: FriendTimelineSession;
+  onClose: () => void;
+}) {
+  const profileHref = `/profile/${encodeURIComponent(session.profile.accountId)}`;
+  return (
+    <div className="ds-overlay" onClick={onClose}>
+      <div
+        className="ds-modal"
+        role="dialog"
+        aria-modal="true"
+        aria-label="学習の詳細"
+        onClick={(event) => event.stopPropagation()}
+      >
+        <div className="ds-modal-head">
+          <div className="lab">学習の詳細</div>
+          <div className="nav">
+            <button type="button" className="ds-iconbtn" onClick={onClose} aria-label="閉じる">
+              <Icon name="close" />
+            </button>
+          </div>
+        </div>
+        <div className="ds-modal-body">
+          <div className="ds-feed-detail-head">
+            <Link
+              href={profileHref}
+              className="ds-feed-avatar md"
+              style={{ backgroundColor: avatarColor(session.profile.accountId) }}
+              aria-label={`${displayName(session.profile)}のプロフィール`}
+            >
+              {(session.profile.username || session.profile.accountId || '?').charAt(0).toUpperCase()}
+            </Link>
+            <div style={{ flex: 1, minWidth: 0 }}>
+              <p style={{ margin: 0, fontSize: 14.5, fontWeight: 600, lineHeight: 1.55, color: 'var(--color-ink)' }}>
+                <Link
+                  href={profileHref}
+                  style={{ color: 'inherit', fontFamily: 'var(--font-display)', fontWeight: 800, textDecoration: 'none' }}
+                >
+                  {displayName(session.profile)}
+                </Link>
+                さんが{session.answerCount}問クイズを解きました
+              </p>
+              <div style={{ display: 'flex', alignItems: 'center', gap: 7, marginTop: 3, fontSize: 12, fontWeight: 600, color: 'var(--color-muted)' }}>
+                <span style={{ fontFamily: 'var(--font-mono)', fontSize: 11 }}>@{session.profile.accountId}</span>
+                <span aria-hidden="true">·</span>
+                <span>{formatRelativeTime(session.lastAnsweredAt)}</span>
+              </div>
+              <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8, marginTop: 11 }}>
+                <span className="ds-feed-chip quiz">
+                  <Icon name="quiz" size={14} />
+                  {session.answerCount}問
+                </span>
+                <span className="ds-feed-chip mastered">
+                  <Icon name="check_circle" size={14} />
+                  {session.masteredCount}語 習得
+                </span>
+              </div>
+            </div>
+          </div>
+          <div>
+            <div className="ds-feed-detail-lab">
+              <Icon name="school" size={13} />
+              習得した単語
+            </div>
+            {session.words.length > 0 ? (
+              <div className="ds-feed-detail-grid">
+                {session.words.map((word) => (
+                  <div key={word.id} className="ds-feed-detail-word">
+                    <span className="en">{word.english}</span>
+                    <span className="ja">{word.japanese}</span>
+                  </div>
+                ))}
+              </div>
+            ) : (
+              <p className="ds-feed-detail-none">習得済みに変わった単語はありません</p>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
   );
 }
 


### PR DESCRIPTION
## 概要

フィードページ（/friends）のレイアウトを参考画像（Studyplus風タイムライン）に合わせて刷新しました。

### 1. 本文幅いっぱいのフルブリード表示
- デスクトップ版の `max-width: 1040px` 中央寄せとカード枠（インク枠 + オフセット影）を廃止し、罫線区切りのフルブリードなリストに変更
- `.ds-scroll.flush`（padding なしのスクロール領域）を追加し、フィードページで使用
- 行の左右パディングをトップバーと揃う 34px に調整。スケルトン・エラー表示・申請パネルもフルブリード前提の余白に追随
- 空状態・ログイン誘導カードはリスト外なので従来のカード表示を維持
- モバイル版はリストに上下罫線を追加

### 2. タップ時の挙動を「下に展開」→「浮き上がるモーダル」に変更
- クイズエントリ行のタップで下方向にアコーディオン展開する仕様を廃止
- 単語詳細と同じ浮き上がり表示に統一
  - デスクトップ: `ds-overlay` / `ds-modal`（既存の dsModalIn アニメーション）
  - モバイル: 単語詳細モーダル（`WordDetailView` variant="modal"）と同じ中央フロート様式 + `animate-fade-in-up`
- モーダル内にユーザー情報・チップ・習得した単語一覧を表示
- `expandedSessions`（Set）ベースの開閉状態を `activeSession` 単一状態に置き換え

### 3. 解いた数・習得数チップを MERKEN デザインシステムに統一
- アンバー（#fef3c7 / #fbbf24）のピル形状を廃止
- ソリッドスタイル（1.5px のインク/アクセント枠 + 角丸 7px + `font-display` extrabold の数字）に変更（モバイル・デスクトップ共通）

## 変更ファイル
- `src/app/friends/page.tsx` — モバイル版タイムライン行 + 浮き上がりモーダル + チップ刷新
- `src/components/desktop/DesktopFeed.tsx` — デスクトップ版フルブリードリスト + ds-modal 詳細表示
- `src/app/desktop.css` — `.ds-scroll.flush` 追加、フィード関連スタイルのフルブリード化、チップ/モーダル用スタイル

## 確認
- `npm run build` ✅
- `npm run lint` ✅（エラーは既存の `gcp-budget-guard/` のみ、変更ファイルは警告なし）
- `npm test` 975/977 pass（失敗2件は signup-verify / words/create の既存失敗で、変更前のコードでも同様に失敗することを確認済み）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011ricfYW8MtcnKC2JtcyKUb

---
_Generated by [Claude Code](https://claude.ai/code/session_011ricfYW8MtcnKC2JtcyKUb)_