### PR TITLE
Support multiple Japanese translations per word with deduplication

### DIFF
--- a/src/app/api/words/enrich-manual/route.ts
+++ b/src/app/api/words/enrich-manual/route.ts
@@ -5,9 +5,11 @@ import { createRouteHandlerClient } from '@/lib/supabase/route-client';
 import { getSupabaseAdmin } from '@/lib/supabase/admin';
 import {
   buildManualEnrichPrompt,
+  dedupeJapaneseTranslations,
   fetchManualEnrichmentFromMaster,
   type ManualMasterEnrichment,
 } from '@/lib/words/manual-enrichment';
+import { upsertAiTranslationSenses } from '@/lib/lexicon/senses';
 import { saveExamplesToLexicon } from '@/lib/ai/generate-example-sentences';
 import { saveQuizContentToLexicon } from '@/lib/lexicon/quiz-content-lexicon';
 import { AI_CONFIG, getAPIKeys } from '@/lib/ai/config';
@@ -25,6 +27,9 @@ import type { WordMorphology } from '../../../../../shared/types';
  * POST /api/words/enrich-manual
  *
  * 手動単語追加時に、未入力の補助フィールドをAIで素早く補完する。
+ * 日本語訳はマスター(lexicon senses)とAIをマージした全訳リスト
+ * (`enriched.translations`) として返し、クライアントが訳ごとに
+ * word_translations レコードを作れるようにする。
  * body パース → AI 呼び出しを即座に開始し、認証チェックと並列実行する。
  * 認証失敗時は AI 結果を破棄して 401 を返す。
  *
@@ -48,8 +53,15 @@ const partOfSpeechTagsSchema = z.preprocess((value) => {
   return [];
 }, z.array(z.string()).default([]));
 
+// AIは訳を配列で返す想定だが、単一文字列で返しても受け付ける
+const japaneseListSchema = z.preprocess((value) => {
+  if (typeof value === 'string') return value ? [value] : [];
+  if (Array.isArray(value)) return value.filter((item) => typeof item === 'string');
+  return [];
+}, z.array(z.string()).default([]));
+
 const aiResponseSchema = z.object({
-  japanese: z.string().optional().default(''),
+  japanese: japaneseListSchema,
   pronunciation: z.string().optional().default(''),
   partOfSpeechTags: partOfSpeechTagsSchema,
   exampleSentence: z.string().optional().default(''),
@@ -57,7 +69,7 @@ const aiResponseSchema = z.object({
 });
 
 const SYSTEM_PROMPT = `英単語の補助情報をJSON形式で返せ。
-japanese: 単語帳向けの簡潔な日本語訳(訳語のみ・説明不要)
+japanese: 単語帳向けの簡潔な日本語訳の配列。意味の異なる主要な訳をすべて挙げる(1〜5個・頻出順・訳語のみ・説明不要)。多義語は必ず複数返す。例: ["走る","経営する","立候補する"]
 pronunciation: IPA発音記号を"/.../"形式で返す
 partOfSpeechTags: [noun/verb/adjective/adverb/idiom/phrasal_verb/other]から1つ
 exampleSentence: 10〜15語の実用的な英文(中高レベル)
@@ -105,7 +117,8 @@ function getEnrichProvider() {
     provider: AI_CONFIG.defaults.gemini.provider,
     model: 'gemini-2.0-flash',
     temperature: 0.3,
-    maxOutputTokens: 256,
+    // 全訳(最大5訳) + 例文ペアが収まるだけの余裕を持たせる
+    maxOutputTokens: 512,
     responseFormat: 'json' as const,
   };
   // GOOGLE_AI_API_KEY があれば直接 Gemini API (Cloud Run バイパス)
@@ -146,6 +159,7 @@ export async function POST(request: NextRequest) {
         success: true,
         enriched: {
           japanese: filledJapanese,
+          translations: [],
           pronunciation: filledPronunciation,
           partOfSpeechTags: filledPosTags,
           exampleSentence: filledExample,
@@ -177,7 +191,9 @@ export async function POST(request: NextRequest) {
       master = null;
     }
 
-    const masterJapanese = needsJapanese ? (master?.japanese ?? '') : '';
+    const masterJapaneseList = needsJapanese
+      ? dedupeJapaneseTranslations(master?.japaneseTranslations ?? [])
+      : [];
     const masterPronunciation = needsPronunciation ? (master?.pronunciation ?? '') : '';
     const masterPosTags = needsPos
       ? normalizePartOfSpeechTags(master?.partOfSpeechTags ?? [])
@@ -185,7 +201,8 @@ export async function POST(request: NextRequest) {
     const masterExample = needsExample ? (master?.exampleSentence ?? '') : '';
     const masterExampleJa = needsExample ? (master?.exampleSentenceJa ?? '') : '';
 
-    const aiNeedsJapanese = needsJapanese && !masterJapanese;
+    // 全訳補完: マスターに訳が1つしか無い場合もAIに全訳を出させてマージする
+    const aiNeedsJapanese = needsJapanese && masterJapaneseList.length < 2;
     const aiNeedsPronunciation = needsPronunciation && !masterPronunciation;
     const aiNeedsPos = needsPos && masterPosTags.length === 0;
     const aiNeedsExample = needsExample && !(masterExample && masterExampleJa);
@@ -231,7 +248,7 @@ export async function POST(request: NextRequest) {
     //    マスターで全フィールドが埋まった場合はAIコール自体が無い。
     const aiStart = Date.now();
     let parsedAi: z.infer<typeof aiResponseSchema> = {
-      japanese: '',
+      japanese: [],
       pronunciation: '',
       partOfSpeechTags: [],
       exampleSentence: '',
@@ -279,8 +296,12 @@ export async function POST(request: NextRequest) {
     // 6. ユーザ入力 > マスター > AI の優先順で埋める
     const generatedFields: string[] = [];
 
-    const aiJapanese = (parsedAi.japanese || '').trim();
-    const finalJapanese = needsJapanese ? (masterJapanese || aiJapanese) : filledJapanese;
+    // マスター訳を先頭に、AI訳をマージして全訳リストを作る（重複除去済み）
+    const aiJapaneseList = dedupeJapaneseTranslations(parsedAi.japanese);
+    const finalJapaneseList = needsJapanese
+      ? dedupeJapaneseTranslations([...masterJapaneseList, ...aiJapaneseList])
+      : [];
+    const finalJapanese = needsJapanese ? (finalJapaneseList[0] ?? '') : filledJapanese;
     if (needsJapanese && finalJapanese) generatedFields.push('japanese');
 
     const aiPronunciation = (parsedAi.pronunciation || '').trim();
@@ -300,7 +321,7 @@ export async function POST(request: NextRequest) {
     const finalExampleJa = filledExampleJa || masterExampleJa || aiExampleJa;
     if (needsExample && finalExample && finalExampleJa) generatedFields.push('exampleSentence');
 
-    // 6b. AI生成した発音・例文をマスターへ書き戻す（fill-if-empty・ベスト
+    // 6b. AI生成した発音・例文・訳をマスターへ書き戻す（fill-if-empty・ベスト
     //     エフォート）。次に同じ単語を追加するユーザーはAIコール不要になる。
     if (master?.entryId) {
       const entryId = master.entryId;
@@ -308,7 +329,11 @@ export async function POST(request: NextRequest) {
       const writeBackExample = aiNeedsExample && aiExample && aiExampleJa
         ? { exampleSentence: aiExample, exampleSentenceJa: aiExampleJa }
         : null;
-      if (writeBackPronunciation || writeBackExample) {
+      // AIが出した訳は insert-only でsenseに追加（既存senseは上書きされない）
+      const writeBackTranslations = aiNeedsJapanese && aiJapaneseList.length > 0
+        ? aiJapaneseList
+        : null;
+      if (writeBackPronunciation || writeBackExample || writeBackTranslations) {
         after(async () => {
           try {
             if (writeBackPronunciation) {
@@ -320,6 +345,17 @@ export async function POST(request: NextRequest) {
               await saveExamplesToLexicon([
                 { lexiconEntryId: entryId, ...writeBackExample },
               ]);
+            }
+            if (writeBackTranslations) {
+              await upsertAiTranslationSenses(
+                getSupabaseAdmin(),
+                entryId,
+                writeBackTranslations.map((japanese, index) => ({
+                  japanese,
+                  meaningSummary: null,
+                  isPrimary: index === 0,
+                })),
+              );
             }
           } catch (writeBackError) {
             console.error('[enrich-manual] Lexicon write-back failed (non-critical):', writeBackError);
@@ -351,6 +387,7 @@ export async function POST(request: NextRequest) {
       totalMs,
       aiWaitMs,
       generatedFields,
+      translationCount: finalJapaneseList.length,
       morphology: Boolean(morphology),
       morphologyCharged: Boolean(coinInfo),
     });
@@ -359,6 +396,7 @@ export async function POST(request: NextRequest) {
       success: true,
       enriched: {
         japanese: finalJapanese,
+        translations: finalJapaneseList,
         pronunciation: finalPronunciation,
         partOfSpeechTags: finalPosTags,
         exampleSentence: finalExample,

--- a/src/app/project/[id]/page.tsx
+++ b/src/app/project/[id]/page.tsx
@@ -42,7 +42,7 @@ import {
   type ProjectWordActivenessFilter,
   type ProjectWordSortOrder,
 } from '@/lib/project/project-page-selectors';
-import type { Project, ProjectShareScope, SubscriptionStatus, VocabularyType, Word, WordStatus } from '@/types';
+import type { Project, ProjectShareScope, SubscriptionStatus, VocabularyType, Word, WordStatus, WordTranslation } from '@/types';
 
 const THUMBS = ['#137FEC', '#664DB3', '#228B22', '#2E66BF', '#D97340', '#3373B3', '#CC4D59', '#3DA1B8'];
 
@@ -1068,6 +1068,7 @@ export default function ProjectPage() {
     setManualWordSavingMessage('情報を生成中...');
 
     let japanese = japaneseInput;
+    let enrichedTranslationTexts: string[] = [];
     let enrichedPronunciation = '';
     let enrichedPartOfSpeechTags: string[] = userPos ? [userPos] : [];
     let enrichedExampleSentence = userExample;
@@ -1091,6 +1092,7 @@ export default function ProjectPage() {
           success?: boolean;
           enriched?: {
             japanese?: string;
+            translations?: string[];
             pronunciation?: string;
             partOfSpeechTags?: string[];
             exampleSentence?: string;
@@ -1099,8 +1101,12 @@ export default function ProjectPage() {
           morphology?: Word['morphology'];
         };
         if (data.success && data.enriched) {
-          if (!japanese && data.enriched.japanese) {
-            japanese = data.enriched.japanese.trim();
+          if (!japanese) {
+            // 全訳補完: 訳ごとに word_translations レコードを作るため配列で受ける
+            enrichedTranslationTexts = (data.enriched.translations ?? [])
+              .map((text) => text.trim())
+              .filter(Boolean);
+            japanese = enrichedTranslationTexts[0] ?? data.enriched.japanese?.trim() ?? '';
           }
           enrichedPronunciation = data.enriched.pronunciation ?? '';
           if (data.enriched.partOfSpeechTags && data.enriched.partOfSpeechTags.length > 0) {
@@ -1126,11 +1132,24 @@ export default function ProjectPage() {
       return;
     }
 
+    // 補完された全訳を訳ごとの WordTranslation レコードに展開する
+    const enrichedTranslations: WordTranslation[] | undefined = enrichedTranslationTexts.length > 0
+      ? enrichedTranslationTexts.map((text, index) => ({
+          translationJa: text,
+          normalizedTranslationJa: text,
+          source: 'ai' as const,
+          meaningRank: index + 1,
+          position: index,
+          isPrimary: index === 0,
+        }))
+      : undefined;
+
     const optimisticWord: Word = {
       id: crypto.randomUUID(),
       projectId,
       english,
       japanese,
+      ...(enrichedTranslations ? { translations: enrichedTranslations, japaneseSource: 'ai' as const } : {}),
       distractors: ['選択肢1', '選択肢2', '選択肢3'],
       pronunciation: enrichedPronunciation || undefined,
       partOfSpeechTags: enrichedPartOfSpeechTags.length > 0 ? enrichedPartOfSpeechTags : undefined,
@@ -1161,6 +1180,7 @@ export default function ProjectPage() {
           projectId,
           english,
           japanese,
+          ...(enrichedTranslations ? { translations: enrichedTranslations, japaneseSource: 'ai' as const } : {}),
           distractors: ['選択肢1', '選択肢2', '選択肢3'],
           ...(enrichedPronunciation ? { pronunciation: enrichedPronunciation } : {}),
           ...(enrichedPartOfSpeechTags.length > 0 ? { partOfSpeechTags: enrichedPartOfSpeechTags } : {}),

--- a/src/lib/words/manual-enrichment.test.ts
+++ b/src/lib/words/manual-enrichment.test.ts
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict';
 
 import {
   buildManualEnrichPrompt,
+  dedupeJapaneseTranslations,
   pickManualMasterEnrichment,
   type ManualEnrichmentMasterRow,
 } from '@/lib/words/manual-enrichment';
@@ -88,6 +89,42 @@ test('pickManualMasterEnrichment supplies a Japanese translation for empty manua
 
   assert.ok(result);
   assert.equal(result.japanese, '経営');
+});
+
+test('pickManualMasterEnrichment gathers all translations from entries and senses', () => {
+  const result = pickManualMasterEnrichment(
+    [
+      row({ id: 'entry-verb', pos: 'verb', translation_ja: '走る' }),
+      row({ id: 'entry-noun', pos: 'noun', translation_ja: '経営', example_sentence: null, example_sentence_ja: null }),
+    ],
+    '',
+    [
+      { lexicon_entry_id: 'entry-verb', translation_ja: '走る' },
+      { lexicon_entry_id: 'entry-verb', translation_ja: '経営する' },
+      { lexicon_entry_id: 'entry-noun', translation_ja: '連続' },
+    ],
+  );
+
+  assert.ok(result);
+  assert.equal(result.japanese, '走る');
+  // 第一訳 → 選ばれたエントリのsense → 他エントリのsense → 他エントリの訳
+  assert.deepEqual(result.japaneseTranslations, ['走る', '経営する', '連続', '経営']);
+});
+
+test('pickManualMasterEnrichment splits multi-meaning master translations into records', () => {
+  const result = pickManualMasterEnrichment([row({ translation_ja: '感覚;分別' })], '');
+
+  assert.ok(result);
+  assert.equal(result.japanese, '感覚;分別');
+  assert.deepEqual(result.japaneseTranslations, ['感覚', '分別']);
+});
+
+test('dedupeJapaneseTranslations removes duplicates, splits joined meanings, and caps the list', () => {
+  assert.deepEqual(
+    dedupeJapaneseTranslations(['走る', '走る', '経営する;立候補する', '']),
+    ['走る', '経営する', '立候補する'],
+  );
+  assert.deepEqual(dedupeJapaneseTranslations(['一', '二', '三'], 2), ['一', '二']);
 });
 
 test('buildManualEnrichPrompt lists only the fields the AI must generate', () => {

--- a/src/lib/words/manual-enrichment.ts
+++ b/src/lib/words/manual-enrichment.ts
@@ -8,6 +8,7 @@
 
 import type { SupabaseClient } from '@supabase/supabase-js';
 import { normalizeHeadword } from '../../../shared/lexicon';
+import { normalizeTranslationText, splitJapaneseTranslations } from '../../../shared/word-translations';
 
 export interface ManualEnrichmentMasterRow {
   id: string;
@@ -18,15 +19,52 @@ export interface ManualEnrichmentMasterRow {
   pronunciation: string | null;
 }
 
+export interface ManualEnrichmentSenseRow {
+  lexicon_entry_id: string;
+  translation_ja: string | null;
+}
+
+/** 手動追加の全訳補完で保持する訳語数の上限（単語帳の一覧性を守る）。 */
+export const MANUAL_ENRICH_MAX_TRANSLATIONS = 8;
+
 export interface ManualMasterEnrichment {
   /** 例文・発音の書き戻し先。マスターにエントリが無い場合は null。 */
   entryId: string | null;
-  /** 日本語訳が未入力のときの補完候補。マスターに無ければ空文字。 */
+  /** 日本語訳が未入力のときの補完候補（第一訳）。マスターに無ければ空文字。 */
   japanese: string;
+  /**
+   * マスターが持つ全訳（品詞違いエントリ + lexicon_senses、重複除去済み）。
+   * 先頭が第一訳。訳ごとに word_translations レコードを作るための材料。
+   */
+  japaneseTranslations: string[];
   pronunciation: string;
   partOfSpeechTags: string[];
   exampleSentence: string;
   exampleSentenceJa: string;
+}
+
+/**
+ * 訳語リストを正規化・重複除去し、上限件数に丸める。
+ * 「;」区切りや番号付きで複数訳が1文字列に入っている場合は分割する。
+ */
+export function dedupeJapaneseTranslations(
+  values: readonly string[],
+  max = MANUAL_ENRICH_MAX_TRANSLATIONS,
+): string[] {
+  const result: string[] = [];
+  const seen = new Set<string>();
+  for (const value of values) {
+    for (const text of splitJapaneseTranslations(value)) {
+      const normalized = normalizeTranslationText(text);
+      if (!normalized) continue;
+      const key = normalized.toLowerCase();
+      if (seen.has(key)) continue;
+      seen.add(key);
+      result.push(normalized);
+      if (result.length >= max) return result;
+    }
+  }
+  return result;
 }
 
 function normalizeText(value: unknown): string {
@@ -50,6 +88,7 @@ function fieldScore(row: ManualEnrichmentMasterRow): number {
 export function pickManualMasterEnrichment(
   rows: ManualEnrichmentMasterRow[],
   japaneseHint: string,
+  senseRows: ManualEnrichmentSenseRow[] = [],
 ): ManualMasterEnrichment | null {
   if (rows.length === 0) return null;
 
@@ -72,9 +111,21 @@ export function pickManualMasterEnrichment(
   const exampleSentenceJa = normalizeText(best.example_sentence_ja);
   const pos = normalizeText(best.pos);
 
+  // 全訳リスト: 第一訳 → 選ばれたエントリの他sense → 他エントリ（品詞違い）の訳。
+  // senseRows は呼び出し側で is_primary 優先の順に並んでいる想定。
+  const orderedSenses = [...senseRows].sort(
+    (a, b) => Number(b.lexicon_entry_id === best.id) - Number(a.lexicon_entry_id === best.id),
+  );
+  const japaneseTranslations = dedupeJapaneseTranslations([
+    japanese,
+    ...orderedSenses.map((sense) => normalizeText(sense.translation_ja)),
+    ...rows.map((row) => normalizeText(row.translation_ja)),
+  ]);
+
   return {
     entryId: best.id,
     japanese,
+    japaneseTranslations,
     pronunciation,
     partOfSpeechTags: pos ? [pos] : [],
     // 例文は英日ペアが揃っている場合のみ採用する
@@ -106,7 +157,28 @@ export async function fetchManualEnrichmentFromMaster(
       return null;
     }
 
-    return pickManualMasterEnrichment((data ?? []) as ManualEnrichmentMasterRow[], japaneseHint);
+    const rows = (data ?? []) as ManualEnrichmentMasterRow[];
+
+    // 全訳補完のため、エントリに紐づく全senseも参照する（ベストエフォート）。
+    // 失敗しても resolved_rows の primary 訳だけで続行する。
+    let senseRows: ManualEnrichmentSenseRow[] = [];
+    if (rows.length > 0) {
+      try {
+        const { data: senses, error: senseError } = await supabaseAdmin
+          .from('lexicon_senses')
+          .select('lexicon_entry_id, translation_ja, is_primary')
+          .in('lexicon_entry_id', rows.map((row) => row.id))
+          .order('is_primary', { ascending: false })
+          .order('created_at', { ascending: true });
+        if (!senseError) {
+          senseRows = (senses ?? []) as ManualEnrichmentSenseRow[];
+        }
+      } catch {
+        senseRows = [];
+      }
+    }
+
+    return pickManualMasterEnrichment(rows, japaneseHint, senseRows);
   } catch (lookupError) {
     console.warn('[manual-enrichment] Unexpected master lookup error, falling back to AI:', lookupError);
     return null;


### PR DESCRIPTION
## Summary

Extends the manual word enrichment flow to gather and deduplicate multiple Japanese translations from both the lexicon master and AI, enabling the creation of multiple `word_translations` records per word. Previously, only a single primary translation was stored; now the system collects all translations from related lexicon entries and senses, deduplicates them, and returns them as an array for the client to persist individually.

## Key Changes

- **New deduplication function** (`dedupeJapaneseTranslations`): Normalizes, splits multi-meaning translations (e.g., "感覚;分別" → ["感覚", "分別"]), removes duplicates (case-insensitive), and caps the list at `MANUAL_ENRICH_MAX_TRANSLATIONS` (8 by default)

- **Enhanced master enrichment** (`pickManualMasterEnrichment`):
  - Now accepts `senseRows` parameter to gather translations from all lexicon senses tied to candidate entries
  - Returns `japaneseTranslations: string[]` (ordered: primary → selected entry's senses → other entries' senses)
  - Fetches lexicon senses from database with `is_primary` ordering for proper prioritization

- **AI response schema update**:
  - Changed `japanese` field from single string to array of strings
  - Updated system prompt to request 1–5 translations per word, with multi-meaning words always returning multiple entries
  - Increased `maxOutputTokens` from 256 to 512 to accommodate full translation lists

- **Enrichment endpoint** (`/api/words/enrich-manual`):
  - Merges master and AI translation lists with deduplication
  - Returns `translations: string[]` in response for client to create individual `word_translations` records
  - Writes back AI-generated translations to lexicon as new senses (insert-only, non-destructive) via `upsertAiTranslationSenses`
  - Tracks `translationCount` in analytics

- **Client-side integration** (`project/[id]/page.tsx`):
  - Receives translation array from enrichment endpoint
  - Expands each translation into a `WordTranslation` record with proper ranking and `isPrimary` flag
  - Passes enriched translations to word creation payload

- **Test coverage**: Added tests for translation gathering, splitting, and deduplication logic

## Implementation Details

- Translations are ordered by priority: user input → master primary → master senses → AI → other entries
- Deduplication is case-insensitive but preserves original casing in output
- Master write-back is best-effort (non-blocking) to avoid delaying user response
- Lexicon sense fetching includes `is_primary` ordering to ensure primary translations appear first in the merged list

https://claude.ai/code/session_01YEXqssQeS1QRzznGGfR4mj