### PR TITLE
手動追加の語源解析を単語帳でも表示 + 手動追加の語源トグル + Vertex AI経路統一

### DIFF
--- a/src/app/api/words/enrich-manual/route.ts
+++ b/src/app/api/words/enrich-manual/route.ts
@@ -13,7 +13,7 @@ import { upsertAiTranslationSenses } from '@/lib/lexicon/senses';
 import { saveExamplesToLexicon } from '@/lib/ai/generate-example-sentences';
 import { saveQuizContentToLexicon } from '@/lib/lexicon/quiz-content-lexicon';
 import { AI_CONFIG, getAPIKeys } from '@/lib/ai/config';
-import { getProviderFromConfig, getProvider, isCloudRunConfigured } from '@/lib/ai/providers';
+import { getProviderFromConfig } from '@/lib/ai/providers';
 import { parseJsonResponse } from '@/lib/ai/utils/json';
 import { normalizePartOfSpeechTags } from '@/lib/ai/part-of-speech';
 import { resolveMorphologyForWords } from '@/lib/morphology/resolve';
@@ -36,6 +36,8 @@ import type { WordMorphology } from '../../../../../shared/types';
  * あわせて語源解析（morphology）もスキャン経路と同じ resolver で best-effort
  * 生成し、成功時のみ `morphology` としてレスポンスに含める。生成は補完 AI と
  * 並列で走り、失敗・タイムアウトしても手動追加は成功させる。
+ * `includeMorphology: false` を指定すると語源解析（とそのコイン消費）を丸ごと
+ * スキップする（手動追加モーダルのトグルから制御）。
  */
 
 const requestSchema = z.object({
@@ -45,6 +47,8 @@ const requestSchema = z.object({
   exampleSentenceJa: z.string().trim().max(500).optional(),
   pronunciation: z.string().trim().max(120).optional(),
   partOfSpeechTags: z.array(z.string().trim().min(1).max(32)).max(10).optional(),
+  // 語源解析のオン/オフ（省略時はオン=従来挙動）。オフ時は生成もコイン消費もしない。
+  includeMorphology: z.boolean().optional().default(true),
 }).strict();
 
 const partOfSpeechTagsSchema = z.preprocess((value) => {
@@ -121,10 +125,9 @@ function getEnrichProvider() {
     maxOutputTokens: 512,
     responseFormat: 'json' as const,
   };
-  // GOOGLE_AI_API_KEY があれば直接 Gemini API (Cloud Run バイパス)
-  const provider = geminiApiKey && isCloudRunConfigured()
-    ? getProvider('gemini', geminiApiKey)
-    : getProviderFromConfig(config, { gemini: geminiApiKey, openai: openaiApiKey });
+  // スキャンと同じ経路: CLOUD_RUN_URL 設定時は Cloud Run ゲートウェイ (Vertex AI)
+  // 経由、未設定時（ローカル開発）のみ直接 API を呼ぶ。
+  const provider = getProviderFromConfig(config, { gemini: geminiApiKey, openai: openaiApiKey });
   return { provider, config };
 }
 
@@ -171,11 +174,10 @@ export async function POST(request: NextRequest) {
 
     // 2a. 語源解析を先に開始 (best-effort, auth 完了を待たない)。
     // resolveManualMorphology は例外を投げず、タイムアウト時は undefined を返す。
-    const morphologyPromise = withTimeout(
-      resolveManualMorphology(englishTrimmed),
-      MORPHOLOGY_TIMEOUT_MS,
-      undefined,
-    );
+    // includeMorphology=false のときは解析自体を行わない（コイン消費もなし）。
+    const morphologyPromise: Promise<WordMorphology | undefined> = input.includeMorphology
+      ? withTimeout(resolveManualMorphology(englishTrimmed), MORPHOLOGY_TIMEOUT_MS, undefined)
+      : Promise.resolve(undefined);
 
     // 2b. lexiconマスターを優先参照（DBクエリ1回・ベストエフォート）。
     // マスターに値がある分はAI生成をスキップし、頻出語のAIコストを
@@ -388,6 +390,7 @@ export async function POST(request: NextRequest) {
       aiWaitMs,
       generatedFields,
       translationCount: finalJapaneseList.length,
+      includeMorphology: input.includeMorphology,
       morphology: Boolean(morphology),
       morphologyCharged: Boolean(coinInfo),
     });

--- a/src/app/api/words/morphology/route.ts
+++ b/src/app/api/words/morphology/route.ts
@@ -1,0 +1,62 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createRouteHandlerClient } from '@/lib/supabase/route-client';
+import { getSupabaseAdmin } from '@/lib/supabase/admin';
+import { getCachedMorphologyByHeadword } from '@/lib/morphology/lexicon';
+import { hasDisplayableMorphology } from '@/lib/morphology/format';
+import { normalizeHeadword } from '../../../../../shared/lexicon';
+
+/**
+ * GET /api/words/morphology?english=<word>
+ *
+ * lexicon 共有キャッシュに保存済みの語源解析を headword で引いて返す。
+ * リール配信（/api/reels）と同じキャッシュ読み取り専用の経路で、AI 生成も
+ * コイン消費も行わない。単語帳の単語詳細が `word.morphology` を持たない
+ * 単語（語源解析がレスポンスに間に合わなかった手動追加語・機能追加前の
+ * 既存語）を表示時にバックフィルするために使う。
+ */
+export async function GET(request: NextRequest) {
+  try {
+    const english = request.nextUrl.searchParams.get('english')?.trim() ?? '';
+    if (!english || english.length > 100) {
+      return NextResponse.json(
+        { success: false, error: '無効なリクエスト形式です' },
+        { status: 400 }
+      );
+    }
+
+    const authHeader = request.headers.get('authorization');
+    const bearerToken = authHeader?.startsWith('Bearer ') ? authHeader.slice(7) : null;
+    const supabase = await createRouteHandlerClient(request);
+    const { data: { user }, error: authError } = bearerToken
+      ? await supabase.auth.getUser(bearerToken)
+      : await supabase.auth.getUser();
+
+    if (authError || !user) {
+      return NextResponse.json(
+        { success: false, error: '認証が必要です。ログインしてください。' },
+        { status: 401 }
+      );
+    }
+
+    const headword = normalizeHeadword(english);
+    if (!headword) {
+      return NextResponse.json({ success: true, morphology: null });
+    }
+
+    const cached = await getCachedMorphologyByHeadword([headword], {
+      supabaseAdmin: getSupabaseAdmin(),
+    });
+    const morphology = cached.get(headword);
+
+    return NextResponse.json({
+      success: true,
+      morphology: hasDisplayableMorphology(morphology) ? morphology : null,
+    });
+  } catch (error) {
+    console.error('[words/morphology] Unexpected error:', error);
+    return NextResponse.json(
+      { success: false, error: '予期しないエラーが発生しました' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/flashcard/[projectId]/page.tsx
+++ b/src/app/flashcard/[projectId]/page.tsx
@@ -18,6 +18,7 @@ import { useTutorialFlow } from '@/hooks/use-tutorial-flow';
 import { getCachedProjectWords, getHasLoaded } from '@/lib/home-cache';
 import { formatPartOfSpeechLabels, getPartOfSpeechLabel } from '@/lib/part-of-speech-labels';
 import { hasDisplayableMorphology } from '@/lib/morphology/format';
+import { useMorphologyBackfill } from '@/hooks/use-morphology-backfill';
 import { triggerHaptic } from '@/lib/haptics';
 import type { Word, SubscriptionStatus } from '@/types';
 
@@ -244,6 +245,13 @@ export default function FlashcardPage() {
   }, [authLoading, projectId, favoritesOnly, collectionId, repository, user, backToProject, words.length]);
 
   const currentWord = words[currentIndex];
+  // word.morphology が無い単語は lexicon 共有キャッシュから表示時に補完し、
+  // words 状態にも反映して再表示時のフェッチを防ぐ。
+  const currentMorphology = useMorphologyBackfill(currentWord ?? null, {
+    onBackfilled: (updated) => {
+      setWords((prev) => prev.map((w) => (w.id === updated.id ? updated : w)));
+    },
+  });
 
   const handleNext = useCallback((withAnimation = false) => {
     if (isAnimating) return;
@@ -456,7 +464,7 @@ export default function FlashcardPage() {
                     )}
                   </div>
                 )}
-                {currentWord && hasDisplayableMorphology(currentWord.morphology) && (
+                {currentWord && hasDisplayableMorphology(currentMorphology) && (
                   <div
                     style={{
                       maxWidth: 460,
@@ -471,9 +479,9 @@ export default function FlashcardPage() {
                     <div className="mono" style={{ fontSize: 10, fontWeight: 700, letterSpacing: '0.08em', textTransform: 'uppercase', color: 'var(--color-accent-ink)', marginBottom: 8, display: 'flex', alignItems: 'center', gap: 5 }}>
                       <Icon name="account_tree" style={{ fontSize: 13 }} />語源
                     </div>
-                    <MorphologyFormulaChips morphology={currentWord.morphology} />
+                    <MorphologyFormulaChips morphology={currentMorphology} />
                     <div className="muted" style={{ fontSize: 13, lineHeight: 1.7, marginTop: 10, whiteSpace: 'pre-line' }}>
-                      {currentWord.morphology.explanation}
+                      {currentMorphology.explanation}
                     </div>
                   </div>
                 )}

--- a/src/app/project/[id]/page.tsx
+++ b/src/app/project/[id]/page.tsx
@@ -26,6 +26,10 @@ import { scheduleWordStatusWrite } from '@/lib/db/debounced-status-write';
 import { consumeManualAddIntent } from '@/lib/home/home-session-storage';
 import { invalidateHomeCache } from '@/lib/home-cache';
 import { markProjectVisited } from '@/lib/project-visit';
+import {
+  readManualMorphologyPref,
+  writeManualMorphologyPref,
+} from '@/lib/preferences/manual-morphology-pref';
 import { saveProjectSharedTags } from '@/lib/shared-projects/client';
 import type { StudyGroupSummary } from '@/lib/shared-projects/types';
 import {
@@ -190,6 +194,16 @@ export default function ProjectPage() {
   const [manualWordSaving, setManualWordSaving] = useState(false);
   const [manualWordSavingMessage, setManualWordSavingMessage] = useState<string | undefined>(undefined);
   const [manualWordAddedCount, setManualWordAddedCount] = useState(0);
+  // 手動追加時の語源解析トグル。オフにすると enrich-manual が語源解析
+  // （とそのコイン消費）をスキップする。選択は端末に記憶する。
+  const [manualWordMorphologyEnabled, setManualWordMorphologyEnabled] = useState(true);
+  useEffect(() => {
+    setManualWordMorphologyEnabled(readManualMorphologyPref());
+  }, []);
+  const handleManualWordMorphologyChange = useCallback((enabled: boolean) => {
+    setManualWordMorphologyEnabled(enabled);
+    writeManualMorphologyPref(enabled);
+  }, []);
   const [showWordLimitModal, setShowWordLimitModal] = useState(false);
 
   // Spotify-style suggestions for an empty wordbook: words picked from the
@@ -1081,6 +1095,7 @@ export default function ProjectPage() {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           english,
+          includeMorphology: manualWordMorphologyEnabled,
           ...(japaneseInput ? { japanese: japaneseInput } : {}),
           ...(userPos ? { partOfSpeechTags: [userPos] } : {}),
           ...(userExample ? { exampleSentence: userExample } : {}),
@@ -1609,10 +1624,12 @@ export default function ProjectPage() {
         japanese={manualWordJapanese}
         partOfSpeech={manualWordPartOfSpeech}
         exampleSentence={manualWordExampleSentence}
+        morphologyEnabled={manualWordMorphologyEnabled}
         onEnglishChange={setManualWordEnglish}
         onJapaneseChange={setManualWordJapanese}
         onPartOfSpeechChange={setManualWordPartOfSpeech}
         onExampleSentenceChange={setManualWordExampleSentence}
+        onMorphologyEnabledChange={handleManualWordMorphologyChange}
         onCancel={closeManualWordModal}
         onConfirm={handleSaveManualWord}
       />
@@ -1994,10 +2011,12 @@ function ManualWordModal({
   japanese,
   partOfSpeech,
   exampleSentence,
+  morphologyEnabled,
   onEnglishChange,
   onJapaneseChange,
   onPartOfSpeechChange,
   onExampleSentenceChange,
+  onMorphologyEnabledChange,
   onCancel,
   onConfirm,
 }: {
@@ -2009,10 +2028,12 @@ function ManualWordModal({
   japanese: string;
   partOfSpeech: string;
   exampleSentence: string;
+  morphologyEnabled: boolean;
   onEnglishChange: (value: string) => void;
   onJapaneseChange: (value: string) => void;
   onPartOfSpeechChange: (value: string) => void;
   onExampleSentenceChange: (value: string) => void;
+  onMorphologyEnabledChange: (enabled: boolean) => void;
   onCancel: () => void;
   onConfirm: () => void;
 }) {
@@ -2097,6 +2118,39 @@ function ManualWordModal({
                 className="w-full rounded-[10px] border-2 border-[var(--solid-ink)] bg-white px-3 py-2.5 font-display text-[15px] font-bold text-[var(--solid-ink)] outline-none disabled:opacity-60"
               />
             </div>
+
+            {/* 語源解析トグル（スキャンパネルと同じチェックカード型） */}
+            <button
+              type="button"
+              onClick={() => onMorphologyEnabledChange(!morphologyEnabled)}
+              disabled={loading}
+              className="flex w-full items-start gap-2 rounded-[10px] border-2 bg-white px-3 py-2.5 text-left transition-all disabled:opacity-60"
+              style={{
+                borderColor: morphologyEnabled ? 'var(--solid-ink)' : 'var(--color-border)',
+                boxShadow: morphologyEnabled ? '2px 2px 0 var(--solid-ink)' : 'none',
+              }}
+            >
+              <span
+                className="mt-[1px] inline-flex h-4 w-4 shrink-0 items-center justify-center rounded-full"
+                style={{
+                  border: `1.25px solid ${morphologyEnabled ? 'var(--color-accent)' : 'var(--color-border)'}`,
+                  background: morphologyEnabled ? 'var(--color-accent)' : '#fff',
+                }}
+              >
+                {morphologyEnabled && <Icon name="check" size={11} className="text-white" />}
+              </span>
+              <span className="min-w-0 flex-1">
+                <span className="flex items-center gap-1 text-[12px] font-bold text-[var(--solid-ink)]">
+                  <span className="truncate">語源解析</span>
+                  <span className="shrink-0 font-mono text-[8px] font-bold tracking-[0.04em] text-[var(--color-accent)]">
+                    +1コイン/語
+                  </span>
+                </span>
+                <span className="mt-0.5 block text-[10px] font-medium text-[var(--color-muted)]">
+                  接頭語・接尾語・接中語と語根の成り立ちを解説
+                </span>
+              </span>
+            </button>
 
             <button
               type="button"

--- a/src/app/project/[id]/words/page.tsx
+++ b/src/app/project/[id]/words/page.tsx
@@ -18,6 +18,10 @@ import { remoteRepository } from '@/lib/db/remote-repository';
 import { sortWordsByPriority } from '@/lib/spaced-repetition';
 import { invalidateHomeCache } from '@/lib/home-cache';
 import { getNextVocabularyType } from '@/lib/vocabulary-type';
+import {
+  readManualMorphologyPref,
+  writeManualMorphologyPref,
+} from '@/lib/preferences/manual-morphology-pref';
 import type { Project, Word, SubscriptionStatus } from '@/types';
 
 export default function WordListPage() {
@@ -48,6 +52,15 @@ export default function WordListPage() {
   const [manualWordExampleSentence, setManualWordExampleSentence] = useState('');
   const [manualWordSaving, setManualWordSaving] = useState(false);
   const [manualWordSavingMessage, setManualWordSavingMessage] = useState<string | undefined>(undefined);
+  // 手動追加時の語源解析トグル。project ページと同じキーで端末に記憶する。
+  const [manualWordMorphologyEnabled, setManualWordMorphologyEnabled] = useState(true);
+  useEffect(() => {
+    setManualWordMorphologyEnabled(readManualMorphologyPref());
+  }, []);
+  const handleManualWordMorphologyChange = (enabled: boolean) => {
+    setManualWordMorphologyEnabled(enabled);
+    writeManualMorphologyPref(enabled);
+  };
 
   const [showWordLimitModal, setShowWordLimitModal] = useState(false);
 
@@ -236,6 +249,7 @@ export default function WordListPage() {
         body: JSON.stringify({
           english,
           japanese,
+          includeMorphology: manualWordMorphologyEnabled,
           ...(userPos ? { partOfSpeechTags: [userPos] } : {}),
           ...(userExample ? { exampleSentence: userExample } : {}),
         }),
@@ -398,6 +412,8 @@ export default function WordListPage() {
         setPartOfSpeech={setManualWordPartOfSpeech}
         exampleSentence={manualWordExampleSentence}
         setExampleSentence={setManualWordExampleSentence}
+        morphologyEnabled={manualWordMorphologyEnabled}
+        setMorphologyEnabled={handleManualWordMorphologyChange}
       />
 
       <DeleteConfirmModal

--- a/src/components/desktop/DesktopWordDetailModal.tsx
+++ b/src/components/desktop/DesktopWordDetailModal.tsx
@@ -6,6 +6,7 @@ import { desktopPosLabel } from '@/components/desktop/desktop-data';
 import { MorphologyFormulaChips } from '@/components/word/MorphologyFormulaChips';
 import { TranslationDisplay } from '@/components/word/TranslationDisplay';
 import { hasDisplayableMorphology } from '@/lib/morphology/format';
+import { useMorphologyBackfill } from '@/hooks/use-morphology-backfill';
 import type { Word } from '@/types';
 
 export function DesktopWordDetailModal({
@@ -23,6 +24,9 @@ export function DesktopWordDetailModal({
   onDelete?: () => void;
   onNav: (dir: -1 | 1) => void;
 }) {
+  // word.morphology が無い単語は lexicon 共有キャッシュから表示時に補完する
+  const morphology = useMorphologyBackfill(word);
+
   return (
     <div className="ds-overlay" onClick={onClose}>
       <div className="ds-modal" onClick={(event) => event.stopPropagation()}>
@@ -109,14 +113,14 @@ export function DesktopWordDetailModal({
               )}
             </div>
 
-          {hasDisplayableMorphology(word.morphology) && (
+          {hasDisplayableMorphology(morphology) && (
             <div>
               <div className="mono" style={{ fontSize: 10, letterSpacing: '0.08em', textTransform: 'uppercase', color: 'var(--color-accent-ink)', fontWeight: 700, display: 'flex', alignItems: 'center', gap: 6, marginBottom: 10 }}>
                 <Icon name="account_tree" style={{ fontSize: 14 }} />語源
               </div>
-              <MorphologyFormulaChips morphology={word.morphology} />
+              <MorphologyFormulaChips morphology={morphology} />
               <div style={{ fontSize: 13, color: 'var(--color-secondary-text)', lineHeight: 1.75, marginTop: 12, whiteSpace: 'pre-line' }}>
-                {word.morphology.explanation}
+                {morphology.explanation}
               </div>
             </div>
           )}

--- a/src/components/home/ProjectModals.tsx
+++ b/src/components/home/ProjectModals.tsx
@@ -297,6 +297,8 @@ export function ManualWordInputModal({
   setPartOfSpeech,
   exampleSentence,
   setExampleSentence,
+  morphologyEnabled,
+  setMorphologyEnabled,
 }: {
   isOpen: boolean;
   onClose: () => void;
@@ -311,6 +313,9 @@ export function ManualWordInputModal({
   setPartOfSpeech: (value: string) => void;
   exampleSentence: string;
   setExampleSentence: (value: string) => void;
+  /** 語源解析トグル（未指定なら非表示 = 従来挙動） */
+  morphologyEnabled?: boolean;
+  setMorphologyEnabled?: (enabled: boolean) => void;
 }) {
   const englishInputRef = useRef<HTMLInputElement>(null);
   const [showOptional, setShowOptional] = useState(false);
@@ -396,6 +401,37 @@ export function ManualWordInputModal({
                   maxLength={100}
                 />
               </div>
+
+              {morphologyEnabled !== undefined && setMorphologyEnabled && (
+                <button
+                  type="button"
+                  onClick={() => setMorphologyEnabled(!morphologyEnabled)}
+                  disabled={isLoading}
+                  className="w-full flex items-start gap-2.5 px-4 py-3 border rounded-[var(--radius-lg)] bg-[var(--color-surface)] text-left transition-colors disabled:opacity-60"
+                  style={{
+                    borderColor: morphologyEnabled ? 'var(--color-primary)' : 'var(--color-border)',
+                  }}
+                >
+                  <span
+                    className="mt-0.5 inline-flex h-4 w-4 shrink-0 items-center justify-center rounded-full"
+                    style={{
+                      border: `1.25px solid ${morphologyEnabled ? 'var(--color-primary)' : 'var(--color-border)'}`,
+                      background: morphologyEnabled ? 'var(--color-primary)' : 'transparent',
+                    }}
+                  >
+                    {morphologyEnabled && <Icon name="check" size={11} className="text-white" />}
+                  </span>
+                  <span className="min-w-0 flex-1">
+                    <span className="flex items-center gap-1.5 text-sm font-medium text-[var(--color-foreground)]">
+                      語源解析
+                      <span className="shrink-0 text-[10px] font-bold text-[var(--color-primary)]">+1コイン/語</span>
+                    </span>
+                    <span className="mt-0.5 block text-xs text-[var(--color-muted)]">
+                      接頭語・接尾語・接中語と語根の成り立ちを解説
+                    </span>
+                  </span>
+                </button>
+              )}
 
               <button
                 type="button"

--- a/src/components/word/WordDetailView.tsx
+++ b/src/components/word/WordDetailView.tsx
@@ -10,6 +10,7 @@ import { getCachedProjectWords, updateProjectWordsCache } from '@/lib/home-cache
 import type { Word, CustomSection, CustomColumn, SubscriptionStatus } from '@/types';
 import { TranslationDisplay } from '@/components/word/TranslationDisplay';
 import { hasDisplayableMorphology } from '@/lib/morphology/format';
+import { useMorphologyBackfill } from '@/hooks/use-morphology-backfill';
 import { speakEnglish } from '@/lib/speech';
 import { MorphologyFormulaChips } from '@/components/word/MorphologyFormulaChips';
 
@@ -143,6 +144,15 @@ export function WordDetailView({
       cached.map((w) => (w.id === updated.id ? updated : w))
     );
   }, []);
+
+  // 語源のバックフィル: word.morphology を持たない単語は、リールと同じ
+  // lexicon 共有キャッシュから表示時に取得して補う（詳細はフック参照）。
+  const handleMorphologyBackfilled = useCallback((updated: Word) => {
+    setWord((prev) => (prev && prev.id === updated.id ? { ...prev, morphology: updated.morphology } : prev));
+    syncHomeCacheForWord(updated);
+    onWordUpdated?.(updated);
+  }, [syncHomeCacheForWord, onWordUpdated]);
+  const morphology = useMorphologyBackfill(word, { onBackfilled: handleMorphologyBackfilled });
 
   useEffect(() => {
     if (authLoading) return;
@@ -498,7 +508,7 @@ export function WordDetailView({
           )}
         </section>
 
-        {hasDisplayableMorphology(word.morphology) && (
+        {hasDisplayableMorphology(morphology) && (
           <>
             <SectionDivider />
             <section className="py-4">
@@ -507,9 +517,9 @@ export function WordDetailView({
                 <span className="font-mono text-[11px] font-bold text-[var(--color-muted)]">語源</span>
               </div>
               {/* 式: un(否定) ＋ anim(心) ＋ ous(形容詞化) */}
-              <MorphologyFormulaChips morphology={word.morphology} />
+              <MorphologyFormulaChips morphology={morphology} />
               <p className="mt-3 whitespace-pre-line text-[13px] leading-[1.6] text-[var(--color-ink-muted)]">
-                {word.morphology.explanation}
+                {morphology.explanation}
               </p>
             </section>
           </>

--- a/src/hooks/use-morphology-backfill.ts
+++ b/src/hooks/use-morphology-backfill.ts
@@ -1,0 +1,96 @@
+'use client';
+
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { useAuth } from '@/hooks/use-auth';
+import { getRepository } from '@/lib/db';
+import { hasDisplayableMorphology } from '@/lib/morphology/format';
+import type { SubscriptionStatus, Word } from '@/types';
+
+/**
+ * 単語詳細表示用の語源バックフィル。
+ *
+ * word.morphology を持たない単語（語源生成がレスポンスに間に合わなかった
+ * 手動追加語・語源機能より前に作られた語など）について、リール配信と同じ
+ * lexicon 共有キャッシュ（GET /api/words/morphology）から表示時に取得して
+ * 補う。取得できた語源は次回以降のために単語行へも best-effort で保存する
+ * （読み取り専用リポジトリでは保存だけ諦めて表示は維持する）。
+ *
+ * 返り値は表示に使う morphology。単語行が既に表示可能な語源を持つ場合は
+ * その値をそのまま返し、フェッチは行わない。
+ */
+export function useMorphologyBackfill(
+  word: Word | null,
+  options: {
+    /** バックフィル成功時に morphology をマージ済みの Word を親状態へ通知する */
+    onBackfilled?: (updated: Word) => void;
+  } = {},
+): Word['morphology'] {
+  const { subscription } = useAuth();
+  const subscriptionStatus: SubscriptionStatus = subscription?.status || 'free';
+  const wasPro = subscription?.plan === 'pro' && subscriptionStatus !== 'active';
+  const repository = useMemo(
+    () => getRepository(subscriptionStatus, wasPro),
+    [subscriptionStatus, wasPro],
+  );
+
+  const [backfilled, setBackfilled] = useState<{
+    wordId: string;
+    morphology: NonNullable<Word['morphology']>;
+  } | null>(null);
+
+  // word オブジェクトやコールバックはレンダー毎に identity が変わりうるので、
+  // fetch effect の依存には入れず ref 経由で最新値を参照する
+  // （この同期 effect は fetch effect より先に宣言してあるので先に実行される）。
+  const wordRef = useRef(word);
+  const onBackfilledRef = useRef(options.onBackfilled);
+  useEffect(() => {
+    wordRef.current = word;
+    onBackfilledRef.current = options.onBackfilled;
+  });
+
+  const wordId = word?.id;
+  const english = word?.english;
+  const hasOwnMorphology = hasDisplayableMorphology(word?.morphology);
+
+  useEffect(() => {
+    if (!wordId || !english || hasOwnMorphology) return;
+    let cancelled = false;
+
+    (async () => {
+      try {
+        const response = await fetch(
+          `/api/words/morphology?english=${encodeURIComponent(english)}`,
+        );
+        if (!response.ok) return;
+        const data = await response.json() as {
+          success?: boolean;
+          morphology?: Word['morphology'] | null;
+        };
+        const morphology = data.success ? data.morphology : null;
+        if (cancelled || !hasDisplayableMorphology(morphology)) return;
+
+        setBackfilled({ wordId, morphology });
+
+        const current = wordRef.current;
+        if (current && current.id === wordId) {
+          onBackfilledRef.current?.({ ...current, morphology });
+        }
+
+        try {
+          await repository.updateWord(wordId, { morphology });
+        } catch {
+          // 読み取り専用リポジトリ等で保存できなくても表示は維持する
+        }
+      } catch (err) {
+        console.warn('[morphology-backfill] Failed (non-critical):', err);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [wordId, english, hasOwnMorphology, repository]);
+
+  if (word && hasOwnMorphology) return word.morphology;
+  return backfilled && backfilled.wordId === wordId ? backfilled.morphology : undefined;
+}

--- a/src/lib/preferences/manual-morphology-pref.ts
+++ b/src/lib/preferences/manual-morphology-pref.ts
@@ -1,0 +1,25 @@
+/**
+ * 手動追加の語源解析トグル設定（端末ローカル保存）
+ *
+ * オンのとき enrich-manual API に includeMorphology: true を渡して語源解析
+ * （とそのコイン消費）を行う。デフォルトはオン（従来挙動）。
+ * localStorage が使えない環境（SSR・プライベートモード等）では常にオン扱い。
+ */
+
+const STORAGE_KEY = 'merken-manual-morphology';
+
+export function readManualMorphologyPref(): boolean {
+  try {
+    return localStorage.getItem(STORAGE_KEY) !== 'off';
+  } catch {
+    return true;
+  }
+}
+
+export function writeManualMorphologyPref(enabled: boolean): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, enabled ? 'on' : 'off');
+  } catch {
+    // 保存できなくても現在のセッション内の state では有効
+  }
+}


### PR DESCRIPTION
## 背景

手動追加した単語の語源解析がリールでは見えるのに単語帳では見えない問題の修正と、手動追加時の語源解析オン/オフトグル追加、手動追加AI補完のVertex AI経路への統一。

リールは lexicon 共有キャッシュから headword で語源を毎回引くのに対し、単語帳は単語行の `morphology` カラムだけを見ていた。手動追加では語源生成が enrich-manual の 8 秒タイムアウトに間に合わないと、レスポンスから落ちて単語行に保存されない一方、生成継続分は lexicon キャッシュに保存されるため「リールでは見えるが単語帳では見えない」状態になっていた（コイン未消費時・語源機能追加前の既存語も同様）。

## 変更内容

### 1. 単語帳での語源表示（バックフィル）
- `GET /api/words/morphology?english=...` を新設。リール配信と同じ lexicon 共有キャッシュの読み取り専用ルート（AI 生成・コイン消費なし、要ログイン）
- `useMorphologyBackfill` フックを新設し、`word.morphology` が無い単語は表示時にキャッシュから補完 + 単語行へ best-effort で永続化（読み取り専用リポジトリでは表示のみ）
- 適用箇所: `WordDetailView`（モバイル単語詳細）、`DesktopWordDetailModal`（デスクトップ単語詳細）、フラッシュカード

### 2. 手動追加の語源解析トグル
- 手動追加モーダル（project ページの `ManualWordModal` / words ページの `ManualWordInputModal`）にスキャンパネルと同型のチェックカード式トグル「語源解析（+1コイン/語）」を追加
- オフ時は enrich-manual に `includeMorphology: false` を送り、サーバー側で語源解析とコイン消費を丸ごとスキップ（デフォルトはオン=従来挙動）
- 選択は `localStorage`（`merken-manual-morphology`）に記憶し、両モーダルで共有

### 3. Vertex AI 経路への統一
- enrich-manual の `getEnrichProvider` から直接 Gemini API バイパス分岐を削除し、スキャンと同じ `getProviderFromConfig`（`CLOUD_RUN_URL` 設定時は Cloud Run ゲートウェイ → Vertex AI）に統一

## 検証
- `npm run lint`: 変更ファイルはエラーなし（`gcp-budget-guard/` の 5 error は既存・無関係）
- `npm test`: 985 pass / 2 fail — 失敗 2 件（otp.contract / words/create）は変更前の main でも失敗する既存の失敗であることを stash 検証で確認済み
- `npm run build`: 成功（`/api/words/morphology` ルート生成を確認）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CEC6wpHnyEdH1oqtecSmbz

---
_Generated by [Claude Code](https://claude.ai/code/session_01CEC6wpHnyEdH1oqtecSmbz)_