### PR TITLE
下部ナビからリールを外し語法コーナーを新設(共有と位置入れ替え)

### DIFF
--- a/src/app/grammar/[bookId]/page.tsx
+++ b/src/app/grammar/[bookId]/page.tsx
@@ -1,0 +1,306 @@
+'use client';
+
+import { use, useEffect, useMemo, useState } from 'react';
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import { Icon } from '@/components/ui/Icon';
+
+// 語法問題集の演習画面 (Vintage型)。
+// 1問ずつ出題 → 選択 → 正誤 + 解説表示 → 次へ、最後に正答率と
+// 間違えた文法項目のまとめを表示する。
+// 問題取得は Pro ゲート付き /api/chatgpt/grammar-questions を cookie セッションで利用。
+
+const CHOICE_LABELS = ['A', 'B', 'C', 'D'] as const;
+
+type GrammarQuestion = {
+  id: string;
+  sentence: string;
+  choices: string[];
+  correctIndex: number;
+  explanation: string;
+  grammarPoint: string | null;
+  sentenceJa: string | null;
+};
+
+type LoadState =
+  | { kind: 'loading' }
+  | { kind: 'ready'; questions: GrammarQuestion[] }
+  | { kind: 'pro-required' }
+  | { kind: 'error'; message: string };
+
+// 空欄マーカーを含む問題文を、空欄を強調したJSXに分解する
+function renderSentence(sentence: string) {
+  const parts = sentence.split('___');
+  return parts.map((part, index) => (
+    <span key={index}>
+      {part}
+      {index < parts.length - 1 && (
+        <span className="mx-1 inline-block min-w-[64px] border-b-2 border-[var(--color-accent)] text-center font-bold text-[var(--color-accent)]">
+          ___
+        </span>
+      )}
+    </span>
+  ));
+}
+
+export default function GrammarPracticePage({ params }: { params: Promise<{ bookId: string }> }) {
+  const { bookId } = use(params);
+  const router = useRouter();
+
+  const [state, setState] = useState<LoadState>({ kind: 'loading' });
+  const [index, setIndex] = useState(0);
+  const [selected, setSelected] = useState<number | null>(null);
+  const [wrongQuestions, setWrongQuestions] = useState<GrammarQuestion[]>([]);
+  const [finished, setFinished] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const load = async () => {
+      try {
+        const response = await fetch(
+          `/api/chatgpt/grammar-questions?bookId=${encodeURIComponent(bookId)}&limit=100`,
+          { cache: 'no-store' },
+        );
+        const payload = (await response.json().catch(() => ({}))) as {
+          success?: boolean;
+          questions?: GrammarQuestion[];
+          error?: string;
+          code?: string;
+        };
+
+        if (cancelled) return;
+
+        if (response.status === 403 && payload.code === 'PRO_REQUIRED') {
+          setState({ kind: 'pro-required' });
+          return;
+        }
+        if (!response.ok || !payload.success) {
+          setState({ kind: 'error', message: payload.error || '問題の取得に失敗しました' });
+          return;
+        }
+        setState({ kind: 'ready', questions: payload.questions ?? [] });
+      } catch {
+        if (!cancelled) {
+          setState({ kind: 'error', message: '通信に失敗しました' });
+        }
+      }
+    };
+
+    void load();
+    return () => {
+      cancelled = true;
+    };
+  }, [bookId]);
+
+  const questions = state.kind === 'ready' ? state.questions : [];
+  const question = questions[index];
+  const answered = selected !== null;
+  const correct = answered && question ? selected === question.correctIndex : false;
+
+  const wrongGrammarPoints = useMemo(() => {
+    const points = wrongQuestions
+      .map((q) => q.grammarPoint)
+      .filter((point): point is string => Boolean(point));
+    return Array.from(new Set(points));
+  }, [wrongQuestions]);
+
+  const handleSelect = (choiceIndex: number) => {
+    if (answered || !question) return;
+    setSelected(choiceIndex);
+    if (choiceIndex !== question.correctIndex) {
+      setWrongQuestions((prev) => [...prev, question]);
+    }
+  };
+
+  const handleNext = () => {
+    if (index + 1 >= questions.length) {
+      setFinished(true);
+      return;
+    }
+    setIndex((prev) => prev + 1);
+    setSelected(null);
+  };
+
+  const handleRetry = () => {
+    setIndex(0);
+    setSelected(null);
+    setWrongQuestions([]);
+    setFinished(false);
+  };
+
+  return (
+    <div className="relative mx-auto min-h-screen w-full max-w-[560px] bg-[var(--color-background)] px-[18px] pb-12 pt-[calc(env(safe-area-inset-top,0px)+12px)] font-[var(--font-body)]">
+      {/* Header */}
+      <div className="flex items-center gap-2 pb-3 pt-1">
+        <button
+          type="button"
+          onClick={() => router.push('/grammar')}
+          className="flex h-[38px] w-[38px] items-center justify-center rounded-[19px] border-2 border-[var(--solid-ink)] bg-white text-[var(--solid-ink)] transition-all duration-100 active:translate-x-px active:translate-y-px"
+          aria-label="一覧に戻る"
+        >
+          <Icon name="chevron_left" size={16} />
+        </button>
+        <div className="min-w-0 flex-1">
+          <div className="font-mono text-[10px] font-bold tracking-[0.08em] text-[var(--color-muted)]">GRAMMAR PRACTICE</div>
+          {state.kind === 'ready' && questions.length > 0 && !finished && (
+            <div className="font-display text-[15px] font-extrabold text-[var(--solid-ink)]">
+              {index + 1} / {questions.length}
+            </div>
+          )}
+        </div>
+        {question?.grammarPoint && !finished && (
+          <span className="shrink-0 rounded-[4px] border border-[var(--solid-ink)] bg-white px-2 py-[3px] font-mono text-[9px] font-bold text-[var(--solid-ink)]">
+            {question.grammarPoint}
+          </span>
+        )}
+      </div>
+
+      {state.kind === 'loading' && (
+        <div className="mt-2 h-[300px] animate-pulse rounded-xl border-2 border-[var(--color-border)] bg-white" />
+      )}
+
+      {state.kind === 'pro-required' && (
+        <div className="rounded-xl border-2 border-[var(--solid-ink)] bg-white p-5">
+          <p className="m-0 text-[13px] leading-[1.8] text-[var(--solid-ink)]">
+            語法問題集はPro限定機能です。
+          </p>
+          <Link
+            href="/subscription"
+            className="mt-4 flex h-11 items-center justify-center rounded-xl border-2 border-[var(--solid-ink)] bg-[var(--solid-ink)] font-bold text-white"
+          >
+            Proプランを見る
+          </Link>
+        </div>
+      )}
+
+      {state.kind === 'error' && (
+        <div className="rounded-xl border-2 border-[var(--solid-ink)] bg-white p-5 text-center">
+          <p className="m-0 text-[13px] text-[var(--solid-ink)]">{state.message}</p>
+        </div>
+      )}
+
+      {state.kind === 'ready' && questions.length === 0 && (
+        <div className="rounded-xl border-2 border-[var(--solid-ink)] bg-white p-5">
+          <p className="m-0 text-[13px] leading-[1.8] text-[var(--solid-ink)]">
+            この問題集にはまだ問題がありません。ChatGPTで問題を追加してください。
+          </p>
+        </div>
+      )}
+
+      {/* 結果画面 */}
+      {state.kind === 'ready' && finished && (
+        <div className="rounded-xl border-2 border-[var(--solid-ink)] bg-white p-6">
+          <div className="font-mono text-[10px] font-bold tracking-[0.08em] text-[var(--color-muted)]">RESULT</div>
+          <div className="mt-2 font-display text-3xl font-extrabold text-[var(--solid-ink)]">
+            {questions.length - wrongQuestions.length} / {questions.length} 問正解
+          </div>
+          {wrongGrammarPoints.length > 0 && (
+            <div className="mt-4">
+              <div className="text-[12px] font-bold text-[var(--solid-ink)]">復習したい文法項目</div>
+              <div className="mt-2 flex flex-wrap gap-1.5">
+                {wrongGrammarPoints.map((point) => (
+                  <span key={point} className="rounded-[4px] border border-[var(--solid-ink)] bg-[#faf7f1] px-2 py-[3px] font-mono text-[10px] font-bold text-[var(--solid-ink)]">
+                    {point}
+                  </span>
+                ))}
+              </div>
+            </div>
+          )}
+          {wrongQuestions.length === 0 && (
+            <p className="m-0 mt-3 text-[12px] text-[var(--solid-ink)]">全問正解です。この調子で次の問題集にも挑戦しましょう 🎉</p>
+          )}
+          <div className="mt-5 flex flex-col gap-2.5">
+            <button
+              type="button"
+              onClick={handleRetry}
+              className="h-12 rounded-xl border-2 border-[var(--solid-ink)] bg-[var(--solid-ink)] font-bold text-white transition-all duration-100 active:translate-x-px active:translate-y-px"
+            >
+              もう一度解く
+            </button>
+            <Link
+              href="/grammar"
+              className="flex h-12 items-center justify-center rounded-xl border-2 border-[var(--solid-ink)] bg-white font-bold text-[var(--solid-ink)] transition-all duration-100 active:translate-x-px active:translate-y-px"
+            >
+              問題集一覧へ
+            </Link>
+          </div>
+        </div>
+      )}
+
+      {/* 出題画面 */}
+      {state.kind === 'ready' && question && !finished && (
+        <>
+          <div className="rounded-xl border-2 border-[var(--solid-ink)] bg-white p-5">
+            <p className="m-0 text-[15px] leading-[2] text-[var(--solid-ink)]">{renderSentence(question.sentence)}</p>
+            {question.sentenceJa && answered && (
+              <p className="m-0 mt-2 text-[11.5px] leading-[1.7] text-[var(--color-muted)]">{question.sentenceJa}</p>
+            )}
+          </div>
+
+          <div className="mt-3.5 flex flex-col gap-2.5">
+            {question.choices.map((choice, choiceIndex) => {
+              const isSelected = selected === choiceIndex;
+              const isCorrectChoice = choiceIndex === question.correctIndex;
+              const showCorrect = answered && isCorrectChoice;
+              const showWrong = answered && isSelected && !isCorrectChoice;
+              return (
+                <button
+                  key={choiceIndex}
+                  type="button"
+                  onClick={() => handleSelect(choiceIndex)}
+                  disabled={answered}
+                  className="flex items-center gap-3 rounded-xl border-2 bg-white px-4 py-3 text-left transition-all duration-100 active:translate-x-px active:translate-y-px disabled:active:translate-x-0 disabled:active:translate-y-0"
+                  style={{
+                    borderColor: showCorrect
+                      ? 'var(--color-accent)'
+                      : showWrong
+                        ? 'var(--color-error, #d33)'
+                        : 'var(--solid-ink)',
+                    background: showCorrect ? 'var(--color-accent-light, #e8f5ec)' : showWrong ? '#fdeceb' : '#fff',
+                  }}
+                >
+                  <span
+                    className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full border-2 font-mono text-[12px] font-bold"
+                    style={{
+                      borderColor: showCorrect ? 'var(--color-accent)' : showWrong ? 'var(--color-error, #d33)' : 'var(--solid-ink)',
+                      color: showCorrect ? 'var(--color-accent)' : showWrong ? 'var(--color-error, #d33)' : 'var(--solid-ink)',
+                    }}
+                  >
+                    {CHOICE_LABELS[choiceIndex]}
+                  </span>
+                  <span className="min-w-0 flex-1 text-[14px] font-bold text-[var(--solid-ink)]">{choice}</span>
+                  {showCorrect && <Icon name="check_circle" size={18} className="shrink-0 text-[var(--color-accent)]" />}
+                  {showWrong && <Icon name="cancel" size={18} className="shrink-0 text-[#d33]" />}
+                </button>
+              );
+            })}
+          </div>
+
+          {/* 解説 (Vintage風: 答え合わせのたびに必ず表示) */}
+          {answered && (
+            <div className="mt-3.5 rounded-xl border-2 border-[var(--solid-ink)] bg-[#faf7f1] p-4">
+              <div className="flex items-center gap-1.5">
+                <Icon name={correct ? 'check_circle' : 'school'} size={16} className={correct ? 'text-[var(--color-accent)]' : 'text-[var(--solid-ink)]'} />
+                <span className="font-display text-[13px] font-extrabold text-[var(--solid-ink)]">
+                  {correct ? '正解！' : `正解は ${CHOICE_LABELS[question.correctIndex]} 「${question.choices[question.correctIndex]}」`}
+                </span>
+              </div>
+              <p className="m-0 mt-2 text-[12.5px] leading-[1.9] text-[var(--solid-ink)]">{question.explanation}</p>
+            </div>
+          )}
+
+          {answered && (
+            <button
+              type="button"
+              onClick={handleNext}
+              className="mt-4 h-12 w-full rounded-xl border-2 border-[var(--solid-ink)] bg-[var(--solid-ink)] font-bold text-white transition-all duration-100 active:translate-x-px active:translate-y-px"
+            >
+              {index + 1 >= questions.length ? '結果を見る' : '次の問題へ'}
+            </button>
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/app/grammar/page.tsx
+++ b/src/app/grammar/page.tsx
@@ -1,0 +1,182 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+import { Icon } from '@/components/ui/Icon';
+
+// 語法コーナー: ChatGPT連携で作成した文法・語法問題集(Vintage型)の一覧。
+// データ取得は Pro ゲート付きの /api/chatgpt/grammar-books を cookie セッションで
+// そのまま利用する(このアプリからの fetch は同一オリジンで cookie が付く)。
+
+const GPT_URL = process.env.NEXT_PUBLIC_CHATGPT_GPT_URL ?? '';
+
+type GrammarBook = {
+  id: string;
+  title: string;
+  updatedAt: string;
+};
+
+type LoadState =
+  | { kind: 'loading' }
+  | { kind: 'ready'; books: GrammarBook[] }
+  | { kind: 'pro-required' }
+  | { kind: 'error'; message: string };
+
+function formatDate(iso: string): string {
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return '';
+  return `${date.getMonth() + 1}/${date.getDate()}`;
+}
+
+export default function GrammarBooksPage() {
+  const [state, setState] = useState<LoadState>({ kind: 'loading' });
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const load = async () => {
+      try {
+        const response = await fetch('/api/chatgpt/grammar-books?limit=50', { cache: 'no-store' });
+        const payload = (await response.json().catch(() => ({}))) as {
+          success?: boolean;
+          books?: GrammarBook[];
+          error?: string;
+          code?: string;
+        };
+
+        if (cancelled) return;
+
+        if (response.status === 403 && payload.code === 'PRO_REQUIRED') {
+          setState({ kind: 'pro-required' });
+          return;
+        }
+        if (!response.ok || !payload.success) {
+          setState({ kind: 'error', message: payload.error || '問題集の取得に失敗しました' });
+          return;
+        }
+        setState({ kind: 'ready', books: payload.books ?? [] });
+      } catch {
+        if (!cancelled) {
+          setState({ kind: 'error', message: '通信に失敗しました' });
+        }
+      }
+    };
+
+    void load();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const gptCta = GPT_URL ? (
+    <a
+      href={GPT_URL}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="flex h-12 items-center justify-center gap-2 rounded-xl border-2 border-[var(--solid-ink)] bg-[var(--solid-ink)] font-bold text-white transition-all duration-100 active:translate-x-px active:translate-y-px"
+    >
+      <Icon name="smart_toy" size={18} />
+      ChatGPTで問題を作る
+    </a>
+  ) : (
+    <Link
+      href="/tips/chatgpt"
+      className="flex h-12 items-center justify-center gap-2 rounded-xl border-2 border-[var(--solid-ink)] bg-[var(--solid-ink)] font-bold text-white transition-all duration-100 active:translate-x-px active:translate-y-px"
+    >
+      <Icon name="smart_toy" size={18} />
+      ChatGPT連携の使い方を見る
+    </Link>
+  );
+
+  return (
+    <div className="relative mx-auto min-h-screen w-full max-w-[560px] bg-[var(--color-background)] px-[18px] pb-32 pt-[calc(env(safe-area-inset-top,0px)+12px)] font-[var(--font-body)]">
+      {/* Header */}
+      <div className="pb-3.5 pt-1">
+        <div className="font-mono text-[10px] font-bold tracking-[0.08em] text-[var(--color-muted)]">GRAMMAR / USAGE</div>
+        <div className="mt-1.5 font-display text-2xl font-extrabold leading-[1.15] tracking-[-0.02em] text-[var(--solid-ink)]">
+          語法問題集
+        </div>
+        <div className="mt-1.5 text-[12px] font-medium text-[var(--color-muted)]">
+          空欄補充・英語4択・解説つき。問題はChatGPTとの会話で作成します
+        </div>
+      </div>
+
+      {state.kind === 'loading' && (
+        <div className="flex flex-col gap-2.5">
+          {[0, 1, 2].map((i) => (
+            <div key={i} className="h-[72px] animate-pulse rounded-xl border-2 border-[var(--color-border)] bg-white" />
+          ))}
+        </div>
+      )}
+
+      {state.kind === 'pro-required' && (
+        <div className="rounded-xl border-2 border-[var(--solid-ink)] bg-white p-5">
+          <div className="flex items-center gap-2">
+            <span className="rounded-[3px] border border-[var(--solid-ink)] bg-white px-[6px] py-[2px] font-mono text-[9px] font-bold tracking-[0.04em] text-[var(--color-accent)]">
+              PRO
+            </span>
+            <span className="font-display text-[15px] font-bold text-[var(--solid-ink)]">Pro限定機能です</span>
+          </div>
+          <p className="m-0 mt-2 text-[12px] leading-[1.8] text-[var(--solid-ink)]">
+            語法問題集はProプラン限定です。アップグレードすると、ChatGPTとの会話でVintage風の語法問題を作成・演習できます。
+          </p>
+          <Link
+            href="/subscription"
+            className="mt-4 flex h-11 items-center justify-center rounded-xl border-2 border-[var(--solid-ink)] bg-[var(--solid-ink)] font-bold text-white"
+          >
+            Proプランを見る
+          </Link>
+        </div>
+      )}
+
+      {state.kind === 'error' && (
+        <div className="rounded-xl border-2 border-[var(--solid-ink)] bg-white p-5 text-center">
+          <p className="m-0 text-[13px] text-[var(--solid-ink)]">{state.message}</p>
+          <button
+            type="button"
+            onClick={() => window.location.reload()}
+            className="mt-3 h-10 rounded-xl border-2 border-[var(--solid-ink)] bg-white px-5 text-[13px] font-bold text-[var(--solid-ink)]"
+          >
+            再読み込み
+          </button>
+        </div>
+      )}
+
+      {state.kind === 'ready' && state.books.length === 0 && (
+        <div className="rounded-xl border-2 border-[var(--solid-ink)] bg-white p-5">
+          <div className="font-display text-[15px] font-bold text-[var(--solid-ink)]">まだ問題集がありません</div>
+          <p className="m-0 mt-2 text-[12px] leading-[1.8] text-[var(--solid-ink)]">
+            ChatGPTのMERKEN GPTに「仮定法の語法問題を10問作って」のように頼むと、ここに問題集が保存されます。
+          </p>
+          <div className="mt-4">{gptCta}</div>
+        </div>
+      )}
+
+      {state.kind === 'ready' && state.books.length > 0 && (
+        <>
+          <div className="flex flex-col gap-2.5">
+            {state.books.map((book) => (
+              <Link
+                key={book.id}
+                href={`/grammar/${book.id}`}
+                className="flex items-center gap-3 rounded-xl border-2 border-[var(--solid-ink)] bg-white px-4 py-3.5 no-underline transition-all duration-100 active:translate-x-px active:translate-y-px"
+              >
+                <span className="flex h-[42px] w-[42px] shrink-0 items-center justify-center rounded-[11px] border-2 border-[var(--solid-ink)] bg-[#faf7f1] text-[var(--solid-ink)]">
+                  <Icon name="menu_book" size={20} />
+                </span>
+                <span className="min-w-0 flex-1">
+                  <span className="block truncate font-display text-[14.5px] font-bold text-[var(--solid-ink)]">{book.title}</span>
+                  <span className="mt-0.5 block font-mono text-[9px] tracking-[0.04em] text-[var(--color-muted)]">
+                    更新 {formatDate(book.updatedAt)}
+                  </span>
+                </span>
+                <Icon name="chevron_right" size={16} className="shrink-0 text-[var(--color-muted)]" />
+              </Link>
+            ))}
+          </div>
+          <div className="mt-5">{gptCta}</div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/components/ui/PersistentAppShell.tsx
+++ b/src/components/ui/PersistentAppShell.tsx
@@ -22,6 +22,8 @@ const HIDE_BOTTOM_NAV_PATHS = [
   '/quick-response/', '/scan/confirm', '/shared/share-wordbook',
   '/subscription', '/collections/new', '/word/', '/favorites', '/profile', '/follows',
   '/groups/', '/reels',
+  // 語法演習画面(/grammar/<bookId>)はナビ非表示。一覧(/grammar)は表示する。
+  '/grammar/',
 ];
 
 function shouldHideShell(pathname: string): boolean {

--- a/src/components/ui/bottom-nav.tsx
+++ b/src/components/ui/bottom-nav.tsx
@@ -4,7 +4,6 @@ import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import { useState } from 'react';
 import { CreateWordbookSheet } from '@/components/home/CreateWordbookSheet';
-import { prefetchReelFeed } from '@/hooks/use-reel-feed';
 
 const HomeIcon = () => (
   <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
@@ -57,19 +56,19 @@ const ScanPlusIcon = () => (
   </svg>
 );
 
-const ReelIcon = () => (
+const GrammarIcon = () => (
   <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-    <rect x="4" y="3" width="16" height="18" rx="3"/>
-    <path d="M4 8h16"/>
-    <path d="M10.5 12.2l4 2.3-4 2.3v-4.6z"/>
+    <path d="M5 4a2 2 0 012-2h12v18H7a2 2 0 00-2 2V4z"/>
+    <path d="M5 20a2 2 0 012-2h12"/>
+    <path d="M9.5 7.5h6M9.5 11h4"/>
   </svg>
 );
 
-const ReelIconFilled = () => (
+const GrammarIconFilled = () => (
   <svg width="22" height="22" viewBox="0 0 24 24" fill="currentColor" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-    <rect x="4" y="3" width="16" height="18" rx="3"/>
-    <path d="M4 8h16" stroke="#fff" strokeWidth="1.5"/>
-    <path d="M10.5 12.2l4 2.3-4 2.3v-4.6z" fill="#fff" stroke="#fff"/>
+    <path d="M5 4a2 2 0 012-2h12v18H7a2 2 0 00-2 2V4z"/>
+    <path d="M5 20a2 2 0 012-2h12" stroke="#fff" strokeWidth="1.5"/>
+    <path d="M9.5 7.5h6M9.5 11h4" stroke="#fff" strokeWidth="1.5"/>
   </svg>
 );
 
@@ -93,12 +92,12 @@ const TABS: TabItem[] = [
     IconActive: HomeIconFilled,
   },
   {
-    k: 'shared',
-    label: '共有',
-    href: '/shared',
-    matchPaths: ['/shared', '/groups'],
-    IconDefault: SharedIcon,
-    IconActive: SharedIconFilled,
+    k: 'grammar',
+    label: '語法',
+    href: '/grammar',
+    matchPaths: ['/grammar'],
+    IconDefault: GrammarIcon,
+    IconActive: GrammarIconFilled,
   },
   {
     k: 'create',
@@ -108,12 +107,12 @@ const TABS: TabItem[] = [
     IconActive: ScanPlusIcon,
   },
   {
-    k: 'reels',
-    label: 'リール',
-    href: '/reels',
-    matchPaths: ['/reels'],
-    IconDefault: ReelIcon,
-    IconActive: ReelIconFilled,
+    k: 'shared',
+    label: '共有',
+    href: '/shared',
+    matchPaths: ['/shared', '/groups'],
+    IconDefault: SharedIcon,
+    IconActive: SharedIconFilled,
   },
   {
     k: 'account',
@@ -207,9 +206,6 @@ export function BottomNav() {
               <Link
                 key={tab.k}
                 href={tab.href!}
-                // リールはフィードAPIが重いので、タップした瞬間に初回ページの
-                // 取得を先行開始して表示までの待ちを短縮する。
-                onPointerDown={tab.k === 'reels' ? () => prefetchReelFeed() : undefined}
                 style={{
                   display: 'flex',
                   flexDirection: 'column',


### PR DESCRIPTION
## 概要

モバイル下部ナビの再編と、語法問題集(#430)の**アプリ内コーナー**を新設します。

- ナビ構成: [ホーム, 共有, 作成, リール, アカウント] → **[ホーム, 語法, 作成, 共有, アカウント]**
  - リールタブを削除(語法が共有の旧位置に入り、共有はリールの旧位置へ)
  - `/reels` ページ自体は残ります(ナビからの導線のみ削除)

## 変更内容

### 下部ナビ (`src/components/ui/bottom-nav.tsx`)
- リールタブ・ReelIcon・`prefetchReelFeed` の呼び出しを削除
- 語法タブ(ブックアイコン、`/grammar`)を追加し、共有タブと配置を入れ替え

### 語法コーナー(新設)
- **`/grammar`**(一覧) — ChatGPT連携で作成した語法問題集をカード表示。状態別UI: ローディング / Pro未加入(アップグレード案内) / 0冊(ChatGPTでの作成手順と公式GPTへの導線) / 一覧+作成CTA
- **`/grammar/[bookId]`**(演習) — Vintage風の演習フロー: 空欄(`___`)を強調した問題文 → 英語4択(A〜D) → 答え合わせごとに**解説を必ず表示**(正解の根拠) → 終了時に正答率と間違えた文法項目(grammarPoint)のまとめ。「もう一度解く」対応
- データ取得は#430のPro限定API(`/api/chatgpt/grammar-books` / `grammar-questions`)をcookieセッションでそのまま利用(新規APIなし)

### シェル (`src/components/ui/PersistentAppShell.tsx`)
- `HIDE_BOTTOM_NAV_PATHS` に `/grammar/` を追加(演習画面はナビ非表示、一覧 `/grammar` は表示 — 既存の `/quiz/` 等と同じ扱い)

## 補足

- `/grammar` はmiddlewareの`protectedPaths`に既登録のため未ログイン時は`/login`へリダイレクト
- デスクトップのサイドバーは今回スコープ外(モバイル下部ナビのみ)

## テスト

- `npx eslint`(変更ファイル)クリーン
- `npm run build` 成功(`/grammar` 静的・`/grammar/[bookId]` 動的ルート生成確認)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GZ3odfsZbmoQKjPBSenQ2E

---
_Generated by [Claude Code](https://claude.ai/code/session_01GZ3odfsZbmoQKjPBSenQ2E)_