### PR TITLE
語法コーナーをデスクトップUIに対応

### DIFF
--- a/src/app/grammar/[bookId]/page.tsx
+++ b/src/app/grammar/[bookId]/page.tsx
@@ -137,7 +137,7 @@ export default function GrammarPracticePage({ params }: { params: Promise<{ book
   };
 
   return (
-    <div className="relative mx-auto min-h-screen w-full max-w-[560px] bg-[var(--color-background)] px-[18px] pb-12 pt-[calc(env(safe-area-inset-top,0px)+12px)] font-[var(--font-body)]">
+    <div className="relative mx-auto min-h-screen w-full max-w-[560px] bg-[var(--color-background)] px-[18px] pb-12 pt-[calc(env(safe-area-inset-top,0px)+12px)] font-[var(--font-body)] lg:max-w-[720px] lg:px-8 lg:pt-10">
       {/* Header */}
       <div className="flex items-center gap-2 pb-3 pt-1">
         <button

--- a/src/app/grammar/page.tsx
+++ b/src/app/grammar/page.tsx
@@ -3,24 +3,20 @@
 import { useEffect, useState } from 'react';
 import Link from 'next/link';
 import { Icon } from '@/components/ui/Icon';
+import {
+  DesktopGrammarBooksView,
+  type GrammarBook,
+  type GrammarBooksLoadState,
+} from '@/components/desktop/DesktopGrammar';
 
 // 語法コーナー: ChatGPT連携で作成した文法・語法問題集(Vintage型)の一覧。
 // データ取得は Pro ゲート付きの /api/chatgpt/grammar-books を cookie セッションで
 // そのまま利用する(このアプリからの fetch は同一オリジンで cookie が付く)。
+// デスクトップは DesktopGrammarBooksView、モバイルは本ファイル内のUIを使う。
 
 const GPT_URL = process.env.NEXT_PUBLIC_CHATGPT_GPT_URL ?? '';
 
-type GrammarBook = {
-  id: string;
-  title: string;
-  updatedAt: string;
-};
-
-type LoadState =
-  | { kind: 'loading' }
-  | { kind: 'ready'; books: GrammarBook[] }
-  | { kind: 'pro-required' }
-  | { kind: 'error'; message: string };
+type LoadState = GrammarBooksLoadState;
 
 function formatDate(iso: string): string {
   const date = new Date(iso);
@@ -119,7 +115,16 @@ export default function GrammarBooksPage() {
   );
 
   return (
-    <div className="relative mx-auto min-h-screen w-full max-w-[560px] bg-[var(--color-background)] px-[18px] pb-32 pt-[calc(env(safe-area-inset-top,0px)+12px)] font-[var(--font-body)]">
+    <>
+      <DesktopGrammarBooksView
+        state={state}
+        gptUrl={GPT_URL}
+        sharingBookId={sharingBookId}
+        sharedBookId={sharedBookId}
+        onShare={(bookId) => void handleShare(bookId)}
+      />
+
+      <div className="relative mx-auto min-h-screen w-full max-w-[560px] bg-[var(--color-background)] px-[18px] pb-32 pt-[calc(env(safe-area-inset-top,0px)+12px)] font-[var(--font-body)] lg:hidden">
       {/* Header */}
       <div className="pb-3.5 pt-1">
         <div className="font-mono text-[10px] font-bold tracking-[0.08em] text-[var(--color-muted)]">GRAMMAR / USAGE</div>
@@ -229,6 +234,7 @@ export default function GrammarBooksPage() {
           <div className="mt-5">{gptCta}</div>
         </>
       )}
-    </div>
+      </div>
+    </>
   );
 }

--- a/src/app/grammar/share/[shareId]/page.tsx
+++ b/src/app/grammar/share/[shareId]/page.tsx
@@ -99,7 +99,7 @@ export default function GrammarSharePage({ params }: { params: Promise<{ shareId
   };
 
   return (
-    <div className="relative mx-auto min-h-screen w-full max-w-[560px] bg-[var(--color-background)] px-[18px] pb-12 pt-[calc(env(safe-area-inset-top,0px)+12px)] font-[var(--font-body)]">
+    <div className="relative mx-auto min-h-screen w-full max-w-[560px] bg-[var(--color-background)] px-[18px] pb-12 pt-[calc(env(safe-area-inset-top,0px)+12px)] font-[var(--font-body)] lg:max-w-[720px] lg:px-8 lg:pt-10">
       {/* Header */}
       <div className="flex items-center gap-2 pb-3 pt-1">
         <button

--- a/src/components/desktop/DesktopGrammar.tsx
+++ b/src/components/desktop/DesktopGrammar.tsx
@@ -1,0 +1,165 @@
+'use client';
+
+import Link from 'next/link';
+import { Icon } from '@/components/ui/Icon';
+import { DesktopButton, DesktopTopbar } from '@/components/desktop/DesktopChrome';
+import { desktopUpdatedLabel } from '@/components/desktop/desktop-data';
+
+// 語法問題集(Vintage型)一覧のデスクトップビュー。
+// DesktopProjectsView と同じ ds-card / ds-table ベースの構成。
+
+export type GrammarBook = {
+  id: string;
+  title: string;
+  updatedAt: string;
+};
+
+export type GrammarBooksLoadState =
+  | { kind: 'loading' }
+  | { kind: 'ready'; books: GrammarBook[] }
+  | { kind: 'pro-required' }
+  | { kind: 'error'; message: string };
+
+export function DesktopGrammarBooksView({
+  state,
+  gptUrl,
+  sharingBookId,
+  sharedBookId,
+  onShare,
+}: {
+  state: GrammarBooksLoadState;
+  gptUrl: string;
+  sharingBookId: string | null;
+  sharedBookId: string | null;
+  onShare: (bookId: string) => void;
+}) {
+  return (
+    <div className="hidden h-full min-h-0 flex-col lg:flex">
+      <DesktopTopbar title="語法問題集" crumb="文法・語法 / 空欄補充・英語4択">
+        {gptUrl ? (
+          <DesktopButton
+            variant="accent"
+            icon="smart_toy"
+            onClick={() => window.open(gptUrl, '_blank', 'noopener,noreferrer')}
+          >
+            ChatGPTで問題を作る
+          </DesktopButton>
+        ) : (
+          <DesktopButton variant="accent" icon="smart_toy" href="/tips/chatgpt">
+            ChatGPT連携の使い方
+          </DesktopButton>
+        )}
+      </DesktopTopbar>
+
+      <div className="ds-scroll">
+        <div style={{ maxWidth: 980 }}>
+          <p className="muted" style={{ fontSize: 12.5, margin: '0 0 16px' }}>
+            空欄補充・英語4択・解説つきの語法問題集。問題はChatGPTとの会話で作成し、ここで演習できます。
+          </p>
+
+          {state.kind === 'loading' && (
+            <div className="ds-card muted" style={{ padding: 50, textAlign: 'center', fontSize: 13 }}>
+              <Icon name="progress_activity" className="animate-spin" style={{ marginRight: 8 }} />
+              読み込み中...
+            </div>
+          )}
+
+          {state.kind === 'pro-required' && (
+            <div className="ds-card" style={{ padding: 24, maxWidth: 560 }}>
+              <div style={{ fontFamily: 'var(--font-display)', fontWeight: 800, fontSize: 16 }}>Pro限定機能です</div>
+              <p className="muted" style={{ fontSize: 13, lineHeight: 1.8, margin: '10px 0 16px' }}>
+                語法問題集はProプラン限定です。アップグレードすると、ChatGPTとの会話でVintage風の語法問題を作成・演習できます。
+              </p>
+              <DesktopButton variant="dark" href="/subscription" icon="workspace_premium">
+                Proプランを見る
+              </DesktopButton>
+            </div>
+          )}
+
+          {state.kind === 'error' && (
+            <div className="ds-card" style={{ padding: 24, color: 'var(--color-error)', borderColor: 'var(--color-error)', fontSize: 13 }}>
+              {state.message}
+            </div>
+          )}
+
+          {state.kind === 'ready' && state.books.length === 0 && (
+            <div className="ds-card" style={{ padding: 40, textAlign: 'center' }}>
+              <div style={{ fontFamily: 'var(--font-display)', fontWeight: 800, fontSize: 15 }}>まだ問題集がありません</div>
+              <p className="muted" style={{ fontSize: 13, lineHeight: 1.8, margin: '10px 0 0' }}>
+                ChatGPTのMERKEN GPTに「仮定法の語法問題を10問作って」のように頼むと、ここに問題集が保存されます。
+              </p>
+            </div>
+          )}
+
+          {state.kind === 'ready' && state.books.length > 0 && (
+            <>
+              <div className="ds-card" style={{ padding: 0, overflow: 'hidden' }}>
+                <table className="ds-table">
+                  <thead>
+                    <tr>
+                      <th>問題集</th>
+                      <th style={{ width: 110 }}>更新</th>
+                      <th style={{ width: 90 }}>共有</th>
+                      <th style={{ width: 120 }} />
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {state.books.map((book) => (
+                      <tr key={book.id}>
+                        <td>
+                          <Link
+                            href={`/grammar/${book.id}`}
+                            style={{ display: 'flex', alignItems: 'center', gap: 12, textDecoration: 'none', color: 'inherit' }}
+                          >
+                            <span
+                              style={{
+                                display: 'flex',
+                                alignItems: 'center',
+                                justifyContent: 'center',
+                                width: 34,
+                                height: 34,
+                                borderRadius: 9,
+                                border: '2px solid var(--solid-ink)',
+                                background: '#faf7f1',
+                              }}
+                            >
+                              <Icon name="menu_book" style={{ fontSize: 18 }} />
+                            </span>
+                            <span style={{ fontFamily: 'var(--font-display)', fontWeight: 700, fontSize: 15 }}>{book.title}</span>
+                          </Link>
+                        </td>
+                        <td className="mono" style={{ fontSize: 11.5, color: 'var(--color-muted)' }}>
+                          {desktopUpdatedLabel(book.updatedAt)}
+                        </td>
+                        <td>
+                          <DesktopButton
+                            variant="ghost"
+                            icon={sharedBookId === book.id ? 'check' : 'ios_share'}
+                            onClick={() => (sharingBookId ? undefined : onShare(book.id))}
+                            title="共有リンクをコピー"
+                          >
+                            {''}
+                          </DesktopButton>
+                        </td>
+                        <td>
+                          <DesktopButton variant="dark" icon="play_arrow" href={`/grammar/${book.id}`}>
+                            演習する
+                          </DesktopButton>
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+              {sharedBookId && (
+                <p className="mono" style={{ fontSize: 11.5, color: 'var(--color-accent)', fontWeight: 700, marginTop: 10 }}>
+                  共有リンクをコピーしました
+                </p>
+              )}
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## 概要

`/grammar` 系ページがデスクトップでモバイル幅のまま表示されていた問題の対応です。単語帳のデスクトップコンポーネント群(`DesktopTopbar` / `ds-card` / `ds-table` / `DesktopButton`)を流用しています。

## 変更内容

- **`src/components/desktop/DesktopGrammar.tsx`(新規)** — `DesktopProjectsView` と同じ構成の一覧ビュー:
  - トップバー(タイトル + パンくず + 「ChatGPTで問題を作る」CTA)
  - 問題集のテーブル表示(タイトル / 更新日 / 共有リンクコピー / 演習ボタン)
  - Pro未加入・0冊・エラー・ローディングの各状態を `ds-card` で表示
- **`/grammar`** — デスクトップ(lg+)は新ビュー、モバイルは従来UIを `lg:hidden` で維持。データ取得・共有処理は共通
- **`/grammar/[bookId]`(演習)・`/grammar/share/[shareId]`(共有閲覧)** — デスクトップで幅を720pxに拡大し余白を調整(演習UIは単一カラムのまま)

## テスト

- `npx eslint` クリーン、`npm run build` 成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GZ3odfsZbmoQKjPBSenQ2E

---
_Generated by [Claude Code](https://claude.ai/code/session_01GZ3odfsZbmoQKjPBSenQ2E)_