### PR TITLE
語法演習画面にデスクトップ専用ビューを追加

### DIFF
--- a/src/app/grammar/[bookId]/page.tsx
+++ b/src/app/grammar/[bookId]/page.tsx
@@ -4,44 +4,24 @@ import { use, useEffect, useMemo, useState } from 'react';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { Icon } from '@/components/ui/Icon';
+import {
+  DesktopGrammarPracticeView,
+  GRAMMAR_CHOICE_LABELS as CHOICE_LABELS,
+  renderGrammarSentence as renderSentence,
+  type GrammarPracticeQuestion as GrammarQuestion,
+} from '@/components/desktop/DesktopGrammar';
 
 // 語法問題集の演習画面 (Vintage型)。
 // 1問ずつ出題 → 選択 → 正誤 + 解説表示 → 次へ、最後に正答率と
 // 間違えた文法項目のまとめを表示する。
 // 問題取得は Pro ゲート付き /api/chatgpt/grammar-questions を cookie セッションで利用。
-
-const CHOICE_LABELS = ['A', 'B', 'C', 'D'] as const;
-
-type GrammarQuestion = {
-  id: string;
-  sentence: string;
-  choices: string[];
-  correctIndex: number;
-  explanation: string;
-  grammarPoint: string | null;
-  sentenceJa: string | null;
-};
+// デスクトップは DesktopGrammarPracticeView、モバイルは本ファイル内のUIを使う。
 
 type LoadState =
   | { kind: 'loading' }
   | { kind: 'ready'; questions: GrammarQuestion[] }
   | { kind: 'pro-required' }
   | { kind: 'error'; message: string };
-
-// 空欄マーカーを含む問題文を、空欄を強調したJSXに分解する
-function renderSentence(sentence: string) {
-  const parts = sentence.split('___');
-  return parts.map((part, index) => (
-    <span key={index}>
-      {part}
-      {index < parts.length - 1 && (
-        <span className="mx-1 inline-block min-w-[64px] border-b-2 border-[var(--color-accent)] text-center font-bold text-[var(--color-accent)]">
-          ___
-        </span>
-      )}
-    </span>
-  ));
-}
 
 export default function GrammarPracticePage({ params }: { params: Promise<{ bookId: string }> }) {
   const { bookId } = use(params);
@@ -136,8 +116,26 @@ export default function GrammarPracticePage({ params }: { params: Promise<{ book
     setFinished(false);
   };
 
+  const answeredCount = finished ? questions.length : index + (answered ? 1 : 0);
+  const correctCount = answeredCount - wrongQuestions.length;
+
   return (
-    <div className="relative mx-auto min-h-screen w-full max-w-[560px] bg-[var(--color-background)] px-[18px] pb-12 pt-[calc(env(safe-area-inset-top,0px)+12px)] font-[var(--font-body)] lg:max-w-[720px] lg:px-8 lg:pt-10">
+    <>
+      <DesktopGrammarPracticeView
+        loadState={state.kind === 'ready' ? { kind: 'ready' } : state}
+        totalQuestions={questions.length}
+        index={index}
+        question={question}
+        selected={selected}
+        finished={finished}
+        correctCount={correctCount}
+        wrongGrammarPoints={wrongGrammarPoints}
+        onSelect={handleSelect}
+        onNext={handleNext}
+        onRetry={handleRetry}
+      />
+
+      <div className="relative mx-auto min-h-screen w-full max-w-[560px] bg-[var(--color-background)] px-[18px] pb-12 pt-[calc(env(safe-area-inset-top,0px)+12px)] font-[var(--font-body)] lg:hidden">
       {/* Header */}
       <div className="flex items-center gap-2 pb-3 pt-1">
         <button
@@ -308,6 +306,7 @@ export default function GrammarPracticePage({ params }: { params: Promise<{ book
           )}
         </>
       )}
-    </div>
+      </div>
+    </>
   );
 }

--- a/src/components/desktop/DesktopGrammar.tsx
+++ b/src/components/desktop/DesktopGrammar.tsx
@@ -2,7 +2,7 @@
 
 import Link from 'next/link';
 import { Icon } from '@/components/ui/Icon';
-import { DesktopButton, DesktopTopbar } from '@/components/desktop/DesktopChrome';
+import { DesktopButton, DesktopDonut, DesktopTopbar } from '@/components/desktop/DesktopChrome';
 import { desktopUpdatedLabel } from '@/components/desktop/desktop-data';
 
 // 語法問題集(Vintage型)一覧のデスクトップビュー。
@@ -19,6 +19,33 @@ export type GrammarBooksLoadState =
   | { kind: 'ready'; books: GrammarBook[] }
   | { kind: 'pro-required' }
   | { kind: 'error'; message: string };
+
+export type GrammarPracticeQuestion = {
+  id: string;
+  sentence: string;
+  choices: string[];
+  correctIndex: number;
+  explanation: string;
+  grammarPoint: string | null;
+  sentenceJa: string | null;
+};
+
+export const GRAMMAR_CHOICE_LABELS = ['A', 'B', 'C', 'D'] as const;
+
+// 空欄マーカー ___ を強調表示に変換する (モバイル/デスクトップ共用)
+export function renderGrammarSentence(sentence: string) {
+  const parts = sentence.split('___');
+  return parts.map((part, index) => (
+    <span key={index}>
+      {part}
+      {index < parts.length - 1 && (
+        <span className="mx-1 inline-block min-w-[64px] border-b-2 border-[var(--color-accent)] text-center font-bold text-[var(--color-accent)]">
+          ___
+        </span>
+      )}
+    </span>
+  ));
+}
 
 export function DesktopGrammarBooksView({
   state,
@@ -159,6 +186,235 @@ export function DesktopGrammarBooksView({
             </>
           )}
         </div>
+      </div>
+    </div>
+  );
+}
+
+// 語法演習のデスクトップビュー。左に問題カード、右に進捗サイドバーの2カラム。
+export function DesktopGrammarPracticeView({
+  loadState,
+  totalQuestions,
+  index,
+  question,
+  selected,
+  finished,
+  correctCount,
+  wrongGrammarPoints,
+  onSelect,
+  onNext,
+  onRetry,
+}: {
+  loadState: { kind: 'loading' } | { kind: 'pro-required' } | { kind: 'error'; message: string } | { kind: 'ready' };
+  totalQuestions: number;
+  index: number;
+  question: GrammarPracticeQuestion | undefined;
+  selected: number | null;
+  finished: boolean;
+  correctCount: number;
+  wrongGrammarPoints: string[];
+  onSelect: (choiceIndex: number) => void;
+  onNext: () => void;
+  onRetry: () => void;
+}) {
+  const answered = selected !== null;
+  const correct = answered && question ? selected === question.correctIndex : false;
+  const answeredCount = finished ? totalQuestions : index + (answered ? 1 : 0);
+
+  return (
+    <div className="hidden h-full min-h-0 flex-col lg:flex">
+      <DesktopTopbar title="語法演習" crumb="文法・語法 / 空欄補充・英語4択">
+        <DesktopButton variant="ghost" icon="arrow_back" href="/grammar">
+          一覧へ戻る
+        </DesktopButton>
+      </DesktopTopbar>
+
+      <div className="ds-scroll">
+        {loadState.kind === 'loading' && (
+          <div className="ds-card muted" style={{ padding: 50, textAlign: 'center', fontSize: 13, maxWidth: 720 }}>
+            <Icon name="progress_activity" className="animate-spin" style={{ marginRight: 8 }} />
+            読み込み中...
+          </div>
+        )}
+
+        {loadState.kind === 'pro-required' && (
+          <div className="ds-card" style={{ padding: 24, maxWidth: 560 }}>
+            <div style={{ fontFamily: 'var(--font-display)', fontWeight: 800, fontSize: 16 }}>Pro限定機能です</div>
+            <p className="muted" style={{ fontSize: 13, lineHeight: 1.8, margin: '10px 0 16px' }}>
+              語法問題集はProプラン限定です。
+            </p>
+            <DesktopButton variant="dark" href="/subscription" icon="workspace_premium">
+              Proプランを見る
+            </DesktopButton>
+          </div>
+        )}
+
+        {loadState.kind === 'error' && (
+          <div className="ds-card" style={{ padding: 24, maxWidth: 560, color: 'var(--color-error)', borderColor: 'var(--color-error)', fontSize: 13 }}>
+            {loadState.message}
+          </div>
+        )}
+
+        {loadState.kind === 'ready' && totalQuestions === 0 && (
+          <div className="ds-card" style={{ padding: 40, textAlign: 'center', maxWidth: 720 }}>
+            <p className="muted" style={{ fontSize: 13, lineHeight: 1.8, margin: 0 }}>
+              この問題集にはまだ問題がありません。ChatGPTで問題を追加してください。
+            </p>
+          </div>
+        )}
+
+        {loadState.kind === 'ready' && totalQuestions > 0 && (
+          <div style={{ display: 'grid', gridTemplateColumns: 'minmax(0, 1fr) 300px', gap: 24, alignItems: 'start', maxWidth: 1100 }}>
+            <div>
+              {finished ? (
+                <div className="ds-card" style={{ padding: 32 }}>
+                  <div className="mono muted" style={{ fontSize: 11, fontWeight: 700, letterSpacing: '0.08em' }}>RESULT</div>
+                  <div style={{ display: 'flex', alignItems: 'center', gap: 28, marginTop: 18 }}>
+                    <DesktopDonut
+                      mastered={correctCount}
+                      review={totalQuestions - correctCount}
+                      total={totalQuestions}
+                      percent={Math.round((correctCount / totalQuestions) * 100)}
+                    />
+                    <div>
+                      <div style={{ fontFamily: 'var(--font-display)', fontWeight: 800, fontSize: 28 }}>
+                        {correctCount} / {totalQuestions} 問正解
+                      </div>
+                      {wrongGrammarPoints.length > 0 ? (
+                        <div style={{ marginTop: 12 }}>
+                          <div style={{ fontSize: 12.5, fontWeight: 700 }}>復習したい文法項目</div>
+                          <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6, marginTop: 8 }}>
+                            {wrongGrammarPoints.map((point) => (
+                              <span key={point} className="ds-chip" style={{ cursor: 'default' }}>{point}</span>
+                            ))}
+                          </div>
+                        </div>
+                      ) : (
+                        <p className="muted" style={{ fontSize: 13, margin: '10px 0 0' }}>全問正解です 🎉</p>
+                      )}
+                    </div>
+                  </div>
+                  <div style={{ display: 'flex', gap: 12, marginTop: 24 }}>
+                    <DesktopButton variant="dark" icon="replay" onClick={onRetry}>
+                      もう一度解く
+                    </DesktopButton>
+                    <DesktopButton variant="ghost" icon="list" href="/grammar">
+                      問題集一覧へ
+                    </DesktopButton>
+                  </div>
+                </div>
+              ) : question ? (
+                <>
+                  <div className="ds-card" style={{ padding: '26px 30px' }}>
+                    <p style={{ margin: 0, fontSize: 19, lineHeight: 2.1 }}>{renderGrammarSentence(question.sentence)}</p>
+                    {question.sentenceJa && answered && (
+                      <p className="muted" style={{ margin: '10px 0 0', fontSize: 13, lineHeight: 1.8 }}>{question.sentenceJa}</p>
+                    )}
+                  </div>
+
+                  <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 12, marginTop: 16 }}>
+                    {question.choices.map((choice, choiceIndex) => {
+                      const isSelected = selected === choiceIndex;
+                      const isCorrectChoice = choiceIndex === question.correctIndex;
+                      const showCorrect = answered && isCorrectChoice;
+                      const showWrong = answered && isSelected && !isCorrectChoice;
+                      return (
+                        <button
+                          key={choiceIndex}
+                          type="button"
+                          onClick={() => onSelect(choiceIndex)}
+                          disabled={answered}
+                          style={{
+                            display: 'flex',
+                            alignItems: 'center',
+                            gap: 12,
+                            padding: '14px 18px',
+                            borderRadius: 14,
+                            border: `2px solid ${showCorrect ? 'var(--color-accent)' : showWrong ? 'var(--color-error, #d33)' : 'var(--solid-ink)'}`,
+                            background: showCorrect ? 'var(--color-accent-light, #e8f5ec)' : showWrong ? '#fdeceb' : '#fff',
+                            cursor: answered ? 'default' : 'pointer',
+                            textAlign: 'left',
+                          }}
+                        >
+                          <span
+                            className="mono"
+                            style={{
+                              display: 'flex',
+                              alignItems: 'center',
+                              justifyContent: 'center',
+                              width: 30,
+                              height: 30,
+                              flexShrink: 0,
+                              borderRadius: '50%',
+                              fontWeight: 700,
+                              fontSize: 13,
+                              border: `2px solid ${showCorrect ? 'var(--color-accent)' : showWrong ? 'var(--color-error, #d33)' : 'var(--solid-ink)'}`,
+                              color: showCorrect ? 'var(--color-accent)' : showWrong ? 'var(--color-error, #d33)' : 'var(--solid-ink)',
+                            }}
+                          >
+                            {GRAMMAR_CHOICE_LABELS[choiceIndex]}
+                          </span>
+                          <span style={{ fontWeight: 700, fontSize: 15, minWidth: 0 }}>{choice}</span>
+                          {showCorrect && <Icon name="check_circle" style={{ marginLeft: 'auto', color: 'var(--color-accent)' }} />}
+                          {showWrong && <Icon name="cancel" style={{ marginLeft: 'auto', color: '#d33' }} />}
+                        </button>
+                      );
+                    })}
+                  </div>
+
+                  {answered && (
+                    <div className="ds-card" style={{ padding: '18px 22px', marginTop: 16, background: '#faf7f1' }}>
+                      <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+                        <Icon
+                          name={correct ? 'check_circle' : 'school'}
+                          style={{ color: correct ? 'var(--color-accent)' : 'var(--solid-ink)' }}
+                        />
+                        <span style={{ fontFamily: 'var(--font-display)', fontWeight: 800, fontSize: 14.5 }}>
+                          {correct
+                            ? '正解！'
+                            : `正解は ${GRAMMAR_CHOICE_LABELS[question.correctIndex]} 「${question.choices[question.correctIndex]}」`}
+                        </span>
+                      </div>
+                      <p style={{ margin: '10px 0 0', fontSize: 13.5, lineHeight: 1.9 }}>{question.explanation}</p>
+                    </div>
+                  )}
+
+                  {answered && (
+                    <div style={{ marginTop: 18 }}>
+                      <DesktopButton variant="dark" icon="arrow_forward" onClick={onNext}>
+                        {index + 1 >= totalQuestions ? '結果を見る' : '次の問題へ'}
+                      </DesktopButton>
+                    </div>
+                  )}
+                </>
+              ) : null}
+            </div>
+
+            <aside className="ds-card" style={{ padding: 20 }}>
+              <div className="mono muted" style={{ fontSize: 10.5, fontWeight: 700, letterSpacing: '0.08em' }}>PROGRESS</div>
+              <div style={{ fontFamily: 'var(--font-display)', fontWeight: 800, fontSize: 24, marginTop: 6 }}>
+                {finished ? totalQuestions : Math.min(index + 1, totalQuestions)} / {totalQuestions}
+              </div>
+              <div className="ds-prog" style={{ marginTop: 10 }}>
+                <div className="fi" style={{ width: `${totalQuestions > 0 ? Math.round((answeredCount / totalQuestions) * 100) : 0}%` }} />
+              </div>
+              <div style={{ display: 'flex', justifyContent: 'space-between', marginTop: 14, fontSize: 12.5 }}>
+                <span>正解</span>
+                <span className="tnum" style={{ fontWeight: 700, color: 'var(--color-accent)' }}>{correctCount}</span>
+              </div>
+              <div style={{ display: 'flex', justifyContent: 'space-between', marginTop: 6, fontSize: 12.5 }}>
+                <span>不正解</span>
+                <span className="tnum" style={{ fontWeight: 700, color: '#d33' }}>{answeredCount - correctCount}</span>
+              </div>
+              {!finished && question?.grammarPoint && (
+                <div style={{ marginTop: 16 }}>
+                  <div className="mono muted" style={{ fontSize: 10, fontWeight: 700, letterSpacing: '0.06em' }}>GRAMMAR POINT</div>
+                  <span className="ds-chip" style={{ marginTop: 6, cursor: 'default' }}>{question.grammarPoint}</span>
+                </div>
+              )}
+            </aside>
+          </div>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
## 概要

#433 では語法の**一覧**のみデスクトップ対応しており、**演習(クイズ)画面**に進むとモバイルUIのままでした。演習画面にもデスクトップ専用ビューを追加します。

## 変更内容

- **`DesktopGrammarPracticeView`(`DesktopGrammar.tsx` に追加)** — lg以上で2カラム構成:
  - **左**: 問題カード(大きめの文字サイズ・空欄ハイライト)→ 選択肢を2列グリッド(A〜D)→ 答え合わせで解説カード → 「次の問題へ / 結果を見る」
  - **右**: 進捗サイドバー(n/N・プログレスバー・正解/不正解カウント・出題中の文法項目チップ)
  - **結果画面**: `DesktopDonut` で正答率を表示し、復習したい文法項目をチップで一覧。「もう一度解く / 問題集一覧へ」
  - トップバーに「一覧へ戻る」
- **共通化**: 空欄ハイライト(`renderGrammarSentence`)と選択肢ラベル(`GRAMMAR_CHOICE_LABELS`)、問題型を `DesktopGrammar.tsx` に集約し、モバイルUIからも参照
- `/grammar/[bookId]` のモバイルUIは `lg:hidden` で従来どおり(状態・誤答記録ロジックは両ビュー共通)

## テスト

- `npx eslint` クリーン、`npm run build` 成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GZ3odfsZbmoQKjPBSenQ2E

---
_Generated by [Claude Code](https://claude.ai/code/session_01GZ3odfsZbmoQKjPBSenQ2E)_