### PR TITLE
デスクトップ棚のタイル幅を復元 + 語法の戻る遷移を修正

### DIFF
--- a/src/app/grammar/[bookId]/list/page.tsx
+++ b/src/app/grammar/[bookId]/list/page.tsx
@@ -27,6 +27,12 @@ export default function GrammarQuestionListPage({ params }: { params: Promise<{ 
   const { bookId } = use(params);
   const router = useRouter();
 
+  // 戻るは来た画面 (ホーム等) に戻す。直接アクセスなど履歴が無いときのみ一覧へフォールバック。
+  const handleBack = () => {
+    if (typeof window !== 'undefined' && window.history.length > 1) router.back();
+    else router.push('/grammar');
+  };
+
   const [state, setState] = useState<LoadState>({ kind: 'loading' });
   const [selectedIndex, setSelectedIndex] = useState<number | null>(null);
   const [formOpen, setFormOpen] = useState(false);
@@ -113,9 +119,9 @@ export default function GrammarQuestionListPage({ params }: { params: Promise<{ 
       <div className="flex items-center gap-2 pb-3 pt-1">
         <button
           type="button"
-          onClick={() => router.push('/grammar')}
+          onClick={handleBack}
           className="flex h-[38px] w-[38px] items-center justify-center rounded-[19px] border-2 border-[var(--solid-ink)] bg-white text-[var(--solid-ink)] transition-all duration-100 active:translate-x-px active:translate-y-px"
-          aria-label="一覧に戻る"
+          aria-label="戻る"
         >
           <Icon name="chevron_left" size={16} />
         </button>

--- a/src/app/grammar/[bookId]/page.tsx
+++ b/src/app/grammar/[bookId]/page.tsx
@@ -33,6 +33,12 @@ export default function GrammarPracticePage({ params }: { params: Promise<{ book
   const isReview = bookId === 'review';
   const router = useRouter();
 
+  // 戻るは来た画面 (ホーム等) に戻す。直接アクセスなど履歴が無いときのみ一覧へフォールバック。
+  const handleBack = () => {
+    if (typeof window !== 'undefined' && window.history.length > 1) router.back();
+    else router.push('/grammar');
+  };
+
   const [state, setState] = useState<LoadState>({ kind: 'loading' });
   const [index, setIndex] = useState(0);
   const [selected, setSelected] = useState<number | null>(null);
@@ -188,9 +194,9 @@ export default function GrammarPracticePage({ params }: { params: Promise<{ book
       <div className="flex items-center gap-2 pb-3 pt-1">
         <button
           type="button"
-          onClick={() => router.push('/grammar')}
+          onClick={handleBack}
           className="flex h-[38px] w-[38px] items-center justify-center rounded-[19px] border-2 border-[var(--solid-ink)] bg-white text-[var(--solid-ink)] transition-all duration-100 active:translate-x-px active:translate-y-px"
-          aria-label="一覧に戻る"
+          aria-label="戻る"
         >
           <Icon name="chevron_left" size={16} />
         </button>

--- a/src/components/desktop/DesktopHome.tsx
+++ b/src/components/desktop/DesktopHome.tsx
@@ -218,8 +218,8 @@ export function DesktopHomeView({
                 </div>
               </button>
             ) : view === 'grid' ? (
-              /* 横スクロールの棚に従来の本棚タイルを並べる (1行10冊の高密度表示) */
-              <div className="ds-shelf-row cols-10">
+              /* 横スクロールの棚に従来の本棚タイルを並べる (タイル幅は保ち、冊数が多いときは横スクロール) */
+              <div className="ds-shelf-row">
                 {pendingScans.map((scan) => (
                   <DesktopGeneratingBookTile key={scan.id} scan={scan} />
                 ))}

--- a/src/components/home/HomeGrammarBooks.tsx
+++ b/src/components/home/HomeGrammarBooks.tsx
@@ -79,8 +79,8 @@ export function DesktopHomeGrammarBooks({ books }: { books: GrammarBook[] }) {
           <Icon name="chevron_right" style={{ fontSize: 16 }} />
         </Link>
       </div>
-      {/* マイ単語帳と同じ ds-book タイルの横スクロール棚 (1行10冊) */}
-      <div className="ds-shelf-row cols-10">
+      {/* マイ単語帳と同じ ds-book タイルの横スクロール棚 (タイル幅は保ち、横スクロール) */}
+      <div className="ds-shelf-row">
         {books.map((book) => (
           <Link
             key={book.id}


### PR DESCRIPTION
#439 マージ後のフォローアップ。最新 main からブランチを作り直して作業しています。

## 変更内容

### 1. デスクトップ本棚のタイル幅を復元
`b569c5b`(「本棚10冊表示」)で導入された `ds-shelf-row cols-10` が、1行に10冊入れるためにタイル幅・文字を圧縮していました。これを外し、**タイル幅は元の大きさのまま**・冊数が多いときは**横スクロール**で見せる挙動に戻しました。
- `DesktopHome.tsx`(マイ単語帳の棚)/ `HomeGrammarBooks.tsx`(語法問題集の棚)の両方
- `.ds-book--compact` は別用途(`DesktopHome.tsx` の compact タイル)で使われているため、CSS 側の該当セレクタは残しています

### 2. 語法ページの「戻る」を来た画面へ
ホームの語法タイルから入ると `/grammar/[bookId]/list` に遷移しますが、左矢印での戻る先が常に `/grammar` 固定で、ホームに戻れませんでした。`router.back()` に変更し、来た画面(ホーム等)へ戻るようにしました。履歴が無い直接アクセス時のみ `/grammar` にフォールバックします。
- 対象: 語法の問題一覧ページ / 演習ページ(モバイル)

## 動作確認
- `npx eslint`(変更ファイル): エラーなし

## 補足
語法クイズ画面まわりの追加要望(共通ヘッダの付与・単語帳部品の流用増・1画面に収める・右上ヒントの削除など)は、対象・仕様の確認後にまとめて別途対応予定です。

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EZc2mE8zpFAiRg6oAqwJJA)_