### PR TITLE
語法クイズUI改善: ヒントバッジ削除・問題一覧の枠を単語一覧に統一 (継続作業)

### DIFF
--- a/src/app/grammar/[bookId]/list/page.tsx
+++ b/src/app/grammar/[bookId]/list/page.tsx
@@ -183,13 +183,14 @@ export default function GrammarQuestionListPage({ params }: { params: Promise<{ 
       )}
 
       {state.kind === 'ready' && questions.length > 0 && (
-        <div className="flex flex-col gap-2.5">
+        /* /project/* の単語一覧と同じ枠 (divide-y の枠なしリスト行) */
+        <div className="divide-y divide-[var(--color-border)]">
           {questions.map((question, questionIndex) => (
             <button
               key={question.id}
               type="button"
               onClick={() => setSelectedIndex(questionIndex)}
-              className="flex items-start gap-3 rounded-xl border-2 border-[var(--solid-ink)] bg-white px-3.5 py-3 text-left transition-all duration-100 active:translate-x-px active:translate-y-px"
+              className="flex w-full items-start gap-2.5 px-1 py-2.5 text-left transition-colors active:bg-[rgba(19,127,236,0.06)]"
             >
               <span className="mt-0.5 shrink-0 font-mono text-[11px] font-bold text-[var(--color-muted)]">
                 {String(questionIndex + 1).padStart(2, '0')}

--- a/src/app/grammar/[bookId]/list/page.tsx
+++ b/src/app/grammar/[bookId]/list/page.tsx
@@ -4,6 +4,7 @@ import { use, useCallback, useEffect, useState } from 'react';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { Icon } from '@/components/ui/Icon';
+import { usePageScrolled } from '@/hooks/use-page-scrolled';
 import {
   DesktopGrammarQuestionListView,
   GrammarQuestionDetailBody,
@@ -32,6 +33,7 @@ export default function GrammarQuestionListPage({ params }: { params: Promise<{ 
     if (typeof window !== 'undefined' && window.history.length > 1) router.back();
     else router.push('/grammar');
   };
+  const pageScrolled = usePageScrolled();
 
   const [state, setState] = useState<LoadState>({ kind: 'loading' });
   const [selectedIndex, setSelectedIndex] = useState<number | null>(null);
@@ -114,9 +116,12 @@ export default function GrammarQuestionListPage({ params }: { params: Promise<{ 
         }}
       />
 
-      <div className="relative mx-auto min-h-screen w-full max-w-[560px] bg-[var(--color-background)] px-[18px] pb-12 pt-3 font-[var(--font-body)] lg:hidden">
-      {/* Header */}
-      <div className="flex items-center gap-2 pb-3 pt-1">
+      <div className="relative mx-auto min-h-screen w-full max-w-[560px] bg-[var(--color-background)] px-[18px] pb-12 font-[var(--font-body)] lg:hidden">
+      {/* Header: 他ページ (単語帳詳細など) と同じ固定ヘッダ。ノッチ帯は全体共通の StatusBarCover が覆う */}
+      <header
+        className={`sticky z-40 -mx-[18px] flex items-center gap-2 border-b-2 bg-[var(--color-background)]/95 px-[18px] py-2.5 backdrop-blur-md ${pageScrolled ? 'border-[var(--solid-ink)]' : 'border-transparent'}`}
+        style={{ top: 'env(safe-area-inset-top, 0px)' }}
+      >
         <button
           type="button"
           onClick={handleBack}
@@ -144,7 +149,7 @@ export default function GrammarQuestionListPage({ params }: { params: Promise<{ 
           <Icon name="play_arrow" size={15} />
           演習する
         </Link>
-      </div>
+      </header>
 
       {state.kind === 'loading' && (
         <div className="flex flex-col gap-2.5">

--- a/src/app/grammar/[bookId]/page.tsx
+++ b/src/app/grammar/[bookId]/page.tsx
@@ -4,6 +4,7 @@ import { use, useEffect, useMemo, useState } from 'react';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { Icon } from '@/components/ui/Icon';
+import { usePageScrolled } from '@/hooks/use-page-scrolled';
 import {
   DesktopGrammarPracticeView,
   GRAMMAR_CHOICE_LABELS as CHOICE_LABELS,
@@ -38,6 +39,7 @@ export default function GrammarPracticePage({ params }: { params: Promise<{ book
     if (typeof window !== 'undefined' && window.history.length > 1) router.back();
     else router.push('/grammar');
   };
+  const pageScrolled = usePageScrolled();
 
   const [state, setState] = useState<LoadState>({ kind: 'loading' });
   const [index, setIndex] = useState(0);
@@ -189,9 +191,12 @@ export default function GrammarPracticePage({ params }: { params: Promise<{ book
         onAskChatGpt={handleAskChatGpt}
       />
 
-      <div className="relative mx-auto min-h-screen w-full max-w-[560px] bg-[var(--color-background)] px-[18px] pb-32 pt-3 font-[var(--font-body)] lg:hidden">
-      {/* Header */}
-      <div className="flex items-center gap-2 pb-3 pt-1">
+      <div className="relative mx-auto min-h-screen w-full max-w-[560px] bg-[var(--color-background)] px-[18px] pb-32 font-[var(--font-body)] lg:hidden">
+      {/* Header: 他ページと同じ固定ヘッダ。ノッチ帯は全体共通の StatusBarCover が覆う */}
+      <header
+        className={`sticky z-40 -mx-[18px] flex items-center gap-2 border-b-2 bg-[var(--color-background)]/95 px-[18px] py-2.5 backdrop-blur-md ${pageScrolled ? 'border-[var(--solid-ink)]' : 'border-transparent'}`}
+        style={{ top: 'env(safe-area-inset-top, 0px)' }}
+      >
         <button
           type="button"
           onClick={handleBack}
@@ -210,7 +215,7 @@ export default function GrammarPracticePage({ params }: { params: Promise<{ book
             </div>
           )}
         </div>
-      </div>
+      </header>
 
       {state.kind === 'loading' && (
         <div className="mt-2 h-[300px] animate-pulse rounded-xl border-2 border-[var(--color-border)] bg-white" />

--- a/src/app/grammar/[bookId]/page.tsx
+++ b/src/app/grammar/[bookId]/page.tsx
@@ -210,11 +210,6 @@ export default function GrammarPracticePage({ params }: { params: Promise<{ book
             </div>
           )}
         </div>
-        {question?.grammarPoint && !finished && (
-          <span className="shrink-0 rounded-[4px] border border-[var(--solid-ink)] bg-white px-2 py-[3px] font-mono text-[9px] font-bold text-[var(--solid-ink)]">
-            {question.grammarPoint}
-          </span>
-        )}
       </div>
 
       {state.kind === 'loading' && (

--- a/src/app/grammar/[bookId]/page.tsx
+++ b/src/app/grammar/[bookId]/page.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { Icon } from '@/components/ui/Icon';
 import { usePageScrolled } from '@/hooks/use-page-scrolled';
+import { DSQuizOption } from '@/components/quiz/DSQuizOption';
 import {
   DesktopGrammarPracticeView,
   GRAMMAR_CHOICE_LABELS as CHOICE_LABELS,
@@ -301,43 +302,20 @@ export default function GrammarPracticePage({ params }: { params: Promise<{ book
             )}
           </div>
 
+          {/* 選択肢は単語帳クイズと同じ DSQuizOption を共用 */}
           <div className="mt-3.5 flex flex-col gap-2.5">
-            {question.choices.map((choice, choiceIndex) => {
-              const isSelected = selected === choiceIndex;
-              const isCorrectChoice = choiceIndex === question.correctIndex;
-              const showCorrect = answered && isCorrectChoice;
-              const showWrong = answered && isSelected && !isCorrectChoice;
-              return (
-                <button
-                  key={choiceIndex}
-                  type="button"
-                  onClick={() => handleSelect(choiceIndex)}
-                  disabled={answered}
-                  className="flex items-center gap-3 rounded-xl border-2 bg-white px-4 py-3 text-left transition-all duration-100 active:translate-x-px active:translate-y-px disabled:active:translate-x-0 disabled:active:translate-y-0"
-                  style={{
-                    borderColor: showCorrect
-                      ? 'var(--color-accent)'
-                      : showWrong
-                        ? 'var(--color-error, #d33)'
-                        : 'var(--solid-ink)',
-                    background: showCorrect ? 'var(--color-accent-light, #e8f5ec)' : showWrong ? '#fdeceb' : '#fff',
-                  }}
-                >
-                  <span
-                    className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full border-2 font-mono text-[12px] font-bold"
-                    style={{
-                      borderColor: showCorrect ? 'var(--color-accent)' : showWrong ? 'var(--color-error, #d33)' : 'var(--solid-ink)',
-                      color: showCorrect ? 'var(--color-accent)' : showWrong ? 'var(--color-error, #d33)' : 'var(--solid-ink)',
-                    }}
-                  >
-                    {CHOICE_LABELS[choiceIndex]}
-                  </span>
-                  <span className="min-w-0 flex-1 text-[14px] font-bold text-[var(--solid-ink)]">{choice}</span>
-                  {showCorrect && <Icon name="check_circle" size={18} className="shrink-0 text-[var(--color-accent)]" />}
-                  {showWrong && <Icon name="cancel" size={18} className="shrink-0 text-[#d33]" />}
-                </button>
-              );
-            })}
+            {question.choices.map((choice, choiceIndex) => (
+              <DSQuizOption
+                key={choiceIndex}
+                label={choice}
+                index={choiceIndex}
+                isSelected={selected === choiceIndex}
+                isCorrect={choiceIndex === question.correctIndex}
+                isRevealed={answered}
+                onSelect={() => handleSelect(choiceIndex)}
+                disabled={answered}
+              />
+            ))}
           </div>
 
           {/* 解説 (Vintage風: 答え合わせのたびに必ず表示) */}

--- a/src/app/quiz/[projectId]/page.tsx
+++ b/src/app/quiz/[projectId]/page.tsx
@@ -1,11 +1,12 @@
 'use client';
 
-import { type ReactNode, useState, useEffect, useCallback, useMemo, useRef } from 'react';
+import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import { useRouter, useParams, useSearchParams, usePathname } from 'next/navigation';
 import { Icon } from '@/components/ui/Icon';
 import { SolidButton } from '@/components/redesign/SolidPage';
 import { TypeInQuizField, ReviewProjectFilterSheet, type ReviewFilterProject, type TypeInQuizFieldHandle } from '@/components/quiz';
 import { TranslationDisplay } from '@/components/word/TranslationDisplay';
+import { DSQuizOption } from '@/components/quiz/DSQuizOption';
 import { getRepository } from '@/lib/db';
 import { remoteRepository } from '@/lib/db/remote-repository';
 import { createBrowserClient } from '@/lib/supabase';
@@ -204,89 +205,6 @@ function buildFallbackWordFromWrongAnswer(wrongAnswer: WrongAnswer): Word {
     repetition: 0,
     isFavorite: false,
   };
-}
-
-/* ---------- DS-styled option card ---------- */
-function DSQuizOption({
-  label,
-  index,
-  isSelected,
-  isCorrect,
-  isRevealed,
-  onSelect,
-  disabled,
-}: {
-  label: string;
-  index: number;
-  isSelected: boolean;
-  isCorrect: boolean;
-  isRevealed: boolean;
-  onSelect: () => void;
-  disabled: boolean;
-}) {
-  const isCorrectAnswer = isRevealed && isCorrect;
-  const isWrongAnswer = isRevealed && isSelected && !isCorrect;
-  const isInactive = isRevealed && !isSelected && !isCorrect;
-
-  let faceBg = '#fff';
-  let borderColor = 'var(--solid-ink)';
-  let shadowColor = 'var(--solid-ink)';
-  let textColor = 'var(--solid-ink)';
-  let badgeBg = '#fff';
-  let badgeColor = 'var(--solid-ink)';
-  let icon: ReactNode = null;
-
-  if (isCorrectAnswer) {
-    faceBg = 'var(--color-accent)';
-    borderColor = 'var(--color-accent-ink)';
-    shadowColor = 'var(--color-accent-ink)';
-    textColor = '#fff';
-    badgeBg = 'rgba(255,255,255,0.22)';
-    badgeColor = '#fff';
-    icon = <Icon name="check" size={18} className="text-white" />;
-  } else if (isWrongAnswer) {
-    faceBg = 'var(--color-error)';
-    borderColor = '#b91c1c';
-    shadowColor = '#b91c1c';
-    textColor = '#fff';
-    badgeBg = 'rgba(255,255,255,0.22)';
-    badgeColor = '#fff';
-    icon = <Icon name="close" size={18} className="text-white" />;
-  } else if (isInactive) {
-    borderColor = 'var(--color-border)';
-    shadowColor = 'var(--color-border)';
-    textColor = 'var(--color-muted)';
-  }
-
-  return (
-    <button
-      type="button"
-      onClick={onSelect}
-      disabled={disabled}
-      className="relative w-full text-left disabled:cursor-not-allowed"
-    >
-      {/* shadow plate */}
-      <div
-        className="absolute inset-0 rounded-xl"
-        style={{ transform: 'translate(2.5px, 2.5px)', background: shadowColor }}
-      />
-      <div
-        className="relative flex items-center gap-[11px] rounded-xl border-2 px-3.5 py-3.5"
-        style={{ background: faceBg, borderColor }}
-      >
-        <div
-          className="flex h-6 w-6 shrink-0 items-center justify-center rounded-md border-2 border-[var(--solid-ink)] font-mono text-[11px] font-bold"
-          style={{ background: badgeBg, color: badgeColor }}
-        >
-          {String.fromCharCode(65 + index)}
-        </div>
-        <div className="flex-1 text-[15px] font-semibold leading-[1.35]" style={{ color: textColor }}>
-          {label}
-        </div>
-        {icon}
-      </div>
-    </button>
-  );
 }
 
 function DSDesktopWordOrderPanel({

--- a/src/components/desktop/DesktopHome.tsx
+++ b/src/components/desktop/DesktopHome.tsx
@@ -269,8 +269,8 @@ export function DesktopHomeView({
             <JoinedGroupGrid groups={joinedGroups} columns={3} />
           </div>
 
-          {/* おすすめの単語帳（マイ単語帳と同じ本棚タイル）。
-              タイルの大きさは固定で、1行6冊を超えたら折り返して表示する */}
+          {/* おすすめの単語帳（マイ単語帳の棚と同じ大きさの本棚タイル）。
+              タイルの大きさはマイ単語帳の棚に揃え、1行4冊を超えたら折り返して表示する */}
           {recommendedBooks.length > 0 && (
             <div style={{ marginTop: 28 }}>
               <div className="ds-sec-head" style={{ marginBottom: 14 }}>
@@ -282,9 +282,9 @@ export function DesktopHomeView({
                   <Icon name="chevron_right" style={{ fontSize: 16 }} />
                 </Link>
               </div>
-              <div style={{ display: 'grid', gridTemplateColumns: 'repeat(6, minmax(0, 1fr))', gap: 12 }}>
+              <div style={{ display: 'grid', gridTemplateColumns: 'repeat(4, minmax(0, 1fr))', gap: 16 }}>
                 {recommendedBooks.map((book) => (
-                  <DesktopRecommendedBookTile key={book.shareId} book={book} compact />
+                  <DesktopRecommendedBookTile key={book.shareId} book={book} />
                 ))}
               </div>
             </div>

--- a/src/components/quiz/DSQuizOption.tsx
+++ b/src/components/quiz/DSQuizOption.tsx
@@ -1,0 +1,88 @@
+import type { ReactNode } from 'react';
+import { Icon } from '@/components/ui/Icon';
+
+/**
+ * DS風の選択肢カード（影付きプレート）。
+ * 単語帳クイズ (/quiz/*) と語法クイズ (/grammar/*) で共用する。
+ */
+export function DSQuizOption({
+  label,
+  index,
+  isSelected,
+  isCorrect,
+  isRevealed,
+  onSelect,
+  disabled,
+}: {
+  label: string;
+  index: number;
+  isSelected: boolean;
+  isCorrect: boolean;
+  isRevealed: boolean;
+  onSelect: () => void;
+  disabled: boolean;
+}) {
+  const isCorrectAnswer = isRevealed && isCorrect;
+  const isWrongAnswer = isRevealed && isSelected && !isCorrect;
+  const isInactive = isRevealed && !isSelected && !isCorrect;
+
+  let faceBg = '#fff';
+  let borderColor = 'var(--solid-ink)';
+  let shadowColor = 'var(--solid-ink)';
+  let textColor = 'var(--solid-ink)';
+  let badgeBg = '#fff';
+  let badgeColor = 'var(--solid-ink)';
+  let icon: ReactNode = null;
+
+  if (isCorrectAnswer) {
+    faceBg = 'var(--color-accent)';
+    borderColor = 'var(--color-accent-ink)';
+    shadowColor = 'var(--color-accent-ink)';
+    textColor = '#fff';
+    badgeBg = 'rgba(255,255,255,0.22)';
+    badgeColor = '#fff';
+    icon = <Icon name="check" size={18} className="text-white" />;
+  } else if (isWrongAnswer) {
+    faceBg = 'var(--color-error)';
+    borderColor = '#b91c1c';
+    shadowColor = '#b91c1c';
+    textColor = '#fff';
+    badgeBg = 'rgba(255,255,255,0.22)';
+    badgeColor = '#fff';
+    icon = <Icon name="close" size={18} className="text-white" />;
+  } else if (isInactive) {
+    borderColor = 'var(--color-border)';
+    shadowColor = 'var(--color-border)';
+    textColor = 'var(--color-muted)';
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={onSelect}
+      disabled={disabled}
+      className="relative w-full text-left disabled:cursor-not-allowed"
+    >
+      {/* shadow plate */}
+      <div
+        className="absolute inset-0 rounded-xl"
+        style={{ transform: 'translate(2.5px, 2.5px)', background: shadowColor }}
+      />
+      <div
+        className="relative flex items-center gap-[11px] rounded-xl border-2 px-3.5 py-3.5"
+        style={{ background: faceBg, borderColor }}
+      >
+        <div
+          className="flex h-6 w-6 shrink-0 items-center justify-center rounded-md border-2 border-[var(--solid-ink)] font-mono text-[11px] font-bold"
+          style={{ background: badgeBg, color: badgeColor }}
+        >
+          {String.fromCharCode(65 + index)}
+        </div>
+        <div className="flex-1 text-[15px] font-semibold leading-[1.35]" style={{ color: textColor }}>
+          {label}
+        </div>
+        {icon}
+      </div>
+    </button>
+  );
+}


### PR DESCRIPTION
語法まわりのUI改善の継続作業(その1)。安全に確定できた分から順次追加していきます。

## この差分の内容
1. **演習右上の文法項目バッジを削除**: 回答前に文法項目(例「仮定法」)が見えると答えのヒントになるため削除。
2. **問題一覧を単語一覧と同じ枠に**: `/grammar/[bookId]/list` の各問題を個別カード枠(`rounded-xl border-2`)から、`/project/[id]` の単語一覧と同じ **`divide-y` の枠なしリスト行**に統一。

## 動作確認
- `npx eslint`(変更ファイル): エラーなし
- `npm run build`: 成功

## 継続対応予定(このPRに順次追加 or 別PR)
- 語法各ページに共通の固定ヘッダ付与
- 選択肢などを単語帳クイズの共通部品(DSQuizOption)に寄せて流用
- 演習画面を1画面に収める(例文が溢れる時のみスクロール)
- 単語追加ボタンをフラッシュカードボタンの右隣へ(モバイル)
- おすすめ単語帳タイルのサイズ統一
- 語法クイズの出題順を単語帳と同じ間隔反復アルゴリズムに(正解済みの再出題を抑制)
- 「訳を見ないと解けない問題」用のフラグ追加 + ChatGPT指示プロンプト更新

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EZc2mE8zpFAiRg6oAqwJJA)_