### PR TITLE
バインダー機能(ホーム表示/追加/公開) + 単語一覧のページ送り + 本棚の戻る修正 ほか

### DIFF
--- a/src/app/binder/[name]/page.tsx
+++ b/src/app/binder/[name]/page.tsx
@@ -1,0 +1,249 @@
+'use client';
+
+import { use, useCallback, useEffect, useMemo, useState } from 'react';
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import { Icon } from '@/components/ui/Icon';
+import { useAuth } from '@/hooks/use-auth';
+import { useToast } from '@/components/ui/toast';
+import { getRepository } from '@/lib/db';
+import { getGuestUserId } from '@/lib/utils';
+import { invalidateHomeCache } from '@/lib/home-cache';
+import type { Project, SubscriptionStatus } from '@/types';
+
+// バインダー (フォルダ) 詳細。中の単語帳を一覧し、単語帳の追加/解除と、
+// バインダーごとの共有ライブラリ公開を行う。マイ単語帳と同じ配色のタイルを使う。
+
+// 単語帳タイルと同じ配色 (home-client / projects の THUMBS と同一)
+const THUMBS = ['#137FEC', '#664DB3', '#228B22', '#2E66BF', '#D97340', '#3373B3', '#CC4D59', '#3DA1B8'];
+function thumbColor(id: string) {
+  let h = 0;
+  for (let i = 0; i < id.length; i++) h = ((h << 5) - h + id.charCodeAt(i)) | 0;
+  return THUMBS[Math.abs(h) % THUMBS.length];
+}
+
+function normalizeBinder(value: string | null | undefined): string {
+  return value?.trim() ?? '';
+}
+
+export default function BinderDetailPage({ params }: { params: Promise<{ name: string }> }) {
+  const { name: rawName } = use(params);
+  const binderName = decodeURIComponent(rawName);
+  const router = useRouter();
+  const { user, subscription, isPro } = useAuth();
+  const { showToast } = useToast();
+
+  const subscriptionStatus: SubscriptionStatus = subscription?.status || 'free';
+  const wasPro = subscription?.plan === 'pro' && subscriptionStatus !== 'active';
+  const repository = useMemo(() => getRepository(subscriptionStatus, wasPro), [subscriptionStatus, wasPro]);
+
+  const [projects, setProjects] = useState<Project[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [addOpen, setAddOpen] = useState(false);
+  const [busyId, setBusyId] = useState<string | null>(null);
+  const [publishing, setPublishing] = useState(false);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      const userId = user ? user.id : getGuestUserId();
+      setProjects(await repository.getProjects(userId));
+    } catch {
+      setProjects([]);
+    } finally {
+      setLoading(false);
+    }
+  }, [repository, user]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const inBinder = useMemo(
+    () => projects.filter((p) => normalizeBinder(p.binder) === binderName),
+    [projects, binderName],
+  );
+  const addable = useMemo(
+    () => projects.filter((p) => normalizeBinder(p.binder) !== binderName),
+    [projects, binderName],
+  );
+
+  const setBinder = async (projectId: string, binder: string | null, failMessage: string) => {
+    if (busyId) return;
+    setBusyId(projectId);
+    try {
+      await repository.updateProject(projectId, { binder });
+      setProjects((prev) => prev.map((p) => (p.id === projectId ? { ...p, binder } : p)));
+      invalidateHomeCache();
+    } catch {
+      showToast({ message: failMessage, type: 'error' });
+    } finally {
+      setBusyId(null);
+    }
+  };
+
+  // バインダー内の単語帳をまとめて共有ライブラリに公開する (Pro限定)
+  const handlePublishBinder = async () => {
+    if (publishing || inBinder.length === 0) return;
+    if (!isPro) {
+      showToast({ message: '共有ライブラリへの公開はProプラン限定です', type: 'error' });
+      return;
+    }
+    if (!window.confirm(`「${binderName}」内の${inBinder.length}冊を共有ライブラリに公開しますか？`)) return;
+    setPublishing(true);
+    let ok = 0;
+    for (const project of inBinder) {
+      try {
+        const res = await fetch('/api/shared-projects/share-wordbook', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ projectId: project.id, sharedTags: [binderName] }),
+        });
+        const payload = (await res.json().catch(() => null)) as { success?: boolean } | null;
+        if (res.ok && payload?.success) ok += 1;
+      } catch {
+        // 続行して残りを公開する
+      }
+    }
+    setPublishing(false);
+    invalidateHomeCache();
+    showToast({
+      message: ok === inBinder.length ? `${ok}冊を公開しました` : `${ok}/${inBinder.length}冊を公開しました`,
+      type: ok > 0 ? 'success' : 'error',
+    });
+  };
+
+  return (
+    <div className="relative mx-auto min-h-screen w-full max-w-[560px] bg-[var(--color-background)] px-[18px] pb-32 pt-3 font-[var(--font-body)] lg:max-w-[720px] lg:px-8 lg:pt-8">
+      {/* Header */}
+      <div className="flex items-center gap-2 pb-3 pt-1">
+        <button
+          type="button"
+          onClick={() => (typeof window !== 'undefined' && window.history.length > 1 ? router.back() : router.push('/'))}
+          className="flex h-[38px] w-[38px] shrink-0 items-center justify-center rounded-[19px] border-2 border-[var(--solid-ink)] bg-white text-[var(--solid-ink)] transition-all duration-100 active:translate-x-px active:translate-y-px"
+          aria-label="戻る"
+        >
+          <Icon name="chevron_left" size={16} />
+        </button>
+        <div className="min-w-0 flex-1">
+          <div className="font-mono text-[10px] font-bold tracking-[0.08em] text-[var(--color-muted)]">BINDER</div>
+          <div className="flex items-center gap-1.5">
+            <Icon name="folder" size={18} filled className="shrink-0 text-[var(--solid-ink)]" />
+            <span className="truncate font-display text-xl font-extrabold text-[var(--solid-ink)]">{binderName}</span>
+            <span className="shrink-0 font-mono text-[11px] tabular-nums text-[var(--color-muted)]">{inBinder.length}冊</span>
+          </div>
+        </div>
+      </div>
+
+      {/* Actions */}
+      <div className="mb-3.5 flex gap-2.5">
+        <button
+          type="button"
+          onClick={() => setAddOpen(true)}
+          className="flex h-11 flex-1 items-center justify-center gap-1.5 rounded-xl border-2 border-[var(--solid-ink)] bg-white text-[13px] font-bold text-[var(--solid-ink)] transition-all duration-100 active:translate-x-px active:translate-y-px"
+        >
+          <Icon name="add" size={17} />
+          単語帳を追加
+        </button>
+        <button
+          type="button"
+          onClick={() => void handlePublishBinder()}
+          disabled={publishing || inBinder.length === 0}
+          className="flex h-11 flex-1 items-center justify-center gap-1.5 rounded-xl border-2 border-[var(--solid-ink)] bg-[var(--solid-ink)] text-[13px] font-bold text-white transition-all duration-100 active:translate-x-px active:translate-y-px disabled:opacity-40"
+        >
+          <Icon name={publishing ? 'progress_activity' : 'public'} size={17} className={publishing ? 'animate-spin' : ''} />
+          {publishing ? '公開中...' : 'バインダーを公開'}
+        </button>
+      </div>
+
+      {loading ? (
+        <div className="flex items-center justify-center py-16 text-[var(--color-muted)]">
+          <Icon name="progress_activity" size={20} className="animate-spin" />
+          <span className="ml-2 text-sm">読み込み中...</span>
+        </div>
+      ) : inBinder.length === 0 ? (
+        <div className="rounded-xl border-2 border-[var(--solid-ink)] bg-white p-5 text-center">
+          <p className="m-0 text-[13px] leading-[1.8] text-[var(--solid-ink)]">
+            このバインダーにはまだ単語帳がありません。「単語帳を追加」から入れましょう。
+          </p>
+        </div>
+      ) : (
+        <div className="flex flex-col gap-2.5">
+          {inBinder.map((project) => (
+            <div
+              key={project.id}
+              className="flex items-center gap-3 rounded-[14px] border-2 border-[var(--solid-ink)] bg-white p-[13px]"
+            >
+              <Link href={`/project/${project.id}`} className="flex min-w-0 flex-1 items-center gap-3 no-underline">
+                <span
+                  className="flex h-[44px] w-[44px] shrink-0 items-center justify-center rounded-[10px] border-2 border-[var(--solid-ink)] bg-cover bg-center font-display text-[18px] font-extrabold text-white"
+                  style={{ backgroundColor: thumbColor(project.id), backgroundImage: project.iconImage ? `url(${project.iconImage})` : undefined }}
+                >
+                  {!project.iconImage && project.title.charAt(0)}
+                </span>
+                <span className="min-w-0 flex-1">
+                  <span className="block truncate text-sm font-bold text-[var(--solid-ink)]">{project.title}</span>
+                </span>
+              </Link>
+              <button
+                type="button"
+                onClick={() => void setBinder(project.id, null, '解除に失敗しました')}
+                disabled={busyId !== null}
+                aria-label="バインダーから外す"
+                className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full border-2 border-[var(--solid-ink)] bg-white text-[var(--solid-ink)] transition-all duration-100 active:translate-x-px active:translate-y-px disabled:opacity-50"
+              >
+                <Icon name="close" size={15} />
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* 単語帳を追加するピッカー */}
+      {addOpen && (
+        <div className="fixed inset-0 z-[80]" style={{ fontFamily: 'var(--font-body)' }}>
+          <div className="absolute inset-0" style={{ background: 'rgba(26,26,26,0.45)' }} onClick={() => setAddOpen(false)} />
+          <div className="absolute inset-x-0 bottom-0 mx-auto max-w-[560px] rounded-t-[20px] border-2 border-[var(--solid-ink)] bg-[var(--color-background)]" style={{ maxHeight: '78dvh' }}>
+            <div className="flex items-center justify-between border-b-2 border-[var(--color-border)] px-4 py-3">
+              <span className="font-display text-[15px] font-extrabold text-[var(--solid-ink)]">バインダーに追加</span>
+              <button type="button" onClick={() => setAddOpen(false)} aria-label="閉じる" className="flex h-8 w-8 items-center justify-center text-[var(--color-secondary-text)]">
+                <Icon name="close" size={18} />
+              </button>
+            </div>
+            <div className="overflow-y-auto p-3" style={{ maxHeight: 'calc(78dvh - 52px)' }}>
+              {addable.length === 0 ? (
+                <p className="m-0 px-2 py-8 text-center text-[13px] text-[var(--color-muted)]">追加できる単語帳がありません。</p>
+              ) : (
+                <div className="flex flex-col gap-2">
+                  {addable.map((project) => (
+                    <button
+                      key={project.id}
+                      type="button"
+                      onClick={() => void setBinder(project.id, binderName, '追加に失敗しました')}
+                      disabled={busyId !== null}
+                      className="flex items-center gap-3 rounded-[12px] border-2 border-[var(--solid-ink)] bg-white p-2.5 text-left transition-all duration-100 active:translate-x-px active:translate-y-px disabled:opacity-50"
+                    >
+                      <span
+                        className="flex h-9 w-9 shrink-0 items-center justify-center rounded-[8px] border-2 border-[var(--solid-ink)] bg-cover bg-center font-display text-[14px] font-extrabold text-white"
+                        style={{ backgroundColor: thumbColor(project.id), backgroundImage: project.iconImage ? `url(${project.iconImage})` : undefined }}
+                      >
+                        {!project.iconImage && project.title.charAt(0)}
+                      </span>
+                      <span className="min-w-0 flex-1">
+                        <span className="block truncate text-[13.5px] font-bold text-[var(--solid-ink)]">{project.title}</span>
+                        {normalizeBinder(project.binder) && (
+                          <span className="block truncate font-mono text-[9px] text-[var(--color-muted)]">現在: {normalizeBinder(project.binder)}</span>
+                        )}
+                      </span>
+                      <Icon name="add" size={17} className="shrink-0 text-[var(--solid-ink)]" />
+                    </button>
+                  ))}
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/flashcard/[projectId]/page.tsx
+++ b/src/app/flashcard/[projectId]/page.tsx
@@ -527,7 +527,7 @@ export default function FlashcardPage() {
       </div>
     </div>
 
-    <div className="fixed inset-0 z-30 flex flex-col overflow-hidden bg-[var(--color-background)] font-[var(--font-body)] lg:hidden">
+    <div className="fixed inset-x-0 top-0 z-30 flex h-[100dvh] flex-col overflow-hidden bg-[var(--color-background)] font-[var(--font-body)] lg:hidden">
       {/* Header: HeaderBtn close | progress | HeaderBtn details */}
       <div
         className="flex shrink-0 items-center justify-between px-4 pb-2.5"

--- a/src/app/grammar/[bookId]/page.tsx
+++ b/src/app/grammar/[bookId]/page.tsx
@@ -191,7 +191,7 @@ export default function GrammarPracticePage({ params }: { params: Promise<{ book
       />
 
       {/* 単語帳クイズと同じ固定ビューポート構成: 内容が収まる限りスクロールしない */}
-      <div className="fixed inset-0 z-30 flex flex-col overflow-hidden bg-[var(--color-background)] font-[var(--font-body)] lg:hidden">
+      <div className="fixed inset-x-0 top-0 z-30 flex h-[100dvh] flex-col overflow-hidden bg-[var(--color-background)] font-[var(--font-body)] lg:hidden">
       <div className="mx-auto flex h-full w-full max-w-[560px] flex-col">
       {/* Header (固定ビューポートの上段。ノッチ帯は全体共通の StatusBarCover が覆う) */}
       <header

--- a/src/app/grammar/page.tsx
+++ b/src/app/grammar/page.tsx
@@ -209,6 +209,14 @@ export default function GrammarBooksPage() {
         </div>
       </div>
 
+      {/* 作成CTA: デスクトップのトップバーと同じく上部に常時表示する */}
+      {state.kind === 'ready' && (
+        <div className="mb-3.5 flex flex-col gap-2.5">
+          {gptCta}
+          {manualCta}
+        </div>
+      )}
+
       {state.kind === 'loading' && (
         <div className="flex flex-col gap-2.5">
           {[0, 1, 2].map((i) => (
@@ -256,10 +264,6 @@ export default function GrammarBooksPage() {
           <p className="m-0 mt-2 text-[12px] leading-[1.8] text-[var(--solid-ink)]">
             ChatGPTのMERKEN GPTに「仮定法の語法問題を10問作って」のように頼むと、ここに問題集が保存されます。
           </p>
-          <div className="mt-4 flex flex-col gap-2.5">
-            {gptCta}
-            {manualCta}
-          </div>
         </div>
       )}
 
@@ -330,10 +334,6 @@ export default function GrammarBooksPage() {
           {sharedBookId && (
             <p className="mt-2 text-center text-[11px] font-bold text-[var(--color-accent)]">共有リンクをコピーしました</p>
           )}
-          <div className="mt-5 flex flex-col gap-2.5">
-            {gptCta}
-            {manualCta}
-          </div>
         </>
       )}
       </div>

--- a/src/app/groups/[groupId]/bookshelf/GroupBookshelfClient.tsx
+++ b/src/app/groups/[groupId]/bookshelf/GroupBookshelfClient.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useState } from 'react';
 import Link from 'next/link';
-import { useParams } from 'next/navigation';
+import { useParams, useRouter } from 'next/navigation';
 import { DesktopButton } from '@/components/desktop/DesktopChrome';
 import { Icon } from '@/components/ui';
 import { useAuth } from '@/hooks/use-auth';
@@ -19,6 +19,14 @@ import { ShareToGroupSheet } from '../share-to-group-sheet';
 export default function GroupBookshelfClient() {
   const params = useParams<{ groupId: string }>();
   const groupId = params?.groupId ?? '';
+  const router = useRouter();
+  // 本棚→グループの戻るは履歴を1つ戻す。グループを push で積むと、グループ側の
+  // 戻る(router.back)で再び本棚に戻ってしまう無限ループになるため。
+  const handleBack = () => {
+    triggerHaptic();
+    if (typeof window !== 'undefined' && window.history.length > 1) router.back();
+    else router.push(`/groups/${encodeURIComponent(groupId)}`);
+  };
   const { user, isPro, loading: authLoading, isAuthenticated } = useAuth();
   const { showToast } = useToast();
 
@@ -121,7 +129,7 @@ export default function GroupBookshelfClient() {
       <div className="hidden h-full min-h-0 flex-col lg:flex">
         <div className="ds-top">
           <DesktopButton
-            href={`/groups/${encodeURIComponent(groupId)}`}
+            onClick={handleBack}
             icon="arrow_back"
             variant="ghost"
             title="グループに戻る"
@@ -159,7 +167,7 @@ export default function GroupBookshelfClient() {
       >
         {stateView ?? (group && (
           <div className="flex flex-col gap-4 px-[14px]">
-            <BookshelfHeader groupId={groupId} groupName={group.name} bookCount={projects.length} />
+            <BookshelfHeader onBack={handleBack} groupName={group.name} bookCount={projects.length} />
 
             {projects.length === 0 ? emptyShelf : (
               <div className="grid grid-cols-2 gap-3">
@@ -193,21 +201,21 @@ export default function GroupBookshelfClient() {
   );
 }
 
-function BookshelfHeader({ groupId, groupName, bookCount }: { groupId: string; groupName: string; bookCount: number }) {
+function BookshelfHeader({ onBack, groupName, bookCount }: { onBack: () => void; groupName: string; bookCount: number }) {
   return (
     <section
       className="rounded-[18px] border-2 border-[var(--solid-ink)] p-4"
       style={{ background: 'linear-gradient(150deg, #FFF6DE 0%, #FFE7BC 100%)' }}
     >
       <div className="flex items-center gap-2">
-        <Link
-          href={`/groups/${encodeURIComponent(groupId)}`}
+        <button
+          type="button"
+          onClick={onBack}
           aria-label="グループに戻る"
-          onClick={() => triggerHaptic()}
           className="inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-full border-2 border-[var(--solid-ink)] bg-white text-[var(--solid-ink)] transition-all duration-100 active:translate-x-px active:translate-y-px"
         >
           <Icon name="arrow_back" size={16} />
-        </Link>
+        </button>
         <div className="font-mono text-[10px] font-bold tracking-[0.08em] text-[var(--color-muted)]">
           GROUP BOOKSHELF
         </div>

--- a/src/app/home-client.tsx
+++ b/src/app/home-client.tsx
@@ -507,6 +507,19 @@ export function HomeClient() {
   const myBooksProjects = overflowProjects.length > 0 ? overflowProjects : listProjects;
   const visibleProjects = myBooksProjects.slice(0, HOME_MY_BOOKS_VISIBLE_LIMIT);
 
+  // ホームに出すバインダー (フォルダ) 一覧。listProjects を binder 名で集計する
+  const homeBinders = useMemo(() => {
+    const byBinder = new Map<string, number>();
+    for (const project of listProjects) {
+      const name = project.binder?.trim();
+      if (!name) continue;
+      byBinder.set(name, (byBinder.get(name) ?? 0) + 1);
+    }
+    return [...byBinder.entries()]
+      .sort((a, b) => a[0].localeCompare(b[0], 'ja'))
+      .map(([name, count]) => ({ name, count }));
+  }, [listProjects]);
+
   // The guided flow starts for any user who hasn't studied yet. Word status only
   // advances past 'new' via quiz/study, so any progress means they've quizzed.
   const hasStudiedBefore = completedToday > 0 || mastered > 0 || review > 0 || stats.activeW > 0;
@@ -728,6 +741,25 @@ export function HomeClient() {
         )}
       </div>
 
+      {/* バインダー (フォルダ): 単語帳タイルと同じ配色でホームに表示 */}
+      {homeBinders.length > 0 && (
+        <>
+          <div className="flex items-baseline justify-between px-5 pb-2.5 pt-1">
+            <div>
+              <div className="font-mono text-[10px] font-semibold tracking-[0.06em] text-[var(--color-muted)]">BINDERS</div>
+              <h2 className="font-display text-[19px] font-extrabold tracking-[-0.01em] text-[var(--solid-ink)]">バインダー</h2>
+            </div>
+          </div>
+          <div className="no-scrollbar -mx-[18px] mb-1 flex snap-x snap-mandatory gap-2.5 overflow-x-auto px-[18px] pb-4 scroll-pl-[18px]">
+            {homeBinders.map((binder) => (
+              <div key={binder.name} className="w-[42%] shrink-0 snap-start">
+                <BinderSquareTile name={binder.name} count={binder.count} />
+              </div>
+            ))}
+          </div>
+        </>
+      )}
+
       {/* 語法問題集（Pro限定・グループ表示の上） */}
       <HomeGrammarBooksSection books={grammarBooks} />
 
@@ -782,6 +814,31 @@ function HomeLoadingScreen() {
     <div className="flex min-h-screen items-center justify-center bg-[var(--color-background)] text-[var(--color-muted)]">
       <Icon name="progress_activity" size={22} className="animate-spin" />
     </div>
+  );
+}
+
+// バインダー (フォルダ) タイル。ProjectSquareTile と同じシェル・配色 (thumbColor) で、
+// キーは binder 名。単語帳タイルと見た目を揃える。
+function BinderSquareTile({ name, count }: { name: string; count: number }) {
+  const bg = thumbColor(name);
+  return (
+    <Link
+      href={`/binder/${encodeURIComponent(name)}`}
+      className="relative flex aspect-square flex-col justify-between overflow-hidden rounded-[14px] border-2 border-[var(--solid-ink)] p-3 text-white shadow-[2px_3px_0_var(--solid-ink)] transition-all duration-100 active:translate-x-px active:translate-y-px active:shadow-[1px_2px_0_var(--solid-ink)]"
+      style={{ backgroundColor: bg }}
+    >
+      <div className="absolute inset-y-0 left-0 w-[6px] bg-[rgba(0,0,0,0.22)]" />
+      <div className="flex items-center gap-1 pl-1.5 drop-shadow-[1px_1px_0_rgba(0,0,0,0.25)]">
+        <Icon name="folder" size={15} filled />
+        <span className="font-mono text-[9.5px] font-bold tracking-[0.04em]">BINDER</span>
+      </div>
+      <div className="pl-1.5">
+        <div className="line-clamp-2 font-display text-[13.5px] font-bold leading-snug drop-shadow-[1px_1px_0_rgba(0,0,0,0.25)]">
+          {name}
+        </div>
+        <div className="mt-1 font-mono text-[9px] tracking-[0.04em] opacity-90">{count}冊</div>
+      </div>
+    </Link>
   );
 }
 

--- a/src/app/project/[id]/page.tsx
+++ b/src/app/project/[id]/page.tsx
@@ -379,6 +379,20 @@ export default function ProjectPage() {
       partOfSpeech: wordFilterPos,
     });
   }, [query, words, wordSortOrder, wordFilterBookmark, wordFilterActiveness, wordFilterPos]);
+
+  // モバイル専用: 20語を超える単語帳は10語ずつページ送りする (フロントのみで完結)
+  const MOBILE_WORDS_PER_PAGE = 10;
+  const paginateWords = filteredWords.length > 20;
+  const wordPageCount = paginateWords ? Math.ceil(filteredWords.length / MOBILE_WORDS_PER_PAGE) : 1;
+  const [wordPage, setWordPage] = useState(0);
+  useEffect(() => {
+    // フィルタ/検索でページ数が減ったら範囲内に戻す
+    setWordPage((prev) => (prev > wordPageCount - 1 ? 0 : prev));
+  }, [wordPageCount]);
+  const pagedMobileWords = paginateWords
+    ? filteredWords.slice(wordPage * MOBILE_WORDS_PER_PAGE, (wordPage + 1) * MOBILE_WORDS_PER_PAGE)
+    : filteredWords;
+
   const selectedDisplayedWordCount = useMemo(
     () => filteredWords.filter((word) => selectedWordIds.has(word.id)).length,
     [filteredWords, selectedWordIds],
@@ -1515,7 +1529,7 @@ export default function ProjectPage() {
       </div>
       )}
 
-      <div className={`flex flex-col px-4 ${selectMode ? 'pb-[160px]' : 'pb-[max(24px,env(safe-area-inset-bottom))]'}`}>
+      <div className={`flex flex-col px-4 ${selectMode ? 'pb-[160px]' : paginateWords ? 'pb-[104px]' : 'pb-[max(24px,env(safe-area-inset-bottom))]'}`}>
         {!wordsLoaded ? (
           <div className="flex items-center justify-center py-12 text-[var(--color-muted)]">
             <Icon name="progress_activity" size={20} className="animate-spin" />
@@ -1535,7 +1549,7 @@ export default function ProjectPage() {
           )
         ) : (
           <div className="divide-y divide-[var(--color-border)]">
-            {filteredWords.map((word, index) => {
+            {pagedMobileWords.map((word, index) => {
               const selected = selectedWordIds.has(word.id);
               return (
               <WordRow
@@ -1543,7 +1557,7 @@ export default function ProjectPage() {
                 word={word}
                 selectMode={selectMode}
                 selected={selected}
-                tourAnchor={index === 0}
+                tourAnchor={index === 0 && wordPage === 0}
                 onToggleSelect={() => handleToggleSelectWord(word)}
                 onCycleStatus={(newStatus) => handleCycleStatus(word.id, newStatus)}
                 onCycleVocabularyType={() => void handleCycleVocabularyType(word)}
@@ -1565,6 +1579,38 @@ export default function ProjectPage() {
           />
         )}
       </div>
+
+      {/* モバイル: 20語を超える単語帳は10語ずつページ送り。下部固定バーの左右矢印で移動 */}
+      {paginateWords && !selectMode && (
+        <div
+          className="fixed inset-x-0 bottom-0 z-40 border-t-2 border-[var(--solid-ink)] bg-[var(--color-background)]/95 backdrop-blur-md lg:hidden"
+          style={{ paddingBottom: 'max(12px, env(safe-area-inset-bottom))' }}
+        >
+          <div className="mx-auto flex w-full max-w-[560px] items-center justify-between gap-2.5 px-[18px] pt-3">
+            <button
+              type="button"
+              onClick={() => setWordPage((p) => Math.max(0, p - 1))}
+              disabled={wordPage === 0}
+              aria-label="前の10語"
+              className="flex h-11 w-11 items-center justify-center rounded-xl border-2 border-[var(--solid-ink)] bg-white text-[var(--solid-ink)] transition-all duration-100 active:translate-x-px active:translate-y-px disabled:opacity-40"
+            >
+              <Icon name="chevron_left" size={20} />
+            </button>
+            <span className="font-mono text-[12px] font-bold tabular-nums text-[var(--solid-ink)]">
+              {wordPage * MOBILE_WORDS_PER_PAGE + 1}–{Math.min(filteredWords.length, (wordPage + 1) * MOBILE_WORDS_PER_PAGE)} / {filteredWords.length}語
+            </span>
+            <button
+              type="button"
+              onClick={() => setWordPage((p) => Math.min(wordPageCount - 1, p + 1))}
+              disabled={wordPage >= wordPageCount - 1}
+              aria-label="次の10語"
+              className="flex h-11 w-11 items-center justify-center rounded-xl border-2 border-[var(--solid-ink)] bg-white text-[var(--solid-ink)] transition-all duration-100 active:translate-x-px active:translate-y-px disabled:opacity-40"
+            >
+              <Icon name="chevron_right" size={20} />
+            </button>
+          </div>
+        </div>
+      )}
 
       <ProjectShareSheet
         open={showShareSheet}

--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -24,6 +24,7 @@ import {
 import { summarizeWordMemory } from '@/lib/words/memory';
 import { excludeReelSavedProjects } from '@/lib/reels/saved-words';
 import { getGuestUserId } from '@/lib/utils';
+import { invalidateHomeCache } from '@/lib/home-cache';
 import type { Project, SubscriptionStatus } from '@/types';
 
 const SORTS = [
@@ -144,6 +145,31 @@ export default function ProjectListPage() {
     void loadProjects();
   }, [loadProjects]);
 
+  // 「...」メニュー: 削除 / バインダー追加。書き込みは同じ repository を使う。
+  const handleDeleteProject = useCallback(async (project: Project) => {
+    if (!window.confirm(`「${project.title}」を削除しますか？この操作は取り消せません。`)) return;
+    try {
+      await repository.deleteProject(project.id);
+      setProjects((prev) => prev.filter((p) => p.id !== project.id));
+      invalidateHomeCache();
+    } catch {
+      window.alert('削除に失敗しました');
+    }
+  }, [repository]);
+
+  const handleSetBinder = useCallback(async (project: Project) => {
+    const input = window.prompt('バインダー名を入力してください (空欄で解除)', project.binder ?? '');
+    if (input === null) return;
+    const binder = input.trim().slice(0, 40) || null;
+    try {
+      await repository.updateProject(project.id, { binder });
+      setProjects((prev) => prev.map((p) => (p.id === project.id ? { ...p, binder } : p)));
+      invalidateHomeCache();
+    } catch {
+      window.alert('バインダーの更新に失敗しました');
+    }
+  }, [repository]);
+
   const filtered = useMemo(() => {
     const normalizedQuery = query.trim().toLowerCase();
     const base = normalizedQuery
@@ -198,6 +224,8 @@ export default function ProjectListPage() {
         learnHref={summaryStats.totalWords > 0 ? '/quiz/all?learn=1&from=/projects' : '/projects'}
         onQueryChange={setQuery}
         onSortChange={setSort}
+        onDeleteProject={(project) => void handleDeleteProject(project)}
+        onSetBinder={(project) => void handleSetBinder(project)}
       />
       <div className="relative min-h-screen bg-[var(--color-background)] pb-[150px] pt-3 font-[var(--font-body)] lg:hidden">
       <div className="px-5 pb-3.5 pt-2.5">

--- a/src/app/quiz/[projectId]/page.tsx
+++ b/src/app/quiz/[projectId]/page.tsx
@@ -1374,7 +1374,7 @@ export default function QuizPage() {
         </div>
       </div>
       {/* Mobile completion */}
-      <div className="fixed inset-0 z-30 flex flex-col bg-[var(--color-background)] font-[var(--font-body)] lg:hidden">
+      <div className="fixed inset-x-0 top-0 z-30 flex h-[100dvh] flex-col bg-[var(--color-background)] font-[var(--font-body)] lg:hidden">
         <div className="flex min-h-0 flex-1 flex-col overflow-y-auto" style={{ paddingTop: 'max(16px, calc(env(safe-area-inset-top) + 16px))' }}>
           <div className="mx-auto w-full max-w-sm px-5 pb-4">
             {/* Score card */}
@@ -1692,7 +1692,7 @@ export default function QuizPage() {
       </div>
     </div>
 
-    <div className="fixed inset-0 z-30 flex flex-col overflow-hidden bg-[var(--color-background)] font-[var(--font-body)] lg:hidden">
+    <div className="fixed inset-x-0 top-0 z-30 flex h-[100dvh] flex-col overflow-hidden bg-[var(--color-background)] font-[var(--font-body)] lg:hidden">
       {/* Header: close + progress dots + flag */}
       <div
         className="flex shrink-0 items-center gap-2.5 px-4 pb-3.5"

--- a/src/components/desktop/DesktopHome.tsx
+++ b/src/components/desktop/DesktopHome.tsx
@@ -110,6 +110,19 @@ export function DesktopHomeView({
   );
   const shelfProjects = projects.slice(gridProjectCount);
 
+  // バインダー (フォルダ) 一覧を binder 名で集計する
+  const homeBinders = (() => {
+    const byBinder = new Map<string, number>();
+    for (const project of projects) {
+      const name = project.binder?.trim();
+      if (!name) continue;
+      byBinder.set(name, (byBinder.get(name) ?? 0) + 1);
+    }
+    return [...byBinder.entries()]
+      .sort((a, b) => a[0].localeCompare(b[0], 'ja'))
+      .map(([name, count]) => ({ name, count }));
+  })();
+
   return (
     <div className="hidden h-full min-h-0 flex-col lg:flex">
       <DesktopTopbar title="ホーム" crumb="HOME / ライブラリ">
@@ -260,6 +273,23 @@ export function DesktopHomeView({
               </div>
             )}
           </div>
+
+          {/* バインダー (フォルダ): マイ単語帳と同じ配色のタイルで表示 */}
+          {homeBinders.length > 0 && (
+            <div style={{ marginTop: 28 }}>
+              <div className="ds-sec-head" style={{ marginBottom: 14 }}>
+                <div style={{ display: 'flex', alignItems: 'baseline', gap: 10 }}>
+                  <h2>バインダー</h2>
+                  <span className="mono muted" style={{ fontSize: 12 }}>{homeBinders.length}</span>
+                </div>
+              </div>
+              <div className="ds-shelf-row">
+                {homeBinders.map((binder) => (
+                  <DesktopBinderTile key={binder.name} name={binder.name} count={binder.count} />
+                ))}
+              </div>
+            </div>
+          )}
 
           {/* 語法問題集（グループ表示の上） */}
           <DesktopHomeGrammarBooks books={grammarBooks} />
@@ -553,6 +583,24 @@ function DesktopGeneratingBookTile({ scan }: { scan: DesktopPendingScan }) {
         </div>
       </div>
     </div>
+  );
+}
+
+// バインダー (フォルダ) タイル。DesktopBookTile と同じ ds-book シェル・配色
+// (desktopThumbColor) で、キーは binder 名。単語帳タイルと見た目を揃える。
+function DesktopBinderTile({ name, count }: { name: string; count: number }) {
+  return (
+    <Link href={`/binder/${encodeURIComponent(name)}`} className="ds-book" style={{ background: desktopThumbColor(name) }}>
+      <div className="bk-spine" />
+      <div>
+        <div className="bk-title">{name}</div>
+        <div className="bk-foot mono">BINDER</div>
+      </div>
+      <div>
+        <Icon name="folder" filled style={{ fontSize: 20 }} />
+        <div className="bk-foot">{count}冊</div>
+      </div>
+    </Link>
   );
 }
 

--- a/src/components/desktop/DesktopProjects.tsx
+++ b/src/components/desktop/DesktopProjects.tsx
@@ -9,6 +9,7 @@ import {
   DesktopTopbar,
 } from '@/components/desktop/DesktopChrome';
 import { DesktopStudySidebar } from '@/components/desktop/DesktopStudySidebar';
+import { ProjectFilterSheet, ProjectSortSheet } from '@/components/desktop/ProjectListSheets';
 import {
   desktopSourceLabel,
   desktopThumbColor,
@@ -53,6 +54,8 @@ export function DesktopProjectsView({
   onSetBinder?: (project: DesktopProjectRow) => void;
 }) {
   const [filter, setFilter] = useState<'all' | 'fav'>('all');
+  const [showFilterSheet, setShowFilterSheet] = useState(false);
+  const [showSortSheet, setShowSortSheet] = useState(false);
   const rows = useMemo(() => {
     return filter === 'fav' ? projects.filter((project) => project.isFavorite) : projects;
   }, [filter, projects]);
@@ -95,24 +98,32 @@ export function DesktopProjectsView({
 
       <div className="ds-scroll" style={{ display: 'grid', gridTemplateColumns: 'minmax(0, 1fr) 300px', gap: 24, alignItems: 'start' }}>
         <div>
-          <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 16 }}>
-            <button type="button" className={'ds-chip' + (filter === 'all' ? ' active' : '')} onClick={() => setFilter('all')}>
-              すべて <span className="tnum" style={{ opacity: 0.7 }}>{projects.length}</span>
-            </button>
-            <button type="button" className={'ds-chip' + (filter === 'fav' ? ' active' : '')} onClick={() => setFilter('fav')}>
-              <Icon name="bookmark" filled style={{ fontSize: 15 }} />保存
-            </button>
-            <button type="button" className={'ds-chip' + (sort === 'newest' ? ' active' : '')} onClick={() => onSortChange('newest')}>
-              <Icon name="schedule" style={{ fontSize: 15 }} />新しい順
-            </button>
-            <button type="button" className={'ds-chip' + (sort === 'words' ? ' active' : '')} onClick={() => onSortChange('words')}>
-              <Icon name="sort" style={{ fontSize: 15 }} />単語が多い順
-            </button>
-            <button type="button" className={'ds-chip' + (sort === 'lastUsed' ? ' active' : '')} onClick={() => onSortChange('lastUsed')}>
-              <Icon name="history" style={{ fontSize: 15 }} />最近使った順
-            </button>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 16 }}>
+            <span className="mono muted tnum" style={{ fontSize: 12 }}>
+              {rows.length} 冊 ・ 合計 {totalWords} 語
+            </span>
             <div style={{ flex: 1 }} />
-            <span className="mono muted" style={{ fontSize: 12 }}>合計 {totalWords} 語</span>
+            {/* フィルタ・並べ替えは /project/* と同じ正方形アイコンボタンにシートを格納 */}
+            <button
+              type="button"
+              className={'ds-btn sm' + (filter === 'fav' ? ' dark' : '')}
+              style={{ width: 36, height: 36, padding: 0 }}
+              onClick={() => setShowFilterSheet(true)}
+              aria-pressed={filter === 'fav'}
+              aria-label="フィルタ"
+            >
+              <Icon name="filter_list" />
+            </button>
+            <button
+              type="button"
+              className={'ds-btn sm' + (sort !== 'newest' ? ' dark' : '')}
+              style={{ width: 36, height: 36, padding: 0 }}
+              onClick={() => setShowSortSheet(true)}
+              aria-pressed={sort !== 'newest'}
+              aria-label="並べ替え"
+            >
+              <Icon name="swap_vert" />
+            </button>
           </div>
 
           {error && (
@@ -171,6 +182,19 @@ export function DesktopProjectsView({
 
         <DesktopStudySidebar stats={summaryStats} reviewHref={reviewHref} learnHref={learnHref} />
             </div>
+
+      <ProjectFilterSheet
+        open={showFilterSheet}
+        onClose={() => setShowFilterSheet(false)}
+        filter={filter}
+        onFilterChange={setFilter}
+      />
+      <ProjectSortSheet
+        open={showSortSheet}
+        onClose={() => setShowSortSheet(false)}
+        sort={sort}
+        onSortChange={onSortChange}
+      />
     </div>
   );
 }

--- a/src/components/desktop/DesktopProjects.tsx
+++ b/src/components/desktop/DesktopProjects.tsx
@@ -36,6 +36,8 @@ export function DesktopProjectsView({
   learnHref,
   onQueryChange,
   onSortChange,
+  onDeleteProject,
+  onSetBinder,
 }: {
   projects: DesktopProjectRow[];
   loading: boolean;
@@ -47,6 +49,8 @@ export function DesktopProjectsView({
   learnHref?: string;
   onQueryChange: (value: string) => void;
   onSortChange: (value: 'newest' | 'words' | 'lastUsed') => void;
+  onDeleteProject?: (project: DesktopProjectRow) => void;
+  onSetBinder?: (project: DesktopProjectRow) => void;
 }) {
   const [filter, setFilter] = useState<'all' | 'fav'>('all');
   const rows = useMemo(() => {
@@ -145,7 +149,7 @@ export function DesktopProjectsView({
                       </tr>
                     )}
                     {group.items.map((project) => (
-                      <DesktopProjectTableRow key={project.id} project={project} />
+                      <DesktopProjectTableRow key={project.id} project={project} onDelete={onDeleteProject} onSetBinder={onSetBinder} />
                     ))}
                   </Fragment>
                 ))}
@@ -171,8 +175,20 @@ export function DesktopProjectsView({
   );
 }
 
-function DesktopProjectTableRow({ project }: { project: DesktopProjectRow }) {
+function DesktopProjectTableRow({
+  project,
+  onDelete,
+  onSetBinder,
+}: {
+  project: DesktopProjectRow;
+  onDelete?: (project: DesktopProjectRow) => void;
+  onSetBinder?: (project: DesktopProjectRow) => void;
+}) {
   const pct = project.totalWords > 0 ? Math.round((project.masteredWords / project.totalWords) * 100) : 0;
+  // メニューはテーブルの overflow:hidden で切れないよう fixed で描画し、
+  // ボタン位置に合わせて配置する。
+  const [menuPos, setMenuPos] = useState<{ top: number; right: number } | null>(null);
+  const hasMenu = Boolean(onDelete || onSetBinder);
 
   return (
     <tr>
@@ -204,7 +220,69 @@ function DesktopProjectTableRow({ project }: { project: DesktopProjectRow }) {
         </div>
       </td>
       <td className="mono" style={{ fontSize: 11.5, color: 'var(--color-muted)' }}>{desktopUpdatedLabel(project.lastUsedAt ?? project.createdAt)}</td>
-      <td><Icon name="more_horiz" style={{ color: 'var(--color-muted)', cursor: 'pointer' }} /></td>
+      <td>
+        {hasMenu ? (
+          <button
+            type="button"
+            aria-label="メニュー"
+            onClick={(event) => {
+              const rect = event.currentTarget.getBoundingClientRect();
+              setMenuPos({ top: rect.bottom + 6, right: Math.max(12, window.innerWidth - rect.right) });
+            }}
+            style={{ background: 'none', border: 'none', padding: 4, cursor: 'pointer', color: 'var(--color-muted)', lineHeight: 0 }}
+          >
+            <Icon name="more_horiz" />
+          </button>
+        ) : (
+          <Icon name="more_horiz" style={{ color: 'var(--color-muted)' }} />
+        )}
+        {menuPos && (
+          <>
+            <button
+              type="button"
+              aria-label="閉じる"
+              onClick={() => setMenuPos(null)}
+              style={{ position: 'fixed', inset: 0, zIndex: 60, background: 'transparent', border: 'none', cursor: 'default' }}
+            />
+            <div
+              style={{
+                position: 'fixed',
+                top: menuPos.top,
+                right: menuPos.right,
+                zIndex: 61,
+                width: 190,
+                overflow: 'hidden',
+                borderRadius: 12,
+                border: '2px solid var(--solid-ink)',
+                background: '#fff',
+                boxShadow: '2px 3px 0 var(--solid-ink)',
+              }}
+            >
+              {onSetBinder && (
+                <button
+                  type="button"
+                  onClick={() => { setMenuPos(null); onSetBinder(project); }}
+                  className="flex w-full items-center gap-2 px-4 py-3 text-left text-[13px] font-bold text-[var(--solid-ink)] hover:bg-[var(--color-surface-secondary)]"
+                >
+                  <Icon name="folder" size={16} />
+                  バインダーに追加
+                </button>
+              )}
+              {onDelete && (
+                <button
+                  type="button"
+                  onClick={() => { setMenuPos(null); onDelete(project); }}
+                  className="flex w-full items-center gap-2 px-4 py-3 text-left text-[13px] font-bold hover:bg-[var(--color-surface-secondary)]"
+                  style={{ color: 'var(--color-error)' }}
+                >
+                  <Icon name="delete" size={16} />
+                  単語帳を削除
+                </button>
+              )}
+            </div>
+          </>
+        )}
+      </td>
     </tr>
   );
 }

--- a/src/components/desktop/DesktopWordDetailModal.tsx
+++ b/src/components/desktop/DesktopWordDetailModal.tsx
@@ -7,6 +7,7 @@ import { MorphologyFormulaChips } from '@/components/word/MorphologyFormulaChips
 import { TranslationDisplay } from '@/components/word/TranslationDisplay';
 import { hasDisplayableMorphology } from '@/lib/morphology/format';
 import { useMorphologyBackfill } from '@/hooks/use-morphology-backfill';
+import { speakEnglish } from '@/lib/speech';
 import type { Word } from '@/types';
 
 export function DesktopWordDetailModal({
@@ -57,6 +58,14 @@ export function DesktopWordDetailModal({
           <div>
             <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
               <div className="word-en">{word.english}</div>
+              <button
+                type="button"
+                className="ds-btn ghost sm"
+                onClick={() => speakEnglish(word.english)}
+                aria-label="発音を再生"
+              >
+                <Icon name="volume_up" style={{ color: 'var(--color-muted)' }} />
+              </button>
               <button type="button" className="ds-btn ghost sm" onClick={onToggleFavorite} aria-label="保存">
                 <Icon
                   name="bookmark"
@@ -87,8 +96,19 @@ export function DesktopWordDetailModal({
               </div>
               {word.exampleSentence ? (
                 <>
-                  <div style={{ fontSize: 16, fontWeight: 600, lineHeight: 1.75 }}>
-                    {renderExample(word.exampleSentence, word.english)}
+                  <div style={{ display: 'flex', alignItems: 'flex-start', gap: 10 }}>
+                    <div style={{ flex: 1, fontSize: 16, fontWeight: 600, lineHeight: 1.75 }}>
+                      {renderExample(word.exampleSentence, word.english)}
+                    </div>
+                    <button
+                      type="button"
+                      className="ds-btn ghost sm"
+                      onClick={() => speakEnglish(word.exampleSentence, { rate: 0.85 })}
+                      aria-label="例文を再生"
+                      style={{ flexShrink: 0 }}
+                    >
+                      <Icon name="volume_up" style={{ color: 'var(--color-muted)' }} />
+                    </button>
                   </div>
                   {word.exampleSentenceJa && (
                     <div style={{ fontSize: 13.5, color: 'var(--color-secondary-text)', lineHeight: 1.75, marginTop: 4 }}>

--- a/src/components/desktop/ProjectListSheets.tsx
+++ b/src/components/desktop/ProjectListSheets.tsx
@@ -1,0 +1,139 @@
+'use client';
+
+import { Icon } from '@/components/ui';
+import { BottomSheetShell } from '@/components/project/WordListSheets';
+
+export type ProjectSort = 'newest' | 'words' | 'lastUsed';
+export type ProjectFilter = 'all' | 'fav';
+
+const PROJECT_SORT_OPTIONS: Array<{
+  value: ProjectSort;
+  label: string;
+  description: string;
+  icon: string;
+}> = [
+  { value: 'newest', label: '新しい順', description: '最近作成した単語帳を先に表示', icon: 'schedule' },
+  { value: 'words', label: '単語が多い順', description: '語数が多い単語帳を先に表示', icon: 'sort' },
+  { value: 'lastUsed', label: '最近使った順', description: '最近使った単語帳を先に表示', icon: 'history' },
+];
+
+type ProjectSortSheetProps = {
+  open: boolean;
+  onClose: () => void;
+  sort: ProjectSort;
+  onSortChange: (v: ProjectSort) => void;
+};
+
+/** /project/* の WordSortSheet と同じ見た目で、単語帳一覧の並べ替えを選ぶシート。 */
+export function ProjectSortSheet({ open, onClose, sort, onSortChange }: ProjectSortSheetProps) {
+  return (
+    <BottomSheetShell open={open} onClose={onClose} title="並べ替え">
+      <div className="flex flex-col gap-[7px]">
+        {PROJECT_SORT_OPTIONS.map((opt) => {
+          const selected = sort === opt.value;
+          return (
+            <button
+              key={opt.value}
+              type="button"
+              onClick={() => { onSortChange(opt.value); onClose(); }}
+              className="flex items-center gap-[11px] rounded-[10px] border-2 border-[var(--solid-ink)] px-3 py-[11px] text-left transition-all"
+              style={{
+                background: selected ? 'var(--solid-ink)' : '#fff',
+                color: selected ? '#fff' : 'var(--solid-ink)',
+                boxShadow: selected ? '2px 2px 0 var(--solid-ink)' : 'none',
+              }}
+            >
+              <div
+                className="flex h-8 w-8 shrink-0 items-center justify-center rounded-[8px]"
+                style={{
+                  background: selected ? 'rgba(255,255,255,0.12)' : 'var(--color-surface-secondary)',
+                  border: selected ? '1px solid rgba(255,255,255,0.2)' : '1px solid var(--color-border)',
+                }}
+              >
+                <Icon name={opt.icon} size={16} />
+              </div>
+              <div className="min-w-0 flex-1">
+                <span className="block text-[14px] font-bold">{opt.label}</span>
+                <span className="block text-[11px] opacity-70 mt-0.5">{opt.description}</span>
+              </div>
+              <div
+                className="flex h-4 w-4 shrink-0 items-center justify-center rounded-full"
+                style={{ border: selected ? '1.5px solid #fff' : '1.5px solid var(--solid-ink)' }}
+              >
+                {selected && <div className="h-[7px] w-[7px] rounded-full bg-white" />}
+              </div>
+            </button>
+          );
+        })}
+      </div>
+    </BottomSheetShell>
+  );
+}
+
+type ProjectFilterSheetProps = {
+  open: boolean;
+  onClose: () => void;
+  filter: ProjectFilter;
+  onFilterChange: (v: ProjectFilter) => void;
+};
+
+/** /project/* の WordFilterSheet と同じ見た目で、単語帳一覧の絞り込みを選ぶシート。 */
+export function ProjectFilterSheet({ open, onClose, filter, onFilterChange }: ProjectFilterSheetProps) {
+  const bookmark = filter === 'fav';
+  return (
+    <BottomSheetShell
+      open={open}
+      onClose={onClose}
+      title="フィルタ"
+      footer={
+        <div
+          className="flex items-center gap-2.5 px-5 pb-[max(28px,env(safe-area-inset-bottom))] pt-3 lg:pb-5"
+          style={{ borderTop: '1px solid rgba(26,26,26,0.1)' }}
+        >
+          <button
+            type="button"
+            onClick={() => onFilterChange('all')}
+            disabled={!bookmark}
+            className="relative flex-1 disabled:opacity-40"
+          >
+            <div className="absolute inset-0 rounded-[10px] bg-[var(--solid-ink)]" style={{ transform: 'translate(2px,2px)' }} />
+            <span className="relative flex h-[42px] items-center justify-center rounded-[10px] border-2 border-[var(--solid-ink)] bg-white text-[13px] font-bold text-[var(--solid-ink)]">
+              リセット
+            </span>
+          </button>
+          <button type="button" onClick={onClose} className="relative flex-1">
+            <div className="absolute inset-0 rounded-[10px] bg-[var(--solid-ink)]" style={{ transform: 'translate(2px,2px)' }} />
+            <span className="relative flex h-[42px] items-center justify-center rounded-[10px] border-2 border-[var(--solid-ink)] bg-[var(--solid-ink)] text-[13px] font-bold text-white">
+              適用
+            </span>
+          </button>
+        </div>
+      }
+    >
+      <div className="space-y-5">
+        <label className="flex cursor-pointer items-center justify-between rounded-[10px] border-2 border-[var(--solid-ink)] bg-white px-3.5 py-3">
+          <span className="flex items-center gap-2 text-[13px] font-bold text-[var(--solid-ink)]">
+            <Icon name="bookmark" size={15} filled={bookmark} />
+            保存した単語帳のみ
+          </span>
+          <div
+            className="flex h-5 w-5 items-center justify-center rounded-[4px] border-2 border-[var(--solid-ink)]"
+            style={{ background: bookmark ? 'var(--solid-ink)' : 'transparent' }}
+          >
+            {bookmark && (
+              <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="white" strokeWidth="3.2" strokeLinecap="round" strokeLinejoin="round">
+                <path d="M4 12l5 5L20 6" />
+              </svg>
+            )}
+          </div>
+          <input
+            type="checkbox"
+            checked={bookmark}
+            onChange={(e) => onFilterChange(e.target.checked ? 'fav' : 'all')}
+            className="sr-only"
+          />
+        </label>
+      </div>
+    </BottomSheetShell>
+  );
+}

--- a/src/components/project/WordListSheets.tsx
+++ b/src/components/project/WordListSheets.tsx
@@ -30,7 +30,7 @@ type BottomSheetShellProps = {
   footer?: React.ReactNode;
 };
 
-function BottomSheetShell({ open, onClose, title, children, footer }: BottomSheetShellProps) {
+export function BottomSheetShell({ open, onClose, title, children, footer }: BottomSheetShellProps) {
   if (!open) return null;
   return (
     <div

--- a/src/components/ui/PersistentAppShell.tsx
+++ b/src/components/ui/PersistentAppShell.tsx
@@ -15,6 +15,9 @@ const NO_SHELL_PATHS = [
   '/offline', '/share-target', '/admin',
   '/level-test', '/ops',
   '/tips',
+  // 共有(公開)ページは自前で ds-app シェル(サイドバー付き)を描画するため、
+  // 共通シェルを重ねるとサイドバーが二重表示になる。共通シェルを外す。
+  '/shared/share-wordbook',
 ];
 
 const HIDE_BOTTOM_NAV_PATHS = [
@@ -56,22 +59,38 @@ export function PersistentAppShell({ children }: { children: ReactNode }) {
   }, []);
 
   useEffect(() => {
+    let touchStartX = 0;
     let touchStartY = 0;
     let hasMoved = false;
     let scrollTimeout: ReturnType<typeof setTimeout>;
 
     const handleTouchStart = (e: TouchEvent) => {
+      touchStartX = e.touches[0].clientX;
       touchStartY = e.touches[0].clientY;
       hasMoved = false;
     };
     const handleTouchMove = (e: TouchEvent) => {
-      if (Math.abs(e.touches[0].clientY - touchStartY) > 8) hasMoved = true;
+      // 縦・横どちらの移動もスクロールとみなす。横スクロール(本棚など)が縦しか
+      // 見ていなかったため検知できず、iPad等で指を離した瞬間に下の単語帳が誤タップ
+      // される不具合があった。動きを検知した時点でスクロール中から遮蔽オーバーレイを
+      // 出しておき、指を離した瞬間の誤タップを確実に飲み込む。
+      if (hasMoved) return;
+      const dx = Math.abs(e.touches[0].clientX - touchStartX);
+      const dy = Math.abs(e.touches[0].clientY - touchStartY);
+      if (dx > 8 || dy > 8) {
+        hasMoved = true;
+        setScrollEnding(true);
+      }
     };
     const handleTouchEnd = () => {
-      if (!hasMoved) return;
-      setScrollEnding(true);
       clearTimeout(scrollTimeout);
-      scrollTimeout = setTimeout(() => setScrollEnding(false), 160);
+      if (hasMoved) {
+        // スクロール直後の誤タップを飲み込むため、少し遮蔽を残してから解除する
+        scrollTimeout = setTimeout(() => setScrollEnding(false), 200);
+      } else {
+        // 実際のタップは通す
+        setScrollEnding(false);
+      }
     };
 
     document.addEventListener('touchstart', handleTouchStart, { passive: true });


### PR DESCRIPTION
#442 マージ後のフォローアップ一括。

## 変更内容
1. **語法作成CTAをモバイル上部に** (#16): 「手動で作成 / ChatGPTで作る」を下部からヘッダ直下に移動(デスクトップのトップバー常時表示と統一)。
2. **バインダー機能** (#17〜#19):
   - ホームに「バインダー」セクションを追加(モバイル/デスクトップ)。単語帳タイルと**同じシェル・配色**(`thumbColor`/`desktopThumbColor`)の新タイルを binder 名で色付け。
   - `/binder/[name]` 詳細ページを新設。「単語帳を追加」ピッカーで `updateProject({binder})` により追加/解除できる**導線**を用意。
   - 「バインダーを公開」で中の単語帳を**まとめて共有ライブラリに公開**(Pro限定)。
3. **単語一覧のページ送り** (#20): モバイル限定・フロントのみ。20語超の単語帳は10語ずつに分割し、下部固定バーの左右矢印でページ送り。
4. **グループ本棚の戻る無限ループ修正** (#21): 本棚→グループの戻るを Link(push)から `router.back()` に変更(履歴が無ければグループへフォールバック)。

## 動作確認
- `npx eslint`(変更ファイル): エラーなし(既存の未使用警告のみ)
- `npm run build`: 成功(`/binder/[name]` ルート生成を確認)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EZc2mE8zpFAiRg6oAqwJJA)_