### PR TITLE
fix(desktop): バインダーに追加を選択式ピッカーに置き換え

### DIFF
--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import Link from 'next/link';
 import { DesktopProjectsView } from '@/components/desktop/DesktopProjects';
+import { BinderPickerSheet } from '@/components/desktop/ProjectListSheets';
 import { Icon } from '@/components/ui/Icon';
 import { SolidEmpty, SolidPanel } from '@/components/redesign/SolidPage';
 import { CreateWordbookSheet } from '@/components/home/CreateWordbookSheet';
@@ -157,18 +158,35 @@ export default function ProjectListPage() {
     }
   }, [repository]);
 
-  const handleSetBinder = useCallback(async (project: Project) => {
-    const input = window.prompt('バインダー名を入力してください (空欄で解除)', project.binder ?? '');
-    if (input === null) return;
-    const binder = input.trim().slice(0, 40) || null;
+  // 「バインダーに追加」は window.prompt ではなくピッカーシートで選ばせる
+  const [binderTarget, setBinderTarget] = useState<Project | null>(null);
+  const handleSetBinder = useCallback((project: Project) => {
+    setBinderTarget(project);
+  }, []);
+
+  const applyBinder = useCallback(async (binder: string | null) => {
+    const target = binderTarget;
+    setBinderTarget(null);
+    if (!target) return;
+    const next = binder?.trim().slice(0, 40) || null;
     try {
-      await repository.updateProject(project.id, { binder });
-      setProjects((prev) => prev.map((p) => (p.id === project.id ? { ...p, binder } : p)));
+      await repository.updateProject(target.id, { binder: next });
+      setProjects((prev) => prev.map((p) => (p.id === target.id ? { ...p, binder: next } : p)));
       invalidateHomeCache();
     } catch {
       window.alert('バインダーの更新に失敗しました');
     }
-  }, [repository]);
+  }, [binderTarget, repository]);
+
+  // 既存のバインダー名一覧 (重複排除・日本語順)
+  const existingBinders = useMemo(() => {
+    const set = new Set<string>();
+    for (const project of projects) {
+      const name = project.binder?.trim();
+      if (name) set.add(name);
+    }
+    return Array.from(set).sort((a, b) => a.localeCompare(b, 'ja'));
+  }, [projects]);
 
   const filtered = useMemo(() => {
     const normalizedQuery = query.trim().toLowerCase();
@@ -225,7 +243,15 @@ export default function ProjectListPage() {
         onQueryChange={setQuery}
         onSortChange={setSort}
         onDeleteProject={(project) => void handleDeleteProject(project)}
-        onSetBinder={(project) => void handleSetBinder(project)}
+        onSetBinder={handleSetBinder}
+      />
+      <BinderPickerSheet
+        key={binderTarget?.id ?? 'closed'}
+        open={binderTarget !== null}
+        onClose={() => setBinderTarget(null)}
+        project={binderTarget}
+        binders={existingBinders}
+        onApply={(binder) => void applyBinder(binder)}
       />
       <div className="relative min-h-screen bg-[var(--color-background)] pb-[150px] pt-3 font-[var(--font-body)] lg:hidden">
       <div className="px-5 pb-3.5 pt-2.5">

--- a/src/components/desktop/ProjectListSheets.tsx
+++ b/src/components/desktop/ProjectListSheets.tsx
@@ -1,7 +1,9 @@
 'use client';
 
+import { useState } from 'react';
 import { Icon } from '@/components/ui';
 import { BottomSheetShell } from '@/components/project/WordListSheets';
+import type { Project } from '@/types';
 
 export type ProjectSort = 'newest' | 'words' | 'lastUsed';
 export type ProjectFilter = 'all' | 'fav';
@@ -133,6 +135,131 @@ export function ProjectFilterSheet({ open, onClose, filter, onFilterChange }: Pr
             className="sr-only"
           />
         </label>
+      </div>
+    </BottomSheetShell>
+  );
+}
+
+type BinderPickerSheetProps = {
+  open: boolean;
+  onClose: () => void;
+  /** 対象の単語帳 (未選択時は null) */
+  project: Project | null;
+  /** 既存のバインダー名一覧 */
+  binders: string[];
+  /** バインダーを適用 (null = バインダーから外す)。適用後にシートは閉じる。 */
+  onApply: (binder: string | null) => void;
+};
+
+/**
+ * 「...」メニューの「バインダーに追加」で開くピッカー。
+ * 既存バインダーからの選択・解除・新規作成をまとめて行える (window.prompt を置き換え)。
+ */
+export function BinderPickerSheet({ open, onClose, project, binders, onApply }: BinderPickerSheetProps) {
+  // 新規作成フォームの状態は、親が key={project.id} で開くたびにマウントし直して初期化する
+  const [creating, setCreating] = useState(false);
+  const [newName, setNewName] = useState('');
+  const current = project?.binder?.trim() || null;
+
+  const submitNew = () => {
+    const name = newName.trim().slice(0, 40);
+    if (!name) return;
+    onApply(name);
+  };
+
+  return (
+    <BottomSheetShell open={open} onClose={onClose} title="バインダーに追加">
+      <div className="flex flex-col gap-[7px]">
+        {project && (
+          <p className="mb-1 truncate font-mono text-[10px] font-bold uppercase tracking-[0.06em] text-[var(--color-muted)]">
+            {project.title}
+          </p>
+        )}
+
+        {binders.map((name) => {
+          const selected = current === name;
+          return (
+            <button
+              key={name}
+              type="button"
+              onClick={() => onApply(name)}
+              className="flex items-center gap-[11px] rounded-[10px] border-2 border-[var(--solid-ink)] px-3 py-[11px] text-left transition-all"
+              style={{
+                background: selected ? 'var(--solid-ink)' : '#fff',
+                color: selected ? '#fff' : 'var(--solid-ink)',
+                boxShadow: selected ? '2px 2px 0 var(--solid-ink)' : 'none',
+              }}
+            >
+              <div
+                className="flex h-8 w-8 shrink-0 items-center justify-center rounded-[8px]"
+                style={{
+                  background: selected ? 'rgba(255,255,255,0.12)' : 'var(--color-surface-secondary)',
+                  border: selected ? '1px solid rgba(255,255,255,0.2)' : '1px solid var(--color-border)',
+                }}
+              >
+                <Icon name="folder" size={16} filled={selected} />
+              </div>
+              <span className="min-w-0 flex-1 truncate text-[14px] font-bold">{name}</span>
+              {selected && <Icon name="check" size={16} className="shrink-0" />}
+            </button>
+          );
+        })}
+
+        {current && (
+          <button
+            type="button"
+            onClick={() => onApply(null)}
+            className="flex items-center gap-[11px] rounded-[10px] border-2 border-[var(--solid-ink)] bg-white px-3 py-[11px] text-left text-[var(--color-error)] transition-all"
+          >
+            <div
+              className="flex h-8 w-8 shrink-0 items-center justify-center rounded-[8px]"
+              style={{ background: 'var(--color-surface-secondary)', border: '1px solid var(--color-border)' }}
+            >
+              <Icon name="folder_off" size={16} />
+            </div>
+            <span className="min-w-0 flex-1 text-[14px] font-bold">バインダーから外す</span>
+          </button>
+        )}
+
+        {creating ? (
+          <div className="flex items-center gap-2 rounded-[10px] border-2 border-[var(--solid-ink)] bg-white px-2.5 py-2">
+            <Icon name="create_new_folder" size={16} className="shrink-0 text-[var(--color-muted)]" />
+            <input
+              autoFocus
+              type="text"
+              value={newName}
+              maxLength={40}
+              onChange={(e) => setNewName(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') submitNew();
+              }}
+              placeholder="新しいバインダー名"
+              className="min-w-0 flex-1 bg-transparent text-[14px] font-bold text-[var(--solid-ink)] outline-none placeholder:font-normal placeholder:text-[var(--color-muted)]"
+            />
+            <button
+              type="button"
+              onClick={submitNew}
+              disabled={!newName.trim()}
+              className="shrink-0 rounded-[8px] bg-[var(--solid-ink)] px-3 py-1.5 text-[12px] font-bold text-white disabled:opacity-40"
+            >
+              作成
+            </button>
+          </div>
+        ) : (
+          <button
+            type="button"
+            onClick={() => setCreating(true)}
+            className="flex items-center gap-[11px] rounded-[10px] border-2 border-dashed border-[var(--solid-ink)] bg-white px-3 py-[11px] text-left transition-all"
+          >
+            <div
+              className="flex h-8 w-8 shrink-0 items-center justify-center rounded-[8px]"
+              style={{ background: 'var(--color-surface-secondary)', border: '1px solid var(--color-border)' }}
+            >
+              <Icon name="add" size={16} />
+            </div>
+            <span className="min-w-0 flex-1 text-[14px] font-bold text-[var(--solid-ink)]">新しいバインダーを作成</span>
+          </button>
+        )}
       </div>
     </BottomSheetShell>
   );


### PR DESCRIPTION
## 概要

デスクトップ「すべて表示」の単語帳「…」メニューにある **バインダーに追加** が、`window.prompt`（バインダー名のテキスト入力だけ）を出す実装になっており、既存のバインダーを一覧から選べず名前を手打ちするしかありませんでした。これを選択式のピッカーシートに置き換えます。

## 変更内容

- `BinderPickerSheet`（新規、`src/components/desktop/ProjectListSheets.tsx`）を追加。
  - 既存バインダーを一覧表示し、クリックで割り当て（現在のバインダーはハイライト）
  - すでにバインダーに入っている場合は「バインダーから外す」を表示
  - インラインで新規バインダーを作成可能（最大40文字）
  - 共通の `BottomSheetShell` を再利用し、並び替え／絞り込みシートと同じオプションカードの見た目に統一
- `src/app/projects/page.tsx`
  - `handleSetBinder` を `window.prompt` からシート表示に変更
  - `applyBinder`（更新＋ホームキャッシュ無効化）と既存バインダー名一覧の算出を追加
  - シートは `key={project.id}` でのマウントし直しにより開くたびにフォーム状態を初期化（effect 内の同期 setState を回避）

## 確認

- `npm run lint` … 変更ファイルはクリーン（既存の `require()` 系エラーのみ残存、無関係）
- `npm run build` … 成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EZc2mE8zpFAiRg6oAqwJJA)_