### PR TITLE
fix(mobile/desktop): バインダー表示・語法作成メニュー・戻る導線・新規作成の一括修正

### DIFF
--- a/src/app/grammar/page.tsx
+++ b/src/app/grammar/page.tsx
@@ -34,6 +34,8 @@ export default function GrammarBooksPage() {
   const [query, setQuery] = useState('');
   const [filter, setFilter] = useState<'all' | 'fav'>('all');
   const [creatingBook, setCreatingBook] = useState(false);
+  // 作成メニュー(右上「+」): ChatGPT / 手動 の2択を格納する
+  const [createMenuOpen, setCreateMenuOpen] = useState(false);
 
   // 保存(お気に入り)を楽観的に切り替える
   const handleToggleFavorite = async (bookId: string, next: boolean) => {
@@ -149,38 +151,6 @@ export default function GrammarBooksPage() {
     };
   }, []);
 
-  const manualCta = (
-    <button
-      type="button"
-      onClick={() => void handleCreateManual()}
-      disabled={creatingBook}
-      className="flex h-12 w-full items-center justify-center gap-2 rounded-xl border-2 border-[var(--solid-ink)] bg-white font-bold text-[var(--solid-ink)] transition-all duration-100 active:translate-x-px active:translate-y-px disabled:opacity-60"
-    >
-      <Icon name="edit" size={18} />
-      手動で問題集を作る
-    </button>
-  );
-
-  const gptCta = GPT_URL ? (
-    <a
-      href={GPT_URL}
-      target="_blank"
-      rel="noopener noreferrer"
-      className="flex h-12 items-center justify-center gap-2 rounded-xl border-2 border-[var(--solid-ink)] bg-[var(--solid-ink)] font-bold text-white transition-all duration-100 active:translate-x-px active:translate-y-px"
-    >
-      <Icon name="smart_toy" size={18} />
-      ChatGPTで問題を作る
-    </a>
-  ) : (
-    <Link
-      href="/tips/chatgpt"
-      className="flex h-12 items-center justify-center gap-2 rounded-xl border-2 border-[var(--solid-ink)] bg-[var(--solid-ink)] font-bold text-white transition-all duration-100 active:translate-x-px active:translate-y-px"
-    >
-      <Icon name="smart_toy" size={18} />
-      ChatGPT連携の使い方を見る
-    </Link>
-  );
-
   return (
     <>
       <DesktopGrammarBooksView
@@ -199,23 +169,82 @@ export default function GrammarBooksPage() {
 
       <div className="relative mx-auto min-h-screen w-full max-w-[560px] bg-[var(--color-background)] px-[18px] pb-32 pt-3 font-[var(--font-body)] lg:hidden">
       {/* Header */}
-      <div className="pb-3.5 pt-1">
-        <div className="font-mono text-[10px] font-bold tracking-[0.08em] text-[var(--color-muted)]">GRAMMAR / USAGE</div>
-        <div className="mt-1.5 font-display text-2xl font-extrabold leading-[1.15] tracking-[-0.02em] text-[var(--solid-ink)]">
-          語法問題集
+      <div className="flex items-start justify-between gap-3 pb-3.5 pt-1">
+        <div className="min-w-0">
+          <div className="font-mono text-[10px] font-bold tracking-[0.08em] text-[var(--color-muted)]">GRAMMAR / USAGE</div>
+          <div className="mt-1.5 font-display text-2xl font-extrabold leading-[1.15] tracking-[-0.02em] text-[var(--solid-ink)]">
+            語法問題集
+          </div>
+          <div className="mt-1.5 text-[12px] font-medium text-[var(--color-muted)]">
+            空欄補充・英語4択・解説つき。問題はChatGPTとの会話で作成します
+          </div>
         </div>
-        <div className="mt-1.5 text-[12px] font-medium text-[var(--color-muted)]">
-          空欄補充・英語4択・解説つき。問題はChatGPTとの会話で作成します
-        </div>
-      </div>
 
-      {/* 作成CTA: デスクトップのトップバーと同じく上部に常時表示する */}
-      {state.kind === 'ready' && (
-        <div className="mb-3.5 flex flex-col gap-2.5">
-          {gptCta}
-          {manualCta}
-        </div>
-      )}
+        {/* 作成メニュー: 右上「+」に ChatGPT / 手動 の2択を格納する */}
+        {state.kind === 'ready' && (
+          <div className="relative shrink-0">
+            <button
+              type="button"
+              onClick={() => setCreateMenuOpen((open) => !open)}
+              aria-label="問題集を作成"
+              aria-haspopup="menu"
+              aria-expanded={createMenuOpen}
+              className="flex h-11 w-11 items-center justify-center rounded-full border-2 border-[var(--solid-ink)] bg-[var(--solid-ink)] text-white shadow-[2px_2px_0_var(--solid-ink)] transition-all duration-100 active:translate-x-px active:translate-y-px active:shadow-[1px_1px_0_var(--solid-ink)]"
+            >
+              <Icon name={createMenuOpen ? 'close' : 'add'} size={22} />
+            </button>
+            {createMenuOpen && (
+              <>
+                <button
+                  type="button"
+                  aria-label="閉じる"
+                  onClick={() => setCreateMenuOpen(false)}
+                  className="fixed inset-0 z-40 cursor-default bg-transparent"
+                />
+                <div
+                  role="menu"
+                  className="absolute right-0 top-[52px] z-50 w-[230px] overflow-hidden rounded-xl border-2 border-[var(--solid-ink)] bg-white shadow-[2px_3px_0_var(--solid-ink)]"
+                >
+                  {GPT_URL ? (
+                    <a
+                      href={GPT_URL}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      role="menuitem"
+                      onClick={() => setCreateMenuOpen(false)}
+                      className="flex items-center gap-2.5 px-4 py-3.5 text-[13.5px] font-bold text-[var(--solid-ink)] no-underline hover:bg-[var(--color-surface-secondary)]"
+                    >
+                      <Icon name="smart_toy" size={18} />
+                      ChatGPTで問題を作る
+                    </a>
+                  ) : (
+                    <Link
+                      href="/tips/chatgpt"
+                      role="menuitem"
+                      onClick={() => setCreateMenuOpen(false)}
+                      className="flex items-center gap-2.5 px-4 py-3.5 text-[13.5px] font-bold text-[var(--solid-ink)] no-underline hover:bg-[var(--color-surface-secondary)]"
+                    >
+                      <Icon name="smart_toy" size={18} />
+                      ChatGPT連携の使い方を見る
+                    </Link>
+                  )}
+                  <div className="h-px bg-[var(--color-border)]" />
+                  <button
+                    type="button"
+                    role="menuitem"
+                    onClick={() => { setCreateMenuOpen(false); void handleCreateManual(); }}
+                    disabled={creatingBook}
+                    className="flex w-full items-center gap-2.5 px-4 py-3.5 text-left text-[13.5px] font-bold text-[var(--solid-ink)] hover:bg-[var(--color-surface-secondary)] disabled:opacity-60"
+                  >
+                    <Icon name="edit" size={18} />
+                    手動で問題集を作る
+                  </button>
+                </div>
+              </>
+            )}
+          </div>
+        )}
+      </div>
 
       {state.kind === 'loading' && (
         <div className="flex flex-col gap-2.5">

--- a/src/app/home-client.tsx
+++ b/src/app/home-client.tsx
@@ -613,7 +613,7 @@ export function HomeClient() {
         showUpgrade={showUpgradeBanner}
         onDismissUpgrade={dismissUpgradeBanner}
       />
-      <div className="relative min-h-screen bg-[var(--color-background)] pb-[110px] pt-3 font-[var(--font-body)] lg:hidden">
+      <div className="relative min-h-screen overflow-x-clip bg-[var(--color-background)] pb-[110px] pt-3 font-[var(--font-body)] lg:hidden">
       <div className="flex items-center justify-between px-[18px] pb-4 pt-2 lg:hidden">
         <div className="font-display text-[26px] font-black leading-none tracking-[0.1em] text-[var(--solid-ink)]">
           MERKEN
@@ -750,12 +750,14 @@ export function HomeClient() {
               <h2 className="font-display text-[19px] font-extrabold tracking-[-0.01em] text-[var(--solid-ink)]">バインダー</h2>
             </div>
           </div>
-          <div className="no-scrollbar -mx-[18px] mb-1 flex snap-x snap-mandatory gap-2.5 overflow-x-auto px-[18px] pb-4 scroll-pl-[18px]">
-            {homeBinders.map((binder) => (
-              <div key={binder.name} className="w-[42%] shrink-0 snap-start">
-                <BinderSquareTile name={binder.name} count={binder.count} />
-              </div>
-            ))}
+          <div className="px-[18px] pb-4">
+            <div className="no-scrollbar -mx-[18px] mb-1 flex snap-x snap-mandatory gap-2.5 overflow-x-auto px-[18px] pb-1 scroll-pl-[18px]">
+              {homeBinders.map((binder) => (
+                <div key={binder.name} className="w-[42%] shrink-0 snap-start">
+                  <BinderSquareTile name={binder.name} count={binder.count} />
+                </div>
+              ))}
+            </div>
           </div>
         </>
       )}

--- a/src/app/home-client.tsx
+++ b/src/app/home-client.tsx
@@ -496,15 +496,21 @@ export function HomeClient() {
   // The reel-saved backing wordbook is an internal bucket for 保存済み — keep it
   // out of the browsable マイ単語帳 list (its words still count in `stats`).
   const listProjects = useMemo(() => excludeReelSavedProjects(projects), [projects]);
+  // バインダー(フォルダ)に入っている単語帳は単体では表示しない。バインダーは1つの
+  // タイルとして表示し、中の単語帳はタップして /binder/[name] に入ってから見せる。
+  const unfiledProjects = useMemo(
+    () => listProjects.filter((project) => !project.binder?.trim()),
+    [listProjects],
+  );
   // ショートカットグリッドに載り切らなかった単語帳だけを下のマイ単語帳リストに
   // 出す（重複表示を避ける）。全部グリッドに収まる場合は従来どおり全件を出す
   // （新規ユーザーのチュートリアルが最初の ProjectRow をアンカーにしているため）。
   const gridProjectCount = Math.min(
-    listProjects.length,
+    unfiledProjects.length,
     homeShortcutContentSlots(favoriteCount > 0),
   );
-  const overflowProjects = listProjects.slice(gridProjectCount);
-  const myBooksProjects = overflowProjects.length > 0 ? overflowProjects : listProjects;
+  const overflowProjects = unfiledProjects.slice(gridProjectCount);
+  const myBooksProjects = overflowProjects.length > 0 ? overflowProjects : unfiledProjects;
   const visibleProjects = myBooksProjects.slice(0, HOME_MY_BOOKS_VISIBLE_LIMIT);
 
   // ホームに出すバインダー (フォルダ) 一覧。listProjects を binder 名で集計する
@@ -667,7 +673,7 @@ export function HomeClient() {
       <HomeShortcutGrid
         goal={{ state: goalState, count: goalCount }}
         savedWordsCount={favoriteCount}
-        projects={listProjects}
+        projects={unfiledProjects}
         groups={myGroups}
         recommendations={visibleRecommendedBooks}
         onStartScan={() => setVocabScanOpen(true)}

--- a/src/app/project/[id]/page.tsx
+++ b/src/app/project/[id]/page.tsx
@@ -1312,7 +1312,14 @@ export default function ProjectPage() {
         className={`sticky z-40 flex items-center gap-2.5 border-b-2 bg-[var(--color-background)]/95 px-[14px] py-2.5 backdrop-blur-md lg:hidden ${pageScrolled ? 'border-[var(--solid-ink)]' : 'border-transparent'}`}
         style={{ top: 'env(safe-area-inset-top, 0px)' }}
       >
-        <HeaderBtn onClick={() => router.replace('/')} aria-label="ホームへ戻る">
+        <HeaderBtn
+          onClick={() => {
+            // 直前の画面（バインダー・単語帳一覧など）に戻す。履歴が無い場合のみホーム。
+            if (typeof window !== 'undefined' && window.history.length > 1) router.back();
+            else router.replace('/');
+          }}
+          aria-label="戻る"
+        >
           <Icon name="arrow_back" size={16} />
         </HeaderBtn>
         <div className="min-w-0 flex-1">

--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -81,6 +81,7 @@ export default function ProjectListPage() {
   const [error, setError] = useState<string | null>(null);
   const [summaryStats, setSummaryStats] = useState<DesktopStudySummaryStats>(EMPTY_DESKTOP_STUDY_SUMMARY);
   const [createSheetOpen, setCreateSheetOpen] = useState(false);
+  const [desktopCreateOpen, setDesktopCreateOpen] = useState(false);
 
   const subscriptionStatus: SubscriptionStatus = subscription?.status || 'free';
   const wasPro = subscription?.plan === 'pro' && subscriptionStatus !== 'active';
@@ -227,7 +228,6 @@ export default function ProjectListPage() {
     }
     return groups;
   }, [filtered]);
-  const hasBinders = binderGroups.some((group) => group.binder !== null);
 
   return (
     <>
@@ -244,6 +244,7 @@ export default function ProjectListPage() {
         onSortChange={setSort}
         onDeleteProject={(project) => void handleDeleteProject(project)}
         onSetBinder={handleSetBinder}
+        onCreateNew={() => setDesktopCreateOpen(true)}
       />
       <BinderPickerSheet
         key={binderTarget?.id ?? 'closed'}
@@ -324,22 +325,20 @@ export default function ProjectListPage() {
             }
           />
         ) : (
-          binderGroups.map((group) => (
-            <div key={group.binder ?? '__unfiled__'} className="flex flex-col gap-2.5">
-              {hasBinders && (
-                <div className="mt-1 flex items-center gap-1.5 px-1">
-                  <Icon name={group.binder ? 'folder' : 'folder_open'} size={14} className="text-[var(--color-muted)]" />
-                  <span className="font-display text-[13px] font-extrabold text-[var(--solid-ink)]">
-                    {group.binder ?? '未分類'}
-                  </span>
-                  <span className="font-mono text-[10px] tabular-nums text-[var(--color-muted)]">{group.items.length}</span>
-                </div>
-              )}
-              {group.items.map((project) => (
+          <>
+            {/* バインダーは単体行で表示。中の単語帳はタップして /binder/[name] で見る */}
+            {binderGroups
+              .filter((group) => group.binder !== null)
+              .map((group) => (
+                <BinderRow key={group.binder} name={group.binder as string} count={group.items.length} />
+              ))}
+            {binderGroups
+              .filter((group) => group.binder === null)
+              .flatMap((group) => group.items)
+              .map((project) => (
                 <BookRow key={project.id} project={project} />
               ))}
-            </div>
-          ))
+          </>
         )}
       </div>
 
@@ -347,6 +346,12 @@ export default function ProjectListPage() {
       <CreateWordbookSheet
         isOpen={createSheetOpen}
         onClose={() => setCreateSheetOpen(false)}
+      />
+      {/* デスクトップの新規作成: ホームと同じく中央モーダルで作成方法を選ばせる（/scan直行にしない） */}
+      <CreateWordbookSheet
+        isOpen={desktopCreateOpen}
+        onClose={() => setDesktopCreateOpen(false)}
+        variant="modal"
       />
     </>
   );
@@ -383,6 +388,37 @@ function BookRow({ project }: { project: ProjectRowStats }) {
             )}
           </div>
 
+          <span className="mr-0.5 inline-flex text-[var(--color-muted)]">
+            <Icon name="chevron_right" size={14} />
+          </span>
+        </div>
+      </SolidPanel>
+    </Link>
+  );
+}
+
+// バインダー(フォルダ)行。単語帳一覧では中身を展開せず、この単体行から
+// /binder/[name] に入って中の単語帳を見せる。配色は単語帳タイルと同じ thumbColor。
+function BinderRow({ name, count }: { name: string; count: number }) {
+  const bg = thumbColor(name);
+  return (
+    <Link href={`/binder/${encodeURIComponent(name)}`}>
+      <SolidPanel
+        className="!rounded-[14px] transition-all duration-100 active:translate-x-px active:translate-y-px"
+        faceClassName="!p-[13px]"
+      >
+        <div className="flex items-center gap-[13px]">
+          <div
+            className="flex h-[44px] w-[44px] shrink-0 items-center justify-center rounded-[10px] border-2 border-[var(--solid-ink)] text-white"
+            style={{ backgroundColor: bg }}
+          >
+            <Icon name="folder" size={22} filled />
+          </div>
+          <div className="min-w-0 flex-1">
+            <div className="font-mono text-[9px] font-bold tracking-[0.08em] text-[var(--color-muted)]">BINDER</div>
+            <div className="truncate text-sm font-bold text-[var(--solid-ink)]">{name}</div>
+            <div className="mt-0.5 text-[10px] tabular-nums text-[var(--color-muted)]">{count}冊</div>
+          </div>
           <span className="mr-0.5 inline-flex text-[var(--color-muted)]">
             <Icon name="chevron_right" size={14} />
           </span>

--- a/src/components/desktop/DesktopProjectDetail.tsx
+++ b/src/components/desktop/DesktopProjectDetail.tsx
@@ -2,6 +2,7 @@
 
 import { type CSSProperties, useEffect, useMemo, useRef, useState } from 'react';
 import Link from 'next/link';
+import { useRouter } from 'next/navigation';
 import { Icon } from '@/components/ui/Icon';
 import {
   DesktopButton,
@@ -96,6 +97,7 @@ export function DesktopProjectDetailView({
   onScan: () => void;
   onManualAdd: () => void;
 }) {
+  const router = useRouter();
   const [addMenuOpen, setAddMenuOpen] = useState(false);
   const addMenuRef = useRef<HTMLDivElement>(null);
   const [sortKey, setSortKey] = useState<SortKey>('order');
@@ -220,7 +222,21 @@ export function DesktopProjectDetailView({
 
   return (
     <div className="hidden h-full min-h-0 flex-col lg:flex">
-      <DesktopTopbar title={project.title} crumb="単語帳 / 一覧">
+      <DesktopTopbar
+        title={project.title}
+        crumb="単語帳 / 一覧"
+        leading={
+          <DesktopButton
+            onClick={() => {
+              // 直前の画面（単語帳一覧・バインダーなど）へ戻す。履歴が無ければ一覧へ。
+              if (typeof window !== 'undefined' && window.history.length > 1) router.back();
+              else router.push('/projects');
+            }}
+            icon="arrow_back"
+            title="戻る"
+          >{''}</DesktopButton>
+        }
+      >
         {/* 「...」メニュー: 単語の追加 / 名称変更 */}
         <div ref={addMenuRef} style={{ position: 'relative' }}>
           <DesktopButton onClick={() => setAddMenuOpen((v) => !v)} icon="more_horiz" title="その他の操作">{''}</DesktopButton>

--- a/src/components/desktop/DesktopProjects.tsx
+++ b/src/components/desktop/DesktopProjects.tsx
@@ -39,6 +39,7 @@ export function DesktopProjectsView({
   onSortChange,
   onDeleteProject,
   onSetBinder,
+  onCreateNew,
 }: {
   projects: DesktopProjectRow[];
   loading: boolean;
@@ -52,6 +53,7 @@ export function DesktopProjectsView({
   onSortChange: (value: 'newest' | 'words' | 'lastUsed') => void;
   onDeleteProject?: (project: DesktopProjectRow) => void;
   onSetBinder?: (project: DesktopProjectRow) => void;
+  onCreateNew?: () => void;
 }) {
   const [filter, setFilter] = useState<'all' | 'fav'>('all');
   const [showFilterSheet, setShowFilterSheet] = useState(false);
@@ -81,7 +83,6 @@ export function DesktopProjectsView({
     if (unfiled.length > 0) groups.push({ binder: null, items: unfiled });
     return groups;
   }, [rows]);
-  const hasBinders = binderGroups.some((group) => group.binder !== null);
 
   return (
     <div className="hidden h-full min-h-0 flex-col lg:flex">
@@ -91,7 +92,7 @@ export function DesktopProjectsView({
           value={query}
           onChange={(event) => onQueryChange(event.target.value)}
         />
-        <DesktopButton href="/scan" variant="accent" icon="add">
+        <DesktopButton onClick={onCreateNew} variant="accent" icon="add">
           新規作成
         </DesktopButton>
       </DesktopTopbar>
@@ -147,22 +148,16 @@ export function DesktopProjectsView({
               </thead>
               <tbody>
                 {binderGroups.map((group) => (
-                  <Fragment key={group.binder ?? '__unfiled__'}>
-                    {hasBinders && (
-                      <tr>
-                        <td colSpan={7} style={{ background: '#faf7f1', padding: '8px 16px' }}>
-                          <span style={{ display: 'inline-flex', alignItems: 'center', gap: 7, fontFamily: 'var(--font-display)', fontWeight: 800, fontSize: 12.5 }}>
-                            <Icon name={group.binder ? 'folder' : 'folder_open'} style={{ fontSize: 16 }} />
-                            {group.binder ?? '未分類'}
-                            <span className="mono muted" style={{ fontSize: 11, fontWeight: 700 }}>{group.items.length}</span>
-                          </span>
-                        </td>
-                      </tr>
-                    )}
-                    {group.items.map((project) => (
-                      <DesktopProjectTableRow key={project.id} project={project} onDelete={onDeleteProject} onSetBinder={onSetBinder} />
-                    ))}
-                  </Fragment>
+                  group.binder !== null ? (
+                    // バインダーは単体行で表示。中身はタップして /binder/[name] で見せる
+                    <DesktopBinderTableRow key={group.binder} name={group.binder} count={group.items.length} />
+                  ) : (
+                    <Fragment key="__unfiled__">
+                      {group.items.map((project) => (
+                        <DesktopProjectTableRow key={project.id} project={project} onDelete={onDeleteProject} onSetBinder={onSetBinder} />
+                      ))}
+                    </Fragment>
+                  )
                 ))}
               </tbody>
             </table>
@@ -196,6 +191,38 @@ export function DesktopProjectsView({
         onSortChange={onSortChange}
       />
     </div>
+  );
+}
+
+// バインダー(フォルダ)を単体行として表示する。行タップで /binder/[name] に入り、
+// 中の単語帳はそこで見せる（一覧では展開しない）。
+function DesktopBinderTableRow({ name, count }: { name: string; count: number }) {
+  return (
+    <tr>
+      <td className="star">
+        <Icon name="folder" filled style={{ color: 'var(--color-muted)' }} />
+      </td>
+      <td>
+        <Link href={`/binder/${encodeURIComponent(name)}`} style={{ display: 'flex', alignItems: 'center', gap: 12, textDecoration: 'none', color: 'inherit' }}>
+          <span
+            className="ds-project-icon ds-project-icon--sm"
+            style={{ background: desktopThumbColor(name), display: 'flex', alignItems: 'center', justifyContent: 'center' }}
+          >
+            <Icon name="folder" size={18} filled style={{ color: '#fff' }} />
+          </span>
+          <span style={{ fontFamily: 'var(--font-display)', fontWeight: 700, fontSize: 15 }}>{name}</span>
+        </Link>
+      </td>
+      <td className="mono" style={{ fontSize: 11.5, color: 'var(--color-muted)' }}>バインダー</td>
+      <td className="tnum" style={{ fontWeight: 700 }}>{count}冊</td>
+      <td />
+      <td className="mono" style={{ fontSize: 11.5, color: 'var(--color-muted)' }}>—</td>
+      <td>
+        <Link href={`/binder/${encodeURIComponent(name)}`} aria-label="バインダーを開く" style={{ color: 'var(--color-muted)', lineHeight: 0 }}>
+          <Icon name="chevron_right" />
+        </Link>
+      </td>
+    </tr>
   );
 }
 


### PR DESCRIPTION
モバイル/デスクトップのUI不具合をまとめて修正します。

## 1. モバイルのバインダー棚 / 横スワイプ
- ホームのバインダー棚が左端をはみ出す問題を修正（単語帳棚と同じ `px-[18px]` ラッパーで囲み、`-mx-[18px]` のブリードが画面端で止まるように）。
- ホーム最上位に `overflow-x-clip` を追加し、横スワイプでページ全体が横に動くことが二度と起きないよう防御（`clip` はスクロールコンテナを作らないので sticky に無害）。

## 2. バインダーは「単体表示」に統一
- バインダーに入っている単語帳は単体では表示せず、バインダーを1つのタイル/行として表示。中の単語帳はタップして `/binder/[name]` に入ってから見せる。
  - ホーム: ショートカットグリッド・マイ単語帳棚の両方から除外（`homeBinders` の集計は全件から行うので冊数は正確）。
  - `/projects`: モバイルは単体行（`BinderRow`）、デスクトップは単体テーブル行（`DesktopBinderTableRow`）で `/binder/[name]` へリンク。

## 3. 語法問題集の作成ボタンを「+」メニューに集約（モバイル）
- 「ChatGPTで問題を作る」「手動で問題集を作る」の2ボタンを、ヘッダー右上の「+」ボタンに格納。タップでドロップダウンに2択を表示。

## 4. 戻る導線
- モバイル `/project/[id]` の戻るボタンを `router.back()`（履歴が無ければホーム）に変更。バインダー→単語帳→戻る でバインダーに戻れる。
- デスクトップの単語帳詳細のトップバーに左矢印（戻る）ボタンを追加（`router.back()`、無ければ `/projects`）。`/projects` 経由で開いた単語帳から戻れる。

## 5. 新規作成
- デスクトップ `/projects` の「新規作成」を `/scan` 直行ではなく、ホームと同じ CreateWordbookSheet モーダルを開くように変更。

## 確認
- `npm run build` 成功 / 変更ファイルの lint はクリーン
- `security` チェックの赤は既存の依存監査（postcss）で、このPRは依存を変更していないため無関係

🤖 Generated with [Claude Code](https://claude.com/claude-code)