### PR TITLE
feat(desktop-home): 学習サイドバー格納 + ビルド高速化(53s→21s)

### DIFF
--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -1,0 +1,26 @@
+name: Typecheck
+
+# `next build` は型チェックをスキップして高速化しているため、
+# 型安全性は専用の tsc --noEmit ジョブでCIとして担保する。
+on:
+  pull_request:
+  push:
+
+jobs:
+  typecheck:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Type check
+        run: npm run typecheck

--- a/next.config.ts
+++ b/next.config.ts
@@ -3,6 +3,9 @@ import type { NextConfig } from "next";
 const nextConfig: NextConfig = {
   poweredByHeader: false,
   reactStrictMode: true,
+  // 型チェックは `next build` から切り離し、専用の `npm run typecheck`
+  // (tsc --noEmit) と CI で担保する。ビルド自体を速く保つため。
+  typescript: { ignoreBuildErrors: true },
   images: {
     formats: ["image/avif", "image/webp"],
   },

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
+    "typecheck": "tsc --noEmit",
     "start": "next start",
     "security:sql": "node scripts/check-sql-injection-guard.mjs",
     "security:secrets": "node scripts/check-secrets-guard.mjs",
@@ -15,7 +16,7 @@
     "security:observe:summary": "node scripts/security-observe-summary.mjs",
     "lint": "npm run security:sql && eslint",
     "lint:web": "eslint src shared next.config.ts postcss.config.mjs eslint.config.mjs scripts/check-deps-audit.mjs scripts/check-secrets-guard.mjs scripts/check-secrets-guard.test.mjs scripts/check-sql-injection-guard.mjs scripts/check-sql-injection-guard.test.mjs scripts/security-observe.mjs scripts/security-observe-summary.mjs",
-    "verify": "npm run lint:web && npm run security:all && npm test && npm run test:security && npm run build",
+    "verify": "npm run typecheck && npm run lint:web && npm run security:all && npm test && npm run test:security && npm run build",
     "test:security:sql": "node --test scripts/check-sql-injection-guard.test.mjs",
     "test:security:secrets": "node --test scripts/check-secrets-guard.test.mjs",
     "test:security:routes": "tsx --test src/app/api/**/*.security.test.ts",

--- a/src/components/desktop/DesktopHome.tsx
+++ b/src/components/desktop/DesktopHome.tsx
@@ -9,7 +9,7 @@
  */
 
 import Link from 'next/link';
-import { useState } from 'react';
+import { useState, useSyncExternalStore } from 'react';
 import { Icon } from '@/components/ui/Icon';
 import { DesktopButton, DesktopTopbar } from '@/components/desktop/DesktopChrome';
 import { DesktopWordSearchOverlay } from '@/components/desktop/DesktopWordSearchOverlay';
@@ -34,6 +34,32 @@ import { seedPinnedReelPreview } from '@/lib/reels/pinned-preview';
 import type { HomeRecommendedBook, HomeReelPreviewItem } from '@/lib/home/recommendations-types';
 import type { Project } from '@/types';
 import type { StudyGroupSummary } from '@/lib/shared-projects/types';
+
+// 右サイドバーの格納状態を localStorage に保存する外部ストア。
+// useSyncExternalStore から購読し、effect 内 setState / ハイドレーション不整合を避ける。
+const SIDEBAR_STORAGE_KEY = 'home-sidebar-collapsed';
+const sidebarStoreListeners = new Set<() => void>();
+function readSidebarCollapsed(): boolean {
+  try {
+    return localStorage.getItem(SIDEBAR_STORAGE_KEY) === '1';
+  } catch {
+    return false;
+  }
+}
+function writeSidebarCollapsed(next: boolean): void {
+  try {
+    localStorage.setItem(SIDEBAR_STORAGE_KEY, next ? '1' : '0');
+  } catch {
+    // 保存できなくても購読者へは通知する
+  }
+  sidebarStoreListeners.forEach((listener) => listener());
+}
+function subscribeSidebarStore(listener: () => void): () => void {
+  sidebarStoreListeners.add(listener);
+  return () => {
+    sidebarStoreListeners.delete(listener);
+  };
+}
 
 type DesktopHomeProject = Project & {
   totalWords: number;
@@ -102,6 +128,14 @@ export function DesktopHomeView({
   // 単語検索（旧サイドバー下部のボタンから移設）。開くたびに初期化する。
   const [wordSearchOpen, setWordSearchOpen] = useState(false);
   const [view, setView] = useState<'grid' | 'list'>('grid');
+  // 右サイドバー（学習サマリー）の格納状態。localStorage に保存して次回も維持する。
+  // useSyncExternalStore で SSR/ハイドレーション不整合と effect 内 setState を避ける。
+  const sidebarCollapsed = useSyncExternalStore(
+    subscribeSidebarStore,
+    readSidebarCollapsed,
+    () => false,
+  );
+  const toggleSidebar = () => writeSidebarCollapsed(!sidebarCollapsed);
   // 上部ショートカットグリッドに載った単語帳は下の一覧から除外し、
   // 溢れた分だけを表示する。
   const gridProjectCount = Math.min(
@@ -139,12 +173,20 @@ export function DesktopHomeView({
         <DesktopButton variant="accent" icon="add" onClick={onStartScan}>
           新規作成
         </DesktopButton>
+        {/* 右サイドバーの表示/格納トグル（格納中でも常にここから戻せる） */}
+        <DesktopButton
+          icon={sidebarCollapsed ? 'chevron_left' : 'chevron_right'}
+          onClick={toggleSidebar}
+          title={sidebarCollapsed ? '学習サマリーを表示' : '学習サマリーを隠す'}
+        >
+          {''}
+        </DesktopButton>
       </DesktopTopbar>
       {wordSearchOpen && user && (
         <DesktopWordSearchOverlay onClose={() => setWordSearchOpen(false)} userId={user.id} />
       )}
 
-      <div className="ds-scroll" style={{ display: 'grid', gridTemplateColumns: '1fr 300px', gap: 24, alignItems: 'start' }}>
+      <div className="ds-scroll" style={{ display: 'grid', gridTemplateColumns: sidebarCollapsed ? 'minmax(0, 1fr)' : 'minmax(0, 1fr) 300px', gap: 24, alignItems: 'start' }}>
         <div style={{ minWidth: 0 }}>
           {error && (
             <div className="ds-card" style={{ padding: 14, marginBottom: 18, color: 'var(--color-error)', borderColor: 'var(--color-error)' }}>
@@ -333,15 +375,28 @@ export function DesktopHomeView({
           )}
         </div>
 
-        {/* 右サイド（モバイルと違い維持） */}
-        <div style={{ display: 'flex', flexDirection: 'column', gap: 18, position: 'sticky', top: 0 }}>
-          {showUpgrade && <DesktopUpgradeCard onDismiss={onDismissUpgrade} />}
-          <DesktopStudySidebar
-            stats={stats}
-            reviewHref={stats.totalWords > 0 ? '/quiz/all?review=1&from=/' : '/projects'}
-            learnHref={stats.totalWords > 0 ? '/quiz/all?learn=1&from=/' : '/projects'}
-          />
-        </div>
+        {/* 右サイド（モバイルと違い維持）。トグルで格納できる。 */}
+        {!sidebarCollapsed && (
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 12, position: 'sticky', top: 0 }}>
+            <div style={{ display: 'flex', justifyContent: 'flex-end' }}>
+              <button
+                type="button"
+                onClick={toggleSidebar}
+                aria-label="学習サマリーを隠す"
+                title="学習サマリーを隠す"
+                style={{ display: 'inline-flex', alignItems: 'center', justifyContent: 'center', width: 30, height: 30, borderRadius: 8, border: '2px solid var(--solid-ink)', background: '#fff', color: 'var(--color-muted)', cursor: 'pointer', boxShadow: '2px 2px 0 var(--solid-ink)' }}
+              >
+                <Icon name="chevron_right" style={{ fontSize: 18 }} />
+              </button>
+            </div>
+            {showUpgrade && <DesktopUpgradeCard onDismiss={onDismissUpgrade} />}
+            <DesktopStudySidebar
+              stats={stats}
+              reviewHref={stats.totalWords > 0 ? '/quiz/all?review=1&from=/' : '/projects'}
+              learnHref={stats.totalWords > 0 ? '/quiz/all?learn=1&from=/' : '/projects'}
+            />
+          </div>
+        )}
       </div>
     </div>
   );

--- a/src/lib/quiz/translation-targets.test.ts
+++ b/src/lib/quiz/translation-targets.test.ts
@@ -92,7 +92,9 @@ test('generateQuizQuestions produces a separate question per distinct translatio
   });
 
   // one question for the primary meaning and one for the distinct meaning
-  const correctAnswers = questions.map((question) => question.options[question.correctIndex]);
+  const correctAnswers = questions.map((question) =>
+    question.type === 'word-order' ? undefined : question.options[question.correctIndex],
+  );
   assert.ok(correctAnswers.includes('感覚'), 'primary meaning is quizzed');
   assert.ok(correctAnswers.includes('分別'), 'distinct meaning is quizzed');
   assert.equal(questions.length, 2);


### PR DESCRIPTION
## 1. ホーム右側の学習サイドバーを格納可能に
- トップバーに表示/格納トグル（常時表示で格納中でも戻せる）＋展開時はサイドバー上部のシェブロンでも隠せる。
- 格納するとグリッドが1カラム全幅になり単語帳エリアが広がる。状態は localStorage に保存（`useSyncExternalStore` でハイドレーション不整合を回避）。

## 2. `next build` の高速化（約53秒 → 約21秒）
`next build` が毎回 ~30秒を型チェックに費やしていました。Next 16 は組み込み ESLint を廃止済みなので、オーバーヘッドはすべて TypeScript でした。型チェックをビルドから切り離し、専用ステップで担保します。

- `next.config.ts`: `typescript.ignoreBuildErrors` でビルド時の型チェックをスキップ（compile 17s + static gen ~1.5s = 約21s）。
- `package.json`: `typecheck`（`tsc --noEmit`）を追加し、`verify` の先頭で実行。
- `.github/workflows/typecheck.yml`: **新規CIジョブ**。push/PR ごとに `tsc --noEmit` を実行し、これまで Vercel ビルドが担っていた型チェックのゲートをCIで復元。
- `tsc --noEmit` で顕在化した既存の型エラーを1件修正（`next build` は単体テストファイルを型チェックしていなかった）。`QuizQuestion` union を `type` 判別子で絞り込んでから `options[correctIndex]` を参照するように修正。

## 確認
- `npm run build` 約21秒に短縮 / `npm run typecheck` クリーン / 該当テスト 3/3 パス
- `security` チェックの赤は既存の依存監査（postcss）で無関係

🤖 Generated with [Claude Code](https://claude.com/claude-code)