### PR TITLE
feat(pwa): オフライン対応（Service Worker ランタイムキャッシュ + オフラインページ）

### DIFF
--- a/public/offline.html
+++ b/public/offline.html
@@ -1,0 +1,130 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+  <meta name="theme-color" content="#137fec" />
+  <title>オフライン - MERKEN</title>
+  <style>
+    :root {
+      --bg: #ffffff;
+      --fg: #0f172a;
+      --muted: #64748b;
+      --primary: #137fec;
+      --card: #f8fafc;
+      --border: #e2e8f0;
+    }
+    @media (prefers-color-scheme: dark) {
+      :root {
+        --bg: #0b1220;
+        --fg: #e2e8f0;
+        --muted: #94a3b8;
+        --primary: #4aa3ff;
+        --card: #111a2e;
+        --border: #1e293b;
+      }
+    }
+    * { box-sizing: border-box; }
+    html, body { height: 100%; margin: 0; }
+    body {
+      background: var(--bg);
+      color: var(--fg);
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Hiragino Sans",
+        "Noto Sans JP", "Yu Gothic", Meiryo, sans-serif;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: max(24px, env(safe-area-inset-top)) 24px max(24px, env(safe-area-inset-bottom));
+      -webkit-font-smoothing: antialiased;
+    }
+    .card {
+      width: 100%;
+      max-width: 360px;
+      text-align: center;
+    }
+    .badge {
+      width: 72px;
+      height: 72px;
+      margin: 0 auto 20px;
+      border-radius: 20px;
+      background: var(--card);
+      border: 1px solid var(--border);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      color: var(--primary);
+    }
+    h1 {
+      font-size: 20px;
+      font-weight: 700;
+      margin: 0 0 8px;
+    }
+    p {
+      font-size: 14px;
+      line-height: 1.7;
+      color: var(--muted);
+      margin: 0 0 24px;
+    }
+    button {
+      appearance: none;
+      border: none;
+      cursor: pointer;
+      background: var(--primary);
+      color: #ffffff;
+      font-size: 15px;
+      font-weight: 600;
+      padding: 13px 24px;
+      border-radius: 999px;
+      width: 100%;
+      max-width: 240px;
+      transition: opacity 0.15s ease;
+    }
+    button:active { opacity: 0.8; }
+    .status {
+      margin-top: 16px;
+      font-size: 12px;
+      color: var(--muted);
+      min-height: 16px;
+    }
+  </style>
+</head>
+<body>
+  <main class="card">
+    <div class="badge" aria-hidden="true">
+      <svg width="34" height="34" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+        stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+        <path d="M1 1l22 22" />
+        <path d="M16.72 11.06A10.94 10.94 0 0 1 19 12.55" />
+        <path d="M5 12.55a10.94 10.94 0 0 1 5.17-2.39" />
+        <path d="M10.71 5.05A16 16 0 0 1 22.58 9" />
+        <path d="M1.42 9a15.91 15.91 0 0 1 4.7-2.88" />
+        <path d="M8.53 16.11a6 6 0 0 1 6.95 0" />
+        <line x1="12" y1="20" x2="12.01" y2="20" />
+      </svg>
+    </div>
+    <h1>オフラインです</h1>
+    <p>
+      インターネットに接続されていません。<br />
+      保存済みの単語帳やクイズはオフラインでも利用できます。接続が回復すると自動的に同期されます。
+    </p>
+    <button type="button" onclick="location.reload()">再読み込み</button>
+    <div class="status" id="status" role="status" aria-live="polite"></div>
+  </main>
+  <script>
+    (function () {
+      var status = document.getElementById('status');
+      function update() {
+        if (navigator.onLine) {
+          if (status) status.textContent = '接続を確認しました。読み込み中…';
+          location.reload();
+        }
+      }
+      window.addEventListener('online', update);
+      // In case connectivity returned before this page finished loading.
+      if (navigator.onLine) {
+        setTimeout(update, 1500);
+      }
+    })();
+  </script>
+</body>
+</html>

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,34 +1,62 @@
 // MERKEN Service Worker
-// Web Push notifications only. Intentionally NO fetch/caching handler.
+// Responsibilities: (1) Web Push notifications, (2) offline support via runtime caching.
 //
-// A fetch/caching handler was tried (offline support) but it broke the installed
-// standalone PWA: because the service worker controls the PWA from launch, any
-// mismatch between a cached app shell and its JS chunks left the PWA stranded on
-// its loading screen. A plain browser tab was unaffected because a freshly
-// registered worker does not control the first load. Keeping this worker
-// caching-free means the PWA loads exactly like a normal page (network), which is
-// reliable. Offline support, if revisited, should use a build-integrated precache
-// (e.g. Serwist) so the shell and its chunks are always cached atomically.
+// OFFLINE STRATEGY — why this is safe.
+// A previous attempt at offline support used a cache-first app shell and broke the
+// installed standalone PWA: because the service worker controls the PWA from launch,
+// a cached shell HTML that referenced hashed JS chunks missing from the cache left
+// the PWA stranded on its loading screen. To avoid ever repeating that, documents
+// here are served NETWORK-FIRST:
+//   - Navigations (documents)        -> network-first. Online = always the fresh
+//     shell straight from the network (byte-for-byte identical to today's no-cache
+//     behavior, so the chunk-mismatch stranding cannot recur). Offline = the last
+//     document cached for that route, else the offline fallback page.
+//   - Immutable build assets
+//     (/_next/static/**)             -> cache-first. Their URLs are content-hashed,
+//     so entries never go stale and old/new builds never collide.
+//   - Other static assets
+//     (icons, manifest, images, fonts) -> stale-while-revalidate.
+//   - RSC payloads & other GETs      -> network-first with cache fallback.
+//   - API / auth / cross-origin / non-GET -> never touched (always network).
+// Net effect: caching only ADDS an offline fallback on top of today's online
+// behavior; it never changes what an online launch loads.
 //
-// The activate handler deletes every legacy `scanvocab-` cache, so users whose
-// installs were poisoned by the previous caching worker recover automatically on
-// the next launch.
+// The activate handler also deletes every legacy `scanvocab-` cache so installs
+// poisoned by the previous caching worker recover automatically on next launch.
 
-const CACHE_PREFIX = 'scanvocab-';
+const SW_VERSION = 'v1';
+const CACHE_PREFIX = 'merken-';
+const STATIC_CACHE = `${CACHE_PREFIX}static-${SW_VERSION}`; // immutable hashed build assets
+const ASSET_CACHE = `${CACHE_PREFIX}assets-${SW_VERSION}`; // icons, manifest, images (SWR)
+const PAGE_CACHE = `${CACHE_PREFIX}pages-${SW_VERSION}`; // navigations / RSC / misc GET
+const CURRENT_CACHES = [STATIC_CACHE, ASSET_CACHE, PAGE_CACHE];
+const LEGACY_CACHE_PREFIX = 'scanvocab-'; // poisoned caches from a prior worker
+const OFFLINE_URL = '/offline.html';
 const DEFAULT_NOTIFICATION_URL = '/';
+
+// --- Lifecycle -------------------------------------------------------------
 
 self.addEventListener('install', (event) => {
   self.skipWaiting();
-  event.waitUntil(Promise.resolve());
+  event.waitUntil((async () => {
+    try {
+      const cache = await caches.open(PAGE_CACHE);
+      await cache.add(new Request(OFFLINE_URL, { cache: 'reload' }));
+    } catch {
+      // Precaching the fallback is best-effort; never block activation on it.
+    }
+  })());
 });
 
 self.addEventListener('activate', (event) => {
   event.waitUntil((async () => {
     const cacheNames = await caches.keys();
     await Promise.all(
-      cacheNames
-        .filter((name) => name.startsWith(CACHE_PREFIX))
-        .map((name) => caches.delete(name))
+      cacheNames.map((name) => {
+        const isLegacy = name.startsWith(LEGACY_CACHE_PREFIX);
+        const isStaleOwn = name.startsWith(CACHE_PREFIX) && !CURRENT_CACHES.includes(name);
+        return isLegacy || isStaleOwn ? caches.delete(name) : undefined;
+      })
     );
     await self.clients.claim();
   })());
@@ -39,6 +67,138 @@ self.addEventListener('message', (event) => {
     self.skipWaiting();
   }
 });
+
+// --- Fetch / caching -------------------------------------------------------
+
+self.addEventListener('fetch', (event) => {
+  const { request } = event;
+
+  // Only handle GET; let the browser deal with POST/PUT/etc. directly.
+  if (request.method !== 'GET') return;
+
+  let url;
+  try {
+    url = new URL(request.url);
+  } catch {
+    return;
+  }
+
+  // Cross-origin (AI APIs, Supabase, Stripe, analytics): never intercept.
+  if (url.origin !== self.location.origin) return;
+
+  // Dynamic / server endpoints must always hit the network.
+  if (
+    url.pathname.startsWith('/api/') ||
+    url.pathname.startsWith('/auth/') ||
+    url.pathname.startsWith('/monitoring')
+  ) {
+    return;
+  }
+
+  // Immutable, content-hashed build output: cache-first.
+  if (url.pathname.startsWith('/_next/static/')) {
+    event.respondWith(cacheFirst(request, STATIC_CACHE));
+    return;
+  }
+
+  // Full-page navigations: network-first with an offline fallback.
+  if (request.mode === 'navigate') {
+    event.respondWith(navigationHandler(request));
+    return;
+  }
+
+  // Icons / manifest / images / fonts: stale-while-revalidate.
+  if (isStaticAsset(url)) {
+    event.respondWith(staleWhileRevalidate(request, ASSET_CACHE));
+    return;
+  }
+
+  // RSC payloads and any other same-origin GET: network-first, cache fallback.
+  event.respondWith(networkFirst(request, PAGE_CACHE));
+});
+
+function isStaticAsset(url) {
+  return (
+    url.pathname === '/manifest.json' ||
+    /\.(?:png|jpe?g|gif|webp|avif|svg|ico|woff2?|ttf|otf|eot)$/i.test(url.pathname)
+  );
+}
+
+// Only cache clean, complete, basic (same-origin) 200 responses. This excludes
+// partial (206), redirected, and opaque responses that must not be replayed.
+function isCacheable(response) {
+  return Boolean(
+    response &&
+    response.status === 200 &&
+    response.type !== 'opaque' &&
+    !response.headers.has('Content-Range')
+  );
+}
+
+async function cacheFirst(request, cacheName) {
+  const cache = await caches.open(cacheName);
+  const cached = await cache.match(request);
+  if (cached) return cached;
+  try {
+    const response = await fetch(request);
+    if (isCacheable(response)) {
+      cache.put(request, response.clone());
+    }
+    return response;
+  } catch {
+    return cached || Response.error();
+  }
+}
+
+async function networkFirst(request, cacheName) {
+  const cache = await caches.open(cacheName);
+  try {
+    const response = await fetch(request);
+    if (isCacheable(response)) {
+      cache.put(request, response.clone());
+    }
+    return response;
+  } catch (error) {
+    const cached = await cache.match(request);
+    if (cached) return cached;
+    throw error;
+  }
+}
+
+async function staleWhileRevalidate(request, cacheName) {
+  const cache = await caches.open(cacheName);
+  const cached = await cache.match(request);
+  const network = fetch(request)
+    .then((response) => {
+      if (isCacheable(response)) {
+        cache.put(request, response.clone());
+      }
+      return response;
+    })
+    .catch(() => undefined);
+  return cached || (await network) || Response.error();
+}
+
+async function navigationHandler(request) {
+  const cache = await caches.open(PAGE_CACHE);
+  try {
+    const response = await fetch(request);
+    if (isCacheable(response)) {
+      cache.put(request, response.clone());
+    }
+    return response;
+  } catch (error) {
+    const cachedExact = await cache.match(request);
+    if (cachedExact) return cachedExact;
+    const cachedPath = await cache.match(new URL(request.url).pathname);
+    if (cachedPath) return cachedPath;
+    const offline = await cache.match(OFFLINE_URL);
+    if (offline) return offline;
+    throw error;
+  }
+}
+
+// --- Web Push --------------------------------------------------------------
 
 self.addEventListener('push', (event) => {
   let payload = {};

--- a/src/lib/pwa/register-sw.ts
+++ b/src/lib/pwa/register-sw.ts
@@ -47,7 +47,7 @@ export async function clearServiceWorkerCaches() {
     const cacheNames = await caches.keys();
     await Promise.all(
       cacheNames
-        .filter((name) => name.startsWith('scanvocab-'))
+        .filter((name) => name.startsWith('scanvocab-') || name.startsWith('merken-'))
         .map((name) => caches.delete(name))
     );
     console.log('[PWA] Cleared service worker caches');


### PR DESCRIPTION
## 概要

PWA をオフラインでも起動・利用できるようにしました。

これまでオフライン用のインフラ（オンライン検知 `use-online-status`、`OfflineBanner`、`OfflineSyncProvider`、同期キュー、`recent-project-offline` の IndexedDB キャッシュ）は揃っていましたが、**アプリシェル／アセットのキャッシュが無いため、オフラインではアプリ自体が起動できませんでした。** 本 PR でその最後のピースを追加します。

## なぜ安全か（過去の破損モードの回避）

`public/sw.js` は以前 cache-first のアプリシェル方式で実装されましたが、**キャッシュ済みシェル HTML が参照するハッシュ付き JS チャンクがキャッシュに存在せず、インストール済み PWA がローディング画面で起動不能になる**問題を起こして撤去された経緯があります（当該コメント参照）。

本 PR はこの破損モードを構造的に回避するため、**ドキュメントを network-first で配信**します。オンライン時は常にネットワークから最新シェルを取得するため（＝現状の無キャッシュ挙動と同一）、シェルとチャンクの不一致は発生し得ません。キャッシュはオンライン挙動に「オフラインフォールバックを追加するだけ」で、オンライン起動時に読み込む内容は一切変えません。

## 変更内容

### `public/sw.js`（キャッシュ戦略を追加）
| リクエスト | 戦略 |
|---|---|
| ナビゲーション（HTML） | **network-first** → オフライン時は当該ルートの最終キャッシュ → 無ければ `/offline.html` |
| 不変ビルド資産 `/_next/static/**` | **cache-first**（URL がハッシュ化され陳腐化・世代衝突なし） |
| アイコン / manifest / 画像 / フォント | **stale-while-revalidate** |
| RSC ペイロード・その他同一オリジン GET | **network-first** + キャッシュフォールバック |
| API / auth / クロスオリジン / 非 GET | **一切介入せず常にネットワーク** |

- 200・非 opaque・Content-Range 無しのレスポンスのみキャッシュ（部分/リダイレクト/opaque を除外）。
- キャッシュ名は `merken-*` に採番。`activate` で旧世代の `merken-*` と、過去に install を汚染したレガシー `scanvocab-*` を掃除。
- **Push 通知（`push` / `notificationclick`）ハンドラは従来どおり維持。**

### `public/offline.html`（新規）
- 自己完結（インライン CSS/JS、外部フェッチ無し）のオフライン画面。ナビゲーションがオフラインで、かつ当該ルートの HTML キャッシュも無い場合に表示。
- 接続回復（`online` イベント）で自動再読み込み。ダーク／ライト両対応。

### `src/lib/pwa/register-sw.ts`
- `clearServiceWorkerCaches()` が新しい `merken-*` キャッシュも掃除するよう拡張。

## 動作確認

- [x] `public/sw.js` 構文チェック（`node --check`）
- [x] `eslint public/sw.js` クリーン（既存の未関連エラーは `gcp-budget-guard/` のみ）
- [x] `tsc --noEmit`：本変更に型エラー無し
- [ ] **要・実機 PWA テスト**：`docs/boundaries.md` が `public/sw.js` は「full PWA testing」必須と定めているため、マージ前にインストール済み PWA での以下を確認してください。
  - オンライン起動が従来どおり（ネットワーク読み込み）
  - 一度訪問したページのオフライン再読み込み
  - 未キャッシュルートへのオフライン遷移で `/offline.html` 表示
  - 新デプロイ後の更新反映（`activate` の旧キャッシュ掃除）

> 実機のインストール済み PWA でのオフライン挙動は本環境では検証できないため、ドラフトのままレビュー・実機確認をお願いします。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EXKWmfYwzu2P7sjoXvpzMp

---
_Generated by [Claude Code](https://claude.ai/code/session_01EXKWmfYwzu2P7sjoXvpzMp)_