### PR TITLE
feat(pwa): オフライン強化 — アイコン/共有単語帳のオフライン化 + リロードループ・dev破壊の修正

### DIFF
--- a/public/offline.html
+++ b/public/offline.html
@@ -113,17 +113,24 @@
   <script>
     (function () {
       var status = document.getElementById('status');
-      function update() {
-        if (navigator.onLine) {
-          if (status) status.textContent = '接続を確認しました。読み込み中…';
-          location.reload();
-        }
-      }
-      window.addEventListener('online', update);
-      // In case connectivity returned before this page finished loading.
-      if (navigator.onLine) {
-        setTimeout(update, 1500);
-      }
+      // navigator.onLine only reports whether a network interface is up, NOT whether
+      // the server is actually reachable. It stays true on captive-portal Wi-Fi, an
+      // ISP outage with the router still up, or weak cellular. Reloading purely on
+      // that flag would loop forever: the reload re-requests the same route, the
+      // service worker re-serves this page, and the script reloads again.
+      //
+      // So we react only to the 'online' TRANSITION event, which fires at most once
+      // per reconnect. Even if the origin is still unreachable right after it fires,
+      // the resulting reload just shows this page again and then stops (no further
+      // 'online' events while the OS considers us online) — never a loop. Manual
+      // retries go through the button.
+      var reloaded = false;
+      window.addEventListener('online', function () {
+        if (reloaded) return;
+        reloaded = true;
+        if (status) status.textContent = '接続を確認しました。読み込み中…';
+        location.reload();
+      });
     })();
   </script>
 </body>

--- a/public/sw.js
+++ b/public/sw.js
@@ -16,32 +16,67 @@
 //     so entries never go stale and old/new builds never collide.
 //   - Other static assets
 //     (icons, manifest, images, fonts) -> stale-while-revalidate.
+//   - Google Fonts (Material Symbols icon font, text fonts) -> cache-first, even
+//     though cross-origin, so icons don't render as raw ligature text offline.
+//   - Public shared-wordbook reads (/api/shared-projects/share/**) -> network-first,
+//     so a wordbook the user merely viewed (never imported) still opens offline.
 //   - RSC payloads & other GETs      -> network-first with cache fallback.
-//   - API / auth / cross-origin / non-GET -> never touched (always network).
+//   - Other API / auth / cross-origin / non-GET -> never touched (always network).
 // Net effect: caching only ADDS an offline fallback on top of today's online
 // behavior; it never changes what an online launch loads.
 //
-// The activate handler also deletes every legacy `scanvocab-` cache so installs
-// poisoned by the previous caching worker recover automatically on next launch.
+// Caching is DISABLED on localhost/dev (see CACHING_ENABLED): Next.js dev chunks
+// live at stable URLs whose bytes change every rebuild, so caching them would serve
+// stale JS and break `npm run dev`. Production /_next/static/ is content-hashed and
+// safe. Web Push still works in dev — only the fetch/caching path is gated.
+//
+// The activate handler deletes every legacy `scanvocab-` cache so installs poisoned
+// by the previous caching worker recover automatically on next launch.
 
 const SW_VERSION = 'v1';
 const CACHE_PREFIX = 'merken-';
 const STATIC_CACHE = `${CACHE_PREFIX}static-${SW_VERSION}`; // immutable hashed build assets
 const ASSET_CACHE = `${CACHE_PREFIX}assets-${SW_VERSION}`; // icons, manifest, images (SWR)
 const PAGE_CACHE = `${CACHE_PREFIX}pages-${SW_VERSION}`; // navigations / RSC / misc GET
-const CURRENT_CACHES = [STATIC_CACHE, ASSET_CACHE, PAGE_CACHE];
+const FONT_CACHE = `${CACHE_PREFIX}fonts-${SW_VERSION}`; // Google Fonts CSS + font files (icons)
+const SHARED_CACHE = `${CACHE_PREFIX}shared-${SW_VERSION}`; // viewed shared-wordbook API responses
+const CURRENT_CACHES = [STATIC_CACHE, ASSET_CACHE, PAGE_CACHE, FONT_CACHE, SHARED_CACHE];
 const LEGACY_CACHE_PREFIX = 'scanvocab-'; // poisoned caches from a prior worker
 const OFFLINE_URL = '/offline.html';
 const DEFAULT_NOTIFICATION_URL = '/';
 
+// Cross-origin Google Fonts hosts that serve the Material Symbols icon font and the
+// text fonts. Handled explicitly (before the cross-origin bypass) so icons keep
+// rendering offline instead of falling back to raw ligature text like "wifi_off".
+const GOOGLE_FONTS_HOSTS = ['fonts.googleapis.com', 'fonts.gstatic.com'];
+
+// Public shared-wordbook read endpoints. Caching their GET responses lets a wordbook
+// the user merely *viewed* (never imported/saved) still open offline.
+const SHARED_WORDBOOK_API_PREFIX = '/api/shared-projects/share/';
+
+// Runtime caching is enabled everywhere EXCEPT localhost/dev. Next.js dev serves its
+// chunks at stable URLs whose bytes change on every rebuild, so cache-first would
+// pin stale JS and break `npm run dev`; production /_next/static/ is content-hashed
+// and safe. Only the fetch/caching path is gated — Web Push registration is not.
+const CACHING_ENABLED =
+  self.location.hostname !== 'localhost' &&
+  self.location.hostname !== '127.0.0.1' &&
+  self.location.hostname !== '[::1]' &&
+  !self.location.hostname.endsWith('.local');
+
 // --- Lifecycle -------------------------------------------------------------
+
+async function precacheOffline() {
+  const cache = await caches.open(PAGE_CACHE);
+  await cache.add(new Request(OFFLINE_URL, { cache: 'reload' }));
+}
 
 self.addEventListener('install', (event) => {
   self.skipWaiting();
   event.waitUntil((async () => {
+    if (!CACHING_ENABLED) return;
     try {
-      const cache = await caches.open(PAGE_CACHE);
-      await cache.add(new Request(OFFLINE_URL, { cache: 'reload' }));
+      await precacheOffline();
     } catch {
       // Precaching the fallback is best-effort; never block activation on it.
     }
@@ -54,10 +89,23 @@ self.addEventListener('activate', (event) => {
     await Promise.all(
       cacheNames.map((name) => {
         const isLegacy = name.startsWith(LEGACY_CACHE_PREFIX);
-        const isStaleOwn = name.startsWith(CACHE_PREFIX) && !CURRENT_CACHES.includes(name);
+        // Off localhost: drop only stale (non-current) own caches. On localhost:
+        // drop ALL own caches so a dev machine poisoned by an earlier build with
+        // caching enabled recovers immediately.
+        const isStaleOwn =
+          name.startsWith(CACHE_PREFIX) && (!CACHING_ENABLED || !CURRENT_CACHES.includes(name));
         return isLegacy || isStaleOwn ? caches.delete(name) : undefined;
       })
     );
+    // Re-assert the offline fallback so a single failed install precache does not
+    // leave the branded offline page missing for the whole SW version.
+    if (CACHING_ENABLED) {
+      try {
+        await precacheOffline();
+      } catch {
+        // best-effort
+      }
+    }
     await self.clients.claim();
   })());
 });
@@ -76,6 +124,9 @@ self.addEventListener('fetch', (event) => {
   // Only handle GET; let the browser deal with POST/PUT/etc. directly.
   if (request.method !== 'GET') return;
 
+  // On localhost/dev, never cache (see CACHING_ENABLED) — pass through to network.
+  if (!CACHING_ENABLED) return;
+
   let url;
   try {
     url = new URL(request.url);
@@ -83,8 +134,23 @@ self.addEventListener('fetch', (event) => {
     return;
   }
 
+  // Google Fonts (Material Symbols icon font + text fonts) are cross-origin but must
+  // survive offline, or icons render as raw ligature text. Cache-first, allowing the
+  // opaque stylesheet response. Handled before the generic cross-origin bypass.
+  if (GOOGLE_FONTS_HOSTS.includes(url.hostname)) {
+    event.respondWith(cacheFirstAllowingOpaque(request, FONT_CACHE));
+    return;
+  }
+
   // Cross-origin (AI APIs, Supabase, Stripe, analytics): never intercept.
   if (url.origin !== self.location.origin) return;
+
+  // Public shared-wordbook reads: cache so a viewed-but-unsaved shared wordbook opens
+  // offline. Network-first keeps it fresh online. Handled before the /api/ bypass.
+  if (url.pathname.startsWith(SHARED_WORDBOOK_API_PREFIX)) {
+    event.respondWith(networkFirst(request, SHARED_CACHE));
+    return;
+  }
 
   // Dynamic / server endpoints must always hit the network.
   if (
@@ -142,6 +208,25 @@ async function cacheFirst(request, cacheName) {
   try {
     const response = await fetch(request);
     if (isCacheable(response)) {
+      cache.put(request, response.clone());
+    }
+    return response;
+  } catch {
+    return cached || Response.error();
+  }
+}
+
+// Cache-first variant for Google Fonts. The stylesheet from fonts.googleapis.com is
+// requested no-cors (an opaque, status-0 response); the font files from
+// fonts.gstatic.com come back CORS (status 200). Both are effectively immutable per
+// URL, so cache-first is correct and lets icons render offline.
+async function cacheFirstAllowingOpaque(request, cacheName) {
+  const cache = await caches.open(cacheName);
+  const cached = await cache.match(request);
+  if (cached) return cached;
+  try {
+    const response = await fetch(request);
+    if (response && (response.status === 200 || response.type === 'opaque')) {
       cache.put(request, response.clone());
     }
     return response;


### PR DESCRIPTION
## 概要

#447(オフライン対応）のフォローアップです。マージ後にユーザー要望と自己レビューで判明した「実利用で崩れる点」を修正・拡張します。変更は **`public/sw.js` と `public/offline.html` の静的2ファイルのみ**（依存・ビルド影響なし）。

## 変更内容

### 1. 🖼 アイコンがオフラインで崩れない（Material Symbols）← ユーザー要望
Material Symbols アイコンフォントは `layout.tsx` で **Google Fonts からクロスオリジン読み込み**しており、SW がクロスオリジンを素通しするためオフラインで未キャッシュ = アイコンがリガチャ文字（`wifi_off` 等）で表示されていました。
`fonts.googleapis.com` / `fonts.gstatic.com` を **cache-first** でキャッシュ（no-cors の opaque スタイルシートも許可）。初回オンライン読み込み後はオフラインでもアイコンが正しく表示されます。本文フォント（Lexend / Noto）は `next/font` で自己ホスト済みのため元々OK。

### 2. 📚 見た共有単語帳を保存（import）なしでもオフライン対応 ← ユーザー要望
`/share/[shareId]` は `/api/shared-projects/share/**` を**ネットワークからのみ取得し IndexedDB に保存しない**ため、オフラインで開けませんでした（自分の単語帳は `fullSync` でアカウント単位に対応済み。ギャップは共有単語帳のみ）。
当該 **GET を network-first でキャッシュ**。オンラインで一度見た共有単語帳は、import しなくてもオフラインで開けます。オンライン時は常に最新を取得します。

### 3. 🔁 オフラインページのリロードループ修正（自己レビューで発見した実バグ）
`offline.html` が `navigator.onLine` だけで自動リロードしていたため、「接続はあるが到達不可」（キャプティブポータル / ISP障害 / 圏際セルラー、いずれも `onLine===true`）で**無限リロード**していました。`online` **遷移イベント時のみ1回リロード**する方式に変更（ループ不可能）。手動「再読み込み」ボタンは従来どおり。

### 4. 🛠 localhost/dev では SW キャッシュを無効化（自己レビューで発見した実バグ）
Next.js の dev チャンクは **URL 固定・中身可変**のため、`/_next/static` の cache-first が古い JS を固定し `npm run dev` を壊していました（Turbopack で実機再現）。`localhost` / `127.0.0.1` / `[::1]` / `*.local` では**フェッチ/キャッシュ経路を無効化**し、既存の汚染キャッシュも `activate` で掃除。Web Push 登録は据え置きなので dev でも通知はテスト可能。本番 `/_next/static` は content-hash 付きで安全なため従来どおりキャッシュ。

### 5. ♻️ offline.html プリキャッシュの自己修復（自己レビューで発見した実バグ）
`install` 時のプリキャッシュが一度失敗すると SW バージョン中ずっと無印フォールバックが欠落していました。`activate` でも**再プリキャッシュ**して自己修復します。

## 設計上の安全性
ドキュメントは従来どおり **network-first**（オンライン時は現状と同一のネットワーク読み込み）を維持。今回の追加は全て「オフライン時のフォールバック追加」であり、オンライン挙動を変えません。過去の cache-first 破損モードは再導入していません。

## 動作確認
- [x] `node --check public/sw.js`（構文OK）
- [x] `eslint public/sw.js`（クリーン）
- [x] 共有単語帳 API パス（プレビュー `share/[shareId]?limit=`・`share/[shareId]/words`）がプレフィックス一致することを確認
- [ ] **要・実機 PWA テスト**（`docs/boundaries.md` の要件）: オフラインでのアイコン表示 / 既視の共有単語帳オフライン表示 / キャプティブポータルでのループ再発なし / `npm run dev` の HMR 正常 / 新デプロイ後の更新反映

> 実機のインストール済み PWA でのオフライン挙動は本環境で検証できないため、ドラフトのままレビュー・実機確認をお願いします。

## CI について
`security` チェックは `security:deps` の **postcss（Next.js 経由の推移的本番依存）high 勧告**で赤になりますが、これは #447 と同じく **本 PR の差分（静的2ファイル、依存変更ゼロ）とは無関係**で main でも同様に失敗する既存事象です。依存側の独立対応が必要なため本 PR では扱いません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EXKWmfYwzu2P7sjoXvpzMp

---
_Generated by [Claude Code](https://claude.ai/code/session_01EXKWmfYwzu2P7sjoXvpzMp)_