### PR TITLE
Fix bottom nav active state for profile tab with dynamic routes

### DIFF
--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -98,6 +98,7 @@ export default function ProfilePage() {
       friendsHref="/follows?tab=following"
       stats={stats}
       statsLoading={statsLoading}
+      withBottomNav
     />
   );
 }

--- a/src/components/profile/ProfileView.tsx
+++ b/src/components/profile/ProfileView.tsx
@@ -52,6 +52,7 @@ export function ProfileView({
   actions,
   stats,
   statsLoading,
+  withBottomNav = false,
 }: {
   title: string;
   backHref: string;
@@ -69,6 +70,8 @@ export function ProfileView({
   actions?: ReactNode;
   stats: CachedStats | null;
   statsLoading: boolean;
+  /** ボトムナビが表示される画面ではナビに隠れないよう下部余白を広げる */
+  withBottomNav?: boolean;
 }) {
   const router = useRouter();
 
@@ -118,7 +121,11 @@ export function ProfileView({
       statsLoading={statsLoading}
       derived={{ recentWeek, weekTotal, maxWeekValue, heat, totalDays, avgPerDay, totalWords, mastered, review, newWords, masteryPercent }}
     />
-    <div className="relative min-h-screen bg-[var(--color-background)] pb-[max(24px,env(safe-area-inset-bottom))] pt-3 font-[var(--font-body)] lg:hidden">
+    <div
+      className={`relative min-h-screen bg-[var(--color-background)] pt-3 font-[var(--font-body)] lg:hidden ${
+        withBottomNav ? 'pb-[110px]' : 'pb-[max(24px,env(safe-area-inset-bottom))]'
+      }`}
+    >
       <div className="mx-auto w-full max-w-xl">
         {/* Top bar */}
         <div className="flex items-center gap-2 px-[18px] pb-1 pt-1">

--- a/src/components/ui/PersistentAppShell.tsx
+++ b/src/components/ui/PersistentAppShell.tsx
@@ -23,7 +23,10 @@ const NO_SHELL_PATHS = [
 const HIDE_BOTTOM_NAV_PATHS = [
   '/project/', '/share/', '/quiz/', '/quiz2/', '/flashcard/',
   '/quick-response/', '/scan/confirm', '/shared/share-wordbook',
-  '/subscription', '/collections/new', '/word/', '/favorites', '/profile', '/follows',
+  '/subscription', '/collections/new', '/word/', '/favorites', '/follows',
+  // 自分のプロフィール(/profile)はボトムナビのタブなのでナビを表示する。
+  // 他ユーザーのプロフィール(/profile/<accountId>)は詳細画面なので非表示のまま。
+  '/profile/',
   '/groups/', '/reels',
   // 語法演習画面(/grammar/<bookId>)はナビ非表示。一覧(/grammar)は表示する。
   '/grammar/',

--- a/src/components/ui/bottom-nav.tsx
+++ b/src/components/ui/bottom-nav.tsx
@@ -95,6 +95,8 @@ interface TabItem {
   label: string;
   href?: string;
   matchPaths?: string[];
+  // 前方一致だと他人のページまで拾ってしまうパス用(例: /profile/[accountId])
+  exactPaths?: string[];
   primary?: boolean;
   IconDefault: React.FC;
   IconActive: React.FC;
@@ -129,8 +131,9 @@ const SHARED_TAB: TabItem = {
 const ACCOUNT_TAB: TabItem = {
   k: 'account',
   label: 'アカウント',
-  href: '/settings',
+  href: '/profile',
   matchPaths: ['/settings', '/subscription'],
+  exactPaths: ['/profile'],
   IconDefault: AccountIcon,
   IconActive: AccountIconFilled,
 };
@@ -173,7 +176,9 @@ export function BottomNav() {
   const tabs = isPro ? PRO_TABS : FREE_TABS;
 
   const isActive = (tab: TabItem) => {
-    if (!tab.matchPaths || !tab.href) return false;
+    if (!tab.href) return false;
+    if (tab.exactPaths?.some((path) => pathname === path)) return true;
+    if (!tab.matchPaths) return false;
     return tab.matchPaths.some(
       (path) => pathname === path || pathname.startsWith(path + '/')
     );


### PR DESCRIPTION
## Summary
Fixes the bottom navigation active state indicator for the account/profile tab when viewing dynamic profile routes (e.g., `/profile/[accountId]`). Previously, the tab would not highlight as active on these routes because the matching logic only supported prefix matching, which would incorrectly match other users' profile pages.

## Changes
- **Added `exactPaths` field to `TabItem` interface**: New optional array for routes that require exact path matching (no prefix matching)
- **Updated account tab configuration**: 
  - Changed default `href` from `/settings` to `/profile`
  - Added `/profile` to `exactPaths` to ensure exact matching on the user's own profile page
  - Kept `/settings` and `/subscription` in `matchPaths` for prefix-based matching
- **Enhanced `isActive()` logic**:
  - Check `exactPaths` first with strict equality (`pathname === path`)
  - Fall back to `matchPaths` prefix matching only if no exact match is found
  - Prevents false positives on dynamic routes like `/profile/[accountId]`

## Implementation Details
The fix ensures that:
1. Navigating to `/profile` (own profile) highlights the account tab
2. Navigating to `/profile/someoneElseId` does NOT highlight the account tab
3. Settings and subscription pages still correctly highlight the account tab via prefix matching
4. The solution is backward compatible—tabs without `exactPaths` continue to work as before

https://claude.ai/code/session_01JgQYXGi6v9vnoHhNp9q3o7