### PR TITLE
Prioritize words with etymology (語源) in reel ranking

### DIFF
--- a/src/app/api/reels/shared.ts
+++ b/src/app/api/reels/shared.ts
@@ -14,8 +14,10 @@ import { decodeReelCursor, encodeReelCursor } from '@/lib/reels/cursor';
 import { eikenLevelsAround } from '@/lib/reels/eiken-cefr';
 import { selectReelCandidates } from '@/lib/reels/ranking';
 import {
+  candidateHeadwords,
   sampleBookWords,
   sharedCefrLookupHeadwords,
+  withCandidateMorphology,
   withSharedCefrLevels,
 } from '@/lib/reels/sampling';
 import { lookupLexiconCefrLevels } from '@/lib/lexicon/eiken-cefr-filter';
@@ -26,7 +28,6 @@ import {
   snapshotTranslationsFromWordTranslationRows,
   type SnapshotTranslation,
 } from '@/lib/shared-projects/snapshot-translations';
-import { normalizeHeadword } from '../../../../shared/lexicon';
 
 type SupabaseAdminClient = ReturnType<typeof getSupabaseAdmin>;
 
@@ -720,23 +721,39 @@ export async function buildReelFeedPage(options: {
     (candidate) => !feedback.excludedKeys.has(candidate.id),
   );
 
-  if (rankingInputs.eikenLevel) {
-    // Shared words carry no CEFR level; fill it from the lexicon so levelFit
-    // can personalize them too. Best-effort — never break the feed on it.
-    try {
-      const headwords = sharedCefrLookupHeadwords(candidates);
-      if (headwords.length > 0) {
-        const levels = await lookupLexiconCefrLevels(headwords, { supabaseAdmin: admin });
-        candidates = withSharedCefrLevels(candidates, levels);
-      }
-    } catch {
-      // cefrLevel stays null → neutral level fit.
-    }
-  }
   // pin された単語（興味なし指定済みは尊重して固定しない）は先頭に置き、
   // 残り枠を通常ランキングで埋める。
-  const pinnedCandidate =
+  const pinnedFiltered =
     pinnedFetched && !feedback.excludedKeys.has(pinnedFetched.id) ? pinnedFetched : null;
+
+  // 語源（morphology）はランキングの優先材料なので、配信枚数分ではなく候補
+  // 全件ぶん先に引く（lexicon キャッシュのみ・生成はしない）。CEFR の補完とは
+  // 独立なので並走させる。どちらも best effort で、失敗してもフィードは出す。
+  const [sharedCefrLevels, morphologyByHeadword] = await Promise.all([
+    rankingInputs.eikenLevel
+      ? // Shared words carry no CEFR level; fill it from the lexicon so levelFit
+        // can personalize them too.
+        lookupLexiconCefrLevels(sharedCefrLookupHeadwords(candidates), {
+          supabaseAdmin: admin,
+        }).catch(() => null) // cefrLevel stays null → neutral level fit.
+      : Promise.resolve(null),
+    getCachedMorphologyByHeadword(
+      candidateHeadwords(pinnedFiltered ? [...candidates, pinnedFiltered] : candidates),
+      { supabaseAdmin: admin },
+    ).catch(() => null), // 語源は任意情報。失敗時は全カード2面のまま配信する。
+  ]);
+
+  if (sharedCefrLevels) {
+    candidates = withSharedCefrLevels(candidates, sharedCefrLevels);
+  }
+  if (morphologyByHeadword) {
+    candidates = withCandidateMorphology(candidates, morphologyByHeadword);
+  }
+  const pinnedCandidate =
+    pinnedFiltered && morphologyByHeadword
+      ? withCandidateMorphology([pinnedFiltered], morphologyByHeadword)[0]
+      : pinnedFiltered;
+
   const rankedSelections = selectReelCandidates(
     pinnedCandidate
       ? candidates.filter((candidate) => candidate.id !== pinnedCandidate.id)
@@ -800,26 +817,14 @@ export async function buildReelFeedPage(options: {
 
   const grantedCandidates = grantedSelections.map((s) => s.candidate);
 
-  // 語源（morphology, lexicon キャッシュ専用・best effort）といいね/コメント等の
-  // エンリッチは互いに独立なので並走させ、応答の直列往復を1本減らす。
-  const [morphologyByHeadword, enriched] = await Promise.all([
-    getCachedMorphologyByHeadword(
-      grantedCandidates.map((candidate) => normalizeHeadword(candidate.english)),
-      { supabaseAdmin: admin },
-    ).catch(() => null), // morphology は任意情報。失敗時は全カード2面のまま配信する。
-    enrichItems(admin, options.userId, grantedCandidates),
-  ]);
+  // 語源は候補段階で貼り済み（ランキングで使うため）。ここでは残りのエンリッチだけ。
+  const enriched = await enrichItems(admin, options.userId, grantedCandidates);
 
-  const items = enriched.map((item) => {
-    const morphology = morphologyByHeadword?.get(normalizeHeadword(item.english));
-    return {
-      ...item,
-      morphology: morphology && !morphology.none && morphology.formula.length > 0
-        ? morphology
-        : null,
-      isRecycled: recycledByKey.get(item.id) ?? false,
-    };
-  });
+  const items = enriched.map((item) => ({
+    ...item,
+    morphology: item.morphology ?? null,
+    isRecycled: recycledByKey.get(item.id) ?? false,
+  }));
 
   const limitReached = usage.limit !== null && usage.current_count >= usage.limit;
   // The feed never runs dry (seen words recycle); nextCursor is null only

--- a/src/lib/morphology/lexicon.ts
+++ b/src/lib/morphology/lexicon.ts
@@ -37,14 +37,25 @@ export async function getCachedMorphologyByHeadword(
 
   const supabaseAdmin = deps.supabaseAdmin ?? getSupabaseAdmin();
 
+  const chunks: string[][] = [];
   for (let index = 0; index < unique.length; index += LOOKUP_CHUNK_SIZE) {
-    const chunk = unique.slice(index, index + LOOKUP_CHUNK_SIZE);
-    const { data, error } = await supabaseAdmin
-      .from('lexicon_entries')
-      .select('normalized_headword, morphology')
-      .in('normalized_headword', chunk)
-      .not('morphology', 'is', null);
+    chunks.push(unique.slice(index, index + LOOKUP_CHUNK_SIZE));
+  }
 
+  // チャンクは互いに素な見出し語の集合なので並列に引ける（リールのように
+  // 数百語を一度に引く呼び出しで直列の往復が積み上がるのを避ける）。
+  // 結果はチャンク順に畳み込むので、行の採用順は直列時と変わらない。
+  const results = await Promise.all(
+    chunks.map((chunk) =>
+      supabaseAdmin
+        .from('lexicon_entries')
+        .select('normalized_headword, morphology')
+        .in('normalized_headword', chunk)
+        .not('morphology', 'is', null),
+    ),
+  );
+
+  for (const { data, error } of results) {
     if (error) {
       throw new Error(`Failed to look up lexicon morphology: ${error.message}`);
     }

--- a/src/lib/reels/ranking.test.ts
+++ b/src/lib/reels/ranking.test.ts
@@ -1,8 +1,23 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 
+import type { WordMorphology } from '@/types';
 import type { ReelBook, ReelCandidate, ReelRankingContext } from './types';
-import { rankReelCandidates, scoreReelCandidate, selectReelCandidates } from './ranking';
+import {
+  hasDisplayableMorphology,
+  rankReelCandidates,
+  scoreReelCandidate,
+  selectReelCandidates,
+} from './ranking';
+
+const MORPHOLOGY: WordMorphology = {
+  formula: [
+    { text: 'in', kind: 'prefix', meaningJa: '中へ' },
+    { text: 'spect', kind: 'root', meaningJa: '見る' },
+  ],
+  explanation: '中を見る → 検査する。',
+  version: 1,
+};
 
 const NOW = '2026-07-03T00:00:00.000Z';
 
@@ -168,6 +183,76 @@ test('interested feedback boosts the book, not-interested penalizes it', () => {
   const neutral = scoreReelCandidate(candidate, neutralCtx, 9);
   assert.ok(scoreReelCandidate(candidate, interestedCtx, 9) > neutral);
   assert.ok(scoreReelCandidate(candidate, notInterestedCtx, 9) < neutral);
+});
+
+// ---------- morphology (語源) priority ----------
+
+test('hasDisplayableMorphology matches the card-side condition', () => {
+  assert.equal(hasDisplayableMorphology({ morphology: MORPHOLOGY }), true);
+  assert.equal(hasDisplayableMorphology({ morphology: null }), false);
+  assert.equal(hasDisplayableMorphology({ morphology: undefined }), false);
+  assert.equal(
+    hasDisplayableMorphology({ morphology: { ...MORPHOLOGY, none: true } }),
+    false,
+    'none:true has no etymology face',
+  );
+  assert.equal(
+    hasDisplayableMorphology({ morphology: { ...MORPHOLOGY, formula: [] } }),
+    false,
+    'an empty formula has no etymology face',
+  );
+});
+
+test('a word with etymology is ranked ahead of one without', () => {
+  const ctx = makeContext();
+  const candidates = [
+    makeCandidate('plain', { book: makeBook({ id: 'book-p' }) }),
+    makeCandidate('etym', { morphology: MORPHOLOGY, book: makeBook({ id: 'book-e' }) }),
+  ];
+  for (const seed of [1, 42, 999, 123456]) {
+    assert.equal(rankReelCandidates(candidates, ctx, seed, 2)[0].id, 'etym');
+  }
+});
+
+test('etymology words fill the page first, off-level ones included', () => {
+  const ctx = makeContext({ eikenLevel: 'pre2' });
+  const candidates = [
+    // Perfectly on-level, popular, fresh — but no etymology.
+    ...Array.from({ length: 20 }, (_, i) =>
+      makeCandidate(`plain${i}`, {
+        source: 'official',
+        cefrLevel: 'A2',
+        book: makeBook({ type: 'official', id: `plain-book-${i}`, likeCount: 5000 }),
+      }),
+    ),
+    // Off-level and unpopular, but they carry a 語源 breakdown.
+    ...Array.from({ length: 8 }, (_, i) =>
+      makeCandidate(`etym${i}`, {
+        source: 'official',
+        cefrLevel: 'C1',
+        morphology: MORPHOLOGY,
+        book: makeBook({ type: 'official', id: `etym-book-${i}`, likeCount: 0 }),
+      }),
+    ),
+  ];
+  const picked = rankReelCandidates(candidates, ctx, 42, 8);
+  assert.ok(
+    picked.every((candidate) => candidate.morphology),
+    `expected an all-etymology page, got ${picked.map((c) => c.id).join(',')}`,
+  );
+});
+
+test('etymology preference never starves the feed', () => {
+  const ctx = makeContext();
+  const candidates = [
+    makeCandidate('etym', { morphology: MORPHOLOGY, book: makeBook({ id: 'book-e' }) }),
+    ...Array.from({ length: 10 }, (_, i) =>
+      makeCandidate(`plain${i}`, { book: makeBook({ id: `book-${i}` }) }),
+    ),
+  ];
+  const picked = rankReelCandidates(candidates, ctx, 5, 8);
+  assert.equal(picked.length, 8, 'plain words still fill the page once etymology runs out');
+  assert.equal(picked[0].id, 'etym', 'the etymology word leads the page');
 });
 
 // ---------- selectReelCandidates (infinite feed / seen recycling) ----------

--- a/src/lib/reels/ranking.ts
+++ b/src/lib/reels/ranking.ts
@@ -93,6 +93,15 @@ function feedbackBias(candidate: ReelCandidate, ctx: ReelRankingContext): number
   return bias;
 }
 
+/**
+ * 表示できる語源解説を持っているか（`none` や空の分解式はカード上で
+ * 語源面が出ないので「無し」扱いにする）。
+ */
+export function hasDisplayableMorphology(candidate: Pick<ReelCandidate, 'morphology'>): boolean {
+  const morphology = candidate.morphology;
+  return Boolean(morphology && !morphology.none && morphology.formula.length > 0);
+}
+
 function popularity(candidate: ReelCandidate): number {
   const likes = Math.max(0, candidate.book.likeCount);
   return Math.min(1, Math.log10(likes + 1) / 2);
@@ -127,6 +136,13 @@ export function scoreReelCandidate(
  * Rank candidates and pick up to `limit` items with book diversity:
  * never two consecutive items from the same book (unless nothing else
  * remains) and at most MAX_ITEMS_PER_BOOK_PER_PAGE per book.
+ *
+ * 語源（morphology）を持つ単語は上位ティアとして先に並べる — リールは語源
+ * カードを流すのが主目的なので、スコアの重み付けでは popularity や level fit に
+ * competed out されうる。ティア内は通常スコア順なので、語源つきの中でも
+ * レベル適合・興味タグ・新着は効き続ける。語源つきが尽きたら通常の単語で
+ * 埋まる（フィードは枯れない）。
+ *
  * Pure and deterministic for a given (candidates, ctx, seed).
  */
 export function rankReelCandidates(
@@ -138,8 +154,15 @@ export function rankReelCandidates(
   if (limit <= 0 || candidates.length === 0) return [];
 
   const scored = candidates
-    .map((candidate) => ({ candidate, score: scoreReelCandidate(candidate, ctx, seed) }))
-    .sort((a, b) => b.score - a.score || a.candidate.id.localeCompare(b.candidate.id));
+    .map((candidate) => ({
+      candidate,
+      tier: hasDisplayableMorphology(candidate) ? 1 : 0,
+      score: scoreReelCandidate(candidate, ctx, seed),
+    }))
+    .sort(
+      (a, b) =>
+        b.tier - a.tier || b.score - a.score || a.candidate.id.localeCompare(b.candidate.id),
+    );
 
   const picked: ReelCandidate[] = [];
   const perBook = new Map<string, number>();

--- a/src/lib/reels/sampling.test.ts
+++ b/src/lib/reels/sampling.test.ts
@@ -1,10 +1,13 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 
+import type { WordMorphology } from '@/types';
 import type { ReelBook, ReelCandidate } from './types';
 import {
+  candidateHeadwords,
   sampleBookWords,
   sharedCefrLookupHeadwords,
+  withCandidateMorphology,
   withSharedCefrLevels,
   type WordSamplingOptions,
 } from './sampling';
@@ -148,6 +151,48 @@ test('withSharedCefrLevels fills shared words via normalized headwords', () => {
 test('withSharedCefrLevels is a no-op for an empty map', () => {
   const candidates = [makeCandidate('a')];
   assert.equal(withSharedCefrLevels(candidates, new Map()), candidates);
+});
+
+// ---------- withCandidateMorphology ----------
+
+const MORPHOLOGY: WordMorphology = {
+  formula: [{ text: 'un', kind: 'prefix', meaningJa: '否定' }],
+  explanation: '否定の un。',
+  version: 1,
+};
+
+test('withCandidateMorphology attaches cached morphology by normalized headword', () => {
+  const candidates = [
+    makeCandidate('a', { english: ' Unhappy ' }),
+    makeCandidate('b', { english: 'banana' }),
+  ];
+  const enriched = withCandidateMorphology(candidates, new Map([['unhappy', MORPHOLOGY]]));
+  assert.deepEqual(enriched[0].morphology, MORPHOLOGY);
+  assert.equal(enriched[1].morphology, null, 'cache miss becomes an explicit null');
+});
+
+test('withCandidateMorphology drops morphology that cannot be displayed', () => {
+  const candidates = [
+    makeCandidate('a', { english: 'none-word' }),
+    makeCandidate('b', { english: 'empty-word' }),
+  ];
+  const enriched = withCandidateMorphology(
+    candidates,
+    new Map([
+      ['none-word', { formula: [], explanation: '', version: 1, none: true } as WordMorphology],
+      ['empty-word', { formula: [], explanation: '解説だけ', version: 1 } as WordMorphology],
+    ]),
+  );
+  assert.equal(enriched[0].morphology, null);
+  assert.equal(enriched[1].morphology, null);
+});
+
+test('candidateHeadwords normalizes every candidate', () => {
+  const candidates = [
+    makeCandidate('a', { english: ' Apple  Pie ' }),
+    makeCandidate('b', { english: 'Banana', cefrLevel: 'A1' }),
+  ];
+  assert.deepEqual(candidateHeadwords(candidates), ['apple pie', 'banana']);
 });
 
 test('sharedCefrLookupHeadwords collects only shared words missing a level', () => {

--- a/src/lib/reels/sampling.ts
+++ b/src/lib/reels/sampling.ts
@@ -1,6 +1,7 @@
 import { normalizeHeadword } from '../../../shared/lexicon';
+import type { WordMorphology } from '@/types';
 import type { CefrLevel } from './eiken-cefr';
-import { hashString, mulberry32 } from './ranking';
+import { hasDisplayableMorphology, hashString, mulberry32 } from './ranking';
 import type { ReelCandidate } from './types';
 
 export type WordSamplingOptions = {
@@ -68,6 +69,26 @@ export function sharedCefrLookupHeadwords(candidates: ReelCandidate[]): string[]
   return candidates
     .filter((candidate) => candidate.source === 'shared' && candidate.cefrLevel === null)
     .map((candidate) => normalizeHeadword(candidate.english));
+}
+
+/** Normalized headwords of every candidate (for the morphology cache lookup). */
+export function candidateHeadwords(candidates: ReelCandidate[]): string[] {
+  return candidates.map((candidate) => normalizeHeadword(candidate.english));
+}
+
+/**
+ * 候補に語源（lexicon キャッシュ）を貼り付ける。ランキングが語源つきを
+ * 優先できるよう、配信対象を絞り込む前の候補全件に対して呼ぶ。表示できない
+ * 語源（none / 分解式なし）は null に潰し、カード側と判定を揃える。
+ */
+export function withCandidateMorphology(
+  candidates: ReelCandidate[],
+  morphologyByHeadword: ReadonlyMap<string, WordMorphology>,
+): ReelCandidate[] {
+  return candidates.map((candidate) => {
+    const morphology = morphologyByHeadword.get(normalizeHeadword(candidate.english)) ?? null;
+    return { ...candidate, morphology: hasDisplayableMorphology({ morphology }) ? morphology : null };
+  });
 }
 
 /**


### PR DESCRIPTION
## Summary

Implements a two-tier ranking system for reel candidates that prioritizes words with displayable etymology (語源) information. Etymology words are ranked ahead of plain words, ensuring the feed showcases morphology breakdowns while maintaining feed continuity when etymology runs out.

## Key Changes

- **New `hasDisplayableMorphology()` function** in `ranking.ts`: Determines if a candidate has valid etymology (non-null, non-`none`, non-empty formula) that can be displayed on the card's etymology face.

- **Two-tier ranking in `rankReelCandidates()`**: Candidates are now sorted by tier (etymology-first) before score, so words with morphology always rank ahead of plain words. Within each tier, normal scoring (level fit, popularity, feedback bias) still applies.

- **Early morphology attachment** in `buildReelFeedPage()`: Morphology is now fetched and attached to all candidates before ranking (not just the final page), enabling the ranking algorithm to prioritize etymology words. This uses parallel `Promise.all()` to fetch morphology and CEFR levels concurrently.

- **New `withCandidateMorphology()` helper** in `sampling.ts`: Attaches cached morphology to candidates by normalized headword, filtering out non-displayable entries (matching card-side logic).

- **New `candidateHeadwords()` helper** in `sampling.ts`: Extracts normalized headwords from all candidates for morphology cache lookup.

- **Parallel morphology chunk lookups** in `getCachedMorphologyByHeadword()`: Large headword lists are now fetched in parallel chunks (instead of serial) to reduce round-trip latency when looking up hundreds of words.

## Implementation Details

- Morphology filtering uses the same `hasDisplayableMorphology()` check in both ranking and sampling layers, ensuring consistent behavior.
- The two-tier system is deterministic and seed-based (like existing ranking), maintaining reproducibility.
- Etymology preference is best-effort: if morphology lookup fails, the feed still renders with plain words.
- Pinned candidates are also enriched with morphology so they can be ranked correctly alongside other candidates.
- Tests verify that etymology words lead the page, fill it first (even off-level ones), and never starve the feed of plain words.

https://claude.ai/code/session_01Hhe7vkt3us66Wt5fSu3VPp