### PR TITLE
Refactor profile navigation: make back button optional, add settings link

### DIFF
--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -84,8 +84,8 @@ export default function ProfilePage() {
   return (
     <ProfileView
       title="プロフィール"
-      backHref="/settings"
       editHref="/settings/account/profile"
+      settingsHref="/settings"
       name={name}
       accountId={accountId}
       initial={initial}

--- a/src/app/settings/account/delete/page.tsx
+++ b/src/app/settings/account/delete/page.tsx
@@ -129,8 +129,14 @@ export default function DeleteAccountPage() {
       <div className="px-[18px] pb-[14px] pt-1">
         <button
           type="button"
-          onClick={() => router.push('/settings/account')}
-          aria-label="アカウントへ戻る"
+          onClick={() => {
+            if (typeof window !== 'undefined' && window.history.length > 1) {
+              router.back();
+              return;
+            }
+            router.push('/settings/account');
+          }}
+          aria-label="戻る"
           className="mb-2 flex h-[38px] w-[38px] items-center justify-center rounded-[19px] border-2 border-[var(--solid-ink)] bg-white text-[var(--solid-ink)] transition-all duration-100 active:translate-x-px active:translate-y-px"
         >
           <Icon name="chevron_left" size={20} />

--- a/src/app/settings/account/page.tsx
+++ b/src/app/settings/account/page.tsx
@@ -28,8 +28,14 @@ export default function AccountSettingsPage() {
       <div className="px-[18px] pb-[14px] pt-1">
         <button
           type="button"
-          onClick={() => router.push('/settings')}
-          aria-label="設定へ戻る"
+          onClick={() => {
+            if (typeof window !== 'undefined' && window.history.length > 1) {
+              router.back();
+              return;
+            }
+            router.push('/settings');
+          }}
+          aria-label="戻る"
           className="mb-2 flex h-[38px] w-[38px] items-center justify-center rounded-[19px] border-2 border-[var(--solid-ink)] bg-white text-[var(--solid-ink)] transition-all duration-100 active:translate-x-px active:translate-y-px"
         >
           <Icon name="chevron_left" size={20} />

--- a/src/app/settings/account/plan/page.tsx
+++ b/src/app/settings/account/plan/page.tsx
@@ -92,8 +92,14 @@ export default function PlanSettingsPage() {
       <div className="px-[18px] pb-[14px] pt-1">
         <button
           type="button"
-          onClick={() => router.push('/settings/account')}
-          aria-label="アカウントへ戻る"
+          onClick={() => {
+            if (typeof window !== 'undefined' && window.history.length > 1) {
+              router.back();
+              return;
+            }
+            router.push('/settings/account');
+          }}
+          aria-label="戻る"
           className="mb-2 flex h-[38px] w-[38px] items-center justify-center rounded-[19px] border-2 border-[var(--solid-ink)] bg-white text-[var(--solid-ink)] transition-all duration-100 active:translate-x-px active:translate-y-px"
         >
           <Icon name="chevron_left" size={20} />

--- a/src/app/settings/account/profile/page.tsx
+++ b/src/app/settings/account/profile/page.tsx
@@ -27,6 +27,16 @@ export default function ProfileSettingsPage() {
   const displayAccountIdValue = accountIdInput ?? accountId ?? '';
   const isAccountIdValid = /^[a-z0-9_]{4,24}$/.test(displayAccountIdValue);
 
+  // プロフィール変更はアカウント設定以外(プロフィール画面の設定ボタンなど)からも
+  // 開かれるので、履歴があれば実際の遷移元へ戻す。直接開かれた場合のみ既定へ。
+  const handleBack = () => {
+    if (typeof window !== 'undefined' && window.history.length > 1) {
+      router.back();
+      return;
+    }
+    router.push('/settings/account');
+  };
+
   const startEditing = () => {
     setUsernameInput(username ?? '');
   };
@@ -66,8 +76,8 @@ export default function ProfileSettingsPage() {
       <div className="px-[18px] pb-[14px] pt-1">
         <button
           type="button"
-          onClick={() => router.push('/settings/account')}
-          aria-label="アカウントへ戻る"
+          onClick={handleBack}
+          aria-label="戻る"
           className="mb-2 flex h-[38px] w-[38px] items-center justify-center rounded-[19px] border-2 border-[var(--solid-ink)] bg-white text-[var(--solid-ink)] transition-all duration-100 active:translate-x-px active:translate-y-px"
         >
           <Icon name="chevron_left" size={20} />

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -27,6 +27,14 @@ export default function SettingsPage() {
 
   const billingEnabled = isBillingEnabled();
 
+  const handleBack = () => {
+    if (typeof window !== 'undefined' && window.history.length > 1) {
+      router.back();
+      return;
+    }
+    router.push('/profile');
+  };
+
   const handleSignOut = async () => {
     if (!window.confirm('ログアウトしますか？')) return;
     await signOut();
@@ -45,6 +53,15 @@ export default function SettingsPage() {
       <div className="relative min-h-screen bg-[var(--color-background)] pb-[110px] pt-3 font-[var(--font-body)] lg:hidden">
       {/* Header */}
       <div className="px-[18px] pb-[14px] pt-1">
+        {/* 設定はプロフィール内の導線から開くので、戻り先はプロフィール */}
+        <button
+          type="button"
+          onClick={handleBack}
+          aria-label="戻る"
+          className="mb-2 flex h-[38px] w-[38px] items-center justify-center rounded-[19px] border-2 border-[var(--solid-ink)] bg-white text-[var(--solid-ink)] transition-all duration-100 active:translate-x-px active:translate-y-px"
+        >
+          <Icon name="chevron_left" size={20} />
+        </button>
         <div className="font-mono text-[10px] font-bold uppercase tracking-[0.08em] text-[var(--color-muted)]">ACCOUNT</div>
         <div className="mt-0.5 font-display text-[26px] font-extrabold leading-[1.1] tracking-[-0.02em] text-[var(--solid-ink)]">設定</div>
       </div>

--- a/src/components/profile/ProfileView.tsx
+++ b/src/components/profile/ProfileView.tsx
@@ -39,6 +39,7 @@ export function ProfileView({
   title,
   backHref,
   editHref,
+  settingsHref,
   name,
   accountId,
   initial,
@@ -55,8 +56,11 @@ export function ProfileView({
   withBottomNav = false,
 }: {
   title: string;
-  backHref: string;
+  /** 未指定なら戻るボタンを出さない(ボトムナビ直下のタブ画面用) */
+  backHref?: string;
   editHref?: string;
+  /** 自分のプロフィールからのみ渡す。設定ページへの導線を表示する */
+  settingsHref?: string;
   name: string;
   accountId: string | null;
   initial: string;
@@ -106,6 +110,7 @@ export function ProfileView({
     <DesktopProfileView
       title={title}
       editHref={editHref}
+      settingsHref={settingsHref}
       name={name}
       accountId={accountId}
       initial={initial}
@@ -129,14 +134,18 @@ export function ProfileView({
       <div className="mx-auto w-full max-w-xl">
         {/* Top bar */}
         <div className="flex items-center gap-2 px-[18px] pb-1 pt-1">
-          <Link
-            href={backHref}
-            onClick={handleBack}
-            aria-label="戻る"
-            className="inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-full text-[var(--solid-ink)] active:bg-[var(--color-surface-secondary)]"
-          >
-            <Icon name="arrow_back" size={22} />
-          </Link>
+          {backHref ? (
+            <Link
+              href={backHref}
+              onClick={handleBack}
+              aria-label="戻る"
+              className="inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-full text-[var(--solid-ink)] active:bg-[var(--color-surface-secondary)]"
+            >
+              <Icon name="arrow_back" size={22} />
+            </Link>
+          ) : (
+            <div className="w-1 shrink-0" />
+          )}
           <div className="min-w-0 flex-1 font-display text-[18px] font-extrabold text-[var(--solid-ink)]">
             {title}
           </div>
@@ -144,6 +153,15 @@ export function ProfileView({
             <Link
               href={editHref}
               aria-label="プロフィールを編集"
+              className="inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-full text-[var(--solid-ink)] active:bg-[var(--color-surface-secondary)]"
+            >
+              <Icon name="edit" size={22} />
+            </Link>
+          )}
+          {settingsHref && (
+            <Link
+              href={settingsHref}
+              aria-label="設定"
               className="inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-full text-[var(--solid-ink)] active:bg-[var(--color-surface-secondary)]"
             >
               <Icon name="settings" size={22} />
@@ -195,6 +213,25 @@ export function ProfileView({
           </div>
 
           {actions && <div className="mt-3 flex items-center gap-2">{actions}</div>}
+
+          {/* 設定への導線。以前はボトムナビから直接開いていたが、プロフィール内に集約した */}
+          {settingsHref && (
+            <Link
+              href={settingsHref}
+              className="mt-3 flex items-center gap-2.5 rounded-[12px] border-2 border-[var(--solid-ink)] bg-white px-3 py-[11px] transition-all duration-100 active:translate-x-px active:translate-y-px"
+            >
+              <span className="inline-flex h-[26px] w-[26px] shrink-0 items-center justify-center rounded-[7px] bg-[rgba(26,26,26,0.05)] text-[var(--solid-ink)]">
+                <Icon name="settings" size={16} />
+              </span>
+              <div className="min-w-0 flex-1">
+                <span className="text-[13px] font-bold text-[var(--solid-ink)]">設定</span>
+                <p className="mt-px truncate text-[10px] leading-4 text-[var(--color-muted)]">
+                  学習ツール・通知・プラン・サポート
+                </p>
+              </div>
+              <Icon name="chevron_right" size={14} className="text-[var(--color-muted)]" />
+            </Link>
+          )}
         </div>
 
         {/* Overview / stats */}
@@ -342,6 +379,7 @@ type ProfileDerivedStats = {
 function DesktopProfileView({
   title,
   editHref,
+  settingsHref,
   name,
   accountId,
   initial,
@@ -359,6 +397,7 @@ function DesktopProfileView({
 }: {
   title: string;
   editHref?: string;
+  settingsHref?: string;
   name: string;
   accountId: string | null;
   initial: string;
@@ -380,8 +419,13 @@ function DesktopProfileView({
     <div className="hidden h-full min-h-0 flex-col lg:flex">
       <DesktopTopbar title={title} crumb="アカウント">
         {editHref && (
-          <DesktopButton href={editHref} icon="settings">
+          <DesktopButton href={editHref} icon="edit">
             プロフィールを編集
+          </DesktopButton>
+        )}
+        {settingsHref && (
+          <DesktopButton href={settingsHref} icon="settings">
+            設定
           </DesktopButton>
         )}
       </DesktopTopbar>


### PR DESCRIPTION
## Summary
Restructures the profile view navigation to make the back button optional and adds a dedicated settings link. This allows the profile page to work as a standalone tab (without a back button) while providing a clear navigation path to settings from the user's own profile.

## Key Changes

- **ProfileView component** (`src/components/profile/ProfileView.tsx`):
  - Made `backHref` prop optional (was required) with JSDoc explaining it's omitted for tab-based navigation
  - Added new optional `settingsHref` prop for settings page navigation (only passed from own profile)
  - Conditionally render back button only when `backHref` is provided; show spacer div otherwise to maintain layout
  - Added settings button in mobile top bar (next to edit button) when `settingsHref` is provided
  - Added settings link card in profile info section with icon, description, and chevron
  - Updated DesktopProfileView to accept and render `settingsHref` button in top bar
  - Fixed desktop edit button icon from "settings" to "edit"

- **Settings pages** (improved back button behavior across all settings routes):
  - `src/app/settings/page.tsx`: Added smart back button that uses browser history if available, falls back to `/profile`
  - `src/app/settings/account/profile/page.tsx`: Implemented same smart back logic, falls back to `/settings/account`
  - `src/app/settings/account/delete/page.tsx`: Added smart back logic, falls back to `/settings/account`
  - `src/app/settings/account/page.tsx`: Added smart back logic, falls back to `/settings`
  - `src/app/settings/account/plan/page.tsx`: Added smart back logic, falls back to `/settings/account`

- **Profile page** (`src/app/profile/page.tsx`):
  - Removed `backHref="/settings"` (no back button needed for tab-based navigation)
  - Added `settingsHref="/settings"` to provide settings navigation from profile
  - Kept `editHref="/settings/account/profile"` for profile editing

## Implementation Details

The smart back button pattern checks `window.history.length > 1` to determine if there's browser history to navigate back through. This allows users to return to their actual navigation origin (e.g., from profile → settings → account → back to profile) rather than always jumping to a hardcoded fallback. If no history exists (direct page load), it falls back to a sensible default route.

The settings link is now consolidated in the profile view rather than being accessed via bottom navigation, improving information architecture and providing a clearer user journey from profile to account settings.

https://claude.ai/code/session_01XVpw3oTV6USsFPLvVZ8fhS