### PR TITLE
Add binder picker sheet for mobile project list

### DIFF
--- a/src/app/project/[id]/page.tsx
+++ b/src/app/project/[id]/page.tsx
@@ -12,6 +12,7 @@ import { ProjectShareSheet } from '@/components/project/ProjectShareSheet';
 import { VocabularyTypeButton } from '@/components/project/VocabularyTypeButton';
 import { GuidedTour, type TourStep } from '@/components/onboarding/GuidedTour';
 import { WordFilterSheet, WordSortSheet } from '@/components/project/WordListSheets';
+import { BinderPickerSheet } from '@/components/desktop/ProjectListSheets';
 import { WordDetailView } from '@/components/word/WordDetailView';
 import { TranslationDisplay } from '@/components/word/TranslationDisplay';
 import { useAuth } from '@/hooks/use-auth';
@@ -180,6 +181,9 @@ export default function ProjectPage() {
   const [renameModalOpen, setRenameModalOpen] = useState(false);
   const [renameValue, setRenameValue] = useState('');
   const [renameLoading, setRenameLoading] = useState(false);
+  // バインダー (フォルダ) ピッカー。既存のバインダー名は開くときに集める
+  const [binderPickerOpen, setBinderPickerOpen] = useState(false);
+  const [binderNames, setBinderNames] = useState<string[]>([]);
   const [selectedWord, setSelectedWord] = useState<Word | null>(null);
   const [deleteWordTarget, setDeleteWordTarget] = useState<Word | null>(null);
   const [deleteWordLoading, setDeleteWordLoading] = useState(false);
@@ -983,13 +987,33 @@ export default function ProjectPage() {
     }
   };
 
-  // バインダー (フォルダ) 名を設定する。空欄で解除
-  const handleSetBinder = async () => {
+  // バインダー (フォルダ) の設定はピッカーシートで行う。window.prompt は
+  // PWA スタンドアロン表示や一部のモバイルブラウザでブロックされるため使わない。
+  const handleOpenBinderPicker = async () => {
     if (!project) return;
     setMenuOpen(false);
-    const input = window.prompt('バインダー名を入力してください (空欄で解除)', project.binder ?? '');
-    if (input === null) return;
-    const binder = input.trim().slice(0, 40) || null;
+    // 既存のバインダー名を集めてから開く (取得に失敗しても新規作成はできる)
+    try {
+      const userId = user ? user.id : getGuestUserId();
+      const projects = await repository.getProjects(userId);
+      const names = new Set<string>();
+      for (const p of projects) {
+        const name = p.binder?.trim();
+        if (name) names.add(name);
+      }
+      setBinderNames(Array.from(names).sort((a, b) => a.localeCompare(b, 'ja')));
+    } catch {
+      setBinderNames([]);
+    }
+    setBinderPickerOpen(true);
+  };
+
+  // バインダーを適用する。null でバインダーから外す
+  const handleApplyBinder = async (rawBinder: string | null) => {
+    setBinderPickerOpen(false);
+    if (!project) return;
+    const binder = rawBinder?.trim().slice(0, 40) || null;
+    if (binder === (project.binder?.trim() || null)) return;
     try {
       await mutationRepository.updateProject(project.id, { binder });
       setProject((p) => (p ? { ...p, binder } : p));
@@ -1296,7 +1320,7 @@ export default function ProjectPage() {
         }}
         onToggleSelectWord={handleToggleSelectWord}
         onRename={handleOpenRename}
-        onSetBinder={() => void handleSetBinder()}
+        onSetBinder={() => void handleOpenBinderPicker()}
         onDeleteProject={() => setDeleteModalOpen(true)}
         onToggleFavorite={(word) => void handleToggleFavorite(word)}
         onCycleVocabularyType={(word) => void handleCycleVocabularyType(word)}
@@ -1356,7 +1380,7 @@ export default function ProjectPage() {
             style={{ top: 'calc(env(safe-area-inset-top, 0px) + 62px)', right: 14 }}
           >
             <MenuButton icon="edit" label="名称変更" onClick={handleOpenRename} />
-            <MenuButton icon="folder" label="バインダー設定" onClick={() => void handleSetBinder()} />
+            <MenuButton icon="folder" label="バインダー設定" onClick={() => void handleOpenBinderPicker()} />
             <MenuButton icon="image" label="画像設定" onClick={handleOpenImagePicker} />
             <MenuButton
               icon="delete"
@@ -1745,6 +1769,15 @@ export default function ProjectPage() {
         onClose={() => setWordShowSortSheet(false)}
         sortOrder={wordSortOrder}
         onSortOrderChange={setWordSortOrder}
+      />
+      {/* バインダー (フォルダ) の設定。モバイル・デスクトップ共通のピッカー */}
+      <BinderPickerSheet
+        key={binderPickerOpen ? `binder-${project.binder ?? ''}` : 'binder-closed'}
+        open={binderPickerOpen}
+        onClose={() => setBinderPickerOpen(false)}
+        project={project}
+        binders={binderNames}
+        onApply={(binder) => void handleApplyBinder(binder)}
       />
 
       <GuidedTour run={runProjectTour} steps={PROJECT_INTRO_TOUR_STEPS} onFinish={markProjectTourSeen} />

--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -336,7 +336,7 @@ export default function ProjectListPage() {
               .filter((group) => group.binder === null)
               .flatMap((group) => group.items)
               .map((project) => (
-                <BookRow key={project.id} project={project} />
+                <BookRow key={project.id} project={project} onSetBinder={handleSetBinder} />
               ))}
           </>
         )}
@@ -357,43 +357,65 @@ export default function ProjectListPage() {
   );
 }
 
-function BookRow({ project }: { project: ProjectRowStats }) {
+function BookRow({
+  project,
+  onSetBinder,
+}: {
+  project: ProjectRowStats;
+  /** 「バインダーに追加」ボタン。デスクトップの「...」メニューと同じピッカーを開く */
+  onSetBinder?: (project: Project) => void;
+}) {
   const bg = thumbColor(project.id);
   return (
-    <Link href={`/project/${project.id}`}>
-      <SolidPanel
-        className="!rounded-[14px] ! transition-all duration-100 active:translate-x-px active:translate-y-px active:!"
-        faceClassName="!p-[13px]"
-      >
-        <div className="flex items-center gap-[13px]">
-          <div
-            className="flex h-[44px] w-[44px] shrink-0 items-center justify-center rounded-[10px] border-2 border-[var(--solid-ink)] bg-center bg-cover font-display text-[18px] font-extrabold text-white"
-            style={{ backgroundColor: bg, backgroundImage: project.iconImage ? `url(${project.iconImage})` : undefined }}
-          >
-            {!project.iconImage && project.title.charAt(0)}
-          </div>
-
-          <div className="min-w-0 flex-1">
-            <div className="truncate text-sm font-bold text-[var(--solid-ink)]">{project.title}</div>
-            <div className="mt-0.5 text-[10px] tabular-nums text-[var(--color-muted)]">
-              {project.totalWords}語
+    // バインダーボタンは <a> の中に <button> を入れないよう Link の兄弟として置く
+    <div className="relative">
+      <Link href={`/project/${project.id}`}>
+        <SolidPanel
+          className="!rounded-[14px] ! transition-all duration-100 active:translate-x-px active:translate-y-px active:!"
+          faceClassName="!p-[13px]"
+        >
+          <div className="flex items-center gap-[13px]">
+            <div
+              className="flex h-[44px] w-[44px] shrink-0 items-center justify-center rounded-[10px] border-2 border-[var(--solid-ink)] bg-center bg-cover font-display text-[18px] font-extrabold text-white"
+              style={{ backgroundColor: bg, backgroundImage: project.iconImage ? `url(${project.iconImage})` : undefined }}
+            >
+              {!project.iconImage && project.title.charAt(0)}
             </div>
-            {project.totalWords > 0 && (
-              <div className="mt-1.5 flex h-[4px] overflow-hidden rounded-full bg-[rgba(26,26,26,0.08)]">
-                {project.masteredWords > 0 && <div style={{ flex: project.masteredWords, background: 'var(--color-success)' }} />}
-                {project.activeWords > 0 && <div style={{ flex: project.activeWords, background: '#2563eb' }} />}
-                {project.reviewWords > 0 && <div style={{ flex: project.reviewWords, background: 'var(--color-warning)' }} />}
-                {project.newWords > 0 && <div style={{ flex: project.newWords, background: 'rgba(26,26,26,0.12)' }} />}
+
+            <div className={`min-w-0 flex-1 ${onSetBinder ? 'pr-[38px]' : ''}`}>
+              <div className="truncate text-sm font-bold text-[var(--solid-ink)]">{project.title}</div>
+              <div className="mt-0.5 text-[10px] tabular-nums text-[var(--color-muted)]">
+                {project.totalWords}語
               </div>
+              {project.totalWords > 0 && (
+                <div className="mt-1.5 flex h-[4px] overflow-hidden rounded-full bg-[rgba(26,26,26,0.08)]">
+                  {project.masteredWords > 0 && <div style={{ flex: project.masteredWords, background: 'var(--color-success)' }} />}
+                  {project.activeWords > 0 && <div style={{ flex: project.activeWords, background: '#2563eb' }} />}
+                  {project.reviewWords > 0 && <div style={{ flex: project.reviewWords, background: 'var(--color-warning)' }} />}
+                  {project.newWords > 0 && <div style={{ flex: project.newWords, background: 'rgba(26,26,26,0.12)' }} />}
+                </div>
+              )}
+            </div>
+
+            {!onSetBinder && (
+              <span className="mr-0.5 inline-flex text-[var(--color-muted)]">
+                <Icon name="chevron_right" size={14} />
+              </span>
             )}
           </div>
-
-          <span className="mr-0.5 inline-flex text-[var(--color-muted)]">
-            <Icon name="chevron_right" size={14} />
-          </span>
-        </div>
-      </SolidPanel>
-    </Link>
+        </SolidPanel>
+      </Link>
+      {onSetBinder && (
+        <button
+          type="button"
+          onClick={() => onSetBinder(project)}
+          aria-label={`「${project.title}」をバインダーに追加`}
+          className="absolute right-[11px] top-1/2 flex h-9 w-9 -translate-y-1/2 items-center justify-center rounded-full border-2 border-[var(--solid-ink)] bg-white text-[var(--solid-ink)] transition-opacity duration-100 active:opacity-60"
+        >
+          <Icon name="create_new_folder" size={16} />
+        </button>
+      )}
+    </div>
   );
 }
 


### PR DESCRIPTION
## Summary
Replaces the `window.prompt()` binder input flow with a dedicated `BinderPickerSheet` component, improving UX on mobile and PWA standalone mode where prompts are often blocked. Adds a "add to binder" button to project cards in the mobile project list view.

## Key Changes

- **Mobile project list**: Added `onSetBinder` callback to `BookRow` component with a floating action button (folder icon) that opens the binder picker sheet
  - Button appears only when `onSetBinder` is provided
  - Positioned absolutely over the project card with proper spacing
  - Includes accessible aria-label

- **Project detail page**: Refactored binder setting flow
  - Replaced `window.prompt()` with `BinderPickerSheet` component (shared with desktop)
  - New `handleOpenBinderPicker()` function fetches existing binder names from all user projects before opening the sheet
  - New `handleApplyBinder()` function applies the selected binder and updates project state
  - Added state management for picker visibility and binder name list

- **Layout improvements**: 
  - Wrapped `BookRow` content in a `<div className="relative">` to enable absolute positioning of the binder button
  - Added conditional right padding (`pr-[38px]`) to project title area when binder button is present
  - Conditionally hide chevron icon when binder button is shown (mobile-only view)

## Implementation Details

- The binder picker sheet is keyed with the current binder value to ensure fresh state when opened
- Existing binder names are collected from all projects and sorted by Japanese locale for better UX
- Binder name fetching is wrapped in try-catch to allow picker to open even if name collection fails
- Applied binder is trimmed and capped at 40 characters, matching existing validation
- No-op if selected binder matches current binder value

https://claude.ai/code/session_01Cb1wY5rUQ72RAp3SH1mLRT