### PR TITLE
Add a pause flow, a duration control, and homophone-tolerant grading

### DIFF
--- a/src/app/api/voice-quiz/recognize/route.ts
+++ b/src/app/api/voice-quiz/recognize/route.ts
@@ -32,10 +32,19 @@ const MAX_AUDIO_BASE64_LENGTH = 2_000_000;
 const SUPPORTED_LANGUAGE_CODES = ['en-US', 'ja-JP'] as const;
 const DEFAULT_LANGUAGE_CODE = 'ja-JP';
 
+// 同音異義語を拾うための候補数。多すぎても判定が緩くなるだけなので絞る。
+const VOICE_QUIZ_MAX_ALTERNATIVES = 5;
+
 const requestSchema = z.object({
   audioBase64: z.string().trim().min(1).max(MAX_AUDIO_BASE64_LENGTH),
   encoding: z.enum(['WEBM_OPUS', 'OGG_OPUS']),
   languageCode: z.enum(SUPPORTED_LANGUAGE_CODES).optional(),
+  /**
+   * 認識のヒント。日本語は同音異義語が別の漢字に変換されやすく、正しく答えても
+   * 表記違いで不正解になる。期待する語を渡して変換先を寄せる。
+   * 答えそのものなので、ログにも応答にも出さない。
+   */
+  phraseHints: z.array(z.string().trim().min(1).max(100)).max(8).optional(),
 }).strict();
 
 interface RecognizeVoiceQuizDeps {
@@ -106,6 +115,8 @@ export async function handleVoiceQuizRecognizePost(
       audioBase64: parsed.data.audioBase64,
       encoding: parsed.data.encoding,
       languageCode,
+      phraseHints: parsed.data.phraseHints,
+      maxAlternatives: VOICE_QUIZ_MAX_ALTERNATIVES,
     });
 
     if (!result.success) {
@@ -125,6 +136,8 @@ export async function handleVoiceQuizRecognizePost(
       success: true,
       transcript: result.transcript,
       confidence: result.confidence,
+      // 同音異義語の別変換を判定側で拾えるように候補も返す。
+      alternatives: result.alternatives,
     });
   } catch (error) {
     console.error('Voice quiz recognize error:', error);

--- a/src/app/voice-quiz/[projectId]/page.tsx
+++ b/src/app/voice-quiz/[projectId]/page.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, useCallback, useMemo, useRef, type CSSProperties }
 import { useRouter, useParams, useSearchParams } from 'next/navigation';
 import { SolidButton } from '@/components/redesign/SolidPage';
 import { Icon } from '@/components/ui/Icon';
+import { Modal } from '@/components/ui/modal';
 import { QuizModeTabs } from '@/components/quiz';
 import { getRepository } from '@/lib/db';
 import { cn, recordCorrectAnswer, recordWrongAnswer, recordActivity, getGuestUserId } from '@/lib/utils';
@@ -14,17 +15,19 @@ import {
   buildVoiceQuizMeaningPrompt,
   canRetryVoiceQuiz,
   DEFAULT_VOICE_QUIZ_ATTEMPTS,
+  DEFAULT_VOICE_QUIZ_DURATION_SEC,
   normalizeVoiceQuizAttempts,
+  normalizeVoiceQuizDuration,
+  VOICE_QUIZ_DURATION_OPTIONS,
   pickVoiceQuizRetryPrompt,
   randomVoiceQuizPromptOffset,
   resolveVoiceQuizCount,
   VOICE_QUIZ_ATTEMPT_OPTIONS,
 } from '@/lib/quiz/voice-quiz-prompt';
-import { isJapaneseAnswerCorrect } from '@/lib/quiz/voice-quiz-answer';
+import { isAnyJapaneseAnswerCorrect, japaneseAnswerHints } from '@/lib/quiz/voice-quiz-answer';
 import { useAuth } from '@/hooks/use-auth';
 import type { Word, SubscriptionStatus } from '@/types';
 
-const TIMER_DURATION_MS = 6000;
 const TIMER_TICK_MS = 50;
 
 /**
@@ -120,14 +123,19 @@ export default function VoiceQuizPage() {
   const [attemptsAllowed, setAttemptsAllowed] = useState(DEFAULT_VOICE_QUIZ_ATTEMPTS);
   const [attemptNumber, setAttemptNumber] = useState(1);
   const [retryMessage, setRetryMessage] = useState('');
+  /** 1回の解答に使える秒数。開始画面で選ぶ。 */
+  const [durationSec, setDurationSec] = useState(DEFAULT_VOICE_QUIZ_DURATION_SEC);
+  const durationMs = durationSec * 1000;
 
   const [setupState, setSetupState] = useState<SetupState>('checking');
   const [phase, setPhase] = useState<Phase>('narrating');
-  const [timeLeft, setTimeLeft] = useState(TIMER_DURATION_MS);
+  const [timeLeft, setTimeLeft] = useState(DEFAULT_VOICE_QUIZ_DURATION_SEC * 1000);
   const [recognizedText, setRecognizedText] = useState('');
   const [isCorrect, setIsCorrect] = useState(false);
   const [isDisqualified, setIsDisqualified] = useState(false);
   const [recognitionErrored, setRecognitionErrored] = useState(false);
+  /** 中断の確認を出しているか。出している間はクイズを止める。 */
+  const [showStopConfirm, setShowStopConfirm] = useState(false);
 
   const streamRef = useRef<MediaStream | null>(null);
   const recordingRef = useRef<string | null>(null);
@@ -138,6 +146,11 @@ export default function VoiceQuizPage() {
   const attemptSettledRef = useRef(false);
   const attemptRef = useRef(1);
   const attemptsAllowedRef = useRef(DEFAULT_VOICE_QUIZ_ATTEMPTS);
+  /**
+   * 解答時間のミリ秒。カウントダウンや録音開始はレンダー外から読むので、
+   * 出題中に値が変わらない ref を唯一の参照元にする。
+   */
+  const durationMsRef = useRef(DEFAULT_VOICE_QUIZ_DURATION_SEC * 1000);
   const questionRunRef = useRef(0);
   /**
    * いま出題中の単語。`setCurrentIndex` の反映は次のレンダーまで待たされるので、
@@ -261,13 +274,15 @@ export default function VoiceQuizPage() {
 
   /** 1回の試行の結果を受けて、再挑戦させるか問題を確定するかを決める。 */
   const handleAttemptResult = useCallback(
-    async (transcript: string, apiErrored: boolean, run: number) => {
+    async (transcript: string, apiErrored: boolean, run: number, alternatives: string[] = []) => {
       if (attemptSettledRef.current) return;
       attemptSettledRef.current = true;
       const word = activeWordRef.current;
       if (!word || questionRunRef.current !== run) return;
 
-      const correct = !!transcript && isJapaneseAnswerCorrect(transcript, word.japanese);
+      // 最有力の変換が同音異義語で外れることがあるので、候補全体で突き合わせる。
+      const heard = [transcript, ...alternatives].filter(Boolean);
+      const correct = isAnyJapaneseAnswerCorrect(heard, word.japanese);
 
       // 音声認識自体が失敗した場合は、ユーザーの責任ではないので再挑戦させずに確定する。
       if (correct || apiErrored || !canRetryVoiceQuiz(attemptRef.current, attemptsAllowedRef.current)) {
@@ -302,7 +317,7 @@ export default function VoiceQuizPage() {
       chunksRef.current = [];
       setRecognizedText('');
       setRetryMessage('');
-      setTimeLeft(TIMER_DURATION_MS);
+      setTimeLeft(durationMsRef.current);
       setPhase('listening');
       timerStartRef.current = Date.now();
 
@@ -339,6 +354,8 @@ export default function VoiceQuizPage() {
                 audioBase64,
                 encoding: recordedEncoding,
                 languageCode: 'ja-JP',
+                // 同音異義語の変換先を正解の表記に寄せる。
+                phraseHints: japaneseAnswerHints(activeWordRef.current?.japanese ?? ''),
               }),
             });
             const data = await response.json();
@@ -347,7 +364,14 @@ export default function VoiceQuizPage() {
               await handleAttemptResult('', true, run);
               return;
             }
-            await handleAttemptResult(typeof data.transcript === 'string' ? data.transcript : '', false, run);
+            await handleAttemptResult(
+              typeof data.transcript === 'string' ? data.transcript : '',
+              false,
+              run,
+              Array.isArray(data.alternatives)
+                ? data.alternatives.filter((item: unknown): item is string => typeof item === 'string')
+                : [],
+            );
           } catch {
             if (questionRunRef.current === run) await handleAttemptResult('', true, run);
           }
@@ -382,7 +406,7 @@ export default function VoiceQuizPage() {
     setIsCorrect(false);
     setIsDisqualified(false);
     setRecognitionErrored(false);
-    setTimeLeft(TIMER_DURATION_MS);
+    setTimeLeft(durationMsRef.current);
     setPhase('narrating');
 
     void (async () => {
@@ -406,7 +430,7 @@ export default function VoiceQuizPage() {
 
     const tick = () => {
       if (!timerStartRef.current || attemptSettledRef.current) return;
-      const remaining = Math.max(0, TIMER_DURATION_MS - (Date.now() - timerStartRef.current));
+      const remaining = Math.max(0, durationMsRef.current - (Date.now() - timerStartRef.current));
       setTimeLeft(remaining);
       if (remaining <= 0) stopRecording();
     };
@@ -435,16 +459,55 @@ export default function VoiceQuizPage() {
    * ボタンは早送り用に残してあるので、待ちたくないときは従来どおり押せる。
    */
   useEffect(() => {
-    if (phase !== 'answered') return;
+    // 中断の確認中は、裏で問題が進んでしまわないように止めておく。
+    if (phase !== 'answered' || showStopConfirm) return;
     const delay = isCorrect ? AUTO_ADVANCE_CORRECT_MS : AUTO_ADVANCE_INCORRECT_MS;
     const timeoutId = window.setTimeout(() => moveToNextRef.current(), delay);
     return () => window.clearTimeout(timeoutId);
-  }, [phase, isCorrect]);
+  }, [phase, isCorrect, showStopConfirm]);
 
-  const beginSession = (attempts: number) => {
+  /**
+   * 中断の確認を開く。開いている間はクイズを完全に止める。
+   * 進行中の読み上げ・録音を切り、run を進めて解決済みのコールバックを無効化する
+   * (これをしないと、確認中に録音が採点まで走ってしまう)。
+   */
+  const requestStop = useCallback(() => {
+    questionRunRef.current += 1;
+    try { recorderRef.current?.stop(); } catch {}
+    stopSpeaking();
+    timerStartRef.current = null;
+    setShowStopConfirm(true);
+  }, []);
+
+  /** 中断をやめて、いまの問題を最初から出題し直す。 */
+  const resumeQuiz = useCallback(() => {
+    setShowStopConfirm(false);
+    const word = activeWordRef.current;
+    if (word) startQuestion(word);
+  }, [startQuestion]);
+
+  /** ここまでの成績で結果画面へ進む。 */
+  const finishEarly = useCallback(() => {
+    setShowStopConfirm(false);
+    setIsComplete(true);
+  }, []);
+
+  /** 記録を見ずに単語帳へ戻る。 */
+  const exitQuiz = useCallback(() => {
+    setShowStopConfirm(false);
+    backToProject();
+  }, [backToProject]);
+
+  const beginSession = (attempts: number, seconds: number) => {
     if (words.length === 0) return;
     attemptsAllowedRef.current = normalizeVoiceQuizAttempts(attempts);
     setAttemptsAllowed(attemptsAllowedRef.current);
+
+    const normalizedSeconds = normalizeVoiceQuizDuration(seconds);
+    durationMsRef.current = normalizedSeconds * 1000;
+    setDurationSec(normalizedSeconds);
+    setTimeLeft(durationMsRef.current);
+
     setCurrentIndex(0);
     setHasStarted(true);
     startQuestion(words[0]);
@@ -546,36 +609,38 @@ export default function VoiceQuizPage() {
             <p className="mt-3 text-sm leading-6 text-[var(--color-muted)]">
               読み上げられた英単語の意味を、
               <br />
-              {Math.round(TIMER_DURATION_MS / 1000)}秒以内に日本語で答えてください。
+              {durationSec}秒以内に日本語で答えてください。
             </p>
 
             <div className="mt-5 grid grid-cols-2 gap-2">
               <StatChip icon="list" label="出題数" value={`${words.length}問`} />
-              <StatChip icon="timer" label="制限時間" value={`${Math.round(TIMER_DURATION_MS / 1000)}秒`} />
+              <StatChip icon="timer" label="解答時間" value={`${durationSec}秒`} />
             </div>
 
-            <p className={cn(EYEBROW, 'mt-6 mb-2 text-left text-[var(--color-muted)]')}>試行回数</p>
-            <div className="flex gap-2" role="group" aria-label="試行回数">
-              {VOICE_QUIZ_ATTEMPT_OPTIONS.map((option) => {
-                const selected = attemptsAllowed === option;
-                return (
-                  <button
-                    key={option}
-                    type="button"
-                    aria-pressed={selected}
-                    onClick={() => setAttemptsAllowed(option)}
-                    className={cn(
-                      'flex-1 rounded-[var(--solid-radius-sm)] border-2 border-[var(--solid-ink)] py-3 font-display text-base font-black transition-all duration-100 active:translate-x-px active:translate-y-px',
-                      selected
-                        ? cn('bg-[var(--solid-ink)] text-[var(--color-surface)]', HARD_SHADOW_SM)
-                        : 'bg-[var(--color-surface)] text-[var(--solid-ink)]',
-                    )}
-                  >
-                    {option}回
-                  </button>
-                );
-              })}
-            </div>
+            <SegmentedOptions
+              label="解答時間"
+              options={VOICE_QUIZ_DURATION_OPTIONS}
+              selected={durationSec}
+              onSelect={setDurationSec}
+              format={(option) => `${option}秒`}
+              className="mt-6"
+            />
+            <p className="mt-3 text-xs leading-5 text-[var(--color-muted)]">
+              {durationSec <= 4
+                ? '短いほどテンポよく進みますが、言い切る前に締め切られることがあります。'
+                : durationSec >= 15
+                ? '長い意味や、考えてから答えたいときに。'
+                : '答え終わったら「話し終わった」を押せば、待たずに次へ進めます。'}
+            </p>
+
+            <SegmentedOptions
+              label="試行回数"
+              options={VOICE_QUIZ_ATTEMPT_OPTIONS}
+              selected={attemptsAllowed}
+              onSelect={setAttemptsAllowed}
+              format={(option) => `${option}回`}
+              className="mt-5"
+            />
             <p className="mt-3 mb-6 min-h-[2.5rem] text-xs leading-5 text-[var(--color-muted)]">
               {attemptsAllowed === 1
                 ? '1回でも間違えるとその問題は終了します。'
@@ -586,7 +651,7 @@ export default function VoiceQuizPage() {
               variant="accent"
               size="lg"
               iconRight="arrow_forward"
-              onClick={() => beginSession(attemptsAllowed)}
+              onClick={() => beginSession(attemptsAllowed, durationSec)}
               className={cn('w-full', HARD_SHADOW)}
             >
               開始する
@@ -688,7 +753,7 @@ export default function VoiceQuizPage() {
   return (
     <div className="h-dvh flex flex-col bg-[var(--color-background)] overflow-hidden fixed inset-0">
       <header className="sticky top-0 flex-shrink-0 flex items-center gap-3 p-4">
-        <CloseButton onClick={backToProject} />
+        <CloseButton onClick={requestStop} label="中断する" />
 
         <div className="h-3 flex-1 overflow-hidden rounded-full border-2 border-[var(--solid-ink)] bg-[var(--color-surface)]">
           <div
@@ -742,7 +807,7 @@ export default function VoiceQuizPage() {
                 <>
                   {/* アイコンではなく残り秒数そのものを大きく出す。 */}
                   <div className="relative h-40 w-40">
-                    <CountdownRing progress={timeLeft / TIMER_DURATION_MS} tone={timerTone} />
+                    <CountdownRing progress={timeLeft / durationMs} tone={timerTone} />
                     <div
                       className={cn(
                         'absolute inset-[20px] flex flex-col items-center justify-center rounded-full border-2 border-[var(--solid-ink)] bg-[var(--color-surface)]',
@@ -871,16 +936,69 @@ export default function VoiceQuizPage() {
           </div>
         </div>
       )}
+
+      <Modal
+        isOpen={showStopConfirm}
+        onClose={resumeQuiz}
+        showCloseButton={false}
+        className={cn(
+          'rounded-[var(--solid-radius)] border-2 border-[var(--solid-ink)] shadow-none',
+          HARD_SHADOW,
+        )}
+      >
+        <div className="p-6 text-center">
+          <p className={cn(EYEBROW, 'text-[var(--color-muted)]')}>Pause</p>
+          <h2 className="mt-1 font-display text-xl font-black text-[var(--solid-ink)]">
+            音読チャレンジを中断しますか?
+          </h2>
+          <p className="mt-2 text-sm leading-6 text-[var(--color-muted)]">
+            全{words.length}問中 {answeredCount}問おわりました。
+            {results.total > 0 && `（正解 ${results.correct}問）`}
+          </p>
+
+          <div className="mt-6 space-y-2.5">
+            <SolidButton
+              variant="accent"
+              size="lg"
+              iconLeft="play_arrow"
+              onClick={resumeQuiz}
+              className={cn('w-full', HARD_SHADOW)}
+            >
+              続ける
+            </SolidButton>
+
+            {/* 1問も解いていないときは見せる結果が無いので出さない。 */}
+            {results.total > 0 && (
+              <SolidButton
+                size="lg"
+                iconLeft="flag"
+                onClick={finishEarly}
+                className={cn('w-full', HARD_SHADOW_SM)}
+              >
+                ここまでの結果を見る
+              </SolidButton>
+            )}
+
+            <button
+              type="button"
+              onClick={exitQuiz}
+              className="w-full py-2 text-sm font-bold text-[var(--color-muted)] underline underline-offset-4"
+            >
+              記録せずに戻る
+            </button>
+          </div>
+        </div>
+      </Modal>
     </div>
   );
 }
 
-function CloseButton({ onClick }: { onClick: () => void }) {
+function CloseButton({ onClick, label = '閉じる' }: { onClick: () => void; label?: string }) {
   return (
     <button
       type="button"
       onClick={onClick}
-      aria-label="閉じる"
+      aria-label={label}
       className={cn(
         'flex h-10 w-10 shrink-0 items-center justify-center rounded-full border-2 border-[var(--solid-ink)] bg-[var(--color-surface)] text-[var(--solid-ink)] transition-all duration-100 active:translate-x-px active:translate-y-px',
         HARD_SHADOW_SM,
@@ -888,6 +1006,50 @@ function CloseButton({ onClick }: { onClick: () => void }) {
     >
       <Icon name="close" size={20} />
     </button>
+  );
+}
+
+/** 開始画面の設定行。解答時間と試行回数で見た目を揃える。 */
+function SegmentedOptions({
+  label,
+  options,
+  selected,
+  onSelect,
+  format,
+  className,
+}: {
+  label: string;
+  options: readonly number[];
+  selected: number;
+  onSelect: (option: number) => void;
+  format: (option: number) => string;
+  className?: string;
+}) {
+  return (
+    <div className={className}>
+      <p className={cn(EYEBROW, 'mb-2 text-left text-[var(--color-muted)]')}>{label}</p>
+      <div className="flex gap-2" role="group" aria-label={label}>
+        {options.map((option) => {
+          const isSelected = selected === option;
+          return (
+            <button
+              key={option}
+              type="button"
+              aria-pressed={isSelected}
+              onClick={() => onSelect(option)}
+              className={cn(
+                'flex-1 rounded-[var(--solid-radius-sm)] border-2 border-[var(--solid-ink)] py-3 font-display text-base font-black transition-all duration-100 active:translate-x-px active:translate-y-px',
+                isSelected
+                  ? cn('bg-[var(--solid-ink)] text-[var(--color-surface)]', HARD_SHADOW_SM)
+                  : 'bg-[var(--color-surface)] text-[var(--solid-ink)]',
+              )}
+            >
+              {format(option)}
+            </button>
+          );
+        })}
+      </div>
+    </div>
   );
 }
 

--- a/src/lib/quiz/voice-quiz-answer.test.ts
+++ b/src/lib/quiz/voice-quiz-answer.test.ts
@@ -2,10 +2,26 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 
 import {
+  isAnyJapaneseAnswerCorrect,
   isJapaneseAnswerCorrect,
   japaneseAnswerCandidates,
+  japaneseAnswerHints,
   normalizeJapaneseAnswer,
 } from './voice-quiz-answer';
+
+test('a homophone transcribed with the wrong kanji is rescued by the other candidates', () => {
+  // 「きづく」を「築く」と変換されても、候補に「気づく」があれば正解にする。
+  assert.equal(isJapaneseAnswerCorrect('築く', '気づく'), false);
+  assert.equal(isAnyJapaneseAnswerCorrect(['築く', '気づく'], '気づく'), true);
+});
+
+test('candidates that are all wrong stay wrong', () => {
+  assert.equal(isAnyJapaneseAnswerCorrect(['走る', '奔る'], '気づく'), false);
+});
+
+test('an empty candidate list is rejected', () => {
+  assert.equal(isAnyJapaneseAnswerCorrect([], '気づく'), false);
+});
 
 test('normalizeJapaneseAnswer folds katakana, width and punctuation', () => {
   assert.equal(normalizeJapaneseAnswer('コーヒー'), normalizeJapaneseAnswer('こーひー'));
@@ -57,6 +73,19 @@ test('a bare stray fragment is rejected', () => {
 test('empty or silent input is rejected', () => {
   assert.equal(isJapaneseAnswerCorrect('', '気づく'), false);
   assert.equal(isJapaneseAnswerCorrect('  ', '気づく'), false);
+});
+
+test('japaneseAnswerHints keeps the original spelling so hints stay usable', () => {
+  // 比較用の候補は長音を落とすが、ヒントは表記のまま渡さないと役に立たない。
+  assert.deepEqual(japaneseAnswerHints('コーヒー'), ['コーヒー']);
+  assert.ok(japaneseAnswerCandidates('コーヒー')[0] !== 'コーヒー');
+});
+
+test('japaneseAnswerHints splits meanings and offers the parenthetical-free form', () => {
+  const hints = japaneseAnswerHints('気づく、(人に)与える');
+  assert.ok(hints.includes('気づく'));
+  assert.ok(hints.includes('(人に)与える'));
+  assert.ok(hints.includes('与える'));
 });
 
 test('japaneseAnswerCandidates splits and folds every meaning', () => {

--- a/src/lib/quiz/voice-quiz-answer.ts
+++ b/src/lib/quiz/voice-quiz-answer.ts
@@ -60,6 +60,27 @@ export function japaneseAnswerCandidates(japanese: string): string[] {
 }
 
 /**
+ * 音声認識に渡すヒント語。
+ *
+ * 比較用の候補 (japaneseAnswerCandidates) は正規化で長音やカタカナを畳んでおり
+ * 「コーヒー」が「こひ」になってしまうため、ヒントには使えない。
+ * ここでは区切りだけ分けて、表記はそのまま残す。
+ */
+export function japaneseAnswerHints(japanese: string): string[] {
+  const hints = new Set<string>();
+
+  for (const part of japanese.split(MEANING_SEPARATORS)) {
+    const trimmed = part.trim();
+    if (trimmed) hints.add(trimmed);
+
+    const withoutParenthetical = part.replace(/[（(][^）)]*[）)]/g, '').trim();
+    if (withoutParenthetical) hints.add(withoutParenthetical);
+  }
+
+  return [...hints];
+}
+
+/**
  * 一方がもう一方を含み、かつ短いほうが長いほうの半分以上あれば正解扱いにする。
  * 「入念に作り上げる」に対して「作り上げる」だけ答えた場合を拾うため。
  * 長さの下限を置かないと「する」だけで通ってしまうので 2 文字未満は弾く。
@@ -88,4 +109,20 @@ export function isJapaneseAnswerCorrect(transcript: string, japanese: string): b
   return japaneseAnswerCandidates(japanese).some((candidate) =>
     isCloseEnough(said, candidate),
   );
+}
+
+/**
+ * 音声認識が返した候補のどれかが正解なら正解とみなす。
+ *
+ * 日本語は同音異義語が多く、正しく発音していても最有力の変換が別の漢字に
+ * なることがある (「きづく」→「築く」/「気づく」)。読みを突き合わせるには
+ * 辞書が要るので、代わりに認識側から複数の変換候補を受け取り、その中に
+ * 正しい表記があれば拾う。音が違う語は候補に出てこないため、
+ * これで正解が甘くなることはない。
+ */
+export function isAnyJapaneseAnswerCorrect(
+  transcripts: readonly string[],
+  japanese: string,
+): boolean {
+  return transcripts.some((transcript) => isJapaneseAnswerCorrect(transcript, japanese));
 }

--- a/src/lib/quiz/voice-quiz-prompt.test.ts
+++ b/src/lib/quiz/voice-quiz-prompt.test.ts
@@ -5,6 +5,11 @@ import {
   buildVoiceQuizMeaningPrompt,
   canRetryVoiceQuiz,
   DEFAULT_VOICE_QUIZ_ATTEMPTS,
+  DEFAULT_VOICE_QUIZ_DURATION_SEC,
+  MAX_VOICE_QUIZ_DURATION_SEC,
+  MIN_VOICE_QUIZ_DURATION_SEC,
+  normalizeVoiceQuizDuration,
+  VOICE_QUIZ_DURATION_OPTIONS,
   DEFAULT_VOICE_QUIZ_COUNT,
   MAX_VOICE_QUIZ_COUNT,
   MAX_VOICE_QUIZ_ATTEMPTS,
@@ -155,4 +160,22 @@ test('resolveVoiceQuizCount falls back to the default for missing or junk values
 
 test('resolveVoiceQuizCount caps absurd values', () => {
   assert.equal(resolveVoiceQuizCount('99999'), MAX_VOICE_QUIZ_COUNT);
+});
+
+test('normalizeVoiceQuizDuration clamps to the supported range', () => {
+  assert.equal(normalizeVoiceQuizDuration(6), 6);
+  assert.equal(normalizeVoiceQuizDuration(1), MIN_VOICE_QUIZ_DURATION_SEC);
+  assert.equal(normalizeVoiceQuizDuration(999), MAX_VOICE_QUIZ_DURATION_SEC);
+});
+
+test('normalizeVoiceQuizDuration falls back to the default for junk input', () => {
+  for (const value of [undefined, null, 'abc', Number.NaN]) {
+    assert.equal(normalizeVoiceQuizDuration(value), DEFAULT_VOICE_QUIZ_DURATION_SEC);
+  }
+});
+
+test('every offered duration survives normalization unchanged', () => {
+  for (const option of VOICE_QUIZ_DURATION_OPTIONS) {
+    assert.equal(normalizeVoiceQuizDuration(option), option);
+  }
 });

--- a/src/lib/quiz/voice-quiz-prompt.ts
+++ b/src/lib/quiz/voice-quiz-prompt.ts
@@ -111,6 +111,32 @@ export const DEFAULT_VOICE_QUIZ_ATTEMPTS = 1;
 /** 選択肢として並べる試行回数。 */
 export const VOICE_QUIZ_ATTEMPT_OPTIONS: readonly number[] = [1, 2, 3];
 
+// ============ 解答時間 (duration) ============
+
+export const MIN_VOICE_QUIZ_DURATION_SEC = 4;
+export const MAX_VOICE_QUIZ_DURATION_SEC = 15;
+export const DEFAULT_VOICE_QUIZ_DURATION_SEC = 6;
+
+/** 開始画面に並べる解答時間の選択肢 (秒)。 */
+export const VOICE_QUIZ_DURATION_OPTIONS: readonly number[] = [4, 6, 10, 15];
+
+/**
+ * 外から来た解答時間を 4〜15秒 に丸める。
+ * 未指定 (null/undefined/空文字) は既定値に落とす。`Number(null)` は 0 になるため、
+ * ここで弾かないと「未指定」が最短の4秒として扱われてしまう。
+ */
+export function normalizeVoiceQuizDuration(value: unknown): number {
+  if (value === null || value === undefined || value === '') {
+    return DEFAULT_VOICE_QUIZ_DURATION_SEC;
+  }
+  const parsed = typeof value === 'number' ? value : Number(value);
+  if (!Number.isFinite(parsed)) return DEFAULT_VOICE_QUIZ_DURATION_SEC;
+  const floored = Math.floor(parsed);
+  if (floored < MIN_VOICE_QUIZ_DURATION_SEC) return MIN_VOICE_QUIZ_DURATION_SEC;
+  if (floored > MAX_VOICE_QUIZ_DURATION_SEC) return MAX_VOICE_QUIZ_DURATION_SEC;
+  return floored;
+}
+
 // ============ 出題数 (count) ============
 
 export const DEFAULT_VOICE_QUIZ_COUNT = 10;

--- a/src/lib/speech/cloud-speech-to-text.test.ts
+++ b/src/lib/speech/cloud-speech-to-text.test.ts
@@ -95,6 +95,83 @@ test('recognizeSpeech returns an empty transcript when GCP found no speech', asy
   }
 });
 
+/** 送信したリクエストボディを覗くための fetch。 */
+function capturingFetch(body: unknown) {
+  const seen: { url: string; payload: Record<string, never> | undefined } = { url: '', payload: undefined };
+  const fetchImpl = (async (url: string, init: { body: string }) => {
+    seen.url = url;
+    seen.payload = JSON.parse(init.body);
+    return { ok: true, status: 200, json: async () => body };
+  }) as unknown as typeof fetch;
+  return { fetchImpl, seen };
+}
+
+test('recognizeSpeech passes phrase hints to GCP as a speech context', async () => {
+  const { fetchImpl, seen } = capturingFetch({ results: [] });
+
+  await recognizeSpeech(
+    { audioBase64: 'AAAA', encoding: 'WEBM_OPUS', phraseHints: ['気づく', '  ', '認識する'] },
+    { apiKey: 'test-key', fetchImpl },
+  );
+
+  const config = (seen.payload as unknown as { config: Record<string, unknown> }).config;
+  assert.deepEqual(config.speechContexts, [{ phrases: ['気づく', '認識する'] }]);
+});
+
+test('recognizeSpeech omits speechContexts when there is nothing to hint', async () => {
+  const { fetchImpl, seen } = capturingFetch({ results: [] });
+
+  await recognizeSpeech(
+    { audioBase64: 'AAAA', encoding: 'WEBM_OPUS', phraseHints: ['   '] },
+    { apiKey: 'test-key', fetchImpl },
+  );
+
+  const config = (seen.payload as unknown as { config: Record<string, unknown> }).config;
+  assert.equal('speechContexts' in config, false);
+});
+
+test('recognizeSpeech clamps maxAlternatives into the range GCP accepts', async () => {
+  for (const [requested, expected] of [[5, 5], [0, 1], [999, 30]] as const) {
+    const { fetchImpl, seen } = capturingFetch({ results: [] });
+    await recognizeSpeech(
+      { audioBase64: 'AAAA', encoding: 'WEBM_OPUS', maxAlternatives: requested },
+      { apiKey: 'test-key', fetchImpl },
+    );
+    const config = (seen.payload as unknown as { config: Record<string, unknown> }).config;
+    assert.equal(config.maxAlternatives, expected);
+  }
+});
+
+test('recognizeSpeech returns every alternative so homophones can be checked', async () => {
+  const result = await recognizeSpeech(
+    { audioBase64: 'AAAA', encoding: 'WEBM_OPUS' },
+    {
+      apiKey: 'test-key',
+      fetchImpl: fakeFetch({
+        ok: true,
+        body: {
+          results: [
+            {
+              alternatives: [
+                { transcript: '築く', confidence: 0.8 },
+                { transcript: '気づく', confidence: 0.7 },
+                { transcript: '気づく' },
+              ],
+            },
+          ],
+        },
+      }),
+    },
+  );
+
+  assert.equal(result.success, true);
+  if (result.success) {
+    assert.equal(result.transcript, '築く');
+    // 重複は畳んだうえで、同音の別変換を残す。
+    assert.deepEqual(result.alternatives, ['築く', '気づく']);
+  }
+});
+
 test('recognizeSpeech surfaces the GCP error message on non-200 responses', async () => {
   const result = await recognizeSpeech(
     { audioBase64: 'AAAA', encoding: 'WEBM_OPUS' },

--- a/src/lib/speech/cloud-speech-to-text.ts
+++ b/src/lib/speech/cloud-speech-to-text.ts
@@ -23,12 +23,25 @@ export interface RecognizeSpeechInput {
   languageCode?: string;
   /** Required for LINEAR16; omitted for WEBM_OPUS/OGG_OPUS so GCP reads it from the container header. */
   sampleRateHertz?: number;
+  /**
+   * 認識のヒントに使う語 (speechContexts)。
+   * 日本語は同音異義語が多く、正しく発音していても別の漢字に変換されて
+   * 不正解になることがある。期待する表記を渡しておくと、音が同じ候補の中から
+   * その表記が選ばれやすくなる。音が違えば選ばれないので、答えの押し付けにはならない。
+   */
+  phraseHints?: string[];
+  /**
+   * 受け取る候補数。1にすると最有力の変換だけになり、同音異義語を取りこぼす。
+   */
+  maxAlternatives?: number;
 }
 
 export interface RecognizeSpeechResult {
   success: true;
   transcript: string;
   confidence: number;
+  /** 認識できた候補すべて (先頭が最有力)。同音異義語の判定に使う。 */
+  alternatives: string[];
 }
 
 /**
@@ -67,6 +80,21 @@ function pickBestAlternative(response: CloudSpeechApiResponse): CloudSpeechApiAl
   return null;
 }
 
+/** 全結果の候補を重複なく平坦化する。同音異義語の別変換がここに並ぶ。 */
+function collectAlternatives(response: CloudSpeechApiResponse): string[] {
+  const transcripts = new Set<string>();
+  for (const result of response.results ?? []) {
+    for (const alternative of result.alternatives ?? []) {
+      const transcript = alternative.transcript?.trim();
+      if (transcript) transcripts.add(transcript);
+    }
+  }
+  return [...transcripts];
+}
+
+/** GCPが受け付ける上限。 */
+const MAX_SPEECH_ALTERNATIVES = 30;
+
 export interface RecognizeSpeechDeps {
   fetchImpl?: typeof fetch;
   apiKey?: string;
@@ -95,12 +123,23 @@ export async function recognizeSpeech(
   const config: Record<string, unknown> = {
     encoding: input.encoding,
     languageCode: input.languageCode ?? 'en-US',
-    maxAlternatives: 1,
+    maxAlternatives: Math.min(
+      Math.max(input.maxAlternatives ?? 1, 1),
+      MAX_SPEECH_ALTERNATIVES,
+    ),
     // 単語1語の短い発話が対象のため、通話・動画向けenhancedモデルは不要。
     model: 'default',
   };
   if (input.encoding === 'LINEAR16' && input.sampleRateHertz) {
     config.sampleRateHertz = input.sampleRateHertz;
+  }
+
+  // 期待する表記をヒントとして渡し、同音異義語の変換先を寄せる。
+  const phrases = (input.phraseHints ?? [])
+    .map((phrase) => phrase.trim())
+    .filter((phrase) => phrase.length > 0);
+  if (phrases.length > 0) {
+    config.speechContexts = [{ phrases }];
   }
 
   try {
@@ -128,6 +167,7 @@ export async function recognizeSpeech(
       success: true,
       transcript: best?.transcript?.trim() ?? '',
       confidence: typeof best?.confidence === 'number' ? best.confidence : 0,
+      alternatives: data ? collectAlternatives(data) : [],
     };
   } catch (error) {
     return {


### PR DESCRIPTION
Three requests for 音読チャレンジ: a way to stop, a way to change the answer time, and grading that survives homophone misconversion.

## 停止導線

Closing the quiz used to drop the learner straight back to the word list, silently discarding the session. The × now opens a confirmation that **first halts everything** — bumps the question run so in-flight callbacks resolve to nothing, stops the recorder and narration, freezes the countdown — then offers:

- **続ける** — re-asks the current question
- **ここまでの結果を見る** — finishes early with the score so far (hidden when nothing has been answered yet)
- **記録せずに戻る** — leaves without recording

Auto-advance is suspended while the dialog is open, so a question can't slip past behind it. Verified: the dialog was still showing after 5s, well past the 3.8s auto-advance window. The confirmation reuses the shared `Modal` (escape key, backdrop, scroll lock) rather than hand-rolling one.

## 録音時間の調整導線

The 6-second window was a hard-coded constant. It's now chosen on the start screen — **4 / 6 / 10 / 15秒** — next to the attempts picker. The two pickers had identical markup, so they now share one `SegmentedOptions` component instead of repeating it.

The countdown reads the duration from a ref, so a question already in flight keeps the value it started with. Verified end to end: selecting 15秒 updates the summary chip and the ring starts at **15** and ticks to **14**.

## 同音異義語

Japanese speech recognition often picks the wrong kanji for a homophone, so a correctly spoken answer was graded wrong — 「きづく」 transcribed as 「築く」 against an expected 「気づく」.

You asked for comparison by hiragana. Matching on *readings* needs a morphological dictionary to convert kanji to kana, and `Word` carries no reading field; kuromoji ships ~15MB of dictionary, too much for either the quiz page or a serverless function. So the fix works with the recogniser instead, which gets the same outcome:

- the expected meanings are sent as **`speechContexts` phrase hints**, biasing conversion toward the right spelling among identical-sounding candidates
- **`maxAlternatives` is raised to 5 and every returned candidate is checked**, so a wrong top pick no longer decides the answer alone

This does not loosen grading — a word that *sounds* different is never returned as a candidate, and an all-wrong candidate list still fails. Existing kana folding (katakana→hiragana, width, punctuation) is unchanged.

One subtlety worth flagging: hints use the **raw** meaning, not the comparison-normalised form. Normalisation folds long vowels (「コーヒー」→「こひ」), which would make the hint worse than useless. That's covered by a test.

If misgrading still shows up in practice, the next step would be storing a reading per word (generated once, like example sentences) and comparing those — a bigger change, happy to do it if needed.

## Verification

- `npm test` — 1275/1277. The 2 failures (`otp.contract`, `words/create`) reproduce on an unmodified tree and are unrelated. 25 tests cover the new behaviour.
- `npx tsc --noEmit` no new errors; `npx eslint` on changed files clean; `npx next build` compiles.
- Driven in a real browser at iPhone size: duration selection, phrase hints on the wire (`phraseHints: ["入念に作り上げる"]`, `languageCode: "ja-JP"`), the pause dialog, and early-finish all confirmed.

`security` will fail for the same pre-existing dependency advisories as before; this branch changes no dependencies.

---
_Generated by [Claude Code](https://claude.ai/code/session_0159t4xQyZDQmD1P7ytrWak5)_