### PR TITLE
Honour the saved quiz mode on every visit, not only when it is chosen

### DIFF
--- a/src/app/api/voice-quiz/recognize/route.test.ts
+++ b/src/app/api/voice-quiz/recognize/route.test.ts
@@ -66,7 +66,7 @@ test('voice-quiz recognize returns the transcript on success', async () => {
     jsonRequest({ audioBase64: 'AAAA', encoding: 'WEBM_OPUS' }, { authorization: 'Bearer token-1' }),
     {
       createClient: async () => createClient() as never,
-      recognize: async () => ({ success: true, transcript: 'clarify', confidence: 0.9 }),
+      recognize: async () => ({ success: true, transcript: 'clarify', confidence: 0.9, alternatives: ['clarify'] }),
     },
   );
 

--- a/src/app/quiz/[projectId]/page.tsx
+++ b/src/app/quiz/[projectId]/page.tsx
@@ -601,7 +601,7 @@ export default function QuizPage() {
    * その形式で始められるようにするため。入力済みの問題数は引き継ぐ
    * (上限の丸めは遷移先で行う)。
    */
-  const goToVoiceQuiz = useCallback(() => {
+  const goToVoiceQuiz = useCallback((options?: { replace?: boolean }) => {
     writeQuizMode('voice');
     const params = new URLSearchParams();
     const parsedInput = Number.parseInt(inputCount, 10);
@@ -609,8 +609,11 @@ export default function QuizPage() {
     if (count && count > 0) params.set('count', String(count));
     if (returnPath) params.set('from', returnPath);
     const query = params.toString();
+    const href = `/voice-quiz/${projectId}${query ? `?${query}` : ''}`;
     // 進行中のクイズ状態(sessionStorage)は消さない。戻ってきたら続きから再開できる。
-    router.push(`/voice-quiz/${projectId}${query ? `?${query}` : ''}`);
+    // 自動送りは replace。push にすると「戻る」でここへ戻され、また送られて堂々巡りになる。
+    if (options?.replace) router.replace(href);
+    else router.push(href);
   }, [inputCount, questionCount, returnPath, router, projectId]);
 
   // 端末の選択を読む。未選択ならクイズの前に選択画面を出す。
@@ -618,6 +621,18 @@ export default function QuizPage() {
     setStoredMode(readQuizMode());
     setModeLoaded(true);
   }, []);
+
+  /**
+   * この端末が音読チャレンジを選んでいるなら、四択を開いても音読へ送る。
+   * 選んだ直後だけでなく「次に開いたとき」も選択を守るために要る。
+   * 遷移は一度きり ——依存が変わるたびに router を叩かないよう ref で止める。
+   */
+  const redirectedToVoiceRef = useRef(false);
+  useEffect(() => {
+    if (!modeLoaded || storedMode !== 'voice' || redirectedToVoiceRef.current) return;
+    redirectedToVoiceRef.current = true;
+    goToVoiceQuiz({ replace: true });
+  }, [modeLoaded, storedMode, goToVoiceQuiz]);
 
   /** 形式を選んだ。四択ならこの画面のまま、音読なら音読チャレンジへ移る。 */
   const chooseMode = useCallback(
@@ -1271,6 +1286,18 @@ export default function QuizPage() {
     );
   }
 
+  /* ---------- 音読チャレンジが選ばれている: 送るまで四択を描かない ---------- */
+  if (storedMode === 'voice') {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-[var(--color-background)]">
+        <div className="text-center">
+          <div className="mx-auto mb-4 h-12 w-12 animate-spin rounded-full border-4 border-[var(--solid-ink)] border-t-transparent" />
+          <p className="text-[var(--color-muted)]">音読チャレンジを開いています...</p>
+        </div>
+      </div>
+    );
+  }
+
   /* ---------- この端末でまだ形式を選んでいない ---------- */
   if (storedMode === null) {
     return (
@@ -1332,7 +1359,8 @@ export default function QuizPage() {
         <div className="flex flex-1 flex-col items-center justify-center p-6">
           <div className="w-full max-w-sm">
             <div className="mb-5">
-              <QuizModeTabs active="normal" onSelect={goToVoiceQuiz} />
+              {/* タブは選ばれたキーを渡してくるので、遷移オプションと混ざらないよう包む。 */}
+              <QuizModeTabs active="normal" onSelect={() => goToVoiceQuiz()} />
             </div>
             <h1 className="mb-2 text-center font-display text-2xl font-black text-[var(--solid-ink)]">問題数を入力</h1>
             <p className="mb-4 text-center text-[var(--color-muted)]">1〜{maxQ}問まで</p>

--- a/src/app/voice-quiz/[projectId]/page.tsx
+++ b/src/app/voice-quiz/[projectId]/page.tsx
@@ -122,6 +122,7 @@ export default function VoiceQuizPage() {
     setModeLoaded(true);
   }, []);
 
+
   /** 形式を選んだ。音読ならこの画面のまま、四択なら通常クイズへ移る。 */
   const chooseMode = useCallback(
     (mode: QuizMode) => {
@@ -199,6 +200,20 @@ export default function VoiceQuizPage() {
   const startListeningRef = useRef<(run: number) => void>(() => {});
 
   const currentWord = words[currentIndex] ?? null;
+
+  /**
+   * この端末が四択を選んでいるなら、音読を開いても四択へ送る。
+   * 通常クイズ側と対になる処理。goToNormalQuiz は replace なので堂々巡りにならない。
+   *
+   * この効果は state の宣言より後ろに置くこと —— 依存配列はレンダー中に評価されるので、
+   * 宣言前に書くと modeLoaded が TDZ に入って落ちる。
+   */
+  const redirectedToNormalRef = useRef(false);
+  useEffect(() => {
+    if (!modeLoaded || storedMode !== 'normal' || redirectedToNormalRef.current) return;
+    redirectedToNormalRef.current = true;
+    goToNormalQuiz();
+  }, [modeLoaded, storedMode, goToNormalQuiz]);
 
   // マイク権限 + MediaRecorder対応を一度だけ確認する。
   useEffect(() => {
@@ -574,6 +589,18 @@ export default function VoiceQuizPage() {
           <p className="text-[var(--color-muted)]">
             {setupState === 'checking' ? 'マイクを確認中...' : '準備中...'}
           </p>
+        </div>
+      </div>
+    );
+  }
+
+  // 四択が選ばれている: 送るまで音読の画面は描かない (マイクも起こさない)。
+  if (storedMode === 'normal') {
+    return (
+      <div className="h-screen flex items-center justify-center bg-[var(--color-background)] overflow-hidden">
+        <div className="text-center">
+          <div className="w-12 h-12 border-4 border-[var(--color-primary)] border-t-transparent rounded-full animate-spin mx-auto mb-4" />
+          <p className="text-[var(--color-muted)]">通常クイズを開いています...</p>
         </div>
       </div>
     );


### PR DESCRIPTION
Fixes the reported bug: **choosing 音声 and then opening a quiz again still gave the four-choice quiz.**

## Cause

The stored mode was only consulted to decide whether to show the first-run chooser:

```ts
if (storedMode === null) { /* 選択画面 */ }
```

Once a mode existed, `/quiz` rendered the four-choice quiz regardless of what the device had chosen. The preference was honoured exactly once — at the moment it was picked — and never again. Shipping the chooser without the corresponding redirect was the gap in #476.

## Fix

Both pages now act on the stored mode on **every** visit: `/quiz` sends a voice device to the voice quiz, and `/voice-quiz` sends a four-choice device back. Each holds a loading state until the redirect lands, so the wrong quiz never flashes — and the voice page avoids waking the microphone on a device that isn't using it.

The redirect **replaces** rather than pushes, so Back doesn't bounce the learner between the two, and a ref keeps it to a single navigation as its dependencies change.

## Two defects this uncovered

- **`goToVoiceQuiz`'s new options argument collided with `QuizModeTabs`.** The tab calls `onSelect(key)`, so it handed the function a string — whose truthy `.replace` method meant every tab switch silently became a replace instead of a push. Caught by `next build`; wrapped at the call site.
- **A `recognize` stub in the route tests never grew the `alternatives` field** added in #475, so it had been failing `tsc` on main while still passing at runtime. I reported "no new type errors" for #475 — my filter there was too narrow and missed it. Fixed here.

## Verification

Driven in a real browser:

| 端末の保存値 | 開いたURL | 結果 |
|---|---|---|
| `voice` | `/quiz` | → `/voice-quiz`、音読の開始画面 ✅ |
| `normal` | `/voice-quiz` | → `/quiz` ✅ |
| 未設定 | `/quiz` | 選択画面 ✅ |

- `npm test` — 1282/1284 (the 2 failures reproduce on an unmodified tree and are unrelated).
- `npx tsc --noEmit` — clean apart from the 2 unrelated pre-existing failures; `npx next build` compiles.

`security` will fail for the same pre-existing dependency advisories; this branch changes no dependencies.

---
_Generated by [Claude Code](https://claude.ai/code/session_0159t4xQyZDQmD1P7ytrWak5)_