### PR TITLE
Let the direction be chosen, and add ways out of a question

### DIFF
--- a/src/app/api/voice-quiz/recognize/route.test.ts
+++ b/src/app/api/voice-quiz/recognize/route.test.ts
@@ -66,7 +66,7 @@ test('voice-quiz recognize returns the transcript on success', async () => {
     jsonRequest({ audioBase64: 'AAAA', encoding: 'WEBM_OPUS' }, { authorization: 'Bearer token-1' }),
     {
       createClient: async () => createClient() as never,
-      recognize: async () => ({ success: true, transcript: 'clarify', confidence: 0.9 }),
+      recognize: async () => ({ success: true, transcript: 'clarify', confidence: 0.9, alternatives: ['clarify'] }),
     },
   );
 

--- a/src/app/quiz/[projectId]/page.tsx
+++ b/src/app/quiz/[projectId]/page.tsx
@@ -601,7 +601,7 @@ export default function QuizPage() {
    * その形式で始められるようにするため。入力済みの問題数は引き継ぐ
    * (上限の丸めは遷移先で行う)。
    */
-  const goToVoiceQuiz = useCallback(() => {
+  const goToVoiceQuiz = useCallback((options?: { replace?: boolean }) => {
     writeQuizMode('voice');
     const params = new URLSearchParams();
     const parsedInput = Number.parseInt(inputCount, 10);
@@ -609,8 +609,11 @@ export default function QuizPage() {
     if (count && count > 0) params.set('count', String(count));
     if (returnPath) params.set('from', returnPath);
     const query = params.toString();
+    const href = `/voice-quiz/${projectId}${query ? `?${query}` : ''}`;
     // 進行中のクイズ状態(sessionStorage)は消さない。戻ってきたら続きから再開できる。
-    router.push(`/voice-quiz/${projectId}${query ? `?${query}` : ''}`);
+    // 自動送りは replace。push にすると「戻る」でここへ戻され、また送られて堂々巡りになる。
+    if (options?.replace) router.replace(href);
+    else router.push(href);
   }, [inputCount, questionCount, returnPath, router, projectId]);
 
   // 端末の選択を読む。未選択ならクイズの前に選択画面を出す。
@@ -618,6 +621,18 @@ export default function QuizPage() {
     setStoredMode(readQuizMode());
     setModeLoaded(true);
   }, []);
+
+  /**
+   * この端末が音読チャレンジを選んでいるなら、四択を開いても音読へ送る。
+   * 選んだ直後だけでなく「次に開いたとき」も選択を守るために要る。
+   * 遷移は一度きり ——依存が変わるたびに router を叩かないよう ref で止める。
+   */
+  const redirectedToVoiceRef = useRef(false);
+  useEffect(() => {
+    if (!modeLoaded || storedMode !== 'voice' || redirectedToVoiceRef.current) return;
+    redirectedToVoiceRef.current = true;
+    goToVoiceQuiz({ replace: true });
+  }, [modeLoaded, storedMode, goToVoiceQuiz]);
 
   /** 形式を選んだ。四択ならこの画面のまま、音読なら音読チャレンジへ移る。 */
   const chooseMode = useCallback(
@@ -1271,6 +1286,18 @@ export default function QuizPage() {
     );
   }
 
+  /* ---------- 音読チャレンジが選ばれている: 送るまで四択を描かない ---------- */
+  if (storedMode === 'voice') {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-[var(--color-background)]">
+        <div className="text-center">
+          <div className="mx-auto mb-4 h-12 w-12 animate-spin rounded-full border-4 border-[var(--solid-ink)] border-t-transparent" />
+          <p className="text-[var(--color-muted)]">音読チャレンジを開いています...</p>
+        </div>
+      </div>
+    );
+  }
+
   /* ---------- この端末でまだ形式を選んでいない ---------- */
   if (storedMode === null) {
     return (
@@ -1332,7 +1359,8 @@ export default function QuizPage() {
         <div className="flex flex-1 flex-col items-center justify-center p-6">
           <div className="w-full max-w-sm">
             <div className="mb-5">
-              <QuizModeTabs active="normal" onSelect={goToVoiceQuiz} />
+              {/* タブは選ばれたキーを渡してくるので、遷移オプションと混ざらないよう包む。 */}
+              <QuizModeTabs active="normal" onSelect={() => goToVoiceQuiz()} />
             </div>
             <h1 className="mb-2 text-center font-display text-2xl font-black text-[var(--solid-ink)]">問題数を入力</h1>
             <p className="mb-4 text-center text-[var(--color-muted)]">1〜{maxQ}問まで</p>

--- a/src/app/voice-quiz/[projectId]/page.tsx
+++ b/src/app/voice-quiz/[projectId]/page.tsx
@@ -11,10 +11,14 @@ import { getRepository } from '@/lib/db';
 import { cn, recordCorrectAnswer, recordWrongAnswer, recordActivity, getGuestUserId } from '@/lib/utils';
 import { calculateNextReview, getStatusAfterAnswer, sortWordsByPriority } from '@/lib/spaced-repetition';
 import { playAnswerFeedbackSound } from '@/lib/audio/answer-feedback';
-import { speakAndWait, speakEnglish, stopSpeaking } from '@/lib/speech';
+import { speakAndWait, stopSpeaking } from '@/lib/speech';
 import {
-  buildVoiceQuizMeaningPrompt,
+  buildVoiceQuizAnswerAnnouncement,
+  buildVoiceQuizPromptFor,
   canRetryVoiceQuiz,
+  DEFAULT_VOICE_QUIZ_DIRECTION,
+  recognitionLanguageFor,
+  type VoiceQuizDirection,
   DEFAULT_VOICE_QUIZ_ATTEMPTS,
   DEFAULT_VOICE_QUIZ_DURATION_SEC,
   MAX_VOICE_QUIZ_DURATION_SEC,
@@ -27,7 +31,11 @@ import {
   resolveVoiceQuizCount,
   VOICE_QUIZ_ATTEMPT_OPTIONS,
 } from '@/lib/quiz/voice-quiz-prompt';
-import { isAnyJapaneseAnswerCorrect, japaneseAnswerHints } from '@/lib/quiz/voice-quiz-answer';
+import {
+  isAnyEnglishAnswerCorrect,
+  isAnyJapaneseAnswerCorrect,
+  japaneseAnswerHints,
+} from '@/lib/quiz/voice-quiz-answer';
 import { useAuth } from '@/hooks/use-auth';
 import type { Word, SubscriptionStatus } from '@/types';
 
@@ -35,11 +43,11 @@ const TIMER_TICK_MS = 50;
 
 /**
  * 「次へ」を押さなくても自動で次の問題へ進むまでの待ち時間。
- * finishQuestion が500ms後に正解を読み上げるので、それを聞き終えられる長さにする。
- * 不正解のときは正解を読み取る時間が要るので長めに取る。
+ * 正解のときはテンポを優先してすぐ進む。読み上げも挟まない。
+ * 不正解のときは「正解は〜です」を聞き終えられるだけの間を取る。
  */
-const AUTO_ADVANCE_CORRECT_MS = 2200;
-const AUTO_ADVANCE_INCORRECT_MS = 3800;
+const AUTO_ADVANCE_CORRECT_MS = 1000;
+const AUTO_ADVANCE_INCORRECT_MS = 4200;
 
 /* --- Merken Design System (Solid) のトークン --- */
 /** 面を持つ要素の枠。ハードシャドウは大きさに応じて2種類使い分ける。 */
@@ -162,6 +170,12 @@ export default function VoiceQuizPage() {
   const [isCorrect, setIsCorrect] = useState(false);
   const [isDisqualified, setIsDisqualified] = useState(false);
   const [recognitionErrored, setRecognitionErrored] = useState(false);
+  /** 出題の向き。開始画面で選ぶ。 */
+  const [direction, setDirection] = useState<VoiceQuizDirection>(DEFAULT_VOICE_QUIZ_DIRECTION);
+  /** 答えるのが日本語か (英→日)。画面の文言と主従はこれで決まる。 */
+  const askingForJapanese = direction === 'en-to-ja';
+  /** 「わからない」で答えを見た問題か。失格とは区別して表示する。 */
+  const [gaveUp, setGaveUp] = useState(false);
   /** 中断の確認を出しているか。出している間はクイズを止める。 */
   const [showStopConfirm, setShowStopConfirm] = useState(false);
   /**
@@ -187,6 +201,8 @@ export default function VoiceQuizPage() {
    * 出題中に値が変わらない ref を唯一の参照元にする。
    */
   const durationMsRef = useRef(DEFAULT_VOICE_QUIZ_DURATION_SEC * 1000);
+  /** 出題中に向きが変わらないよう、出題〜採点はこの ref を参照する。 */
+  const directionRef = useRef<VoiceQuizDirection>(DEFAULT_VOICE_QUIZ_DIRECTION);
   const questionRunRef = useRef(0);
   /**
    * いま出題中の単語。`setCurrentIndex` の反映は次のレンダーまで待たされるので、
@@ -281,17 +297,19 @@ export default function VoiceQuizPage() {
 
   /** 1問を確定させる。以降この問題では再挑戦しない。 */
   const finishQuestion = useCallback(
-    async (transcript: string, correct: boolean, apiErrored: boolean) => {
+    async (transcript: string, correct: boolean, apiErrored: boolean, skipped = false) => {
       const word = activeWordRef.current;
       if (!word) return;
       timerStartRef.current = null;
 
-      const disqualified = !transcript;
+      // 「わからない」は自分から答えを見に行った操作なので、時間切れの失格とは分ける。
+      const disqualified = !skipped && !transcript;
 
       playAnswerFeedbackSound(correct);
       setRecognizedText(transcript);
       setIsCorrect(correct);
       setIsDisqualified(disqualified);
+      setGaveUp(skipped);
       setRecognitionErrored(apiErrored);
       setPhase('answered');
 
@@ -308,8 +326,18 @@ export default function VoiceQuizPage() {
       }
       recordActivity();
 
-      // 正解の発音を聞かせる。
-      window.setTimeout(() => speakEnglish(word.english), 500);
+      // 正解ならすぐ次へ行くので何も読まない。外したときだけ正解を知らせる。
+      if (!correct) {
+        const announcement = buildVoiceQuizAnswerAnnouncement(directionRef.current, word);
+        const announcementRun = questionRunRef.current;
+        void (async () => {
+          for (const segment of announcement) {
+            // 次の問題へ進んだあとに前の答えが流れ続けないよう、毎回確かめる。
+            if (questionRunRef.current !== announcementRun) return;
+            await speakAndWait(segment.text, segment.lang);
+          }
+        })();
+      }
 
       try {
         const newStatus = getStatusAfterAnswer(word.status, correct);
@@ -332,7 +360,9 @@ export default function VoiceQuizPage() {
 
       // 最有力の変換が同音異義語で外れることがあるので、候補全体で突き合わせる。
       const heard = [transcript, ...alternatives].filter(Boolean);
-      const correct = isAnyJapaneseAnswerCorrect(heard, word.japanese);
+      const correct = directionRef.current === 'en-to-ja'
+        ? isAnyJapaneseAnswerCorrect(heard, word.japanese)
+        : isAnyEnglishAnswerCorrect(heard, word.english);
 
       // 音声認識自体が失敗した場合は、ユーザーの責任ではないので再挑戦させずに確定する。
       if (correct || apiErrored || !canRetryVoiceQuiz(attemptRef.current, attemptsAllowedRef.current)) {
@@ -403,9 +433,12 @@ export default function VoiceQuizPage() {
               body: JSON.stringify({
                 audioBase64,
                 encoding: recordedEncoding,
-                languageCode: 'ja-JP',
-                // 同音異義語の変換先を正解の表記に寄せる。
-                phraseHints: japaneseAnswerHints(activeWordRef.current?.japanese ?? ''),
+                languageCode: recognitionLanguageFor(directionRef.current),
+                // 期待する表記をヒントに渡す。日本語は同音異義語の変換先を寄せるため、
+                // 英語は綴りの近い語に流れるのを防ぐため。
+                phraseHints: directionRef.current === 'en-to-ja'
+                  ? japaneseAnswerHints(activeWordRef.current?.japanese ?? '')
+                  : [activeWordRef.current?.english ?? ''].filter(Boolean),
               }),
             });
             const data = await response.json();
@@ -455,6 +488,7 @@ export default function VoiceQuizPage() {
     setRecognizedText('');
     setIsCorrect(false);
     setIsDisqualified(false);
+    setGaveUp(false);
     setRecognitionErrored(false);
     setTimeLeft(durationMsRef.current);
     setPhase('narrating');
@@ -462,8 +496,9 @@ export default function VoiceQuizPage() {
     void (async () => {
       // 出題文は1文だが、英単語の部分だけ英語の声に切り替える。
       // 日本語の声で英単語を読ませると別の単語に聞こえてしまうため。
-      const segments = buildVoiceQuizMeaningPrompt(
-        word.english,
+      const segments = buildVoiceQuizPromptFor(
+        directionRef.current,
+        word,
         promptOffsetRef.current + run,
       );
       for (const segment of segments) {
@@ -517,6 +552,23 @@ export default function VoiceQuizPage() {
   }, [phase, isCorrect, showStopConfirm]);
 
   /**
+   * 「わからない」。答えをすぐ出す。
+   *
+   * 録音は捨て、音声認識には一切かけない —— 分からないと分かっている発話を
+   * 送っても、待ち時間とAPI利用が増えるだけで得るものが無い。
+   * run を進めてから recorder を止めるので、進行中の onstop は送信前に降りる。
+   */
+  const giveUp = useCallback(() => {
+    if (attemptSettledRef.current) return;
+    attemptSettledRef.current = true;
+    questionRunRef.current += 1;
+    try { recorderRef.current?.stop(); } catch {}
+    stopSpeaking();
+    timerStartRef.current = null;
+    void finishQuestion('', false, false, true);
+  }, [finishQuestion]);
+
+  /**
    * 中断の確認を開く。開いている間はクイズを完全に止める。
    * 進行中の読み上げ・録音を切り、run を進めて解決済みのコールバックを無効化する
    * (これをしないと、確認中に録音が採点まで走ってしまう)。
@@ -550,6 +602,7 @@ export default function VoiceQuizPage() {
 
   const beginSession = (attempts: number, seconds: number) => {
     if (words.length === 0) return;
+    directionRef.current = direction;
     attemptsAllowedRef.current = normalizeVoiceQuizAttempts(attempts);
     setAttemptsAllowed(attemptsAllowedRef.current);
 
@@ -683,14 +736,48 @@ export default function VoiceQuizPage() {
               音読チャレンジ
             </h1>
             <p className="mt-3 text-sm leading-6 text-[var(--color-muted)]">
-              読み上げられた英単語の意味を、
+              {askingForJapanese ? '読み上げられた英単語の意味を、' : '読み上げられた意味の英単語を、'}
               <br />
-              {durationSec}秒以内に日本語で答えてください。
+              {durationSec}秒以内に{askingForJapanese ? '日本語' : '英語'}で答えてください。
             </p>
 
             <div className="mt-5 grid grid-cols-2 gap-2">
               <StatChip icon="list" label="出題数" value={`${words.length}問`} />
               <StatChip icon="timer" label="解答時間" value={`${durationSec}秒`} />
+            </div>
+
+            <p className={cn(EYEBROW, 'mt-6 mb-2 text-left text-[var(--color-muted)]')}>出題の向き</p>
+            <div className="flex gap-2" role="group" aria-label="出題の向き">
+              {([
+                { key: 'en-to-ja' as const, label: '英 → 日', hint: '意味を日本語で' },
+                { key: 'ja-to-en' as const, label: '日 → 英', hint: '英単語を英語で' },
+              ]).map((option) => {
+                const selected = direction === option.key;
+                return (
+                  <button
+                    key={option.key}
+                    type="button"
+                    aria-pressed={selected}
+                    onClick={() => setDirection(option.key)}
+                    className={cn(
+                      'flex-1 rounded-[var(--solid-radius-sm)] border-2 border-[var(--solid-ink)] px-2 py-2.5 transition-all duration-100 active:translate-x-px active:translate-y-px',
+                      selected
+                        ? cn('bg-[var(--solid-ink)] text-[var(--color-surface)]', HARD_SHADOW_SM)
+                        : 'bg-[var(--color-surface)] text-[var(--solid-ink)]',
+                    )}
+                  >
+                    <span className="block font-display text-base font-black">{option.label}</span>
+                    <span
+                      className={cn(
+                        'mt-0.5 block text-[10px] font-bold',
+                        selected ? 'text-[var(--color-surface)]/70' : 'text-[var(--color-muted)]',
+                      )}
+                    >
+                      {option.hint}
+                    </span>
+                  </button>
+                );
+              })}
             </div>
 
             <SegmentedOptions
@@ -879,7 +966,18 @@ export default function VoiceQuizPage() {
   return (
     <div className="h-dvh flex flex-col bg-[var(--color-background)] overflow-hidden fixed inset-0">
       <header className="sticky top-0 flex-shrink-0 flex items-center gap-3 p-4">
-        <CloseButton onClick={requestStop} label="中断する" />
+        {/* アイコンだけだと終了できると分からないので、文字を出す。 */}
+        <button
+          type="button"
+          onClick={requestStop}
+          className={cn(
+            'inline-flex shrink-0 items-center gap-1 rounded-full border-2 border-[var(--solid-ink)] bg-[var(--color-surface)] px-3 py-1.5 font-display text-xs font-black text-[var(--solid-ink)] transition-all duration-100 active:translate-x-px active:translate-y-px',
+            HARD_SHADOW_SM,
+          )}
+        >
+          <Icon name="close" size={15} />
+          終了
+        </button>
 
         <div className="h-3 flex-1 overflow-hidden rounded-full border-2 border-[var(--solid-ink)] bg-[var(--color-surface)]">
           <div
@@ -911,9 +1009,9 @@ export default function VoiceQuizPage() {
               <div className={cn(SOLID_SURFACE, HARD_SHADOW, 'mb-7 px-5 py-4 text-center')}>
                 <p className={cn(EYEBROW, 'text-[var(--color-accent)]')}>Question</p>
                 <p className="mt-1.5 font-display text-[1.75rem] font-black leading-tight text-[var(--solid-ink)]">
-                  {currentWord.english}
+                  {askingForJapanese ? currentWord.english : currentWord.japanese}
                 </p>
-                {currentWord.pronunciation && (
+                {askingForJapanese && currentWord.pronunciation && (
                   <p className="mt-1 font-mono text-xs text-[var(--color-muted)]">
                     {currentWord.pronunciation}
                   </p>
@@ -964,13 +1062,13 @@ export default function VoiceQuizPage() {
                   <div className="flex items-center gap-2">
                     <span className="h-2.5 w-2.5 shrink-0 rounded-full bg-[var(--color-error,#ef4444)] animate-pulse" />
                     <p className="font-display text-base font-black text-[var(--solid-ink)]">
-                      録音中 — 日本語で意味を答えてください
+                      録音中 — {askingForJapanese ? '日本語で意味を答えてください' : '英語で答えてください'}
                     </p>
                   </div>
 
                   {attemptsAllowed > 1 && <AttemptPill current={attemptNumber} total={attemptsAllowed} />}
 
-                  {/* 6秒待たずに送れるようにする。何をすればいいかも明示される。 */}
+                  {/* 時間切れを待たずに送れるようにする。何をすればいいかも明示される。 */}
                   <SolidButton
                     variant="accent"
                     size="lg"
@@ -979,6 +1077,16 @@ export default function VoiceQuizPage() {
                     className={cn('mt-1 w-full', HARD_SHADOW)}
                   >
                     話し終わった
+                  </SolidButton>
+
+                  {/* 音声認識にかけず、すぐ答えを出す。 */}
+                  <SolidButton
+                    size="md"
+                    iconLeft="help"
+                    onClick={giveUp}
+                    className={cn('w-full', HARD_SHADOW_SM)}
+                  >
+                    わからない
                   </SolidButton>
                 </>
               )}
@@ -1013,7 +1121,7 @@ export default function VoiceQuizPage() {
               {phase === 'answered' && (
                 <>
                   <PhaseOrb
-                    icon={isCorrect ? 'check' : isDisqualified ? 'timer_off' : 'close'}
+                    icon={isCorrect ? 'check' : gaveUp ? 'help' : isDisqualified ? 'timer_off' : 'close'}
                     className={isCorrect ? 'bg-[var(--color-success)]' : 'bg-[var(--color-error,#ef4444)]'}
                     iconClassName="text-white"
                   />
@@ -1023,7 +1131,7 @@ export default function VoiceQuizPage() {
                       isCorrect ? 'text-[var(--color-success)]' : 'text-[var(--color-error,#ef4444)]',
                     )}
                   >
-                    {isCorrect ? '正解!' : isDisqualified ? '失格!' : '不正解'}
+                    {isCorrect ? '正解!' : gaveUp ? 'わからない' : isDisqualified ? '失格!' : '不正解'}
                   </p>
                   {recognitionErrored && (
                     <p className="text-xs text-[var(--color-muted)]">音声認識に失敗しました</p>
@@ -1033,10 +1141,10 @@ export default function VoiceQuizPage() {
                   <div className={cn(SOLID_SURFACE, HARD_SHADOW, 'mt-1 w-full px-5 py-4')}>
                     <p className={cn(EYEBROW, 'text-[var(--color-muted)]')}>Answer</p>
                     <p className="mt-1 font-display text-[1.75rem] font-black leading-tight text-[var(--solid-ink)]">
-                      {currentWord.japanese}
+                      {askingForJapanese ? currentWord.japanese : currentWord.english}
                     </p>
                     <p className="mt-1 font-mono text-sm text-[var(--color-muted)]">
-                      {currentWord.english}
+                      {askingForJapanese ? currentWord.english : currentWord.japanese}
                     </p>
                   </div>
                 </>

--- a/src/app/voice-quiz/[projectId]/page.tsx
+++ b/src/app/voice-quiz/[projectId]/page.tsx
@@ -122,6 +122,7 @@ export default function VoiceQuizPage() {
     setModeLoaded(true);
   }, []);
 
+
   /** 形式を選んだ。音読ならこの画面のまま、四択なら通常クイズへ移る。 */
   const chooseMode = useCallback(
     (mode: QuizMode) => {
@@ -199,6 +200,20 @@ export default function VoiceQuizPage() {
   const startListeningRef = useRef<(run: number) => void>(() => {});
 
   const currentWord = words[currentIndex] ?? null;
+
+  /**
+   * この端末が四択を選んでいるなら、音読を開いても四択へ送る。
+   * 通常クイズ側と対になる処理。goToNormalQuiz は replace なので堂々巡りにならない。
+   *
+   * この効果は state の宣言より後ろに置くこと —— 依存配列はレンダー中に評価されるので、
+   * 宣言前に書くと modeLoaded が TDZ に入って落ちる。
+   */
+  const redirectedToNormalRef = useRef(false);
+  useEffect(() => {
+    if (!modeLoaded || storedMode !== 'normal' || redirectedToNormalRef.current) return;
+    redirectedToNormalRef.current = true;
+    goToNormalQuiz();
+  }, [modeLoaded, storedMode, goToNormalQuiz]);
 
   // マイク権限 + MediaRecorder対応を一度だけ確認する。
   useEffect(() => {
@@ -574,6 +589,18 @@ export default function VoiceQuizPage() {
           <p className="text-[var(--color-muted)]">
             {setupState === 'checking' ? 'マイクを確認中...' : '準備中...'}
           </p>
+        </div>
+      </div>
+    );
+  }
+
+  // 四択が選ばれている: 送るまで音読の画面は描かない (マイクも起こさない)。
+  if (storedMode === 'normal') {
+    return (
+      <div className="h-screen flex items-center justify-center bg-[var(--color-background)] overflow-hidden">
+        <div className="text-center">
+          <div className="w-12 h-12 border-4 border-[var(--color-primary)] border-t-transparent rounded-full animate-spin mx-auto mb-4" />
+          <p className="text-[var(--color-muted)]">通常クイズを開いています...</p>
         </div>
       </div>
     );

--- a/src/lib/quiz/voice-quiz-answer.test.ts
+++ b/src/lib/quiz/voice-quiz-answer.test.ts
@@ -2,7 +2,10 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 
 import {
+  isAnyEnglishAnswerCorrect,
   isAnyJapaneseAnswerCorrect,
+  isEnglishAnswerCorrect,
+  normalizeEnglishAnswer,
   isJapaneseAnswerCorrect,
   japaneseAnswerCandidates,
   japaneseAnswerHints,
@@ -93,4 +96,27 @@ test('japaneseAnswerCandidates splits and folds every meaning', () => {
   assert.equal(candidates.length, 2);
   assert.ok(candidates.includes('気づく'));
   assert.ok(candidates.includes('認識する'));
+});
+
+// ============ 日→英 ============
+
+test('an English answer matches regardless of case and punctuation', () => {
+  assert.equal(isEnglishAnswerCorrect('Elaborate.', 'elaborate'), true);
+  assert.equal(isEnglishAnswerCorrect('  elaborate  ', 'elaborate'), true);
+});
+
+test('a wrong English answer is rejected', () => {
+  assert.equal(isEnglishAnswerCorrect('elaborated', 'elaborate'), false);
+  assert.equal(isEnglishAnswerCorrect('', 'elaborate'), false);
+});
+
+test('any English candidate may carry the right spelling', () => {
+  assert.equal(isAnyEnglishAnswerCorrect(['a lab rate', 'elaborate'], 'elaborate'), true);
+  assert.equal(isAnyEnglishAnswerCorrect(['a lab rate'], 'elaborate'), false);
+  assert.equal(isAnyEnglishAnswerCorrect([], 'elaborate'), false);
+});
+
+test('multi-word English answers collapse internal spacing', () => {
+  assert.equal(normalizeEnglishAnswer('give   up'), 'give up');
+  assert.equal(isEnglishAnswerCorrect('give  up', 'give up'), true);
 });

--- a/src/lib/quiz/voice-quiz-answer.ts
+++ b/src/lib/quiz/voice-quiz-answer.ts
@@ -126,3 +126,34 @@ export function isAnyJapaneseAnswerCorrect(
 ): boolean {
   return transcripts.some((transcript) => isJapaneseAnswerCorrect(transcript, japanese));
 }
+
+// ============ 日→英 (英単語を答える) ============
+
+/**
+ * 英語の答えを比較用に畳む。
+ * 認識結果には句読点や語間の揺れが混ざるので、英数字と1つの空白だけに落とす。
+ */
+export function normalizeEnglishAnswer(value: string): string {
+  return value
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9\s]/g, '')
+    .replace(/\s+/g, ' ');
+}
+
+/** 認識結果が、その単語の綴りとして妥当かを判定する。 */
+export function isEnglishAnswerCorrect(transcript: string, english: string): boolean {
+  const said = normalizeEnglishAnswer(transcript);
+  return said.length > 0 && said === normalizeEnglishAnswer(english);
+}
+
+/**
+ * 候補のどれかが正解なら正解とみなす。
+ * 英語でも "to elaborate" と "elaborate" のように候補が割れることがある。
+ */
+export function isAnyEnglishAnswerCorrect(
+  transcripts: readonly string[],
+  english: string,
+): boolean {
+  return transcripts.some((transcript) => isEnglishAnswerCorrect(transcript, english));
+}

--- a/src/lib/quiz/voice-quiz-prompt.test.ts
+++ b/src/lib/quiz/voice-quiz-prompt.test.ts
@@ -2,7 +2,12 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 
 import {
+  buildVoiceQuizAnswerAnnouncement,
   buildVoiceQuizMeaningPrompt,
+  buildVoiceQuizPromptFor,
+  buildVoiceQuizWordPrompt,
+  isVoiceQuizDirection,
+  recognitionLanguageFor,
   canRetryVoiceQuiz,
   DEFAULT_VOICE_QUIZ_ATTEMPTS,
   DEFAULT_VOICE_QUIZ_DURATION_SEC,
@@ -178,4 +183,60 @@ test('every offered duration survives normalization unchanged', () => {
   for (const option of VOICE_QUIZ_DURATION_OPTIONS) {
     assert.equal(normalizeVoiceQuizDuration(option), option);
   }
+});
+
+// ============ 出題の向き ============
+
+test('ja-to-en prompts read the meaning and never leak the English word', () => {
+  const segments = buildVoiceQuizWordPrompt('入念に作り上げる', 0);
+
+  assert.equal(segments.length, 1);
+  assert.equal(segments[0].lang, 'ja');
+  assert.ok(segments[0].text.includes('入念に作り上げる'));
+  // 全体が日本語なので、綴りが混ざる余地が無いことを固定する。
+  assert.ok(!/[a-z]/i.test(segments[0].text));
+});
+
+test('buildVoiceQuizPromptFor picks the prompt that matches the direction', () => {
+  const word = { english: 'elaborate', japanese: '入念に作り上げる' };
+
+  const enToJa = buildVoiceQuizPromptFor('en-to-ja', word, 0);
+  assert.ok(enToJa.some((s) => s.lang === 'en' && s.text === 'elaborate'));
+
+  const jaToEn = buildVoiceQuizPromptFor('ja-to-en', word, 0);
+  assert.ok(jaToEn.every((s) => s.lang === 'ja'));
+  assert.ok(!voiceQuizPromptToText(jaToEn).includes('elaborate'));
+});
+
+test('recognitionLanguageFor follows the language the learner speaks', () => {
+  assert.equal(recognitionLanguageFor('en-to-ja'), 'ja-JP');
+  assert.equal(recognitionLanguageFor('ja-to-en'), 'en-US');
+});
+
+test('isVoiceQuizDirection accepts only the two directions', () => {
+  assert.equal(isVoiceQuizDirection('en-to-ja'), true);
+  assert.equal(isVoiceQuizDirection('ja-to-en'), true);
+  for (const value of ['', 'en', null, undefined, 0]) {
+    assert.equal(isVoiceQuizDirection(value), false);
+  }
+});
+
+test('the answer announcement switches voice only for an English answer', () => {
+  const word = { english: 'elaborate', japanese: '入念に作り上げる' };
+
+  // 英→日: 答えも日本語なので1文で読ませる。
+  const jaAnswer = buildVoiceQuizAnswerAnnouncement('en-to-ja', word);
+  assert.equal(jaAnswer.length, 1);
+  assert.equal(jaAnswer[0].lang, 'ja');
+  assert.ok(jaAnswer[0].text.includes('入念に作り上げる'));
+
+  // 日→英: 綴りの部分だけ英語の声にする。
+  const enAnswer = buildVoiceQuizAnswerAnnouncement('ja-to-en', word);
+  const english = enAnswer.filter((s) => s.lang === 'en');
+  assert.equal(english.length, 1);
+  assert.equal(english[0].text, 'elaborate');
+});
+
+test('an empty answer produces no announcement', () => {
+  assert.deepEqual(buildVoiceQuizAnswerAnnouncement('en-to-ja', { english: 'x', japanese: '  ' }), []);
 });

--- a/src/lib/quiz/voice-quiz-prompt.ts
+++ b/src/lib/quiz/voice-quiz-prompt.ts
@@ -10,8 +10,44 @@
  * 構造上、答えが漏れる経路が存在しない。
  */
 
+/**
+ * 出題の向き。
+ * - `en-to-ja`: 英単語を出して、意味を日本語で答えさせる
+ * - `ja-to-en`: 日本語の意味を読み上げて、英単語を答えさせる
+ */
+export type VoiceQuizDirection = 'en-to-ja' | 'ja-to-en';
+
+export const DEFAULT_VOICE_QUIZ_DIRECTION: VoiceQuizDirection = 'en-to-ja';
+
+export function isVoiceQuizDirection(value: unknown): value is VoiceQuizDirection {
+  return value === 'en-to-ja' || value === 'ja-to-en';
+}
+
+/** 向きごとの音声認識の言語。答えを話す側の言語になる。 */
+export function recognitionLanguageFor(direction: VoiceQuizDirection): 'ja-JP' | 'en-US' {
+  return direction === 'en-to-ja' ? 'ja-JP' : 'en-US';
+}
+
 /** テンプレート内で英単語に置き換わる位置。 */
 export const VOICE_QUIZ_WORD_PLACEHOLDER = '{word}';
+
+/** テンプレート内で日本語訳に置き換わる位置。 */
+export const VOICE_QUIZ_MEANING_PLACEHOLDER = '{meaning}';
+
+/**
+ * 日→英の出題文。読み上げるのは日本語訳だけで、英単語(正解)は出てこない。
+ * 全体が日本語なので、英→日と違って声を切り替える必要がない。
+ */
+export const VOICE_QUIZ_WORD_PROMPT_TEMPLATES: readonly string[] = [
+  `「${VOICE_QUIZ_MEANING_PLACEHOLDER}」という意味の単語、英語で何と言う?`,
+  `「${VOICE_QUIZ_MEANING_PLACEHOLDER}」を英語で言うと?`,
+  `次の意味に当てはまる英単語は? 「${VOICE_QUIZ_MEANING_PLACEHOLDER}」`,
+  `「${VOICE_QUIZ_MEANING_PLACEHOLDER}」。これを英語で答えてください。`,
+  `英語で何と言うでしょう? 「${VOICE_QUIZ_MEANING_PLACEHOLDER}」`,
+  `「${VOICE_QUIZ_MEANING_PLACEHOLDER}」という意味の英単語を答えてください。`,
+  `では次です。「${VOICE_QUIZ_MEANING_PLACEHOLDER}」を英語で。`,
+  `「${VOICE_QUIZ_MEANING_PLACEHOLDER}」にあたる英単語は何でしょう?`,
+];
 
 /**
  * 英→日の出題文。英単語を文の途中に挟んだ、読み上げて自然な日本語1文にする。
@@ -33,6 +69,36 @@ export const VOICE_QUIZ_MEANING_PROMPT_TEMPLATES: readonly string[] = [
 export interface VoiceQuizPromptSegment {
   text: string;
   lang: 'ja' | 'en';
+}
+
+/**
+ * 不正解・失格・「わからない」のあとに正解を知らせる文。
+ * 答えの語だけが可変で、前後は固定なので、読み上げ音声を作り置きできる。
+ */
+export const VOICE_QUIZ_ANSWER_PREFIX = '正解は、';
+export const VOICE_QUIZ_ANSWER_SUFFIX = 'です。';
+
+/**
+ * 「正解は、○○ です。」を読み上げ用のセグメントで組み立てる。
+ * 日→英では答えが英単語なので、そこだけ英語の声に切り替える。
+ */
+export function buildVoiceQuizAnswerAnnouncement(
+  direction: VoiceQuizDirection,
+  word: { english: string; japanese: string },
+): VoiceQuizPromptSegment[] {
+  const answer = direction === 'en-to-ja' ? word.japanese.trim() : word.english.trim();
+  if (!answer) return [];
+
+  // 英→日は答えも日本語なので、切らずに1文で読ませたほうが自然に聞こえる。
+  if (direction === 'en-to-ja') {
+    return [{ text: `${VOICE_QUIZ_ANSWER_PREFIX}${answer}${VOICE_QUIZ_ANSWER_SUFFIX}`, lang: 'ja' }];
+  }
+
+  return [
+    { text: VOICE_QUIZ_ANSWER_PREFIX, lang: 'ja' },
+    { text: answer, lang: 'en' },
+    { text: VOICE_QUIZ_ANSWER_SUFFIX, lang: 'ja' },
+  ];
 }
 
 /** 間違えたときに、もう一度promptするための掛け声。 */
@@ -83,6 +149,29 @@ export function buildVoiceQuizMeaningPrompt(
     { text: trimmedWord, lang: 'en' as const },
     { text: after.trim(), lang: 'ja' as const },
   ].filter((segment) => segment.text.length > 0);
+}
+
+/**
+ * 日→英の出題文。全体が日本語なので1片で返し、英→日と同じ形で扱えるようにする。
+ */
+export function buildVoiceQuizWordPrompt(
+  meaning: string,
+  index: number,
+): VoiceQuizPromptSegment[] {
+  const text = rotate(VOICE_QUIZ_WORD_PROMPT_TEMPLATES, index)
+    .replaceAll(VOICE_QUIZ_MEANING_PLACEHOLDER, meaning.trim());
+  return [{ text, lang: 'ja' }];
+}
+
+/** 出題の向きに応じた読み上げを組み立てる。 */
+export function buildVoiceQuizPromptFor(
+  direction: VoiceQuizDirection,
+  word: { english: string; japanese: string },
+  index: number,
+): VoiceQuizPromptSegment[] {
+  return direction === 'en-to-ja'
+    ? buildVoiceQuizMeaningPrompt(word.english, index)
+    : buildVoiceQuizWordPrompt(word.japanese, index);
 }
 
 /** 出題文を画面に出すときの表示用テキスト (読み上げと同じ並び)。 */


### PR DESCRIPTION
## 出題の向き（日→英を選べるように）

日→英 is selectable again alongside 英→日, chosen on the start screen.

The direction decides **four** things at once, so each is derived from it rather than hard-coded:

| | 英→日 | 日→英 |
|---|---|---|
| 出題 | 英単語（＋発音記号） | 日本語の意味 |
| 認識言語 | `ja-JP` | `en-US` |
| 判定 | 日本語コンパレータ | 英語コンパレータ |
| ヒント | 語義の表記 | 綴り |

The Japanese-to-English prompt is a single Japanese utterance — nothing to switch voices for — and a test pins that **no Latin letters can reach it**, so the spelling can't leak into the question.

The direction is fixed into a ref when the session starts: reading it from state during grading would let a mid-session change rewrite how an already-asked question is judged.

## 「わからない」ボタン

Recording is discarded and **never sent for recognition** — sending speech from someone who has already said they don't know buys nothing but latency and API spend. The run counter is bumped before the recorder stops, so the in-flight `onstop` exits before it would upload.

It settles the question immediately, doesn't consume a retry, and is recorded as its own outcome rather than a timeout 失格, which it isn't.

Measured in a browser: **216ms to the answer, with `/api/voice-quiz/recognize` called 0 times.**

## 正解のアナウンス

A wrong answer is now read aloud as 「正解は、○○ です。」 — verified on the wire as `ja:正解は、` → `en:elaborate` → `ja:です。`, so only the spelling switches voice in 日→英. The fixed halves are kept separate from the answer so they can be pre-generated as natural audio in the next change.

A **correct** answer says nothing and advances in **1s** (was 2.2s): there is nothing to tell someone who just got it right, and waiting only costs tempo. The wrong-answer wait grows to 4.2s so the announcement finishes first.

## 終了ボタン

The header's bare × gave no hint that it ends the quiz, so it's now a labelled 「終了」 button opening the same confirmation (続ける / ここまでの結果を見る / 記録せずに戻る).

## Verification

Driven in a real browser at iPhone size, direction set to 日→英:

- 読み上げ: `ja-JP:次の意味に当てはまる英単語は? 「入念に作り上げる」` — 綴りなし ✅
- 出題カード: 入念に作り上げる / 指示: 「録音中 — 英語で答えてください」 ✅
- わからない: 216ms、recognize 呼び出し 0 ✅
- 不正解アナウンス: `正解は、` + `elaborate` + `です。` ✅
- 終了 → 中断ダイアログ ✅

`npm test` 1292/1294 (the 2 failures reproduce on an unmodified tree); `tsc` clean; `eslint` clean; `next build` compiles.

Still to come: pre-generating the fixed phrases as natural TTS audio (prompts, 掛け声, 正解/不正解, and the announcement halves above).

`security` will fail for the same pre-existing dependency advisories; this branch changes no dependencies.

---
_Generated by [Claude Code](https://claude.ai/code/session_0159t4xQyZDQmD1P7ytrWak5)_