### PR TITLE
Start the daily-study quiz again, and stop leaking synthetic speech

### DIFF
--- a/src/app/quiz/[projectId]/page.tsx
+++ b/src/app/quiz/[projectId]/page.tsx
@@ -464,6 +464,12 @@ export default function QuizPage() {
   const returnPath = searchParams.get('from');
   const reviewMode = searchParams.get('review') === '1';
   const learnMode = searchParams.get('learn') === '1';
+  /**
+   * 音読チャレンジに送れない出題か。
+   * 音読側は単語帳を1冊だけ読み込む作りで、`all` や復習・今日の学習のような
+   * 横断出題を扱えない。ここが true のときはクイズ形式の選択を適用しない。
+   */
+  const voiceQuizUnavailable = projectId === 'all' || reviewMode || learnMode;
   const wrongMode = searchParams.get('wrong') === '1';
   const favoritesMode = searchParams.get('favorites') === '1';
   const reminderMode = searchParams.get('reminder') === '1';
@@ -626,13 +632,18 @@ export default function QuizPage() {
    * この端末が音読チャレンジを選んでいるなら、四択を開いても音読へ送る。
    * 選んだ直後だけでなく「次に開いたとき」も選択を守るために要る。
    * 遷移は一度きり ——依存が変わるたびに router を叩かないよう ref で止める。
+   *
+   * ただし音読チャレンジは単語帳1冊ぶんしか出題できない。「今日の学習」のような
+   * 横断出題 (/quiz/all?learn=1) を送っても向こうで単語帳が見つからず、
+   * 弾かれて戻ってくるだけなので、その場合は端末の選択より四択を優先する。
    */
   const redirectedToVoiceRef = useRef(false);
   useEffect(() => {
-    if (!modeLoaded || storedMode !== 'voice' || redirectedToVoiceRef.current) return;
+    if (!modeLoaded || storedMode !== 'voice' || voiceQuizUnavailable) return;
+    if (redirectedToVoiceRef.current) return;
     redirectedToVoiceRef.current = true;
     goToVoiceQuiz({ replace: true });
-  }, [modeLoaded, storedMode, goToVoiceQuiz]);
+  }, [modeLoaded, storedMode, goToVoiceQuiz, voiceQuizUnavailable]);
 
   /** 形式を選んだ。四択ならこの画面のまま、音読なら音読チャレンジへ移る。 */
   const chooseMode = useCallback(
@@ -1287,7 +1298,7 @@ export default function QuizPage() {
   }
 
   /* ---------- 音読チャレンジが選ばれている: 送るまで四択を描かない ---------- */
-  if (storedMode === 'voice') {
+  if (storedMode === 'voice' && !voiceQuizUnavailable) {
     return (
       <div className="flex min-h-screen items-center justify-center bg-[var(--color-background)]">
         <div className="text-center">
@@ -1299,7 +1310,7 @@ export default function QuizPage() {
   }
 
   /* ---------- この端末でまだ形式を選んでいない ---------- */
-  if (storedMode === null) {
+  if (storedMode === null && !voiceQuizUnavailable) {
     return (
       <div className="flex min-h-screen flex-col bg-[var(--color-background)]">
         <div className="p-4">
@@ -1635,9 +1646,11 @@ export default function QuizPage() {
           </button>
           <div className="ds-qbar"><div className="fi" style={{ width: `${Math.round((currentIndex / Math.max(total, 1)) * 100)}%` }} /></div>
           <span className="ds-qcount">{currentIndex + 1} <span className="muted" style={{ fontWeight: 500 }}>/ {total}</span></span>
-          <button type="button" className="x" onClick={() => setShowModeSwitch(true)} aria-label="クイズの解き方を変える" title="クイズの解き方">
-            <Icon name="mic" />
-          </button>
+          {!voiceQuizUnavailable && (
+            <button type="button" className="x" onClick={() => setShowModeSwitch(true)} aria-label="クイズの解き方を変える" title="クイズの解き方">
+              <Icon name="mic" />
+            </button>
+          )}
         </div>
         <div className="mono muted" style={{ fontSize: 12, marginTop: 6 }}>{desktopSubtitle}</div>
 
@@ -1843,14 +1856,16 @@ export default function QuizPage() {
             {currentIndex + 1}<span className="text-[var(--color-muted)]">/{total}</span>
           </span>
         </div>
-        <button
-          type="button"
-          onClick={() => setShowModeSwitch(true)}
-          aria-label="クイズの解き方を変える"
-          className="inline-flex h-8 w-8 items-center justify-center text-[var(--solid-ink)]"
-        >
-          <Icon name="mic" size={19} />
-        </button>
+        {!voiceQuizUnavailable && (
+          <button
+            type="button"
+            onClick={() => setShowModeSwitch(true)}
+            aria-label="クイズの解き方を変える"
+            className="inline-flex h-8 w-8 items-center justify-center text-[var(--solid-ink)]"
+          >
+            <Icon name="mic" size={19} />
+          </button>
+        )}
         {(reviewMode || learnMode) && (
           <button
             type="button"

--- a/src/app/voice-quiz/[projectId]/page.tsx
+++ b/src/app/voice-quiz/[projectId]/page.tsx
@@ -270,6 +270,15 @@ export default function VoiceQuizPage() {
     const load = async () => {
       try {
         const ownerUserId = user ? user.id : getGuestUserId();
+        // 音読チャレンジは単語帳1冊ぶんしか出題できない。横断出題の入口
+        // (/voice-quiz/all や復習・今日の学習) を踏んだら、行き止まりにせず
+        // 四択へ渡す。ここで backToProject に落とすと、クイズが始まらないまま
+        // ホームへ戻されたように見える。
+        if (projectId === 'all') {
+          goToNormalQuiz();
+          return;
+        }
+
         const project = await repository.getProject(projectId);
         if (!project || project.userId !== ownerUserId) {
           backToProject();
@@ -296,7 +305,7 @@ export default function VoiceQuizPage() {
     };
 
     load();
-  }, [authLoading, projectId, repository, user, backToProject, requestedCount]);
+  }, [authLoading, projectId, repository, user, backToProject, goToNormalQuiz, requestedCount]);
 
   /** 1問を確定させる。以降この問題では再挑戦しない。 */
   const finishQuestion = useCallback(
@@ -331,16 +340,18 @@ export default function VoiceQuizPage() {
 
       // 判定を声でも伝える。外したときは続けて正解を読み上げる。
       // 正解のときは短い一言だけ —— すぐ次の問題へ進むので、長く喋る間が無い。
-      const resultKey: VoiceQuizResultKey = correct
+      // 「わからない」は自分から答えを見に行った操作なので、判定は読み上げず
+      // すぐ正解へ移る。正解/不正解/時間切れだけ一言添える。
+      const resultKey: VoiceQuizResultKey | null = correct
         ? 'correct'
         : skipped
-        ? 'gaveUp'
+        ? null
         : disqualified
         ? 'disqualified'
         : 'incorrect';
 
       const announcement: VoiceQuizPromptSegment[] = [
-        { text: VOICE_QUIZ_RESULT_ANNOUNCEMENTS[resultKey], lang: 'ja' },
+        ...(resultKey ? [{ text: VOICE_QUIZ_RESULT_ANNOUNCEMENTS[resultKey], lang: 'ja' as const }] : []),
         ...(correct ? [] : buildVoiceQuizAnswerAnnouncement(directionRef.current, word)),
       ];
 

--- a/src/lib/quiz/voice-quiz-audio.test.ts
+++ b/src/lib/quiz/voice-quiz-audio.test.ts
@@ -13,7 +13,9 @@ import {
   VOICE_QUIZ_MEANING_PROMPT_TEMPLATES,
   VOICE_QUIZ_RETRY_TEMPLATES,
   VOICE_QUIZ_WORD_PLACEHOLDER,
-  buildVoiceQuizMeaningPrompt,
+  VOICE_QUIZ_WORD_PROMPT_TEMPLATES,
+  buildVoiceQuizAnswerAnnouncement,
+  buildVoiceQuizPromptFor,
   pickVoiceQuizRetryPrompt,
 } from './voice-quiz-prompt';
 
@@ -36,16 +38,44 @@ test('no clip carries a placeholder — the variable parts are never pre-generat
   }
 });
 
-test('the fixed halves of every English-to-Japanese prompt are covered', () => {
-  // 出題文の前後は必ず音声にできていること。ここが欠けると
-  // 1問ごとに合成音声と自然な音声が混ざって聞こえる。
+/**
+ * 実際に読み上げる並びを歩いて、固定部分に音声が無いものを見つける。
+ *
+ * 台本に文言が載っていても、読み上げ側がそれを1つに繋げて喋っていれば
+ * 索引に当たらず合成音声のままになる —— 実際にそれで
+ * 「正解は、○○ です。」と日→英の出題文が合成音声で残っていた。
+ * 文言の一覧ではなく、組み立てた結果を突き合わせる。
+ */
+function uncoveredFixedSegments(segments: { text: string; lang: string }[], variable: string[]) {
   const index = voiceQuizAudioIndex();
+  return segments
+    .filter((segment) => !variable.includes(segment.text)) // 単語・訳は対象外
+    .filter((segment) => !index.has(segment.text))
+    .map((segment) => segment.text);
+}
 
+test('every fixed part of an English-to-Japanese question has audio', () => {
+  const word = { english: 'elaborate', japanese: '入念に作り上げる' };
   for (let i = 0; i < VOICE_QUIZ_MEANING_PROMPT_TEMPLATES.length; i += 1) {
-    for (const segment of buildVoiceQuizMeaningPrompt('elaborate', i)) {
-      if (segment.lang === 'en') continue; // 単語そのものは対象外
-      assert.ok(index.has(segment.text), `no clip for: ${segment.text}`);
-    }
+    const segments = buildVoiceQuizPromptFor('en-to-ja', word, i);
+    assert.deepEqual(uncoveredFixedSegments(segments, [word.english]), []);
+  }
+});
+
+test('every fixed part of a Japanese-to-English question has audio', () => {
+  const word = { english: 'elaborate', japanese: '入念に作り上げる' };
+  for (let i = 0; i < VOICE_QUIZ_WORD_PROMPT_TEMPLATES.length; i += 1) {
+    const segments = buildVoiceQuizPromptFor('ja-to-en', word, i);
+    assert.deepEqual(uncoveredFixedSegments(segments, [word.japanese]), []);
+  }
+});
+
+test('the answer announcement is split so its fixed halves have audio', () => {
+  const word = { english: 'elaborate', japanese: '入念に作り上げる' };
+  for (const direction of ['en-to-ja', 'ja-to-en'] as const) {
+    const segments = buildVoiceQuizAnswerAnnouncement(direction, word);
+    // 繋げて1文にしていたら、答え以外の部分が索引に当たらず落ちる。
+    assert.deepEqual(uncoveredFixedSegments(segments, [word.english, word.japanese]), []);
   }
 });
 

--- a/src/lib/quiz/voice-quiz-audio.ts
+++ b/src/lib/quiz/voice-quiz-audio.ts
@@ -15,11 +15,12 @@
  */
 
 import {
-  VOICE_QUIZ_ANSWER_PREFIX,
-  VOICE_QUIZ_ANSWER_SUFFIX,
+  buildVoiceQuizAnswerAnnouncement,
+  buildVoiceQuizPromptFor,
   VOICE_QUIZ_MEANING_PROMPT_TEMPLATES,
   VOICE_QUIZ_RETRY_TEMPLATES,
-  VOICE_QUIZ_WORD_PLACEHOLDER,
+  VOICE_QUIZ_WORD_PROMPT_TEMPLATES,
+  type VoiceQuizDirection,
 } from './voice-quiz-prompt';
 
 /** 生成した音声を置くディレクトリ (public 配下)。 */
@@ -38,49 +39,83 @@ export const VOICE_QUIZ_RESULT_ANNOUNCEMENTS = {
   correct: '正解!',
   incorrect: '不正解。',
   disqualified: '時間切れです。',
-  gaveUp: '答えを見てみましょう。',
 } as const;
 
 export type VoiceQuizResultKey = keyof typeof VOICE_QUIZ_RESULT_ANNOUNCEMENTS;
 
 /**
- * 英→日の出題文から、単語を挟む前後の固定部分だけを取り出す。
- * 「この単語、」「の意味を日本語で言ってみて。」のような断片になる。
+ * 差し替え位置の目印。実際の語彙と衝突しない文字列を入れて組み立て、
+ * これ以外の断片＝単語に依存しない固定部分、として拾う。
  */
-function meaningPromptFragments(): VoiceQuizAudioClip[] {
+const SAMPLE_WORD = { english: '\u0000EN\u0000', japanese: '\u0000JA\u0000' };
+
+function isSampleText(text: string): boolean {
+  return text === SAMPLE_WORD.english || text === SAMPLE_WORD.japanese;
+}
+
+/**
+ * 出題文の固定部分を、実際に読み上げるビルダーから取り出す。
+ *
+ * ここでテンプレートを切り直すと、ビルダー側の切り方が変わったときに
+ * 静かに食い違って「音声を用意したのに使われない」状態になる
+ * (実際にそれで合成音声が残った)。組み立てた結果だけを見る。
+ */
+function promptFragments(
+  direction: VoiceQuizDirection,
+  templateCount: number,
+  idPrefix: string,
+): VoiceQuizAudioClip[] {
   const clips: VoiceQuizAudioClip[] = [];
 
-  VOICE_QUIZ_MEANING_PROMPT_TEMPLATES.forEach((template, index) => {
-    const at = template.indexOf(VOICE_QUIZ_WORD_PLACEHOLDER);
-    if (at < 0) return;
+  for (let index = 0; index < templateCount; index += 1) {
+    buildVoiceQuizPromptFor(direction, SAMPLE_WORD, index).forEach((segment, position) => {
+      if (isSampleText(segment.text)) return;
+      clips.push({ id: `${idPrefix}-${index}-${position}`, text: segment.text, lang: segment.lang });
+    });
+  }
 
-    const before = template.slice(0, at).trim();
-    const after = template.slice(at + VOICE_QUIZ_WORD_PLACEHOLDER.length).trim();
+  return clips;
+}
 
-    if (before) clips.push({ id: `prompt-${index}-before`, text: before, lang: 'ja' });
-    if (after) clips.push({ id: `prompt-${index}-after`, text: after, lang: 'ja' });
-  });
+/** 「正解は、」「です。」など、正解を知らせる文の固定部分。 */
+function answerAnnouncementFragments(): VoiceQuizAudioClip[] {
+  const clips: VoiceQuizAudioClip[] = [];
+
+  for (const direction of ['en-to-ja', 'ja-to-en'] as const) {
+    buildVoiceQuizAnswerAnnouncement(direction, SAMPLE_WORD).forEach((segment, position) => {
+      if (isSampleText(segment.text)) return;
+      clips.push({ id: `answer-${direction}-${position}`, text: segment.text, lang: segment.lang });
+    });
+  }
 
   return clips;
 }
 
 /** 事前生成する固定文のすべて。 */
 export function voiceQuizAudioClips(): VoiceQuizAudioClip[] {
-  return [
-    ...meaningPromptFragments(),
+  const clips = [
+    ...promptFragments('en-to-ja', VOICE_QUIZ_MEANING_PROMPT_TEMPLATES.length, 'prompt'),
+    ...promptFragments('ja-to-en', VOICE_QUIZ_WORD_PROMPT_TEMPLATES.length, 'word-prompt'),
     ...VOICE_QUIZ_RETRY_TEMPLATES.map((text, index) => ({
       id: `retry-${index}`,
       text,
       lang: 'ja' as const,
     })),
-    { id: 'answer-prefix', text: VOICE_QUIZ_ANSWER_PREFIX, lang: 'ja' },
-    { id: 'answer-suffix', text: VOICE_QUIZ_ANSWER_SUFFIX, lang: 'ja' },
+    ...answerAnnouncementFragments(),
     ...Object.entries(VOICE_QUIZ_RESULT_ANNOUNCEMENTS).map(([key, text]) => ({
       id: `result-${key}`,
       text,
       lang: 'ja' as const,
     })),
   ];
+
+  // 同じ文言が複数のテンプレートに出ることがある。音声は1つでよい。
+  const seen = new Set<string>();
+  return clips.filter((clip) => {
+    if (seen.has(clip.text)) return false;
+    seen.add(clip.text);
+    return true;
+  });
 }
 
 /** 文言から音声ファイルを引くための索引。同じ文言は1つの音声を共有する。 */

--- a/src/lib/quiz/voice-quiz-prompt.test.ts
+++ b/src/lib/quiz/voice-quiz-prompt.test.ts
@@ -190,11 +190,12 @@ test('every offered duration survives normalization unchanged', () => {
 test('ja-to-en prompts read the meaning and never leak the English word', () => {
   const segments = buildVoiceQuizWordPrompt('入念に作り上げる', 0);
 
-  assert.equal(segments.length, 1);
-  assert.equal(segments[0].lang, 'ja');
-  assert.ok(segments[0].text.includes('入念に作り上げる'));
+  // 固定部分と訳を切り分ける (固定部分だけ作り置きの音声で読めるようにするため)。
+  assert.ok(segments.length > 1);
+  assert.ok(segments.every((segment) => segment.lang === 'ja'));
+  assert.ok(segments.some((segment) => segment.text === '入念に作り上げる'));
   // 全体が日本語なので、綴りが混ざる余地が無いことを固定する。
-  assert.ok(!/[a-z]/i.test(segments[0].text));
+  assert.ok(!/[a-z]/i.test(voiceQuizPromptToText(segments)));
 });
 
 test('buildVoiceQuizPromptFor picks the prompt that matches the direction', () => {
@@ -224,11 +225,11 @@ test('isVoiceQuizDirection accepts only the two directions', () => {
 test('the answer announcement switches voice only for an English answer', () => {
   const word = { english: 'elaborate', japanese: '入念に作り上げる' };
 
-  // 英→日: 答えも日本語なので1文で読ませる。
+  // 英→日: すべて日本語だが、前後の固定部分は切り分けておく。
   const jaAnswer = buildVoiceQuizAnswerAnnouncement('en-to-ja', word);
-  assert.equal(jaAnswer.length, 1);
-  assert.equal(jaAnswer[0].lang, 'ja');
-  assert.ok(jaAnswer[0].text.includes('入念に作り上げる'));
+  assert.ok(jaAnswer.every((segment) => segment.lang === 'ja'));
+  assert.ok(jaAnswer.some((segment) => segment.text === '入念に作り上げる'));
+  assert.ok(jaAnswer.some((segment) => segment.text === '正解は、'));
 
   // 日→英: 綴りの部分だけ英語の声にする。
   const enAnswer = buildVoiceQuizAnswerAnnouncement('ja-to-en', word);

--- a/src/lib/quiz/voice-quiz-prompt.ts
+++ b/src/lib/quiz/voice-quiz-prompt.ts
@@ -39,14 +39,14 @@ export const VOICE_QUIZ_MEANING_PLACEHOLDER = '{meaning}';
  * 全体が日本語なので、英→日と違って声を切り替える必要がない。
  */
 export const VOICE_QUIZ_WORD_PROMPT_TEMPLATES: readonly string[] = [
-  `「${VOICE_QUIZ_MEANING_PLACEHOLDER}」という意味の単語、英語で何と言う?`,
-  `「${VOICE_QUIZ_MEANING_PLACEHOLDER}」を英語で言うと?`,
-  `次の意味に当てはまる英単語は? 「${VOICE_QUIZ_MEANING_PLACEHOLDER}」`,
-  `「${VOICE_QUIZ_MEANING_PLACEHOLDER}」。これを英語で答えてください。`,
-  `英語で何と言うでしょう? 「${VOICE_QUIZ_MEANING_PLACEHOLDER}」`,
-  `「${VOICE_QUIZ_MEANING_PLACEHOLDER}」という意味の英単語を答えてください。`,
-  `では次です。「${VOICE_QUIZ_MEANING_PLACEHOLDER}」を英語で。`,
-  `「${VOICE_QUIZ_MEANING_PLACEHOLDER}」にあたる英単語は何でしょう?`,
+  `${VOICE_QUIZ_MEANING_PLACEHOLDER}。これを英語で何と言う?`,
+  `${VOICE_QUIZ_MEANING_PLACEHOLDER}。英語で言うと?`,
+  `次の意味に当てはまる英単語は? ${VOICE_QUIZ_MEANING_PLACEHOLDER}`,
+  `${VOICE_QUIZ_MEANING_PLACEHOLDER}。これを英語で答えてください。`,
+  `英語で何と言うでしょう? ${VOICE_QUIZ_MEANING_PLACEHOLDER}`,
+  `${VOICE_QUIZ_MEANING_PLACEHOLDER}。この意味の英単語を答えてください。`,
+  `では次です。${VOICE_QUIZ_MEANING_PLACEHOLDER}。英語で。`,
+  `${VOICE_QUIZ_MEANING_PLACEHOLDER}。これにあたる英単語は何でしょう?`,
 ];
 
 /**
@@ -89,9 +89,14 @@ export function buildVoiceQuizAnswerAnnouncement(
   const answer = direction === 'en-to-ja' ? word.japanese.trim() : word.english.trim();
   if (!answer) return [];
 
-  // 英→日は答えも日本語なので、切らずに1文で読ませたほうが自然に聞こえる。
+  // 向きによらず前後を切り分ける。つなげて1文にすると、せっかく作り置きした
+  // 「正解は、」「です。」に一致せず、文まるごと合成音声になってしまう。
   if (direction === 'en-to-ja') {
-    return [{ text: `${VOICE_QUIZ_ANSWER_PREFIX}${answer}${VOICE_QUIZ_ANSWER_SUFFIX}`, lang: 'ja' }];
+    return [
+      { text: VOICE_QUIZ_ANSWER_PREFIX, lang: 'ja' },
+      { text: answer, lang: 'ja' },
+      { text: VOICE_QUIZ_ANSWER_SUFFIX, lang: 'ja' },
+    ];
   }
 
   return [
@@ -108,6 +113,20 @@ export const VOICE_QUIZ_RETRY_TEMPLATES: readonly string[] = [
   'ちがうよ。もう一回!',
   'もう一度どうぞ。',
 ];
+
+/**
+ * 読み上げる価値のある断片か。
+ * テンプレートの切れ端が句読点やカギ括弧だけになることがあり、そのまま渡すと
+ * 무音や不自然な読みになるうえ、音声を作る分だけ無駄になる。
+ */
+function trimFragment(text: string): string {
+  // 差し込み位置の直後に残る句読点は、前の語で切れているので読ませない。
+  return text.trim().replace(/^[、。，．\s]+/, '').trim();
+}
+
+function isSpeakable(text: string): boolean {
+  return /[\p{Letter}\p{Number}]/u.test(text);
+}
 
 function rotate(templates: readonly string[], index: number): string {
   const count = templates.length;
@@ -145,22 +164,33 @@ export function buildVoiceQuizMeaningPrompt(
   const after = template.slice(placeholderAt + VOICE_QUIZ_WORD_PLACEHOLDER.length);
 
   return [
-    { text: before.trim(), lang: 'ja' as const },
+    { text: trimFragment(before), lang: 'ja' as const },
     { text: trimmedWord, lang: 'en' as const },
-    { text: after.trim(), lang: 'ja' as const },
-  ].filter((segment) => segment.text.length > 0);
+    { text: trimFragment(after), lang: 'ja' as const },
+  ].filter((segment) => isSpeakable(segment.text));
 }
 
 /**
- * 日→英の出題文。全体が日本語なので1片で返し、英→日と同じ形で扱えるようにする。
+ * 日→英の出題文。全体が日本語だが、英→日と同じように意味の前後で切り分ける。
+ * 固定部分は作り置きの音声で読めるので、合成音声になるのは日本語訳だけで済む。
  */
 export function buildVoiceQuizWordPrompt(
   meaning: string,
   index: number,
 ): VoiceQuizPromptSegment[] {
-  const text = rotate(VOICE_QUIZ_WORD_PROMPT_TEMPLATES, index)
-    .replaceAll(VOICE_QUIZ_MEANING_PLACEHOLDER, meaning.trim());
-  return [{ text, lang: 'ja' }];
+  const template = rotate(VOICE_QUIZ_WORD_PROMPT_TEMPLATES, index);
+  const at = template.indexOf(VOICE_QUIZ_MEANING_PLACEHOLDER);
+  const trimmed = meaning.trim();
+
+  if (at < 0) {
+    return [{ text: template, lang: 'ja' }];
+  }
+
+  return [
+    { text: trimFragment(template.slice(0, at)), lang: 'ja' as const },
+    { text: trimmed, lang: 'ja' as const },
+    { text: trimFragment(template.slice(at + VOICE_QUIZ_MEANING_PLACEHOLDER.length)), lang: 'ja' as const },
+  ].filter((segment) => isSpeakable(segment.text));
 }
 
 /** 出題の向きに応じた読み上げを組み立てる。 */


### PR DESCRIPTION
## 今日の学習でクイズが始まらない

「今日の学習」opens **`/quiz/all?learn=1`** — a cross-project set. The voice-mode redirect sent that to `/voice-quiz/all`, which loads exactly one wordbook, found no project called `all`, and bounced to `from=/`. A device that had chosen 音声 landed on the **home page instead of a quiz**.

Reproduced before fixing:

```
[保存=normal] 着地: /quiz/all?learn=1&from=/   → 出題される
[保存=voice]  着地: /                          → クイズが始まらない
```

**Fix:** the preference yields to what the voice quiz can actually serve. `all`, 復習 and 今日の学習 stay on the four-choice quiz — the redirect is skipped, the first-run chooser isn't shown (choosing 声 would only lead somewhere broken), and the mode switch is hidden. The voice quiz also hands `/voice-quiz/all` to the four-choice quiz rather than dead-ending, so an old link recovers instead of dropping the learner home.

After the fix:

| 入口 | 保存 | 着地 |
|---|---|---|
| `/quiz/all?learn=1` | voice | `/quiz/all` ✅ |
| `/quiz/all?review=1` | voice | `/quiz/all` ✅ |
| `/quiz/p1` | voice | `/voice-quiz/p1` ✅（従来どおり） |
| `/quiz/p1` | normal | `/quiz/p1` ✅ |
| `/voice-quiz/all` | normal | `/quiz/all` ✅ |
| `/quiz/all?learn=1` | 未選択 | 選択画面を出さず出題 ✅ |

## まだ合成音声が残っていた件

Two places built a whole sentence in one piece, so nothing matched the recorded clips:

- the 英→日 answer was read as a single 「正解は、○○ です。」 string — the recorded 「正解は、」 and 「です。」 were **never reached**
- 日→英 questions embedded the meaning inline, leaving the **entire question** synthetic

Both are now split at the variable part, so only the word or the meaning is synthesised.

**The root cause was duplication:** the catalogue re-sliced the templates itself, so it could silently disagree with how the quiz actually speaks. It now builds through the *same functions* the quiz speaks through. The coverage test walks the built segments instead of the wording list and fails if any fixed part has no clip — I verified it has teeth by putting the concatenation back:

```
not ok 5 - the answer announcement is split so its fixed halves have audio
```

Two smaller things fell out: fragments that were only punctuation (a lone 「 from the quoted templates) were being turned into clips, and fragments starting with the punctuation left at the seam read badly — both are trimmed. The 日→英 templates lost their 「」, which exist for reading and do nothing when spoken.

**Clips: 22 → 30, 283 characters total** (about $0.005 at Neural2 rates). Since the ids changed, regenerate with `--force`:

```
GOOGLE_CLOUD_TTS_API_KEY=xxx npm run audio:voice-quiz -- --force
```

## 答えを見てみましょう

Dropped as requested — pressing わからない now goes straight to the answer.

## Verification

`npm test` 1302/1304 (the 2 failures reproduce on an unmodified tree); `tsc` clean; `eslint` clean; `next build` compiles. Entry points driven in a real browser as tabulated above.

`security` will fail for the same pre-existing dependency advisories; this branch changes no dependencies.

---
_Generated by [Claude Code](https://claude.ai/code/session_0159t4xQyZDQmD1P7ytrWak5)_