### PR TITLE
Stop the recording encoder from blowing the argument limit on a phone

### DIFF
--- a/src/app/voice-quiz/[projectId]/page.tsx
+++ b/src/app/voice-quiz/[projectId]/page.tsx
@@ -14,7 +14,7 @@ import { calculateNextReview, getStatusAfterAnswer, sortWordsByPriority } from '
 import { playAnswerFeedbackSound } from '@/lib/audio/answer-feedback';
 import { stopSpeaking } from '@/lib/speech';
 import { speakVoiceQuiz, stopVoiceQuizAudio } from '@/lib/quiz/voice-quiz-speech';
-import { passthroughEncodingFor, toLinear16 } from '@/lib/speech/recorded-audio';
+import { bytesToBase64, passthroughEncodingFor, toLinear16 } from '@/lib/speech/recorded-audio';
 import { VOICE_QUIZ_RESULT_ANNOUNCEMENTS, type VoiceQuizResultKey } from '@/lib/quiz/voice-quiz-audio';
 import {
   buildVoiceQuizAnswerAnnouncement,
@@ -100,21 +100,6 @@ function pickRecordingSetup(): RecordingSetup | null {
     MediaRecorder.isTypeSupported(mimeType),
   );
   return { mimeType: supported ?? null };
-}
-
-/** Uint8Array の中身だけを ArrayBuffer として取り出す。 */
-function toArrayBuffer(bytes: Uint8Array): ArrayBuffer {
-  return bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength) as ArrayBuffer;
-}
-
-function arrayBufferToBase64(buffer: ArrayBuffer): string {
-  let binary = '';
-  const bytes = new Uint8Array(buffer);
-  const chunkSize = 0x8000;
-  for (let i = 0; i < bytes.length; i += chunkSize) {
-    binary += String.fromCharCode(...bytes.subarray(i, i + chunkSize));
-  }
-  return btoa(binary);
 }
 
 /**
@@ -560,8 +545,8 @@ export default function VoiceQuizPage() {
               return;
             }
 
-            const audioBase64 = arrayBufferToBase64(
-              converted ? toArrayBuffer(converted.pcm) : await blob.arrayBuffer(),
+            const audioBase64 = bytesToBase64(
+              converted ? converted.pcm : new Uint8Array(await blob.arrayBuffer()),
             );
             const response = await fetch('/api/voice-quiz/recognize', {
               method: 'POST',
@@ -581,7 +566,9 @@ export default function VoiceQuizPage() {
             const data = await response.json().catch(() => null);
             if (questionRunRef.current !== run) return;
             if (!response.ok || !data?.success) {
-              const message = typeof data?.error === 'string' ? data.error : '';
+              const message = typeof data?.error === 'string' && data.error
+                ? data.error
+                : `サーバーが応答しませんでした (HTTP ${response.status})`;
 
               // 上限・未設定・未ログインは、次の問題でも同じように落ちる。
               // 残りを機械的に失敗させても得るものが無いので、ここで止める。
@@ -611,13 +598,18 @@ export default function VoiceQuizPage() {
                 ? data.alternatives.filter((item: unknown): item is string => typeof item === 'string')
                 : [],
             );
-          } catch {
+          } catch (error) {
             if (questionRunRef.current !== run) return;
+            // 例外の中身まで出す。ここだけ文言が空で、端末に何が起きたのか
+            // 画面からは分からなかった (PWAではコンソールも開けない)。
+            const detail = error instanceof Error ? `${error.name}: ${error.message}` : String(error);
+            console.error('Voice quiz recognize threw:', error);
             consecutiveRecognitionErrorsRef.current += 1;
             if (consecutiveRecognitionErrorsRef.current >= MAX_CONSECUTIVE_RECOGNITION_ERRORS) {
-              blockSession('音声認識に接続できませんでした。通信状況を確認してください。');
+              blockSession(`音声を送れませんでした (${detail})`);
               return;
             }
+            setRecognitionErrorMessage(`音声を送れませんでした (${detail})`);
             await handleAttemptResult('', true, run);
           }
         })();

--- a/src/app/voice-quiz/[projectId]/page.tsx
+++ b/src/app/voice-quiz/[projectId]/page.tsx
@@ -42,6 +42,7 @@ import {
   japaneseAnswerHints,
 } from '@/lib/quiz/voice-quiz-answer';
 import { useAuth } from '@/hooks/use-auth';
+import { createBrowserClient } from '@/lib/supabase';
 import type { Word, SubscriptionStatus } from '@/types';
 
 const TIMER_TICK_MS = 50;
@@ -82,19 +83,23 @@ const CANDIDATE_MIME_TYPES = [
   'audio/mp4',
 ];
 
-/** ブラウザの既定で録ることを表す値。MediaRecorder には何も渡さない。 */
-const BROWSER_DEFAULT_MIME_TYPE = '';
+/**
+ * 録音の設定。`mimeType` が null なら MediaRecorder に何も渡さず、
+ * ブラウザの既定で録る。「指定なし」と「録音できない」を空文字で表すと、
+ * falsy 判定に引っかかって録音そのものが素通りされる。
+ */
+type RecordingSetup = { mimeType: string | null };
 
 /**
  * 録音に使う MIME を選ぶ。エンコーディングは録音後の実際の出力から決める。
  * null は「この端末では録音できない」。
  */
-function pickSupportedMimeType(): string | null {
+function pickRecordingSetup(): RecordingSetup | null {
   if (typeof MediaRecorder === 'undefined') return null;
-  return (
-    CANDIDATE_MIME_TYPES.find((mimeType) => MediaRecorder.isTypeSupported(mimeType))
-    ?? BROWSER_DEFAULT_MIME_TYPE
+  const supported = CANDIDATE_MIME_TYPES.find((mimeType) =>
+    MediaRecorder.isTypeSupported(mimeType),
   );
+  return { mimeType: supported ?? null };
 }
 
 /** Uint8Array の中身だけを ArrayBuffer として取り出す。 */
@@ -110,6 +115,25 @@ function arrayBufferToBase64(buffer: ArrayBuffer): string {
     binary += String.fromCharCode(...bytes.subarray(i, i + chunkSize));
   }
   return btoa(binary);
+}
+
+/**
+ * 認識APIに付ける見出し。
+ *
+ * このアプリの他の認証付きAPIと同じく、アクセストークンを明示的に載せる。
+ * Cookie だけに頼ると、ホーム画面に追加した iOS の PWA が Safari とは別の
+ * 保存領域を持つために、ログイン済みでも 401 で弾かれることがある ——
+ * 端末側の音声認識が「なぜかスマホだけ失敗する」形で出る。
+ */
+async function recognizeRequestHeaders(): Promise<HeadersInit> {
+  const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+  try {
+    const { data: { session } } = await createBrowserClient().auth.getSession();
+    if (session?.access_token) headers.Authorization = `Bearer ${session.access_token}`;
+  } catch {
+    // 取れなければ Cookie に任せる。ここで諦めると出題そのものが止まる。
+  }
+  return headers;
 }
 
 type Phase = 'narrating' | 'listening' | 'grading' | 'retrying' | 'answered';
@@ -232,7 +256,7 @@ export default function VoiceQuizPage() {
   const [showModeSwitch, setShowModeSwitch] = useState(false);
 
   const streamRef = useRef<MediaStream | null>(null);
-  const recordingRef = useRef<string | null>(null);
+  const recordingRef = useRef<RecordingSetup | null>(null);
   const recorderRef = useRef<MediaRecorder | null>(null);
   const chunksRef = useRef<Blob[]>([]);
   const timerStartRef = useRef<number | null>(null);
@@ -284,12 +308,12 @@ export default function VoiceQuizPage() {
   useEffect(() => {
     let cancelled = false;
     (async () => {
-      const mimeType = pickSupportedMimeType();
-      if (!mimeType || typeof navigator === 'undefined' || !navigator.mediaDevices?.getUserMedia) {
+      const setup = pickRecordingSetup();
+      if (!setup || typeof navigator === 'undefined' || !navigator.mediaDevices?.getUserMedia) {
         if (!cancelled) setSetupState('unsupported');
         return;
       }
-      recordingRef.current = mimeType;
+      recordingRef.current = setup;
       try {
         const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
         if (cancelled) {
@@ -495,7 +519,7 @@ export default function VoiceQuizPage() {
       setPhase('listening');
       timerStartRef.current = Date.now();
 
-      const mimeType = recordingRef.current;
+      const { mimeType } = recordingRef.current;
       const recorder = mimeType
         ? new MediaRecorder(streamRef.current, { mimeType })
         : new MediaRecorder(streamRef.current);
@@ -510,7 +534,7 @@ export default function VoiceQuizPage() {
           setPhase('grading');
           try {
             // 要求した mimeType ではなく、MediaRecorder が実際に採用した型で判断する。
-            const recordedMimeType = recorder.mimeType || mimeType;
+            const recordedMimeType = recorder.mimeType || mimeType || '';
             const blob = new Blob(chunksRef.current, { type: recordedMimeType });
 
             if (blob.size === 0) {
@@ -541,7 +565,7 @@ export default function VoiceQuizPage() {
             );
             const response = await fetch('/api/voice-quiz/recognize', {
               method: 'POST',
-              headers: { 'Content-Type': 'application/json' },
+              headers: await recognizeRequestHeaders(),
               body: JSON.stringify({
                 audioBase64,
                 encoding: passthrough ?? 'LINEAR16',

--- a/src/lib/speech/recorded-audio.test.ts
+++ b/src/lib/speech/recorded-audio.test.ts
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict';
 
 import {
   LINEAR16_SAMPLE_RATE,
+  bytesToBase64,
   floatsToPcm16,
   mixToMono,
   passthroughEncodingFor,
@@ -81,4 +82,25 @@ test('out-of-range samples are clamped, not wrapped', () => {
   const view = new DataView(floatsToPcm16(new Float32Array([2, -2])).buffer);
   assert.equal(view.getInt16(0, true), 32767);
   assert.equal(view.getInt16(2, true), -32767);
+});
+
+/**
+ * 6秒ぶんの録音でも数万バイトになる。スプレッド展開で base64 にしていた
+ * 頃は、そこで引数の上限に当たって RangeError になり、送信前に落ちていた ——
+ * PCでは通り、スマホだけ「音声認識に失敗しました」になる形で出る。
+ */
+test('base64 encoding survives a recording far past any argument limit', () => {
+  const bytes = new Uint8Array(200_000);
+  for (let i = 0; i < bytes.length; i += 1) bytes[i] = i % 256;
+
+  const encoded = bytesToBase64(bytes);
+  assert.equal(encoded, Buffer.from(bytes).toString('base64'));
+});
+
+test('base64 encoding matches for the awkward lengths around a chunk boundary', () => {
+  for (const length of [0, 1, 2, 3, 32767, 32768, 32769, 65536]) {
+    const bytes = new Uint8Array(length);
+    for (let i = 0; i < length; i += 1) bytes[i] = (i * 7) % 256;
+    assert.equal(bytesToBase64(bytes), Buffer.from(bytes).toString('base64'), `length ${length}`);
+  }
 });

--- a/src/lib/speech/recorded-audio.ts
+++ b/src/lib/speech/recorded-audio.ts
@@ -93,6 +93,23 @@ export function floatsToPcm16(samples: Float32Array): Uint8Array {
   return bytes;
 }
 
+/**
+ * バイト列を base64 にする。
+ *
+ * `String.fromCharCode(...bytes)` は展開したぶんが引数になるため、
+ * 配列が大きいと呼び出しの上限に当たって RangeError で落ちる。
+ * 上限は処理系とスタックの余裕で決まり、スマホのほうが先に当たる ——
+ * 「PCでは通るのにスマホだけ音声認識が失敗する」の形で出る。
+ * 1バイトずつ積めば上限そのものが無い。
+ */
+export function bytesToBase64(bytes: Uint8Array): string {
+  let binary = '';
+  for (let i = 0; i < bytes.length; i += 1) {
+    binary += String.fromCharCode(bytes[i]);
+  }
+  return btoa(binary);
+}
+
 type AudioContextConstructor = new () => AudioContext;
 
 function audioContextConstructor(): AudioContextConstructor | null {
@@ -117,8 +134,10 @@ export async function toLinear16(blob: Blob): Promise<Linear16Audio | null> {
   const Ctor = audioContextConstructor();
   if (!Ctor || blob.size === 0) return null;
 
-  const context = new Ctor();
+  let context: AudioContext | null = null;
   try {
+    // 生成自体が落ちることがある (音声セッションを取れない、など)。
+    context = new Ctor();
     const decoded = await context.decodeAudioData(await blob.arrayBuffer());
     const channels = Array.from({ length: decoded.numberOfChannels }, (_, i) =>
       decoded.getChannelData(i),
@@ -131,6 +150,6 @@ export async function toLinear16(blob: Blob): Promise<Linear16Audio | null> {
     return null;
   } finally {
     // 端末のオーディオを掴んだままにしない。閉じられなくても実害は無い。
-    void context.close?.();
+    void context?.close?.();
   }
 }


### PR DESCRIPTION
## 症状から辿った原因

画面には「音声認識に失敗しました」だけが出て、**その下に理由が出ていませんでした**。文言が空になる経路は**送信全体を包む `catch` だけ**です。つまりサーバーに拒否されたのではなく、**リクエストが端末から出る前に例外で落ちていた**ことになります。

```js
binary += String.fromCharCode(...bytes.subarray(i, i + 0x8000));  // 32768個を引数に展開
```

スプレッドで展開した要素は**すべて引数としてスタックに積まれます**。上限は処理系の引数上限とスタック残量で決まるため、**スマホはPCよりずっと早く当たります**。しかも録音が32KBを超えて2チャンク目に入って初めて発生します。

報告された症状と一致します:

- PC（Brave / Safari）では通る
- スマホも**録音が小さいうちは通っていた**
- 録音が大きくなった時点から毎回失敗
- 例外なので**文言が空**の「音声認識に失敗しました」→ 3回連続で「音声認識を続けられません」

1バイトずつ積む実装（`bytesToBase64`）に変更。この方式に上限はありません。200KB と旧チャンク境界前後の長さで Node の `Buffer.toString('base64')` と一致することをテストで固定しています。

## 併せて直したもの

**空の失敗メッセージ自体がバグでした。** `catch` は例外の名前と本文を画面に出し、本文の無いHTTPエラーはステータスを出します。インストール済みPWAではコンソールを開けないため、次に失敗したときは画面が理由を名乗ります。

**認識APIだけが Cookie 頼みでした。** 他の認証付きAPI（スキャン、スキャンジョブ、カスタムモード等）は全て `Authorization: Bearer <access_token>` を付けており、ルート側もそれを優先して読みます。ホーム画面に追加した iOS PWA は Safari と保存領域が別なので、JS側はログイン済みでもサーバーには Cookie が届かず 401 になり得ます。トークンを送るようにし、Cookie はフォールバックとして残しています。

**前PRで私が入れた `''` センチネルのバグ。** 「ブラウザ既定のコンテナで録る」を空文字で表したのに、2箇所が truthy 判定でした（`setSetupState('unsupported')` と `startListening` の早期 return）。iOS は `audio/mp4` を supported と答えるので発火はしませんが、候補がどれも通らない環境では**何も録音しないまま素通り**します。`{ mimeType: string | null }` にして「未指定」と「非対応」を取り違えられないようにしました。

**`AudioContext` の生成を try の内側へ。** iOS では生成自体が落ちることがあり、ガードの外にありました。

## 検証

`npm test` 1381/1383 pass、ビルド成功。失敗2件（`otp.contract` / `words/create`）は main 由来で、この変更前から落ちています。

**実機での確認をお願いします。** まだ失敗する場合、今度は画面に理由（例: `RangeError: Maximum call stack size exceeded`）が出るので、その文言で確定できます。