### PR TITLE
Add collapsible derivatives section to word detail views

### DIFF
--- a/src/components/desktop/DesktopWordDetailModal.tsx
+++ b/src/components/desktop/DesktopWordDetailModal.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Fragment } from 'react';
+import { Fragment, useState } from 'react';
 import { Icon } from '@/components/ui/Icon';
 import { desktopPosLabel } from '@/components/desktop/desktop-data';
 import { MorphologyFormulaChips } from '@/components/word/MorphologyFormulaChips';
@@ -31,6 +31,7 @@ export function DesktopWordDetailModal({
   // word.morphology が無い単語は lexicon 共有キャッシュから表示時に補完する
   const morphology = useMorphologyBackfill(word);
   const derivedWords = useDerivedWordsBackfill(word);
+  const [derivedWordsExpanded, setDerivedWordsExpanded] = useState(false);
 
   return (
     <div className="ds-overlay" onClick={onClose}>
@@ -151,10 +152,19 @@ export function DesktopWordDetailModal({
 
           {hasDisplayableDerivedWords(derivedWords) && (
             <div>
-              <div className="mono" style={{ fontSize: 10, letterSpacing: '0.08em', textTransform: 'uppercase', color: 'var(--color-accent-ink)', fontWeight: 700, display: 'flex', alignItems: 'center', gap: 6, marginBottom: 10 }}>
-                <Icon name="family_history" style={{ fontSize: 14 }} />派生語
-              </div>
-              <DerivedWordsList derivedWords={derivedWords} />
+              <button
+                type="button"
+                onClick={() => setDerivedWordsExpanded((prev) => !prev)}
+                aria-expanded={derivedWordsExpanded}
+                aria-label={derivedWordsExpanded ? '派生語を閉じる' : '派生語を開く'}
+                style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', width: '100%', marginBottom: derivedWordsExpanded ? 10 : 0 }}
+              >
+                <span className="mono" style={{ fontSize: 10, letterSpacing: '0.08em', textTransform: 'uppercase', color: 'var(--color-accent-ink)', fontWeight: 700, display: 'flex', alignItems: 'center', gap: 6 }}>
+                  <Icon name="family_history" style={{ fontSize: 14 }} />派生語
+                </span>
+                <Icon name={derivedWordsExpanded ? 'expand_less' : 'expand_more'} style={{ fontSize: 18, color: 'var(--color-muted)' }} />
+              </button>
+              {derivedWordsExpanded && <DerivedWordsList derivedWords={derivedWords} />}
             </div>
           )}
 

--- a/src/components/word/WordDetailView.tsx
+++ b/src/components/word/WordDetailView.tsx
@@ -126,6 +126,7 @@ export function WordDetailView({
   const [editJapanese, setEditJapanese] = useState('');
   const [editExampleSentence, setEditExampleSentence] = useState('');
   const [editExampleSentenceJa, setEditExampleSentenceJa] = useState('');
+  const [derivedWordsExpanded, setDerivedWordsExpanded] = useState(false);
 
   // Swapy — order tracking via ref (NOT state) to avoid re-render conflicts
   const swapyContainerRef = useRef<HTMLDivElement>(null);
@@ -540,11 +541,24 @@ export function WordDetailView({
           <>
             <SectionDivider />
             <section className="py-4">
-              <div className="mb-3 flex items-center justify-between">
+              <button
+                type="button"
+                onClick={() => setDerivedWordsExpanded((prev) => !prev)}
+                aria-expanded={derivedWordsExpanded}
+                aria-label={derivedWordsExpanded ? '派生語を閉じる' : '派生語を開く'}
+                className="flex w-full items-center justify-between"
+              >
                 <SectionHeading title="DERIVATIVES" />
-                <span className="font-mono text-[11px] font-bold text-[var(--color-muted)]">派生語</span>
-              </div>
-              <DerivedWordsList derivedWords={derivedWords} />
+                <span className="flex items-center gap-1">
+                  <span className="font-mono text-[11px] font-bold text-[var(--color-muted)]">派生語</span>
+                  <Icon name={derivedWordsExpanded ? 'expand_less' : 'expand_more'} size={18} />
+                </span>
+              </button>
+              {derivedWordsExpanded && (
+                <div className="mt-3">
+                  <DerivedWordsList derivedWords={derivedWords} />
+                </div>
+              )}
             </section>
           </>
         )}


### PR DESCRIPTION
## Summary
Add expand/collapse functionality to the "DERIVATIVES" (派生語) section in both mobile and desktop word detail views. The section now starts collapsed and can be toggled open/closed via a button with appropriate aria labels and visual indicators.

## Changes
- **WordDetailView.tsx**: 
  - Added `derivedWordsExpanded` state to track collapse/expand state
  - Converted the derivatives header from a static div to an interactive button
  - Added expand/collapse icon that rotates based on state
  - Conditionally render `DerivedWordsList` only when expanded
  
- **DesktopWordDetailModal.tsx**:
  - Added `derivedWordsExpanded` state to track collapse/expand state
  - Converted the derivatives header from a static div to an interactive button
  - Added expand/collapse icon that rotates based on state
  - Conditionally render `DerivedWordsList` only when expanded

## Implementation Details
- Both components use the same UX pattern: a button with `aria-expanded` and `aria-label` attributes for accessibility
- The expand/collapse icon uses Material Design icons (`expand_more` / `expand_less`)
- Sections start in collapsed state (`false`) to reduce initial visual clutter
- Styling preserved from original implementations while adapting to button element structure

https://claude.ai/code/session_0135CQjgC1QvWQqnFfVK1dx1