### PR TITLE
security check の依存監査を通す

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5121,9 +5121,9 @@
       "license": "ISC"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -6496,9 +6496,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "funding": [
         {
           "type": "github",
@@ -8513,9 +8513,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",
@@ -10541,9 +10541,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"

--- a/package.json
+++ b/package.json
@@ -66,13 +66,15 @@
     "typescript": "^5"
   },
   "overrides": {
-    "brace-expansion@^5.0.0": "^5.0.8",
+    "brace-expansion@^5.0.0": "^5.0.9",
+    "fast-uri": "^3.1.5",
     "form-data": "4.0.6",
     "minimatch": "^10.2.1",
+    "nanoid": "^3.3.18",
     "postcss": "^8.5.23",
     "protobufjs": "7.6.3",
     "sharp": "^0.35.0",
-    "undici": "7.28.0",
+    "undici": "7.29.0",
     "ws": "8.21.0"
   }
 }

--- a/security/deps-audit-allowlist.json
+++ b/security/deps-audit-allowlist.json
@@ -1,22 +1,3 @@
 {
-  "entries": [
-    {
-      "package": "postcss",
-      "advisory": "GHSA-qx2v-qp2m-jg93",
-      "reason": "next が同梱する postcss の脆弱性。修正版 postcss は未リリースで、npm audit の fixAvailable は next のメジャーダウングレードのみ。postcss はビルド時に自分たちの CSS のみを処理し、攻撃者が制御する CSS 入力は扱わない。postcss の修正版が出たら bump して本エントリを削除する。",
-      "expires_on": "2026-10-31"
-    },
-    {
-      "package": "postcss",
-      "advisory": "GHSA-6g55-p6wh-862q",
-      "reason": "同上（next 同梱 postcss / 修正版未リリース / ビルド時に自分たちの CSS のみ処理）。",
-      "expires_on": "2026-10-31"
-    },
-    {
-      "package": "postcss",
-      "advisory": "GHSA-r28c-9q8g-f849",
-      "reason": "同上（next 同梱 postcss / 修正版未リリース / ビルド時に自分たちの CSS のみ処理）。",
-      "expires_on": "2026-10-31"
-    }
-  ]
+  "entries": []
 }


### PR DESCRIPTION
## 何を直したか

`Security Checks` ワークフローが `npm run security:all` の **依存監査 (`security:deps`)** で落ち続けていた。SQL guard / secrets guard / `npm run test:security` は元から通っており、失敗はこの1ステップのみ。

```
Blocking advisory: high brace-expansion@4.0.0 - 5.0.8 (ghsa-rgw5-rvv9-x895)
Blocking advisory: high fast-uri@3.0.0 - 3.1.4 (ghsa-7p8r-x3mc-p8w7)
Blocking advisory: high nanoid@<3.3.18 (ghsa-2v37-7h3g-55p8)
Blocking advisory: high undici@7.0.0 - 7.28.0 (ghsa-4cwx-7wf7-3272, ghsa-8xcm-r25x-g524, ghsa-jr45-8vmc-qm54, ghsa-m8rv-5g2x-5cg5, ghsa-v3r7-h72x-cjcm)
Dependency audit failed: high=4, critical=0.
```

4件すべて修正版が公開済みで、かつ既存の依存レンジ内に収まるため、**allowlist で握りつぶさず overrides のバージョンを引き上げて実際に解消**した。

## 変更内容

### `package.json` の overrides

| パッケージ | before | after | 経路 |
|---|---|---|---|
| `brace-expansion@^5.0.0` | `^5.0.8` | `^5.0.9` | @sentry/nextjs → glob → minimatch |
| `fast-uri` | (なし) | `^3.1.5` | @sentry/nextjs → webpack → schema-utils → ajv |
| `nanoid` | (なし) | `^3.3.18` | critters → postcss |
| `undici` | `7.28.0` | `7.29.0` | apns2 (`undici: ^7.9.0`) |

`brace-expansion` と `undici` は既に override 済みだったが、ピン先のバージョン自体 (5.0.8 / 7.28.0) が後から advisory のレンジに入ってしまっていた。`undici` は 8.x も出ているが、apns2 の要求が `^7.9.0` なのでメジャーを跨がず 7.29.0 に留めた。いずれも semver 互換のパッチ/マイナー移動のみ。

### `security/deps-audit-allowlist.json`

postcss の3エントリ (`GHSA-qx2v-qp2m-jg93` / `GHSA-6g55-p6wh-862q` / `GHSA-r28c-9q8g-f849`) を削除した。postcss は既に修正版 `^8.5.23` に override 済みで、`npm audit --omit=dev` の結果に postcss が出てこなくなっている。エントリ自身が「postcss の修正版が出たら bump して本エントリを削除する」と記載していた条件を満たしている。放置すると `expires_on` の 2026-10-31 到来時に `expires_on is in the past` で監査が落ちるため、ここで掃除した。allowlist は空配列になる (スクリプト側は `entries: []` を正常系として扱う)。

## 確認したこと

| コマンド | 結果 |
|---|---|
| `npm run security:all` | ✅ SQL 0 violations / secrets 0 violations / **deps high=0, critical=0** |
| `npm run test:security` | ✅ 6 + 7 + 9 + 36 pass, 0 fail |
| `npm run lint:web` | ✅ 0 errors (warning 69件は既存) |
| `npm run build` | ✅ 成功 |
| `npm test` | 1404 pass / **2 fail** — 下記の通り本 PR とは無関係の既存失敗 |

### 既知の失敗 (本 PR の範囲外)

`npm test` の以下2件は **変更前の状態でも同じく失敗する**ことを確認済み (変更を stash → `npm ci` → 再実行して再現)。依存バンプとは無関係の既存の壊れで、`Security Checks` ワークフローの対象外でもあるため本 PR では手を入れていない。

- `signup-verify valid OTP saves onboarding profile and returns default official wordbooks for local import` (`src/app/api/auth/otp.contract.test.ts`)
- `words/create inserts raw words, returns resolved lexicon entries, and enqueues unresolved ids only` (`src/app/api/words/create/route.test.ts`) — `expected: ~` に対し `actual: 'passive'`

別途対応が必要であれば切り出してください。

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lbx8x4nzaxTzwosqJPn7FH)_