### PR TITLE
単語の一括取得を全ページ取り切るようにする（古い単語帳が0語で表示される不具合）

### DIFF
--- a/src/lib/db/remote-repository.test.ts
+++ b/src/lib/db/remote-repository.test.ts
@@ -1,7 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import fs from 'node:fs';
-import { buildWordsCreateRequestWord, WORDS_SELECT_COLUMNS } from './remote-repository';
+import { buildWordsCreateRequestWord, fetchAllRows, SUPABASE_MAX_ROWS, WORDS_SELECT_COLUMNS } from './remote-repository';
 import {
   RESOLVED_WORD_DISPLAY_WITH_PRONUNCIATION_SELECT_COLUMNS,
   RESOLVED_WORD_DISPLAY_SELECT_COLUMNS,
@@ -220,5 +220,85 @@ test('shared preview fetches only a limited page with an exact count through fal
   assert.match(
     source,
     /async getWordsForSharePreview\(projectId: string, limit = 5\): Promise<SharedWordsPreview> \{[\s\S]*?this\.selectShareWordsWithFallback\([\s\S]*?\.select\(columns, \{ count: 'exact' \}\)[\s\S]*?\.limit\(limit\)/
+  );
+});
+
+test('fetchAllRows keeps paging past the PostgREST row cap', async () => {
+  const all = Array.from({ length: 2300 }, (_, i) => ({ id: i }));
+  const ranges: Array<[number, number]> = [];
+
+  const result = await fetchAllRows(
+    (from, to) => {
+      ranges.push([from, to]);
+      return Promise.resolve({ data: all.slice(from, to + 1), error: null });
+    },
+    SUPABASE_MAX_ROWS,
+  );
+
+  assert.equal(result.error, null);
+  assert.deepEqual(result.data, all);
+  assert.deepEqual(ranges, [[0, 999], [1000, 1999], [2000, 2999]]);
+});
+
+test('fetchAllRows stops after a single short page', async () => {
+  let calls = 0;
+  const result = await fetchAllRows((from, to) => {
+    calls++;
+    return Promise.resolve({ data: [{ id: from }, { id: to }], error: null });
+  }, SUPABASE_MAX_ROWS);
+
+  assert.equal(calls, 1);
+  assert.equal((result.data as unknown[]).length, 2);
+});
+
+test('fetchAllRows stops when an exactly-full last page is followed by an empty one', async () => {
+  const all = Array.from({ length: 2000 }, (_, i) => ({ id: i }));
+  let calls = 0;
+
+  const result = await fetchAllRows((from, to) => {
+    calls++;
+    return Promise.resolve({ data: all.slice(from, to + 1), error: null });
+  }, SUPABASE_MAX_ROWS);
+
+  assert.equal(calls, 3);
+  assert.deepEqual(result.data, all);
+});
+
+test('fetchAllRows surfaces an error instead of returning a partial page', async () => {
+  const error = { code: '57014', message: 'statement timeout' };
+  const result = await fetchAllRows(
+    (from) => Promise.resolve(
+      from === 0
+        ? { data: Array.from({ length: SUPABASE_MAX_ROWS }, (_, i) => ({ id: i })), error: null }
+        : { data: null, error },
+    ),
+    SUPABASE_MAX_ROWS,
+  );
+
+  assert.equal(result.error, error);
+});
+
+test('every unbounded words query pages through fetchAllRows with a unique sort key', () => {
+  const source = fs.readFileSync(new URL('./remote-repository.ts', import.meta.url), 'utf8');
+
+  // words.created_at は一括登録で同値になるため、created_at だけで並べた
+  // ページングはページ境界で行を取りこぼす。id の第2キーが必須。
+  for (const label of [
+    'getWords',
+    'getWordsForShareView',
+    'getAllWordsByProjectIds',
+    'getWordsUpdatedSince',
+  ]) {
+    const pattern = new RegExp(
+      `fetchAllRows\\(\\(from, to\\) => this\\.select\\w+WordsWithFallback\\([\\s\\S]*?` +
+      `\\.order\\('id', \\{ ascending: true \\}\\)[\\s\\S]*?\\.range\\(from, to\\)[\\s\\S]*?'${label}',`
+    );
+    assert.match(source, pattern, `${label} should page through fetchAllRows ordered by id`);
+  }
+
+  assert.match(
+    source,
+    /async getWordIdsByProjectIds\([\s\S]*?fetchAllRows\(\(from, to\) => this\.supabase[\s\S]*?\.range\(from, to\)\)/,
+    'getWordIdsByProjectIds feeds delete detection and must not truncate',
   );
 });

--- a/src/lib/db/remote-repository.ts
+++ b/src/lib/db/remote-repository.ts
@@ -321,6 +321,49 @@ function normalizeWordsCreateDerivedWords(
   return { items, version: 1 };
 }
 
+/**
+ * PostgREST の db-max-rows。これを超える行数を返すクエリは、エラーも警告も
+ * 出さずに先頭 N 件で打ち切られる。
+ */
+export const SUPABASE_MAX_ROWS = 1000;
+
+/**
+ * 上限で無言に切られるのを防ぐため、range() で全ページを取り切る。
+ *
+ * 呼び出し側のクエリには **一意になる並び順** が必要。words.created_at は
+ * `DEFAULT now()`(トランザクション時刻)なので、一括登録された単語は
+ * created_at が完全に同値になる(実データで最大625件が同値)。同値行の
+ * ページ間の順序は保証されないため、created_at だけで並べると
+ * ページ境界で重複・欠落が起きる。id を第2キーに入れること。
+ *
+ * ページ取得が途中で失敗したら、部分的な結果を返さずエラーを返す。
+ * 欠けた状態を正常な結果として扱うのが今回の不具合の本質だったため、
+ * ここでは黙って減らさず、呼び出し側で throw させる。
+ */
+export async function fetchAllRows<T extends SupabaseSelectResult>(
+  fetchPage: (from: number, to: number) => PromiseLike<T>,
+  pageSize: number = SUPABASE_MAX_ROWS,
+): Promise<T> {
+  const first = await fetchPage(0, pageSize - 1);
+  if (first.error) return first;
+
+  const rows: unknown[] = Array.isArray(first.data) ? [...(first.data as unknown[])] : [];
+  let lastPageSize = rows.length;
+
+  // 満杯のページが返る間は続きがある可能性がある。短いページが来たら終端。
+  while (lastPageSize === pageSize) {
+    const next = await fetchPage(rows.length, rows.length + pageSize - 1);
+    if (next.error) return next;
+
+    const page = Array.isArray(next.data) ? (next.data as unknown[]) : [];
+    rows.push(...page);
+    lastPageSize = page.length;
+    if (page.length === 0) break;
+  }
+
+  return { ...first, data: rows } as T;
+}
+
 export function buildWordsCreateRequestWord(word: Word): WordsCreateRequestWord {
   return {
     id: word.id,
@@ -685,14 +728,16 @@ export class RemoteWordRepository implements WordRepository {
   }
 
   async getWords(projectId: string): Promise<Word[]> {
-    const { data, error } = await this.selectFullWordsWithFallback(
+    const { data, error } = await fetchAllRows((from, to) => this.selectFullWordsWithFallback(
       (columns) => this.supabase
         .from('words')
         .select(columns)
         .eq('project_id', projectId)
-        .order('created_at', { ascending: false }),
+        .order('created_at', { ascending: false })
+        .order('id', { ascending: true })
+        .range(from, to),
       'getWords',
-    );
+    ));
 
     if (error) throw new Error(`Failed to get words: ${error.message}`);
 
@@ -704,14 +749,16 @@ export class RemoteWordRepository implements WordRepository {
    * Omits heavy fields (related_words, usage_patterns, SM-2 fields) not needed for share display.
    */
   async getWordsForShareView(projectId: string): Promise<Word[]> {
-    const { data, error } = await this.selectShareWordsWithFallback(
+    const { data, error } = await fetchAllRows((from, to) => this.selectShareWordsWithFallback(
       (columns) => this.supabase
         .from('words')
         .select(columns)
         .eq('project_id', projectId)
-        .order('created_at', { ascending: false }),
+        .order('created_at', { ascending: false })
+        .order('id', { ascending: true })
+        .range(from, to),
       'getWordsForShareView',
-    );
+    ));
 
     if (error) throw new Error(`Failed to get shared words: ${error.message}`);
 
@@ -793,14 +840,16 @@ export class RemoteWordRepository implements WordRepository {
   async getAllWordsByProjectIds(projectIds: string[]): Promise<Record<string, Word[]>> {
     if (projectIds.length === 0) return {};
 
-    const { data, error } = await this.selectFullWordsWithFallback(
+    const { data, error } = await fetchAllRows((from, to) => this.selectFullWordsWithFallback(
       (columns) => this.supabase
         .from('words')
         .select(columns)
         .in('project_id', projectIds)
-        .order('created_at', { ascending: false }),
+        .order('created_at', { ascending: false })
+        .order('id', { ascending: true })
+        .range(from, to),
       'getAllWordsByProjectIds',
-    );
+    ));
 
     if (error) throw new Error(`Failed to get all words: ${error.message}`);
 
@@ -821,14 +870,16 @@ export class RemoteWordRepository implements WordRepository {
   async getWordsUpdatedSince(projectIds: string[], since: string): Promise<Word[]> {
     if (projectIds.length === 0) return [];
 
-    const { data, error } = await this.selectFullWordsWithFallback(
+    const { data, error } = await fetchAllRows((from, to) => this.selectFullWordsWithFallback(
       (columns) => this.supabase
         .from('words')
         .select(columns)
         .in('project_id', projectIds)
-        .gt('updated_at', since),
+        .gt('updated_at', since)
+        .order('id', { ascending: true })
+        .range(from, to),
       'getWordsUpdatedSince',
-    );
+    ));
 
     if (error) throw new Error(`Failed to get updated words: ${error.message}`);
     return (data as unknown as WordRow[]).map(mapWordFromRow);
@@ -838,10 +889,14 @@ export class RemoteWordRepository implements WordRepository {
   async getWordIdsByProjectIds(projectIds: string[]): Promise<string[]> {
     if (projectIds.length === 0) return [];
 
-    const { data, error } = await this.supabase
+    // 差分同期の削除検知に使う。ここが上限で切られると、取り切れなかった
+    // 単語が「サーバ側で削除された」と誤判定され、ローカルDBから消される。
+    const { data, error } = await fetchAllRows((from, to) => this.supabase
       .from('words')
       .select('id')
-      .in('project_id', projectIds);
+      .in('project_id', projectIds)
+      .order('id', { ascending: true })
+      .range(from, to));
 
     if (error) throw new Error(`Failed to get word IDs: ${error.message}`);
     return (data as { id: string }[]).map(r => r.id);
@@ -1136,10 +1191,12 @@ export class RemoteWordRepository implements WordRepository {
 
     // Get word counts for all relevant projects in one query
     const allProjectIds = [...new Set(cpRows.map((r) => r.project_id as string))];
-    const { data: wordRows, error: wError } = await this.supabase
+    const { data: wordRows, error: wError } = await fetchAllRows((from, to) => this.supabase
       .from('words')
       .select('project_id, status')
-      .in('project_id', allProjectIds);
+      .in('project_id', allProjectIds)
+      .order('id', { ascending: true })
+      .range(from, to));
 
     if (wError) throw new Error(`Failed to get word stats: ${wError.message}`);
 


### PR DESCRIPTION
## 症状

単語帳一覧・単語帳詳細で、**古い単語帳ほど「0語」で表示される**。単語はDBに残っているのに、取得側が上限で無言に切り捨てていた。

実測（23冊 / 1,281語）では **2026-08-05 より前に作られた281語・8冊分が丸ごと不可視**：

| 単語帳 | 語数 | 非表示 | 最古の単語 |
|---|---|---|---|
| 速単 わからんところ | 69 | 69 | 7/13 |
| 鉄壁熟語表現・3 | 65 | 65 | 7/20 |
| 速読英単語1~5 絶対知らなさそうなやつ | 45 | 45 | 7/06 |
| リールで保存した単語 | 30 | 30 | 7/06 |
| 奈良T 九大プリント | 25 | 25 | 7/13 |
| EX Unit2 | 13 | 13 | 7/30 |
| 奈良Tプリント | 12 | 12 | 7/19 |
| Unit7 わからんところ | 50 | 22 | 8/05 |

## 原因

`getAllWordsByProjectIds` はユーザーの全単語帳の単語を1クエリで取得する。PostgREST は `db-max-rows`（1000）を超える応答を**エラーも警告も出さずに**先頭1000件で打ち切る。並びが `created_at DESC` なので落ちるのは常に古い側で、結果として古い単語帳から順に空になる。

取得側は `grouped[pid] = []` で初期化してから詰めるだけなので、「取得できなかった」と「本当に0語」を区別できないまま画面に出ていた。

実ログでも `content-range: 0-999` で打ち切られていることを確認済み。

### 二次被害

同じ無制限クエリが `getWordIdsByProjectIds` にもあり、これは差分同期の削除検知に使われている（`hybrid-repository.ts` の `_deltaSync`）。切り捨てられたIDリストと突き合わせるため、取り切れなかった単語が「サーバ側で削除された」と誤判定され、**ローカルDBからも削除される**。再読込しても戻らなかったのはこのため。サーバの `words` テーブル自体は無傷。

## 変更内容

- `range()` で全ページ取り切る `fetchAllRows` を追加
- 単語を無制限に引いていた6箇所に適用：`getWords` / `getWordsForShareView` / `getAllWordsByProjectIds` / `getWordsUpdatedSince` / `getWordIdsByProjectIds` / バインダー集計の語数カウント
- ページングの並び順に `id` を第2キーとして追加

### id を第2キーに入れた理由

`words.created_at` は `DEFAULT now()`（＝トランザクション時刻）なので、**一括登録された単語の created_at は完全に同値になる**。本番データで最大625件が同一 `created_at` だった。同値行のページ間の順序は保証されないため、`created_at` だけで並べたページングはページ境界で重複・欠落を起こす。

### エラー時の扱い

途中のページが失敗したら、部分的な結果を返さずエラーを返す。欠けた結果を正常扱いすることが今回の不具合そのものだったため、黙って減らさない方針にした。

## テスト

`src/lib/db/remote-repository.test.ts` に5件追加：

- 上限を超えても全ページ取り切る（2,300件 → range 3回）
- 短いページで終端する（1リクエストで済ませる）
- ちょうど満杯で終わる場合に空ページで終端する
- 途中失敗時に部分結果ではなくエラーを返す
- 無制限だった各クエリが `fetchAllRows` + `id` 第2キーを通っていることのソース検査

```
npx tsx --test src/lib/db/remote-repository.test.ts \
  src/lib/db/hybrid-repository.test.ts src/lib/db/sync-queue.test.ts \
  src/lib/projects/load-helpers.test.ts
# 31 pass / 0 fail
```

`npx eslint` は対象2ファイルともクリーン。`npx tsc --noEmit` は本PRの変更ファイルにエラーなし（`grammar/route.security.test.ts` と `quiz/translation-targets.test.ts` の3件は main 既存のもので、本PRとは無関係）。

## 補足（このPRの対象外）

- `.in('project_id', ids)` は単語帳が数百冊になるとURL長が問題になり得る。今回は失敗すればエラーになる（無言の欠落ではない）ため対象外とした
- ページサイズは `SUPABASE_MAX_ROWS = 1000` 固定。`db-max-rows` を下げる場合はこの定数も合わせる必要がある

---
_Generated by [Claude Code](https://claude.ai/code/session_013yvmjkuKj4mRMd9EKMNmp4)_