### PR TITLE
マイグレーションのコメントを実際のアイコンサイズに合わせる

### DIFF
--- a/supabase/migrations/20260814090000_add_profile_avatar.sql
+++ b/supabase/migrations/20260814090000_add_profile_avatar.sql
@@ -1,13 +1,15 @@
 -- Account icon (avatar) for user profiles.
 -- Stored as a compact square JPEG data URL, mirroring how project icons are
 -- persisted (projects.icon_image). Keeping it in the row avoids introducing a
--- storage bucket + signed-URL lifecycle just for a 192px thumbnail.
+-- storage bucket + signed-URL lifecycle just for a small thumbnail.
 ALTER TABLE public.profiles
   ADD COLUMN IF NOT EXISTS avatar_url TEXT;
 
--- Guard against oversized payloads: the client crops/compresses to ~192px JPEG
--- (well under 40KB base64), so 200_000 chars is a generous ceiling that still
--- keeps profile lookups (which are fetched in list views) cheap.
+-- Guard against oversized payloads: the client crops/compresses to a 160px JPEG
+-- (~10KB, so well under 20KB base64), so 200_000 chars is a generous ceiling
+-- that still keeps profile lookups (which are fetched in list views) cheap.
+-- ACCOUNT_ICON_SIZE / MAX_AVATAR_DATA_URL_LENGTH in src/lib/profile/avatar.ts
+-- must stay in sync with this constraint.
 ALTER TABLE public.profiles
   DROP CONSTRAINT IF EXISTS profiles_avatar_url_length;
 ALTER TABLE public.profiles


### PR DESCRIPTION
## 概要

#499 でアイコン生成サイズを 192px から 160px に下げた際、`supabase/migrations/20260814090000_add_profile_avatar.sql` のコメントだけ古い値（192px / 40KB）のまま残っていたので直した。

**コメントのみの修正で DDL は変更していない。** このマイグレーションはまだ本番未適用のため、追加のマイグレーションを切る必要はない（適用済みのファイルであれば新規マイグレーションにするところ）。

あわせて、上限値 200,000 が `src/lib/profile/avatar.ts` の `MAX_AVATAR_DATA_URL_LENGTH` と揃っている必要がある旨を参照先つきで明記した。片方だけ変えると DB の CHECK 制約に弾かれるため。

## 検証

- `npm run lint` の SQL guard 通過（958 ファイル、違反 0）
- DDL に変更がないため挙動への影響なし

---
_Generated by [Claude Code](https://claude.ai/code/session_01H9N8gZFmThqxnXLJdaTEjw)_