### PR TITLE
Redesign battle lobby UI for better mobile layout

### DIFF
--- a/src/app/battle/[roomId]/page.tsx
+++ b/src/app/battle/[roomId]/page.tsx
@@ -7,7 +7,9 @@ import { useBattleRoom } from '@/hooks/use-battle-room';
 import { Icon } from '@/components/ui/Icon';
 import {
   BattleChoiceButton,
+  BattleHeaderButton,
   BattleInviteCode,
+  BattleLeaveConfirm,
   BattleNotice,
   BattleQuestionCard,
   BattleResultPanel,
@@ -78,6 +80,7 @@ export default function BattleRoomPage({ params }: { params: Promise<{ roomId: s
   }, [room, userId, roomId, refresh]);
 
   const handleLeave = useCallback(async () => {
+    setConfirmLeave(false);
     await leaveBattle();
     router.push('/battle');
   }, [leaveBattle, router]);
@@ -181,92 +184,79 @@ export default function BattleRoomPage({ params }: { params: Promise<{ roomId: s
   };
 
   return (
-    <BattleScreen
-      bodyClassName="py-3.5"
-      header={
-        <BattleScreenHeader
-          eyebrow="REALTIME BATTLE"
-          title={viewer.opponent ? `vs ${viewer.opponent.displayName}` : '単語対戦'}
-          onBack={() => setConfirmLeave(true)}
-        >
-          <BattleScoreboard
-            self={viewer.self}
-            opponent={viewer.opponent}
-            progressLabel={getBattleProgressLabel(room)}
-            timer={{
-              remainingMs,
-              durationMs: room.roundDurationMs,
-              paused: resolved,
-            }}
-          />
-        </BattleScreenHeader>
-      }
-      footer={
-        confirmLeave ? (
-          <div className="flex items-center gap-2">
-            <p className="min-w-0 flex-1 text-[12px] font-bold text-[var(--color-muted)]">
-              降参すると相手の勝ちになります。
-            </p>
-            <button
-              type="button"
-              onClick={() => setConfirmLeave(false)}
-              className="h-9 shrink-0 rounded-[10px] border-2 border-[var(--solid-ink)] bg-[var(--color-surface)] px-3 text-[12.5px] font-bold text-[var(--solid-ink)]"
-            >
-              続ける
-            </button>
-            <button
-              type="button"
-              onClick={handleLeave}
-              className="h-9 shrink-0 rounded-[10px] border-2 border-[var(--color-error)] bg-[var(--color-error)] px-3 text-[12.5px] font-bold text-white"
-            >
-              降参する
-            </button>
-          </div>
-        ) : (
-          <button
-            type="button"
-            onClick={() => setConfirmLeave(true)}
-            className="mx-auto flex h-9 items-center gap-1 text-[12px] font-bold text-[var(--color-muted)]"
-          >
-            <Icon name="flag" size={14} />
-            対戦を降参する
-          </button>
-        )
-      }
-    >
-      {currentQuestion ? (
-        <>
-          <BattleQuestionCard
-            prompt={currentQuestion.prompt}
-            round={currentQuestion.roundIndex + 1}
-          />
-
-          <div className="mt-3.5 flex flex-col gap-2.5">
-            {currentQuestion.choices.map((choice, index) => (
-              <BattleChoiceButton
-                key={`${currentQuestion.roundIndex}-${index}`}
-                label={choice}
-                index={index}
-                state={choiceState(index)}
-                onSelect={() => submitAnswer(index)}
+    <>
+      <BattleScreen
+        fill
+        bodyClassName="pt-3"
+        header={
+          <BattleScreenHeader
+            eyebrow="REALTIME BATTLE"
+            title={viewer.opponent ? `vs ${viewer.opponent.displayName}` : '単語対戦'}
+            right={
+              <BattleHeaderButton
+                icon="flag"
+                label="対戦を降参する"
+                tone="danger"
+                onClick={() => setConfirmLeave(true)}
               />
-            ))}
-          </div>
+            }
+          >
+            <BattleScoreboard
+              self={viewer.self}
+              opponent={viewer.opponent}
+              progressLabel={getBattleProgressLabel(room)}
+              timer={{
+                remainingMs,
+                durationMs: room.roundDurationMs,
+                paused: resolved,
+              }}
+            />
+          </BattleScreenHeader>
+        }
+      >
+        {currentQuestion ? (
+          <>
+            {/* 上段=出題、下段=ボタン盤。画面の高さを2つで分け合う */}
+            <div className="flex min-h-[120px] flex-1 items-center justify-center py-2">
+              <BattleQuestionCard
+                prompt={currentQuestion.prompt}
+                round={currentQuestion.roundIndex + 1}
+              />
+            </div>
 
-          {outcome !== 'live' && (
-            <div className="mt-3.5">
+            {/* 決着表示は高さを確保した枠に出す（盤面がずれると早押しの邪魔になる） */}
+            <div className="flex h-[40px] shrink-0 items-center justify-center">
               <BattleRoundStatus outcome={outcome} />
             </div>
-          )}
-        </>
-      ) : (
-        <div className="flex items-center justify-center gap-2 py-14 text-[var(--color-muted)]">
-          <Icon name="progress_activity" size={20} className="animate-spin" />
-          <span className="text-sm font-bold">
-            {questions.length === 0 ? '問題を読み込んでいます...' : '次の問題を準備しています...'}
-          </span>
-        </div>
-      )}
-    </BattleScreen>
+
+            {/* 4択は2×2のボタン盤。親指の届く下半分を使い、面を大きく取る */}
+            <div className="grid min-h-[200px] flex-[1.15] grid-cols-2 grid-rows-2 gap-2.5">
+              {currentQuestion.choices.map((choice, index) => (
+                <BattleChoiceButton
+                  key={`${currentQuestion.roundIndex}-${index}`}
+                  label={choice}
+                  index={index}
+                  state={choiceState(index)}
+                  onSelect={() => submitAnswer(index)}
+                />
+              ))}
+            </div>
+          </>
+        ) : (
+          <div className="flex flex-1 items-center justify-center gap-2 text-[var(--color-muted)]">
+            <Icon name="progress_activity" size={20} className="animate-spin" />
+            <span className="text-sm font-bold">
+              {questions.length === 0 ? '問題を読み込んでいます...' : '次の問題を準備しています...'}
+            </span>
+          </div>
+        )}
+      </BattleScreen>
+
+      <BattleLeaveConfirm
+        isOpen={confirmLeave}
+        onClose={() => setConfirmLeave(false)}
+        onConfirm={handleLeave}
+      />
+    </>
   );
 }

--- a/src/app/battle/page.tsx
+++ b/src/app/battle/page.tsx
@@ -7,12 +7,14 @@ import { useProjects } from '@/hooks/use-projects';
 import { Icon } from '@/components/ui/Icon';
 import {
   BattleInviteCode,
+  BattleModeTabs,
   BattleNotice,
+  BattleRuleStrip,
   BattleScreen,
   BattleScreenHeader,
-  BattleSegmentedField,
+  BattleSetupCard,
   BattleWaitingPanel,
-  BattleWordbookField,
+  type BattleLobbyMode,
 } from '@/components/battle';
 import {
   BATTLE_DEFAULT_QUESTION_COUNT,
@@ -22,23 +24,18 @@ import {
 } from '@/lib/battle/config';
 import type { BattleRoom } from '@/lib/battle/types';
 
-type LobbyMode = 'idle' | 'matching' | 'hosting';
+/** ロビーの滞在状態。設定画面か、マッチング待ちか、フレンドの参加待ちか。 */
+type LobbyStage = 'setup' | 'matching' | 'hosting';
 
 const QUESTION_COUNT_OPTIONS = [
-  { label: '5問', value: 5 },
-  { label: '10問', value: 10 },
-  { label: '20問', value: 20 },
+  { label: '5', value: 5 },
+  { label: '10', value: 10 },
+  { label: '20', value: 20 },
 ];
 const ROUND_DURATION_OPTIONS = [
   { label: '10秒', value: 10_000 },
   { label: '15秒', value: 15_000 },
   { label: '20秒', value: 20_000 },
-];
-
-const BATTLE_RULES = [
-  { icon: 'shuffle', text: 'お互いの単語帳から交互に出題' },
-  { icon: 'bolt', text: '先に正解した方が +1（誤答はその問題を失権）' },
-  { icon: 'toll', text: 'コインは消費しません' },
 ];
 
 export default function BattleLobbyPage() {
@@ -49,15 +46,16 @@ export default function BattleLobbyPage() {
   const [projectId, setProjectId] = useState<string>('');
   const [questionCount, setQuestionCount] = useState(BATTLE_DEFAULT_QUESTION_COUNT);
   const [roundDurationMs, setRoundDurationMs] = useState(BATTLE_DEFAULT_ROUND_DURATION_MS);
-  const [mode, setMode] = useState<LobbyMode>('idle');
+  const [mode, setMode] = useState<BattleLobbyMode>('random');
+  const [stage, setStage] = useState<LobbyStage>('setup');
   const [hostedRoom, setHostedRoom] = useState<BattleRoom | null>(null);
   const [joinCode, setJoinCode] = useState('');
   const [error, setError] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
   const [codeCopied, setCodeCopied] = useState(false);
 
-  const modeRef = useRef<LobbyMode>('idle');
-  modeRef.current = mode;
+  const stageRef = useRef<LobbyStage>('setup');
+  stageRef.current = stage;
 
   useEffect(() => {
     if (!projectId && projects.length > 0) {
@@ -98,7 +96,7 @@ export default function BattleLobbyPage() {
         router.push(`/battle/${payload.roomId}`);
         return;
       }
-      setMode('matching');
+      setStage('matching');
     } catch (err) {
       setError(err instanceof Error ? err.message : 'マッチングに失敗しました。');
     } finally {
@@ -107,19 +105,19 @@ export default function BattleLobbyPage() {
   }, [projectId, questionCount, roundDurationMs, postJson, router]);
 
   const cancelRandomMatch = useCallback(async () => {
-    setMode('idle');
+    setStage('setup');
     await fetch('/api/battle/match', { method: 'DELETE' }).catch(() => {});
   }, []);
 
   // While queued, poll for the room the server paired us into.
   useEffect(() => {
-    if (mode !== 'matching') return;
+    if (stage !== 'matching') return;
 
     const interval = setInterval(async () => {
       try {
         const response = await fetch('/api/battle/match', { cache: 'no-store' });
         const payload = await response.json().catch(() => null);
-        if (payload?.matched && payload.roomId && modeRef.current === 'matching') {
+        if (payload?.matched && payload.roomId && stageRef.current === 'matching') {
           router.push(`/battle/${payload.roomId}`);
         }
       } catch {
@@ -128,7 +126,7 @@ export default function BattleLobbyPage() {
     }, BATTLE_MATCH_POLL_INTERVAL_MS);
 
     return () => clearInterval(interval);
-  }, [mode, router]);
+  }, [stage, router]);
 
   const createFriendRoom = useCallback(async () => {
     if (!projectId) return;
@@ -142,7 +140,7 @@ export default function BattleLobbyPage() {
       });
       setHostedRoom(payload.room as BattleRoom);
       setCodeCopied(false);
-      setMode('hosting');
+      setStage('hosting');
     } catch (err) {
       setError(err instanceof Error ? err.message : 'ルームの作成に失敗しました。');
     } finally {
@@ -152,7 +150,7 @@ export default function BattleLobbyPage() {
 
   // The host waits here until someone joins with the invite code.
   useEffect(() => {
-    if (mode !== 'hosting' || !hostedRoom) return;
+    if (stage !== 'hosting' || !hostedRoom) return;
 
     const interval = setInterval(async () => {
       try {
@@ -167,7 +165,7 @@ export default function BattleLobbyPage() {
     }, BATTLE_MATCH_POLL_INTERVAL_MS);
 
     return () => clearInterval(interval);
-  }, [mode, hostedRoom, router]);
+  }, [stage, hostedRoom, router]);
 
   const joinFriendRoom = useCallback(async () => {
     if (!projectId) return;
@@ -199,7 +197,7 @@ export default function BattleLobbyPage() {
       setCodeCopied(true);
       setTimeout(() => setCodeCopied(false), 2000);
     } catch {
-      // クリップボードが使えない環境ではコードを読み上げてもらう前提で何もしない。
+      // クリップボードが使えない環境では、表示されたコードを読んでもらう。
     }
   }, [hostedRoom]);
 
@@ -244,7 +242,7 @@ export default function BattleLobbyPage() {
     );
   }
 
-  if (mode === 'matching') {
+  if (stage === 'matching') {
     return (
       <BattleScreen header={header} center>
         <BattleWaitingPanel
@@ -266,14 +264,14 @@ export default function BattleLobbyPage() {
     );
   }
 
-  if (mode === 'hosting' && hostedRoom) {
+  if (stage === 'hosting' && hostedRoom) {
     return (
       <BattleScreen header={header} center>
         <BattleWaitingPanel
           title="フレンドの参加を待っています"
           description="このコードを相手に伝えてください。参加した時点で自動的に対戦が始まります。"
           onCancel={() => {
-            setMode('idle');
+            setStage('setup');
             setHostedRoom(null);
           }}
         >
@@ -298,28 +296,10 @@ export default function BattleLobbyPage() {
   const canStart = !busy && Boolean(selectedProject);
 
   return (
-    <BattleScreen header={header} bodyClassName="pb-[130px] pt-3.5 lg:pb-10">
-      {/* 何をする機能かを1枚で伝えるヒーロー */}
-      <section className="relative overflow-hidden rounded-[18px] border-2 border-[var(--color-accent-ink)] bg-[var(--color-accent)] p-5 text-white shadow-[3px_4px_0_var(--solid-ink)]">
-        <div className="absolute inset-y-0 left-0 w-[7px] bg-[rgba(0,0,0,0.22)]" />
-        <div className="flex items-center gap-2">
-          <Icon name="swords" size={22} className="drop-shadow-[1px_1px_0_rgba(0,0,0,0.25)]" />
-          <h2 className="font-display text-[17px] font-black drop-shadow-[1px_1px_0_rgba(0,0,0,0.25)]">
-            早押し4択でリアルタイム対戦
-          </h2>
-        </div>
-        <ul className="mt-3 flex flex-col gap-1.5">
-          {BATTLE_RULES.map((rule) => (
-            <li key={rule.text} className="flex items-center gap-2 text-[12.5px] font-bold opacity-95">
-              <Icon name={rule.icon} size={15} className="shrink-0" />
-              {rule.text}
-            </li>
-          ))}
-        </ul>
-      </section>
-
+    // 設定は1画面に収まる短さなので、余白を上下に散らして中央に置く。
+    <BattleScreen header={header} bodyClassName="py-4" center>
       {error && (
-        <div className="mt-3.5 flex items-start gap-2 rounded-[12px] border-2 border-[var(--color-error)] bg-[var(--color-error-light)] p-3">
+        <div className="mb-3 flex items-start gap-2 rounded-[12px] border-2 border-[var(--color-error)] bg-[var(--color-error-light)] p-3">
           <Icon name="error" size={16} className="mt-[1px] shrink-0 text-[var(--color-error)]" />
           <p className="min-w-0 flex-1 text-[12.5px] font-bold leading-[1.6] text-[var(--color-error)]">
             {error}
@@ -335,100 +315,102 @@ export default function BattleLobbyPage() {
         </div>
       )}
 
-      <div className="mt-5 flex flex-col gap-4">
-        <BattleWordbookField
+      {/* 1. どちらのモードか */}
+      <BattleModeTabs value={mode} onChange={setMode} />
+
+      {/* 2. 両モード共通の設定（1枚のカードに行として収める） */}
+      <div className="mt-3">
+        <BattleSetupCard
           projects={projects}
-          value={projectId}
-          loading={projectsLoading}
-          onChange={setProjectId}
+          projectId={projectId}
+          projectsLoading={projectsLoading}
+          onProjectChange={setProjectId}
+          questionCount={questionCount}
+          questionCountOptions={QUESTION_COUNT_OPTIONS}
+          onQuestionCountChange={setQuestionCount}
+          roundDurationMs={roundDurationMs}
+          roundDurationOptions={ROUND_DURATION_OPTIONS}
+          onRoundDurationChange={setRoundDurationMs}
+          disabled={busy}
         />
-
-        <div className="grid grid-cols-2 gap-3">
-          <BattleSegmentedField
-            icon="format_list_numbered"
-            label="問題数"
-            options={QUESTION_COUNT_OPTIONS}
-            value={questionCount}
-            onChange={setQuestionCount}
-            disabled={busy}
-          />
-          <BattleSegmentedField
-            icon="timer"
-            label="1問の制限時間"
-            options={ROUND_DURATION_OPTIONS}
-            value={roundDurationMs}
-            onChange={setRoundDurationMs}
-            disabled={busy}
-          />
-        </div>
+        {!selectedProject && !projectsLoading && (
+          <p className="mt-1.5 px-1 text-[11.5px] font-bold text-[var(--color-muted)]">
+            対戦には単語帳が1冊以上必要です。
+          </p>
+        )}
       </div>
 
-      <button
-        type="button"
-        onClick={startRandomMatch}
-        disabled={!canStart}
-        className="mt-6 flex h-[58px] items-center justify-center gap-2 rounded-[16px] border-2 border-[var(--color-accent-ink)] bg-[var(--color-accent)] font-display text-[16px] font-black text-white shadow-[3px_4px_0_var(--solid-ink)] transition-all duration-100 active:translate-x-px active:translate-y-px active:shadow-[2px_3px_0_var(--solid-ink)] disabled:opacity-50 disabled:shadow-none"
-      >
-        <Icon name="bolt" size={22} />
-        ランダムマッチを始める
-      </button>
-      {!selectedProject && !projectsLoading && (
-        <p className="mt-2 text-center text-[11.5px] font-bold text-[var(--color-muted)]">
-          対戦には単語帳が1冊以上必要です。
-        </p>
-      )}
+      {/* 3. 選んだモードのアクション */}
+      <div className="mt-4">
+        {mode === 'random' ? (
+          <>
+            <button
+              type="button"
+              onClick={startRandomMatch}
+              disabled={!canStart}
+              className="flex h-[58px] w-full items-center justify-center gap-2 rounded-[16px] border-2 border-[var(--color-accent-ink)] bg-[var(--color-accent)] font-display text-[16px] font-black text-white shadow-[3px_4px_0_var(--solid-ink)] transition-all duration-100 active:translate-x-px active:translate-y-px active:shadow-[2px_3px_0_var(--solid-ink)] disabled:opacity-50 disabled:shadow-none"
+            >
+              <Icon name="bolt" size={22} />
+              マッチングを開始
+            </button>
+            <p className="mt-2 text-center text-[11.5px] leading-[1.6] text-[var(--color-muted)]">
+              待機中の相手と自動でマッチします。
+            </p>
+          </>
+        ) : (
+          <div className="overflow-hidden rounded-[16px] border-2 border-[var(--solid-ink)] bg-[var(--color-surface)]">
+            <div className="p-3">
+              <button
+                type="button"
+                onClick={createFriendRoom}
+                disabled={!canStart}
+                className="flex h-[50px] w-full items-center justify-center gap-1.5 rounded-[12px] border-2 border-[var(--color-accent-ink)] bg-[var(--color-accent)] font-display text-[15px] font-bold text-white transition-all duration-100 active:translate-x-px active:translate-y-px disabled:opacity-50"
+              >
+                <Icon name="add_link" size={18} />
+                招待コードを作る
+              </button>
+              <p className="mt-1.5 text-center text-[11px] text-[var(--color-muted)]">
+                6桁のコードを相手に伝えて対戦します。
+              </p>
+            </div>
 
-      <div className="my-6 flex items-center gap-3">
-        <span className="h-[2px] flex-1 bg-[var(--color-border)]" />
-        <span className="font-mono text-[10px] font-bold tracking-[0.08em] text-[var(--color-muted)]">
-          OR
-        </span>
-        <span className="h-[2px] flex-1 bg-[var(--color-border)]" />
+            <div className="flex items-center gap-2 px-3">
+              <span className="h-[2px] flex-1 bg-[var(--color-border)]" />
+              <span className="font-mono text-[9.5px] font-bold tracking-[0.06em] text-[var(--color-muted)]">
+                または
+              </span>
+              <span className="h-[2px] flex-1 bg-[var(--color-border)]" />
+            </div>
+
+            <div className="flex gap-2 p-3">
+              <input
+                value={joinCode}
+                onChange={(event) => setJoinCode(event.target.value.toUpperCase())}
+                placeholder="コードを入力"
+                maxLength={8}
+                inputMode="text"
+                autoCapitalize="characters"
+                autoComplete="off"
+                aria-label="招待コード"
+                className="h-[50px] min-w-0 flex-1 rounded-[12px] border-2 border-[var(--solid-ink)] bg-[var(--color-surface)] px-3 text-center font-display text-[16px] font-black tracking-[0.2em] text-[var(--solid-ink)] placeholder:text-[13px] placeholder:font-bold placeholder:tracking-normal placeholder:text-[var(--color-muted)]"
+              />
+              <button
+                type="button"
+                onClick={joinFriendRoom}
+                disabled={busy || !selectedProject || joinCode.trim().length === 0}
+                className="h-[50px] shrink-0 rounded-[12px] border-2 border-[var(--solid-ink)] bg-[var(--solid-ink)] px-6 font-display text-[14px] font-bold text-[var(--color-surface)] transition-all duration-100 active:translate-x-px active:translate-y-px disabled:opacity-40"
+              >
+                参加
+              </button>
+            </div>
+          </div>
+        )}
       </div>
 
-      <section className="rounded-[18px] border-2 border-[var(--solid-ink)] bg-[var(--color-surface)] p-4">
-        <div className="flex items-center gap-2">
-          <Icon name="group" size={18} className="text-[var(--solid-ink)]" />
-          <h2 className="font-display text-[15px] font-extrabold text-[var(--solid-ink)]">
-            フレンド対戦
-          </h2>
-        </div>
-        <p className="mt-1 text-[11.5px] leading-[1.6] text-[var(--color-muted)]">
-          6桁の招待コードで、決まった相手とだけ対戦します。
-        </p>
-
-        <button
-          type="button"
-          onClick={createFriendRoom}
-          disabled={!canStart}
-          className="mt-3.5 flex h-12 w-full items-center justify-center gap-1.5 rounded-[12px] border-2 border-[var(--solid-ink)] bg-[var(--color-surface)] font-display text-[14px] font-bold text-[var(--solid-ink)] shadow-[2px_3px_0_var(--solid-ink)] transition-all duration-100 active:translate-x-px active:translate-y-px active:shadow-[1px_2px_0_var(--solid-ink)] disabled:opacity-50 disabled:shadow-none"
-        >
-          <Icon name="add_link" size={17} />
-          招待コードを作る
-        </button>
-
-        <div className="mt-3 flex gap-2">
-          <input
-            value={joinCode}
-            onChange={(event) => setJoinCode(event.target.value.toUpperCase())}
-            placeholder="コードを入力"
-            maxLength={8}
-            inputMode="text"
-            autoCapitalize="characters"
-            autoComplete="off"
-            aria-label="招待コード"
-            className="min-w-0 flex-1 rounded-[12px] border-2 border-[var(--solid-ink)] bg-[var(--color-surface)] px-3 py-3 text-center font-display text-[16px] font-black tracking-[0.2em] text-[var(--solid-ink)] placeholder:font-body placeholder:text-[13px] placeholder:font-bold placeholder:tracking-normal placeholder:text-[var(--color-muted)]"
-          />
-          <button
-            type="button"
-            onClick={joinFriendRoom}
-            disabled={busy || !selectedProject || joinCode.trim().length === 0}
-            className="shrink-0 rounded-[12px] border-2 border-[var(--solid-ink)] bg-[var(--solid-ink)] px-5 font-display text-[14px] font-bold text-[var(--color-surface)] transition-all duration-100 active:translate-x-px active:translate-y-px disabled:opacity-40"
-          >
-            参加
-          </button>
-        </div>
-      </section>
+      {/* 4. ルールは補足なので小さく最後に */}
+      <div className="mt-5">
+        <BattleRuleStrip />
+      </div>
     </BattleScreen>
   );
 }

--- a/src/components/battle/BattleFields.tsx
+++ b/src/components/battle/BattleFields.tsx
@@ -1,153 +1,267 @@
 'use client';
 
 /**
- * ロビーの入力フィールド群（単語帳選択・問題数/制限時間のセグメント・招待コード）。
- * 見た目はアプリ共通の solid（太枠 + ハードシャドウ）に揃えている。
+ * ロビーを構成するパーツ。
+ *
+ * 縦積みの塊を並べるのではなく、
+ *  - モードは 2択のタブ（同時に1つだけ見せる）
+ *  - 対戦設定は「1枚のカードに行を積む」設定リスト（ラベル左・操作右の横並び）
+ *  - ルールは3列のストリップ
+ * という構成にして、1画面に収まるようにしている。
  */
 
 import { useId } from 'react';
 import { Icon } from '@/components/ui/Icon';
+import { cn } from '@/lib/utils';
 import type { Project } from '@/types';
 
-export function BattleFieldLabel({ icon, label, hint }: { icon: string; label: string; hint?: string }) {
+export type BattleLobbyMode = 'random' | 'friend';
+
+const MODE_TABS: { key: BattleLobbyMode; icon: string; label: string }[] = [
+  { key: 'random', icon: 'bolt', label: 'ランダム' },
+  { key: 'friend', icon: 'group', label: 'フレンド' },
+];
+
+/** ランダム / フレンドの切り替えタブ。 */
+export function BattleModeTabs({
+  value,
+  onChange,
+}: {
+  value: BattleLobbyMode;
+  onChange: (mode: BattleLobbyMode) => void;
+}) {
   return (
-    <div className="mb-2 flex items-baseline gap-1.5 px-0.5">
-      <Icon name={icon} size={15} className="translate-y-[2px] text-[var(--color-muted)]" />
-      <span className="font-display text-[13px] font-extrabold text-[var(--solid-ink)]">{label}</span>
-      {hint && <span className="font-mono text-[10px] font-bold text-[var(--color-muted)]">{hint}</span>}
+    <div
+      role="tablist"
+      aria-label="対戦モード"
+      className="grid grid-cols-2 gap-1 rounded-[14px] border-2 border-[var(--solid-ink)] bg-[var(--color-surface-secondary)] p-1"
+    >
+      {MODE_TABS.map((tab) => {
+        const active = tab.key === value;
+        return (
+          <button
+            key={tab.key}
+            type="button"
+            role="tab"
+            aria-selected={active}
+            onClick={() => onChange(tab.key)}
+            className={cn(
+              'flex h-[42px] items-center justify-center gap-1.5 rounded-[10px] font-display text-[14px] font-extrabold transition-colors duration-100',
+              active
+                ? 'bg-[var(--solid-ink)] text-[var(--color-surface)]'
+                : 'text-[var(--color-muted)]',
+            )}
+          >
+            <Icon name={tab.icon} size={17} />
+            {tab.label}
+          </button>
+        );
+      })}
     </div>
   );
 }
 
-/**
- * 出題元の単語帳を選ぶ。ネイティブの <select> を solid カードに重ねて、
- * モバイルの選択UI（ホイール）をそのまま使えるようにしている。
- */
-export function BattleWordbookField({
-  projects,
-  value,
-  loading,
-  onChange,
+/** 設定リストの1行（ラベル左・操作右）。 */
+function SettingRow({
+  icon,
+  label,
+  children,
+  last,
 }: {
-  projects: Project[];
-  value: string;
-  loading: boolean;
-  onChange: (projectId: string) => void;
+  icon: string;
+  label: string;
+  children: React.ReactNode;
+  last?: boolean;
 }) {
-  const selectId = useId();
-  const selected = projects.find((project) => project.id === value) ?? null;
-
   return (
-    <section>
-      <BattleFieldLabel icon="menu_book" label="出題に使う単語帳" />
-
-      {loading ? (
-        <div className="h-[62px] animate-pulse rounded-[14px] border-2 border-[var(--color-border)] bg-[var(--color-surface-secondary)]" />
-      ) : projects.length === 0 ? (
-        <div className="rounded-[14px] border-2 border-dashed border-[var(--color-border)] bg-[var(--color-surface)] p-4 text-center">
-          <p className="text-[12.5px] font-bold leading-[1.7] text-[var(--color-muted)]">
-            単語帳がまだありません。
-            <br />
-            先に単語帳を作ると対戦できます。
-          </p>
-        </div>
-      ) : (
-        <div className="relative">
-          <label htmlFor={selectId} className="sr-only">
-            出題に使う単語帳
-          </label>
-          <select
-            id={selectId}
-            value={value}
-            onChange={(event) => onChange(event.target.value)}
-            className="absolute inset-0 z-10 h-full w-full cursor-pointer opacity-0"
-          >
-            {projects.map((project) => (
-              <option key={project.id} value={project.id}>
-                {project.title}
-              </option>
-            ))}
-          </select>
-          <div className="flex items-center gap-3 rounded-[14px] border-2 border-[var(--solid-ink)] bg-[var(--color-surface)] p-3 shadow-[2px_3px_0_var(--solid-ink)]">
-            <div
-              className="flex h-[42px] w-[42px] shrink-0 items-center justify-center rounded-[10px] border-2 border-[var(--solid-ink)] bg-[var(--color-surface-secondary)] bg-cover bg-center font-display text-[17px] font-extrabold text-[var(--solid-ink)]"
-              style={
-                selected?.iconImage
-                  ? { backgroundImage: `url(${selected.iconImage})` }
-                  : undefined
-              }
-            >
-              {!selected?.iconImage && (selected?.title.charAt(0) ?? '?')}
-            </div>
-            <div className="min-w-0 flex-1">
-              <div className="font-mono text-[9.5px] font-bold tracking-[0.06em] text-[var(--color-muted)]">
-                MY BOOK
-              </div>
-              <div className="truncate font-display text-[14.5px] font-extrabold text-[var(--solid-ink)]">
-                {selected?.title ?? '単語帳を選ぶ'}
-              </div>
-            </div>
-            <Icon name="unfold_more" size={18} className="shrink-0 text-[var(--color-muted)]" />
-          </div>
-        </div>
+    <div
+      className={cn(
+        'flex items-center gap-2 px-3 py-2.5',
+        !last && 'border-b-2 border-[var(--color-border)]',
       )}
-
-      <p className="mt-1.5 px-0.5 text-[11px] leading-[1.6] text-[var(--color-muted)]">
-        問題はお互いの単語帳から交互に選ばれます。
-      </p>
-    </section>
+    >
+      <Icon name={icon} size={16} className="shrink-0 text-[var(--color-muted)]" />
+      <span className="min-w-0 flex-1 truncate font-display text-[13px] font-extrabold text-[var(--solid-ink)]">
+        {label}
+      </span>
+      {children}
+    </div>
   );
 }
 
-/** 問題数・制限時間などのセグメント選択。 */
-export function BattleSegmentedField<T extends number>({
-  icon,
-  label,
-  hint,
+/** 行の右側に置く小さめのセグメント（1本のトラックに収める）。 */
+function InlineSegment<T extends number>({
+  ariaLabel,
   options,
   value,
   onChange,
   disabled,
 }: {
-  icon: string;
-  label: string;
-  hint?: string;
+  ariaLabel: string;
   options: { label: string; value: T }[];
   value: T;
   onChange: (value: T) => void;
   disabled?: boolean;
 }) {
   return (
-    <section>
-      <BattleFieldLabel icon={icon} label={label} hint={hint} />
-      <div
-        role="radiogroup"
-        aria-label={label}
-        className="grid gap-1.5"
-        style={{ gridTemplateColumns: `repeat(${options.length}, minmax(0, 1fr))` }}
-      >
-        {options.map((option) => {
-          const active = option.value === value;
-          return (
-            <button
-              key={option.value}
-              type="button"
-              role="radio"
-              aria-checked={active}
+    <div
+      role="radiogroup"
+      aria-label={ariaLabel}
+      className="flex shrink-0 gap-0.5 rounded-[10px] border-2 border-[var(--solid-ink)] bg-[var(--color-surface-secondary)] p-[3px]"
+    >
+      {options.map((option) => {
+        const active = option.value === value;
+        return (
+          <button
+            key={option.value}
+            type="button"
+            role="radio"
+            aria-checked={active}
+            disabled={disabled}
+            onClick={() => onChange(option.value)}
+            className={cn(
+              'h-[28px] min-w-[46px] rounded-[7px] px-2 font-mono text-[12px] font-bold tabular-nums transition-colors duration-100 disabled:opacity-50',
+              active
+                ? 'bg-[var(--solid-ink)] text-[var(--color-surface)]'
+                : 'text-[var(--color-muted)]',
+            )}
+          >
+            {option.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+/**
+ * 対戦設定（単語帳・問題数・制限時間）を1枚にまとめたカード。
+ * 単語帳の行はネイティブ <select> を重ねて、モバイルの選択UIをそのまま使う。
+ */
+export function BattleSetupCard({
+  projects,
+  projectId,
+  projectsLoading,
+  onProjectChange,
+  questionCount,
+  questionCountOptions,
+  onQuestionCountChange,
+  roundDurationMs,
+  roundDurationOptions,
+  onRoundDurationChange,
+  disabled,
+}: {
+  projects: Project[];
+  projectId: string;
+  projectsLoading: boolean;
+  onProjectChange: (projectId: string) => void;
+  questionCount: number;
+  questionCountOptions: { label: string; value: number }[];
+  onQuestionCountChange: (value: number) => void;
+  roundDurationMs: number;
+  roundDurationOptions: { label: string; value: number }[];
+  onRoundDurationChange: (value: number) => void;
+  disabled?: boolean;
+}) {
+  const selectId = useId();
+  const selected = projects.find((project) => project.id === projectId) ?? null;
+
+  return (
+    <section className="overflow-hidden rounded-[16px] border-2 border-[var(--solid-ink)] bg-[var(--color-surface)] shadow-[2px_3px_0_var(--solid-ink)]">
+      {/* 単語帳 */}
+      <div className="relative flex items-center gap-2.5 border-b-2 border-[var(--color-border)] p-3">
+        {projects.length > 0 && (
+          <>
+            <label htmlFor={selectId} className="sr-only">
+              出題に使う単語帳
+            </label>
+            <select
+              id={selectId}
+              value={projectId}
+              onChange={(event) => onProjectChange(event.target.value)}
               disabled={disabled}
-              onClick={() => onChange(option.value)}
-              className={`h-[46px] rounded-[12px] border-2 font-display text-[14px] font-extrabold transition-all duration-100 active:translate-x-px active:translate-y-px disabled:opacity-50 ${
-                active
-                  ? 'border-[var(--solid-ink)] bg-[var(--solid-ink)] text-[var(--color-surface)] shadow-[2px_3px_0_var(--color-border)]'
-                  : 'border-[var(--solid-ink)] bg-[var(--color-surface)] text-[var(--solid-ink)]'
-              }`}
+              className="absolute inset-0 z-10 h-full w-full cursor-pointer opacity-0"
             >
-              {option.label}
-            </button>
-          );
-        })}
+              {projects.map((project) => (
+                <option key={project.id} value={project.id}>
+                  {project.title}
+                </option>
+              ))}
+            </select>
+          </>
+        )}
+        <div
+          className="flex h-[38px] w-[38px] shrink-0 items-center justify-center rounded-[9px] border-2 border-[var(--solid-ink)] bg-[var(--color-surface-secondary)] bg-cover bg-center font-display text-[15px] font-extrabold text-[var(--solid-ink)]"
+          style={selected?.iconImage ? { backgroundImage: `url(${selected.iconImage})` } : undefined}
+        >
+          {!selected?.iconImage && (selected?.title.charAt(0) ?? '?')}
+        </div>
+        <div className="min-w-0 flex-1">
+          <div className="font-mono text-[9px] font-bold tracking-[0.06em] text-[var(--color-muted)]">
+            出題に使う単語帳
+          </div>
+          <div className="truncate font-display text-[14px] font-extrabold text-[var(--solid-ink)]">
+            {projectsLoading
+              ? '読み込み中...'
+              : selected?.title ?? '単語帳がありません'}
+          </div>
+        </div>
+        {projects.length > 0 && (
+          <Icon name="unfold_more" size={17} className="shrink-0 text-[var(--color-muted)]" />
+        )}
       </div>
+
+      <SettingRow icon="format_list_numbered" label="問題数">
+        <InlineSegment
+          ariaLabel="問題数"
+          options={questionCountOptions}
+          value={questionCount}
+          onChange={onQuestionCountChange}
+          disabled={disabled}
+        />
+      </SettingRow>
+
+      <SettingRow icon="timer" label="1問の制限時間" last>
+        <InlineSegment
+          ariaLabel="1問の制限時間"
+          options={roundDurationOptions}
+          value={roundDurationMs}
+          onChange={onRoundDurationChange}
+          disabled={disabled}
+        />
+      </SettingRow>
     </section>
+  );
+}
+
+const RULES: { icon: string; title: string; detail: string }[] = [
+  { icon: 'shuffle', title: '両者の単語帳', detail: '交互に出題' },
+  { icon: 'bolt', title: '先に正解', detail: '+1点' },
+  { icon: 'toll', title: 'コイン', detail: '消費なし' },
+];
+
+/** ルールを3列で横に並べたストリップ。 */
+export function BattleRuleStrip() {
+  return (
+    <div className="grid grid-cols-3 overflow-hidden rounded-[14px] border-2 border-[var(--color-border)] bg-[var(--color-surface)]">
+      {RULES.map((rule, index) => (
+        <div
+          key={rule.title}
+          className={cn(
+            'px-2 py-2.5 text-center',
+            index < RULES.length - 1 && 'border-r-2 border-[var(--color-border)]',
+          )}
+        >
+          <Icon name={rule.icon} size={16} className="text-[var(--color-accent)]" />
+          <div className="mt-0.5 truncate font-display text-[11px] font-extrabold text-[var(--solid-ink)]">
+            {rule.title}
+          </div>
+          <div className="truncate font-mono text-[9.5px] font-bold text-[var(--color-muted)]">
+            {rule.detail}
+          </div>
+        </div>
+      ))}
+    </div>
   );
 }
 

--- a/src/components/battle/BattleLeaveConfirm.tsx
+++ b/src/components/battle/BattleLeaveConfirm.tsx
@@ -1,0 +1,49 @@
+'use client';
+
+/**
+ * 降参の確認ダイアログ。早押し中の誤タップで対戦が終わらないよう、
+ * 退出は必ずここを通す。
+ */
+
+import { Modal } from '@/components/ui/modal';
+import { Icon } from '@/components/ui/Icon';
+
+export function BattleLeaveConfirm({
+  isOpen,
+  onClose,
+  onConfirm,
+}: {
+  isOpen: boolean;
+  onClose: () => void;
+  onConfirm: () => void;
+}) {
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} showCloseButton={false}>
+      <div className="p-6 text-center">
+        <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-[var(--color-error-light)]">
+          <Icon name="flag" size={22} className="text-[var(--color-error)]" />
+        </div>
+        <h3 className="font-display text-[16px] font-black text-[var(--solid-ink)]">降参しますか？</h3>
+        <p className="mt-2 text-[13px] leading-[1.7] text-[var(--color-muted)]">
+          途中で退出すると、この対戦は相手の勝ちになります。
+        </p>
+        <div className="mt-5 flex gap-2">
+          <button
+            type="button"
+            onClick={onClose}
+            className="h-11 flex-1 rounded-[12px] border-2 border-[var(--solid-ink)] bg-[var(--color-surface)] font-display text-[14px] font-bold text-[var(--solid-ink)]"
+          >
+            続ける
+          </button>
+          <button
+            type="button"
+            onClick={onConfirm}
+            className="h-11 flex-1 rounded-[12px] border-2 border-[var(--color-error)] bg-[var(--color-error)] font-display text-[14px] font-bold text-white"
+          >
+            降参する
+          </button>
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/src/components/battle/BattleQuestion.tsx
+++ b/src/components/battle/BattleQuestion.tsx
@@ -3,7 +3,7 @@
 /**
  * 出題カード・選択肢ボタン・ラウンド結果の帯。
  * 出題は「英単語 → 日本語の意味を4択」。早押しなので、押せる状態かどうかが
- * ひと目で分かることを最優先にしている。
+ * ひと目で分かること、押しやすいこと（2×2のボタン盤）を優先している。
  */
 
 import { Icon } from '@/components/ui/Icon';
@@ -28,7 +28,7 @@ const CHOICE_LABELS = ['A', 'B', 'C', 'D'];
 
 export function BattleQuestionCard({ prompt, round }: { prompt: string; round: number }) {
   return (
-    <div className="rounded-[18px] border-2 border-[var(--solid-ink)] bg-[var(--color-surface)] px-5 py-6 text-center shadow-[3px_4px_0_var(--solid-ink)]">
+    <div className="w-full rounded-[18px] border-2 border-[var(--solid-ink)] bg-[var(--color-surface)] px-5 py-6 text-center shadow-[3px_4px_0_var(--solid-ink)]">
       <div className="font-mono text-[9.5px] font-bold tracking-[0.08em] text-[var(--color-muted)]">
         Q{round} · この単語の意味は？
       </div>
@@ -47,6 +47,10 @@ export function BattleQuestionCard({ prompt, round }: { prompt: string; round: n
   );
 }
 
+/**
+ * 選択肢。2×2 のグリッドに置く前提で、面は正方形寄り・ラベルは中央。
+ * 記号（A〜D）は左上のコーナーに逃がして、意味の可読性を落とさない。
+ */
 export function BattleChoiceButton({
   label,
   index,
@@ -64,8 +68,8 @@ export function BattleChoiceButton({
   let borderColor = 'var(--solid-ink)';
   let shadowColor = 'var(--solid-ink)';
   let textColor = 'var(--solid-ink)';
-  let badgeBg = 'var(--color-surface)';
-  let badgeColor = 'var(--solid-ink)';
+  let badgeBg = 'var(--color-surface-secondary)';
+  let badgeColor = 'var(--color-muted)';
   let icon: string | null = null;
 
   if (state === 'correct') {
@@ -88,7 +92,6 @@ export function BattleChoiceButton({
     borderColor = 'var(--color-border)';
     shadowColor = 'var(--color-border)';
     textColor = 'var(--color-muted)';
-    badgeColor = 'var(--color-muted)';
   } else if (state === 'selected') {
     faceBg = 'var(--color-surface-secondary)';
     badgeBg = 'var(--solid-ink)';
@@ -103,7 +106,7 @@ export function BattleChoiceButton({
         triggerHaptic();
         onSelect();
       }}
-      className={`relative w-full text-left disabled:cursor-default ${state === 'locked' ? 'opacity-55' : ''}`}
+      className={`relative h-full w-full disabled:cursor-default ${state === 'locked' ? 'opacity-55' : ''}`}
     >
       {/* ハードシャドウの受け皿（クイズの選択肢と同じ作り） */}
       <div
@@ -111,22 +114,29 @@ export function BattleChoiceButton({
         style={{ transform: 'translate(2.5px, 2.5px)', background: shadowColor }}
       />
       <div
-        className="relative flex items-center gap-3 rounded-[14px] border-2 px-3.5 py-[15px]"
+        className="relative flex h-full min-h-[86px] flex-col items-center justify-center rounded-[14px] border-2 px-2.5 py-3"
         style={{ background: faceBg, borderColor }}
       >
         <span
-          className="flex h-[26px] w-[26px] shrink-0 items-center justify-center rounded-[8px] border-2 font-mono text-[11px] font-bold"
-          style={{ background: badgeBg, borderColor, color: badgeColor }}
+          className="absolute left-2 top-2 flex h-[20px] w-[20px] items-center justify-center rounded-[6px] font-mono text-[10px] font-bold"
+          style={{ background: badgeBg, color: badgeColor }}
         >
           {CHOICE_LABELS[index] ?? index + 1}
         </span>
+        {icon && (
+          <Icon
+            name={icon}
+            size={16}
+            className="absolute right-2 top-2"
+            style={{ color: textColor }}
+          />
+        )}
         <span
-          className="min-w-0 flex-1 break-words text-[15px] font-bold leading-[1.4]"
+          className="break-words text-center text-[15px] font-bold leading-[1.35]"
           style={{ color: textColor }}
         >
           {label}
         </span>
-        {icon && <Icon name={icon} size={18} className="shrink-0 text-white" />}
       </div>
     </button>
   );
@@ -169,25 +179,28 @@ const OUTCOME_STYLE: Record<
   // 誤答は「そのラウンドの失権」。決着はまだなので相手の回答を待つ。
   missed: {
     icon: 'close',
-    text: '不正解... 相手の回答を待ちます',
+    text: '不正解... 相手の回答待ち',
     bg: 'var(--color-error-light)',
     border: 'var(--color-error)',
     color: 'var(--color-error)',
   },
 };
 
-/** ラウンドの決着（または回答済み待ち）を伝える帯。 */
+/**
+ * ラウンドの状況を伝えるピル。
+ * 決着時に現れても盤面がずれないよう、呼び出し側で高さを確保した枠に置く。
+ */
 export function BattleRoundStatus({ outcome }: { outcome: BattleRoundOutcome }) {
   if (outcome === 'live') return null;
 
   const style = OUTCOME_STYLE[outcome];
   return (
     <div
-      className="flex items-center justify-center gap-1.5 rounded-[12px] border-2 py-2.5"
+      className="inline-flex items-center gap-1.5 rounded-full border-2 px-3.5 py-1.5"
       style={{ background: style.bg, borderColor: style.border, color: style.color }}
     >
-      <Icon name={style.icon} size={16} />
-      <span className="font-display text-[13.5px] font-extrabold">{style.text}</span>
+      <Icon name={style.icon} size={15} />
+      <span className="font-display text-[12.5px] font-extrabold">{style.text}</span>
     </div>
   );
 }

--- a/src/components/battle/BattleScreen.tsx
+++ b/src/components/battle/BattleScreen.tsx
@@ -7,6 +7,8 @@
  * 同じ「固定ビューポート」パターン）。モバイルでは body の safe-area padding を
  * 抜けるために fixed で置き、デスクトップでは ds-live-main（100dvh・overflow
  * hidden のグリッド列）の中に収まるよう static に戻す。
+ *
+ * 対戦はボトムナビを出さない専用フローなので、本文は画面いっぱいを使える。
  */
 
 import Link from 'next/link';
@@ -17,18 +19,18 @@ import { cn } from '@/lib/utils';
 
 export function BattleScreen({
   header,
-  footer,
   children,
-  /** ボトムナビが重なる画面（ロビー）では下に余白を足す。 */
   bodyClassName,
   center = false,
+  fill = false,
 }: {
   header: ReactNode;
-  footer?: ReactNode;
   children: ReactNode;
   bodyClassName?: string;
   /** 本文を上下中央に置く（待機・結果画面）。 */
   center?: boolean;
+  /** 本文を画面いっぱいに伸ばし、中で flex 配分させる（対戦中）。 */
+  fill?: boolean;
 }) {
   return (
     <div className="fixed inset-x-0 top-0 z-30 flex h-[100dvh] flex-col overflow-hidden bg-[var(--color-background)] font-[var(--font-body)] lg:static lg:z-auto lg:h-full">
@@ -37,28 +39,22 @@ export function BattleScreen({
         <div
           className={cn(
             'mx-auto flex w-full max-w-[560px] flex-col px-[18px]',
-            center && 'min-h-full justify-center',
+            (center || fill) && 'min-h-full',
+            center && 'justify-center',
             bodyClassName,
           )}
+          style={{ paddingBottom: 'max(14px, env(safe-area-inset-bottom))' }}
         >
           {children}
         </div>
       </div>
-      {footer && (
-        <div
-          className="shrink-0 border-t-2 border-[var(--color-border)] bg-[var(--color-background)] px-[18px] pt-2.5"
-          style={{ paddingBottom: 'max(10px, env(safe-area-inset-bottom))' }}
-        >
-          <div className="mx-auto w-full max-w-[560px]">{footer}</div>
-        </div>
-      )}
     </div>
   );
 }
 
 /**
  * 固定ヘッダ。上段は 戻る + ラベル + 右アクション、`children` があれば
- * その下（スコアボードやタイマー）も固定領域に含める。
+ * その下（スコアボードなど）も固定領域に含める。
  */
 export function BattleScreenHeader({
   eyebrow,
@@ -109,6 +105,35 @@ export function BattleScreenHeader({
         {children}
       </div>
     </header>
+  );
+}
+
+/** ヘッダ右に置く丸アイコンボタン。 */
+export function BattleHeaderButton({
+  icon,
+  label,
+  onClick,
+  tone = 'default',
+}: {
+  icon: string;
+  label: string;
+  onClick: () => void;
+  tone?: 'default' | 'danger';
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-label={label}
+      className={cn(
+        'flex h-[36px] w-[36px] shrink-0 items-center justify-center rounded-full border-2 bg-[var(--color-surface)] transition-all duration-100 active:translate-x-px active:translate-y-px',
+        tone === 'danger'
+          ? 'border-[var(--color-error)] text-[var(--color-error)]'
+          : 'border-[var(--solid-ink)] text-[var(--solid-ink)]',
+      )}
+    >
+      <Icon name={icon} size={17} />
+    </button>
   );
 }
 

--- a/src/components/battle/index.ts
+++ b/src/components/battle/index.ts
@@ -2,14 +2,16 @@ export { BattleEntrySection } from './BattleEntrySection';
 export {
   BattleScreen,
   BattleScreenHeader,
+  BattleHeaderButton,
   BattleNotice,
   BattleWaitingPanel,
 } from './BattleScreen';
 export {
-  BattleFieldLabel,
   BattleInviteCode,
-  BattleSegmentedField,
-  BattleWordbookField,
+  BattleModeTabs,
+  BattleRuleStrip,
+  BattleSetupCard,
+  type BattleLobbyMode,
 } from './BattleFields';
 export { BattleScoreboard } from './BattleScoreboard';
 export {
@@ -20,3 +22,4 @@ export {
   type BattleRoundOutcome,
 } from './BattleQuestion';
 export { BattleResultPanel } from './BattleResultPanel';
+export { BattleLeaveConfirm } from './BattleLeaveConfirm';

--- a/src/components/ui/PersistentAppShell.tsx
+++ b/src/components/ui/PersistentAppShell.tsx
@@ -28,9 +28,8 @@ const HIDE_BOTTOM_NAV_PATHS = [
   // 他ユーザーのプロフィール(/profile/<accountId>)は詳細画面なので非表示のまま。
   '/profile/',
   '/groups/', '/reels',
-  // 対戦ルーム(/battle/<roomId>)は早押しの専用画面なのでナビを出さない。
-  // ロビー(/battle)はタブ的な入口なので表示したまま。
-  '/battle/',
+  // 対戦はロビーも含めて専用フロー（1画面に収める設計）なのでナビは出さない。
+  '/battle',
   // 語法演習画面(/grammar/<bookId>)はナビ非表示。一覧(/grammar)は表示する。
   '/grammar/',
   // バインダー詳細は自前の固定下部バー（単語帳を追加/公開）を持つため、


### PR DESCRIPTION
## Summary
Restructured the battle lobby interface to fit on a single screen by reorganizing components into a more compact, mobile-friendly layout. Replaced vertical stacking of full-width sections with a tabbed mode selector, consolidated settings into a single card, and added a horizontal rule strip.

## Key Changes

### Battle Lobby Layout (`src/app/battle/page.tsx`)
- Replaced hero section with mode tabs (Random/Friend) at the top
- Consolidated wordbook, question count, and round duration settings into a single `BattleSetupCard` component
- Added `BattleRuleStrip` to display rules in a 3-column horizontal layout
- Reorganized action buttons to be mode-specific (Random match vs. Friend invite/join)
- Changed layout from `pb-[130px]` (accounting for bottom nav) to `py-4` with `center` prop for better vertical distribution
- Updated button labels and helper text for clarity

### Battle Fields Components (`src/components/battle/BattleFields.tsx`)
- **Removed**: `BattleFieldLabel`, `BattleWordbookField`, `BattleSegmentedField` (replaced with new components)
- **Added**: 
  - `BattleModeTabs` – Tab-style mode selector (Random/Friend) with icon + label
  - `BattleSetupCard` – Single card containing wordbook selector, question count, and round duration as horizontal rows
  - `BattleRuleStrip` – 3-column rule display (shuffle, bolt, toll icons with descriptions)
  - `SettingRow` – Reusable row component for settings (label left, control right)
  - `InlineSegment` – Compact segmented control for inline use within settings rows
- **Exported**: `BattleLobbyMode` type ('random' | 'friend')

### Battle Room UI (`src/app/battle/[roomId]/page.tsx`)
- Replaced footer-based leave confirmation with modal dialog (`BattleLeaveConfirm`)
- Added `BattleHeaderButton` component for the leave button in header
- Reorganized question/choice layout to use flexbox with better space distribution:
  - Top section: question card (flex-1, centered)
  - Middle section: round status (fixed h-[40px])
  - Bottom section: 2×2 choice button grid (flex-[1.15], larger touch targets)
- Changed `BattleScreen` to use `fill` prop instead of `footer` prop
- Removed `py-3.5` body padding in favor of `pt-3` with safe-area handling

### Screen Component Updates (`src/components/battle/BattleScreen.tsx`)
- Removed `footer` prop and footer rendering logic
- Added `fill` prop to allow body to stretch full height (for battle room)
- Updated `BattleScreenHeader` to accept `right` prop for header actions
- Added new `BattleHeaderButton` component for icon buttons in header
- Improved safe-area padding handling in body

### New Modal Component (`src/components/battle/BattleLeaveConfirm.tsx`)
- Created dedicated leave confirmation modal with icon, title, description, and action buttons
- Prevents accidental forfeit during active gameplay

### Choice Button Styling (`src/components/battle/BattleQuestion.tsx`)
- Updated badge background color from `var(--color-surface)` to `var(--color-surface-secondary)` for better visual hierarchy
- Changed button height from `text-left` to `h-full` for grid layout compatibility
- Improved comment documentation about 2×2 grid layout and button design

### Component Exports (`src/components/battle/index.ts`)
- Updated exports to reflect new component structure
- Removed `BattleFieldLabel`, `BattleSegmentedField`, `BattleWordbookField`
- Added `BattleModeTabs`, `BattleSetupCard`, `BattleRuleStrip`, `BattleHeaderButton`, `BattleLeaveConfirm`
- Exported `BattleLobbyMode` type

### Navigation Config (`src/components/ui/PersistentAppShell.tsx`)

https://claude.ai/code/session_01HyG46QFA5uecpt3kd23u7G