### PR TITLE
単語一覧の枠をそろえ、スキャンの英検を非表示・アカウント周りのヘッダを固定

### DIFF
--- a/src/app/project/[id]/page.tsx
+++ b/src/app/project/[id]/page.tsx
@@ -10,6 +10,7 @@ import { WordLimitModal } from '@/components/limits';
 import { ScanCaptureModal } from '@/components/home/ScanCaptureModal';
 import { ProjectShareSheet } from '@/components/project/ProjectShareSheet';
 import { SelectCheckbox, WordRow, posShort } from '@/components/project/WordRow';
+import { StackedBar } from '@/components/project/WordStatusBar';
 import { GuidedTour, type TourStep } from '@/components/onboarding/GuidedTour';
 import { WordFilterSheet, WordSortSheet } from '@/components/project/WordListSheets';
 import { BinderPickerSheet } from '@/components/desktop/ProjectListSheets';
@@ -2404,40 +2405,6 @@ function ToolChip({ icon, label }: { icon: string; label: string }) {
     <span className="inline-flex items-center gap-[5px] rounded-full border-2 border-[var(--color-border)] bg-white px-2.5 py-1.5 text-[12px] font-semibold text-[var(--color-muted)]">
       <Icon name={icon} size={12} />
       <span className="text-[#4a4a4a]">{label}</span>
-    </span>
-  );
-}
-
-function StackedBar({ total, m, a, l, n }: { total: number; m: number; a: number; l: number; n: number }) {
-  const pctM = total ? (m / total) * 100 : 0;
-  const pctA = total ? (a / total) * 100 : 0;
-  const pctL = total ? (l / total) * 100 : 0;
-  const pctN = total ? (n / total) * 100 : 0;
-
-  return (
-    <div>
-      <div className="flex h-2.5 overflow-hidden rounded-full border-2 border-[var(--solid-ink)] bg-white">
-        <div style={{ width: `${pctM}%`, background: 'var(--color-success)' }} />
-        <div style={{ width: `${pctA}%`, background: '#2563eb' }} />
-        <div style={{ width: `${pctL}%`, background: 'var(--color-warning)' }} />
-        <div style={{ width: `${pctN}%`, background: 'rgba(26,26,26,0.12)' }} />
-      </div>
-      <div className="mt-[7px] flex flex-wrap gap-3.5 font-[var(--font-body)]">
-        <BarDot color="var(--color-success)" label="習得" count={m} />
-        <BarDot color="#2563eb" label="定着中" count={a} />
-        <BarDot color="var(--color-warning)" label="学習中" count={l} />
-        <BarDot color="rgba(26,26,26,0.35)" label="未学習" count={n} />
-      </div>
-    </div>
-  );
-}
-
-function BarDot({ color, label, count }: { color: string; label: string; count: number }) {
-  return (
-    <span className="inline-flex items-center gap-[5px]">
-      <span className="h-[7px] w-[7px] rounded-[3.5px]" style={{ background: color }} />
-      <span className="text-[11px] font-semibold text-[#4a4a4a]">{label}</span>
-      <span className="font-mono text-[11px] tabular-nums text-[var(--color-muted)]">{count}</span>
     </span>
   );
 }

--- a/src/app/settings/account/page.tsx
+++ b/src/app/settings/account/page.tsx
@@ -7,6 +7,7 @@ import { useAuth } from '@/hooks/use-auth';
 import { useProfile } from '@/hooks/use-profile';
 import { isBillingEnabled } from '@/lib/billing/feature';
 import type { Subscription } from '@/types';
+import { StickyPageHeader } from '@/components/ui/StickyPageHeader';
 
 function getPlanHint(subscription: Subscription | null, isPro: boolean): string {
   if (!isPro) return 'FREE';
@@ -24,25 +25,19 @@ export default function AccountSettingsPage() {
   const planHint = getPlanHint(subscription, isPro);
 
   return (
-    <div className="relative min-h-screen bg-[var(--color-background)] pb-[110px] pt-3 font-[var(--font-body)] lg:hidden">
-      <div className="px-[18px] pb-[14px] pt-1">
-        <button
-          type="button"
-          onClick={() => {
-            if (typeof window !== 'undefined' && window.history.length > 1) {
-              router.back();
-              return;
-            }
-            router.push('/settings');
-          }}
-          aria-label="戻る"
-          className="mb-2 flex h-[38px] w-[38px] items-center justify-center rounded-[19px] border-2 border-[var(--solid-ink)] bg-white text-[var(--solid-ink)] transition-all duration-100 active:translate-x-px active:translate-y-px"
-        >
-          <Icon name="chevron_left" size={20} />
-        </button>
-        <div className="font-mono text-[10px] font-bold uppercase tracking-[0.08em] text-[var(--color-muted)]">ACCOUNT</div>
-        <div className="mt-0.5 font-display text-[26px] font-extrabold leading-[1.1] tracking-[-0.02em] text-[var(--solid-ink)]">アカウント</div>
-      </div>
+    <div className="relative min-h-screen bg-[var(--color-background)] pb-[110px] font-[var(--font-body)] lg:hidden">
+      <StickyPageHeader
+        eyebrow="ACCOUNT"
+        title="アカウント"
+        onBack={() => {
+          if (typeof window !== 'undefined' && window.history.length > 1) {
+            router.back();
+            return;
+          }
+          router.push('/settings');
+        }}
+        className="mb-3"
+      />
 
       <SettingsGroup label="プロフィール">
         <SettingsRow

--- a/src/app/settings/account/profile/page.tsx
+++ b/src/app/settings/account/profile/page.tsx
@@ -8,6 +8,7 @@ import { ProfileAvatar } from '@/components/profile/ProfileAvatar';
 import { profileAvatarColor } from '@/components/profile/ProfileView';
 import { useProfile } from '@/hooks/use-profile';
 import { processAccountIconFile } from '@/lib/image-utils';
+import { StickyPageHeader } from '@/components/ui/StickyPageHeader';
 
 type IconAction = 'idle' | 'saving' | 'removing';
 
@@ -303,19 +304,8 @@ export default function ProfileSettingsPage() {
       </div>
     </div>
 
-    <div className="relative min-h-screen bg-[var(--color-background)] pb-[110px] pt-3 font-[var(--font-body)] lg:hidden">
-      <div className="px-[18px] pb-[14px] pt-1">
-        <button
-          type="button"
-          onClick={handleBack}
-          aria-label="戻る"
-          className="mb-2 flex h-[38px] w-[38px] items-center justify-center rounded-[19px] border-2 border-[var(--solid-ink)] bg-white text-[var(--solid-ink)] transition-all duration-100 active:translate-x-px active:translate-y-px"
-        >
-          <Icon name="chevron_left" size={20} />
-        </button>
-        <div className="font-mono text-[10px] font-bold uppercase tracking-[0.08em] text-[var(--color-muted)]">PROFILE</div>
-        <div className="mt-0.5 font-display text-[26px] font-extrabold leading-[1.1] tracking-[-0.02em] text-[var(--solid-ink)]">プロフィール変更</div>
-      </div>
+    <div className="relative min-h-screen bg-[var(--color-background)] pb-[110px] font-[var(--font-body)] lg:hidden">
+      <StickyPageHeader eyebrow="PROFILE" title="プロフィール変更" onBack={handleBack} className="mb-3" />
 
       <div className="px-[18px] pb-4">
         <div className="overflow-hidden rounded-[12px] border-2 border-[var(--solid-ink)] bg-white">

--- a/src/app/settings/customize/page.tsx
+++ b/src/app/settings/customize/page.tsx
@@ -4,6 +4,7 @@ import { useRouter } from 'next/navigation';
 import { StudyReminderSettings } from '@/components/settings/StudyReminderSettings';
 import { ExampleGenreSettings } from '@/components/settings/ExampleGenreSettings';
 import { Icon } from '@/components/ui';
+import { StickyPageHeader } from '@/components/ui/StickyPageHeader';
 
 export default function CustomizePage() {
   const router = useRouter();
@@ -34,19 +35,14 @@ export default function CustomizePage() {
         </div>
       </div>
 
-      <div className="relative min-h-screen bg-[var(--color-background)] pb-[110px] pt-3 font-[var(--font-body)] lg:hidden">
-        <div className="px-[18px] pb-[14px] pt-1">
-          <button
-            type="button"
-            onClick={() => router.push('/settings')}
-            aria-label="設定へ戻る"
-            className="mb-2 flex h-[38px] w-[38px] items-center justify-center rounded-[19px] border-2 border-[var(--solid-ink)] bg-white text-[var(--solid-ink)] transition-all duration-100 active:translate-x-px active:translate-y-px"
-          >
-            <Icon name="chevron_left" size={20} />
-          </button>
-          <div className="font-mono text-[10px] font-bold uppercase tracking-[0.08em] text-[var(--color-muted)]">CUSTOMIZE</div>
-          <div className="mt-0.5 font-display text-[26px] font-extrabold leading-[1.1] tracking-[-0.02em] text-[var(--solid-ink)]">カスタマイズ</div>
-        </div>
+      <div className="relative min-h-screen bg-[var(--color-background)] pb-[110px] font-[var(--font-body)] lg:hidden">
+        <StickyPageHeader
+          eyebrow="CUSTOMIZE"
+          title="カスタマイズ"
+          backLabel="設定へ戻る"
+          onBack={() => router.push('/settings')}
+          className="mb-3"
+        />
 
         <div className="px-[18px] pb-3">
           <StudyReminderSettings variant="mobile" />

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -4,8 +4,8 @@ import { useRouter } from 'next/navigation';
 import Link from 'next/link';
 import { DesktopSettingsView } from '@/components/desktop/DesktopAccount';
 import { Icon } from '@/components/ui';
+import { StickyPageHeader } from '@/components/ui/StickyPageHeader';
 import { SolidPanel } from '@/components/redesign/SolidPage';
-import { ReviewLimitPicker } from '@/components/settings/ReviewLimitPicker';
 import { useAuth } from '@/hooks/use-auth';
 import { useProfile } from '@/hooks/use-profile';
 import { isBillingEnabled } from '@/lib/billing/feature';
@@ -58,24 +58,12 @@ export default function SettingsPage() {
         usernameSaving={profileSaving}
         usernameError={profileError}
       />
-      <div className="relative min-h-screen bg-[var(--color-background)] pb-[110px] pt-3 font-[var(--font-body)] lg:hidden">
-      {/* Header */}
-      <div className="px-[18px] pb-[14px] pt-1">
-        {/* 設定はプロフィール内の導線から開くので、戻り先はプロフィール */}
-        <button
-          type="button"
-          onClick={handleBack}
-          aria-label="戻る"
-          className="mb-2 flex h-[38px] w-[38px] items-center justify-center rounded-[19px] border-2 border-[var(--solid-ink)] bg-white text-[var(--solid-ink)] transition-all duration-100 active:translate-x-px active:translate-y-px"
-        >
-          <Icon name="chevron_left" size={20} />
-        </button>
-        <div className="font-mono text-[10px] font-bold uppercase tracking-[0.08em] text-[var(--color-muted)]">ACCOUNT</div>
-        <div className="mt-0.5 font-display text-[26px] font-extrabold leading-[1.1] tracking-[-0.02em] text-[var(--solid-ink)]">設定</div>
-      </div>
+      <div className="relative min-h-screen bg-[var(--color-background)] pb-[110px] font-[var(--font-body)] lg:hidden">
+      {/* 設定はプロフィール内の導線から開くので、戻り先はプロフィール */}
+      <StickyPageHeader eyebrow="ACCOUNT" title="設定" onBack={handleBack} />
 
       {/* Profile card */}
-      <div className="px-[18px] pb-[14px]">
+      <div className="px-[18px] pb-[14px] pt-3">
         {authLoading ? (
           <SolidPanel className="!rounded-[14px] !" faceClassName="!p-[14px]">
             <div className="flex h-14 items-center justify-center">
@@ -87,7 +75,7 @@ export default function SettingsPage() {
             className="!rounded-[14px] !"
             faceClassName="!p-[14px]"
           >
-            <Link href="/profile" className="flex items-center gap-3">
+            <div className="flex items-center gap-3">
               {avatarUrl ? (
                 // eslint-disable-next-line @next/next/no-img-element
                 <img
@@ -113,8 +101,7 @@ export default function SettingsPage() {
                   {isPro ? 'PRO PLAN' : 'FREE PLAN'}
                 </div>
               </div>
-              <Icon name="chevron_right" size={22} className="shrink-0 text-[var(--color-muted)]" />
-            </Link>
+            </div>
           </SolidPanel>
         ) : (
           <SolidPanel className="!rounded-[14px] !" faceClassName="!p-[14px]">
@@ -188,28 +175,9 @@ export default function SettingsPage() {
         </Link>
       </div>
 
-      {/* 豆知識 — 語源（接頭語・接尾語・接中語）コーナー */}
+      {/* 豆知識 — 中身は /tips にまとめ、設定には入口だけ置く */}
       <SettingsGroup label="豆知識">
-        <SettingsRow icon="text_fields" label="接頭語（プレフィックス）" description="un- / re- / pre- など、頭に付くパーツの意味と例" href="/tips/prefixes" />
-        <SettingsRow icon="text_fields" label="接尾語（サフィックス）" description="-tion / -ous / -able など、品詞を決めるパーツ" href="/tips/suffixes" />
-        <SettingsRow icon="text_fields" label="接中語（インフィックス）" description="therm-o-meter の -o- など、語根をつなぐパーツ" href="/tips/infixes" />
-      </SettingsGroup>
-
-      <SettingsGroup label="学習">
-        <div className="px-3 py-[11px]">
-          <div className="flex items-center gap-2.5">
-            <span className="inline-flex h-[26px] w-[26px] shrink-0 items-center justify-center rounded-[7px] bg-[rgba(26,26,26,0.05)] text-[var(--solid-ink)]">
-              <Icon name="event_repeat" size={16} />
-            </span>
-            <div className="min-w-0 flex-1">
-              <span className="text-[13px] font-bold text-[var(--solid-ink)]">1日の復習上限</span>
-              <p className="mt-px text-[10px] leading-4 text-[var(--color-muted)]">
-                復習クイズに出す問題数の上限。間違いが多い単語・CEFRが高い単語から優先して選ばれます
-              </p>
-            </div>
-          </div>
-          <ReviewLimitPicker className="mt-2.5 pl-[36.5px]" />
-        </div>
+        <SettingsRow icon="lightbulb" label="豆知識" description="接頭語・接尾語・接中語のパーツ辞典" href="/tips" />
       </SettingsGroup>
 
       <SettingsGroup label="カスタマイズ">

--- a/src/app/tips/page.tsx
+++ b/src/app/tips/page.tsx
@@ -1,0 +1,87 @@
+'use client';
+
+/**
+ * 豆知識のトップ。接頭語・接尾語・接中語の各ページはここから開く。
+ * 設定ページには「豆知識」の入口だけを置き、中身はこのページにまとめる。
+ */
+
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import { Icon } from '@/components/ui/Icon';
+import { StickyPageHeader } from '@/components/ui/StickyPageHeader';
+import { getAffixesByKind } from '@/lib/morphology/affix-catalog';
+
+const TIPS: Array<{
+  href: string;
+  label: string;
+  description: string;
+  count: number;
+}> = [
+  {
+    href: '/tips/prefixes',
+    label: '接頭語（プレフィックス）',
+    description: 'un- / re- / pre- など、頭に付くパーツの意味と例',
+    count: getAffixesByKind('prefix').length,
+  },
+  {
+    href: '/tips/suffixes',
+    label: '接尾語（サフィックス）',
+    description: '-tion / -ous / -able など、品詞を決めるパーツ',
+    count: getAffixesByKind('suffix').length,
+  },
+  {
+    href: '/tips/infixes',
+    label: '接中語（インフィックス）',
+    description: 'therm-o-meter の -o- など、語根をつなぐパーツ',
+    count: getAffixesByKind('infix').length,
+  },
+];
+
+export default function TipsIndexPage() {
+  const router = useRouter();
+
+  const handleBack = () => {
+    if (typeof window !== 'undefined' && window.history.length > 1) {
+      router.back();
+      return;
+    }
+    router.push('/settings');
+  };
+
+  return (
+    <div className="relative min-h-screen bg-[var(--color-background)] pb-[110px] font-[var(--font-body)]">
+      <StickyPageHeader eyebrow="TIPS" title="豆知識" onBack={handleBack} />
+
+      <div className="mx-auto w-full max-w-[560px] px-[18px] pt-3">
+        <p className="m-0 text-[12px] leading-[1.8] text-[var(--color-muted)]">
+          単語をパーツに分けて覚えるための解説です。接頭語・接尾語・接中語の意味が分かると、
+          初見の単語でも意味と品詞を推測できます。
+        </p>
+
+        <div className="mt-3.5 divide-y divide-[var(--color-border)] overflow-hidden rounded-[12px] border-2 border-[var(--solid-ink)] bg-white">
+          {TIPS.map((tip) => (
+            <Link key={tip.href} href={tip.href} className="flex items-center gap-2.5 px-3 py-[13px]">
+              <span className="inline-flex h-[26px] w-[26px] shrink-0 items-center justify-center rounded-[7px] bg-[rgba(26,26,26,0.05)] text-[var(--solid-ink)]">
+                <Icon name="text_fields" size={16} />
+              </span>
+              <span className="min-w-0 flex-1">
+                <span className="block text-[13px] font-bold text-[var(--solid-ink)]">{tip.label}</span>
+                <span className="mt-px block truncate text-[10px] leading-4 text-[var(--color-muted)]">
+                  {tip.description}
+                </span>
+              </span>
+              <span className="shrink-0 font-mono text-[10px] tabular-nums text-[var(--color-muted)]">
+                {tip.count}項目
+              </span>
+              <Icon name="chevron_right" size={14} className="shrink-0 text-[var(--color-muted)]" />
+            </Link>
+          ))}
+        </div>
+
+        <div className="mt-4 text-center font-mono text-[9px] tracking-[0.04em] text-[var(--color-muted)]">
+          MERKEN 豆知識 · 語源で覚える受験英語
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/words/page.tsx
+++ b/src/app/words/page.tsx
@@ -12,26 +12,24 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { WordFilterPanel, WordFilterSheet } from '@/components/words/WordFilterPanel';
 import { WordRow } from '@/components/project/WordRow';
+import { StackedBar } from '@/components/project/WordStatusBar';
 import { Icon } from '@/components/ui/Icon';
 import { WordDetailView } from '@/components/word/WordDetailView';
 import { useInfiniteScrollSentinel } from '@/hooks/use-infinite-scroll';
+import { usePageScrolled } from '@/hooks/use-page-scrolled';
 import { useWordLibrary } from '@/hooks/use-word-library';
 import { scheduleWordStatusWrite } from '@/lib/db/debounced-status-write';
 import { invalidateHomeCache } from '@/lib/home-cache';
 import { getNextVocabularyType } from '@/lib/vocabulary-type';
 import {
   DEFAULT_WORD_FILTER,
-  FEATURE_LABELS,
   SORT_LABELS,
-  STATUS_LABELS,
   clearFilterConditions,
   countActiveFilters,
   deriveFilterOptions,
   describeActiveFilters,
   filterAndSortWords,
-  hasFeature,
   summarizeStatuses,
-  type FeatureKey,
   type SortKey,
   type WordFilterState,
   type WordListEntry,
@@ -52,45 +50,9 @@ const SORT_KEYS: SortKey[] = [
   'wrong',
 ];
 
-const STATUS_BAR_COLORS: Record<WordStatus, string> = {
-  mastered: 'var(--color-success)',
-  active: '#2563eb',
-  review: '#137fec',
-  new: 'rgba(26,26,26,0.15)',
-};
-
-/** 行の下に出す要素マーク。絞り込み結果を目で確認できるようにする。 */
-const META_FEATURE_KEYS: FeatureKey[] = [
-  'example',
-  'pronunciation',
-  'morphology',
-  'derived',
-  'multiMeaning',
-  'custom',
-];
-
-/**
- * 単語帳をまたぐ一覧なので、行に「どの単語帳の語か」を足す。
- * 単語帳詳細の行には無い情報なので、WordRow の metaLine として渡す。
- */
-function WordMetaLine({ entry }: { entry: WordListEntry }) {
-  const marks = META_FEATURE_KEYS.filter((key) => hasFeature(entry, key)).map(
-    (key) => FEATURE_LABELS[key],
-  );
-
-  return (
-    <div className="mt-[3px] flex items-center gap-1.5 overflow-hidden font-mono text-[9px] text-[var(--color-muted)]">
-      <span className="truncate">{entry.projectTitle}</span>
-      {marks.length > 0 && <span className="shrink-0 truncate opacity-70">{marks.join('・')}</span>}
-      {entry.wrongCount > 0 && (
-        <span className="shrink-0 font-bold text-[var(--color-error)]">誤答{entry.wrongCount}</span>
-      )}
-    </div>
-  );
-}
-
 export default function WordsPage() {
   const { entries, loading, error, repository, applyWordUpdate, removeWord } = useWordLibrary();
+  const pageScrolled = usePageScrolled();
   const [filter, setFilter] = useState<WordFilterState>(DEFAULT_WORD_FILTER);
   const [sheetOpen, setSheetOpen] = useState(false);
   const [visibleCount, setVisibleCount] = useState(PAGE_SIZE);
@@ -209,91 +171,110 @@ export default function WordsPage() {
 
   return (
     <div
-      className="mx-auto min-h-screen w-full max-w-[560px] bg-[var(--color-background)] px-[18px] pb-32 pt-3 lg:max-w-[1180px] lg:pb-10"
+      className="relative flex min-h-screen w-full flex-col bg-[var(--color-background)] pb-32 lg:pb-10"
       style={{ fontFamily: 'var(--font-body)' }}
     >
-      <div className="pb-3 pt-1">
-        <div className="font-mono text-[10px] font-bold tracking-[0.08em] text-[var(--color-muted)]">
-          ALL WORDS
+      {/* スクロールしても上部に固定されるヘッダー(単語帳詳細と同じパターン)。
+          下線はコンテンツがヘッダの下に潜り込んだときだけ出す。 */}
+      <header
+        className={`sticky z-40 border-b-2 bg-[var(--color-background)]/95 px-[14px] pb-2.5 pt-2.5 backdrop-blur-md ${
+          pageScrolled ? 'border-[var(--solid-ink)]' : 'border-transparent'
+        }`}
+        style={{ top: 'env(safe-area-inset-top, 0px)' }}
+      >
+        <div className="flex items-baseline gap-2">
+          <span className="font-display text-[18px] font-extrabold leading-none tracking-[-0.02em] text-[var(--solid-ink)]">
+            単語一覧
+          </span>
+          <span className="font-mono text-[10px] font-bold tracking-[0.08em] text-[var(--color-muted)]">
+            ALL WORDS
+          </span>
+          <span className="ml-auto shrink-0 font-mono text-[11px] font-bold tabular-nums text-[var(--color-muted)]">
+            <span className="text-[14px] text-[var(--solid-ink)]">{results.length}</span>
+            <span> / {entries.length}語</span>
+          </span>
         </div>
-        <div className="mt-1.5 font-display text-2xl font-extrabold leading-[1.15] tracking-[-0.02em] text-[var(--solid-ink)]">
-          単語一覧
-        </div>
-        <div className="mt-1.5 text-[12px] font-medium text-[var(--color-muted)]">
-          単語帳をまたいで、条件を組み合わせて単語を探せます
-        </div>
-      </div>
 
-      <div className="lg:grid lg:grid-cols-[286px_1fr] lg:items-start lg:gap-6">
+        {/* 検索・絞り込み・並べ替えを一列に並べる */}
+        <div className="mt-2 flex items-center gap-2">
+          <div className="flex h-10 min-w-0 flex-1 items-center gap-2 rounded-xl border-[1.5px] border-[var(--color-border)] bg-white px-3">
+            <Icon name="search" size={16} className="shrink-0 text-[var(--color-muted)]" />
+            <input
+              value={filter.query}
+              onChange={(event) => setFilter((prev) => ({ ...prev, query: event.target.value }))}
+              placeholder="単語・意味・例文で検索"
+              className="min-w-0 flex-1 bg-transparent text-[13px] text-[var(--solid-ink)] outline-none placeholder:text-[var(--color-muted)]"
+            />
+            {filter.query && (
+              <button
+                type="button"
+                onClick={() => setFilter((prev) => ({ ...prev, query: '' }))}
+                aria-label="検索をクリア"
+                className="shrink-0 text-[var(--color-muted)]"
+              >
+                <Icon name="close" size={15} />
+              </button>
+            )}
+          </div>
+
+          <button
+            type="button"
+            onClick={() => setSheetOpen(true)}
+            aria-label="絞り込み"
+            className="relative flex h-10 w-10 shrink-0 items-center justify-center rounded-xl border-2 border-[var(--solid-ink)] bg-white text-[var(--solid-ink)] lg:hidden"
+          >
+            <Icon name="tune" size={17} />
+            {activeCount > 0 && (
+              <span className="absolute -right-1.5 -top-1.5 flex h-[17px] min-w-[17px] items-center justify-center rounded-full bg-[var(--solid-ink)] px-1 font-mono text-[9.5px] font-bold tabular-nums text-white">
+                {activeCount}
+              </span>
+            )}
+          </button>
+
+          {/* 並べ替え: 端末標準のピッカーを出すため select をそのまま重ねる */}
+          <label className="relative flex h-10 shrink-0 items-center gap-1.5 rounded-xl border-[1.5px] border-[var(--color-border)] bg-white px-2.5 text-[var(--solid-ink)]">
+            <Icon name="swap_vert" size={16} className="shrink-0 text-[var(--color-muted)]" />
+            <span className="hidden max-w-[150px] truncate text-[11.5px] font-bold lg:inline">
+              {SORT_LABELS[filter.sort]}
+            </span>
+            <select
+              value={filter.sort}
+              onChange={(event) =>
+                setFilter((prev) => ({ ...prev, sort: event.target.value as SortKey }))
+              }
+              aria-label="並べ替え"
+              className="absolute inset-0 h-full w-full cursor-pointer opacity-0"
+            >
+              {SORT_KEYS.map((key) => (
+                <option key={key} value={key}>
+                  {SORT_LABELS[key]}
+                </option>
+              ))}
+            </select>
+          </label>
+        </div>
+      </header>
+
+      {/* 学習度の内訳。単語帳詳細と同じバーを、枠を持たせず背景の上に置く */}
+      {results.length > 0 && (
+        <div className="px-4 pb-1 pt-3 lg:px-5">
+          <StackedBar
+            total={results.length}
+            m={statusSummary.mastered}
+            a={statusSummary.active}
+            l={statusSummary.review}
+            n={statusSummary.new}
+          />
+        </div>
+      )}
+
+      <div className="px-4 pt-2.5 lg:grid lg:grid-cols-[286px_1fr] lg:items-start lg:gap-6 lg:px-5">
         {/* デスクトップ: 左に絞り込みを常設 */}
-        <aside className="sticky top-4 hidden max-h-[calc(100dvh-40px)] overflow-y-auto rounded-2xl border-2 border-[var(--solid-ink)] bg-white p-4 lg:block">
+        <aside className="sticky top-[104px] hidden max-h-[calc(100dvh-124px)] overflow-y-auto rounded-2xl border-2 border-[var(--solid-ink)] bg-white p-4 lg:block">
           <WordFilterPanel {...panelProps} />
         </aside>
 
         <div className="min-w-0">
-          {/* 検索 + 並べ替え + (モバイル)絞り込みボタン */}
-          <div className="sticky top-0 z-20 -mx-[18px] bg-[var(--color-background)] px-[18px] pb-2.5 pt-1 lg:static lg:mx-0 lg:px-0">
-            <div className="flex items-center gap-2">
-              <div className="flex h-10 min-w-0 flex-1 items-center gap-2 rounded-xl border-[1.5px] border-[var(--color-border)] bg-white px-3">
-                <Icon name="search" size={16} className="shrink-0 text-[var(--color-muted)]" />
-                <input
-                  value={filter.query}
-                  onChange={(event) => setFilter((prev) => ({ ...prev, query: event.target.value }))}
-                  placeholder="単語・意味・例文で検索"
-                  className="min-w-0 flex-1 bg-transparent text-[13px] text-[var(--solid-ink)] outline-none placeholder:text-[var(--color-muted)]"
-                />
-                {filter.query && (
-                  <button
-                    type="button"
-                    onClick={() => setFilter((prev) => ({ ...prev, query: '' }))}
-                    aria-label="検索をクリア"
-                    className="shrink-0 text-[var(--color-muted)]"
-                  >
-                    <Icon name="close" size={15} />
-                  </button>
-                )}
-              </div>
-
-              <button
-                type="button"
-                onClick={() => setSheetOpen(true)}
-                className="flex h-10 shrink-0 items-center gap-1.5 rounded-xl border-2 border-[var(--solid-ink)] bg-white px-3 text-[12px] font-bold text-[var(--solid-ink)] lg:hidden"
-              >
-                <Icon name="tune" size={16} />
-                絞り込み
-                {activeCount > 0 && (
-                  <span className="rounded-full bg-[var(--solid-ink)] px-[6px] py-px font-mono text-[9.5px] font-bold tabular-nums text-white">
-                    {activeCount}
-                  </span>
-                )}
-              </button>
-            </div>
-
-            <div className="mt-2 flex items-center gap-2">
-              <label className="flex h-9 min-w-0 items-center gap-1.5 rounded-xl border-[1.5px] border-[var(--color-border)] bg-white px-2.5">
-                <Icon name="swap_vert" size={15} className="shrink-0 text-[var(--color-muted)]" />
-                <select
-                  value={filter.sort}
-                  onChange={(event) =>
-                    setFilter((prev) => ({ ...prev, sort: event.target.value as SortKey }))
-                  }
-                  aria-label="並べ替え"
-                  className="min-w-0 bg-transparent text-[11.5px] font-bold text-[var(--solid-ink)] outline-none"
-                >
-                  {SORT_KEYS.map((key) => (
-                    <option key={key} value={key}>
-                      {SORT_LABELS[key]}
-                    </option>
-                  ))}
-                </select>
-              </label>
-
-              <div className="ml-auto shrink-0 font-mono text-[11px] font-bold tabular-nums text-[var(--color-muted)]">
-                <span className="text-[15px] text-[var(--solid-ink)]">{results.length}</span>
-                <span> / {entries.length}語</span>
-              </div>
-            </div>
-          </div>
 
           {/* 適用中の条件: 1つずつ外せる */}
           {activeChips.length > 0 && (
@@ -319,38 +300,20 @@ export default function WordsPage() {
             </div>
           )}
 
-          {/* 絞り込み結果の学習度の内訳 */}
-          {results.length > 0 && (
-            <div className="mb-2.5 rounded-xl border-[1.5px] border-[var(--color-border)] bg-white px-3 py-2.5">
-              <div className="flex h-1.5 overflow-hidden rounded-sm border border-[var(--color-border)]">
-                {(['mastered', 'active', 'review', 'new'] as WordStatus[]).map((status) => (
-                  <div
-                    key={status}
-                    style={{ flex: statusSummary[status], background: STATUS_BAR_COLORS[status] }}
-                  />
-                ))}
-              </div>
-              <div className="mt-1.5 flex flex-wrap gap-x-3 gap-y-1 font-mono text-[10px] font-bold">
-                {(['mastered', 'active', 'review', 'new'] as WordStatus[]).map((status) => (
-                  <span key={status} style={{ color: STATUS_BAR_COLORS[status] === 'rgba(26,26,26,0.15)' ? 'var(--color-muted)' : STATUS_BAR_COLORS[status] }}>
-                    ● {STATUS_LABELS[status]} {statusSummary[status]}
-                  </span>
-                ))}
-              </div>
-            </div>
-          )}
-
           {error && (
             <p className="mb-2 text-[11px] font-bold text-[var(--color-error)]">{error}</p>
           )}
 
           {loading ? (
-            <div className="flex flex-col gap-1.5">
+            <div className="divide-y divide-[var(--color-border)]">
               {[0, 1, 2, 3, 4, 5].map((index) => (
-                <div
-                  key={index}
-                  className="h-[68px] animate-pulse rounded-[10px] border-[1.5px] border-[var(--color-border)] bg-white"
-                />
+                <div key={index} className="flex items-center gap-2.5 px-1 py-2.5">
+                  <div className="h-[43px] w-[13px] animate-pulse rounded bg-[var(--color-border)]" />
+                  <div className="flex-1">
+                    <div className="h-[15px] w-1/3 animate-pulse rounded bg-[var(--color-border)]" />
+                    <div className="mt-1.5 h-[11px] w-1/2 animate-pulse rounded bg-[var(--color-border)]" />
+                  </div>
+                </div>
               ))}
             </div>
           ) : entries.length === 0 ? (
@@ -377,15 +340,14 @@ export default function WordsPage() {
             </div>
           ) : (
             <>
-              {/* 行は単語帳詳細と同じ WordRow を使う (区切り線つきの一覧) */}
-              <div className="divide-y divide-[var(--color-border)] rounded-xl border-[1.5px] border-[var(--color-border)] bg-white px-3">
+              {/* 行も枠も単語帳詳細と同じ (区切り線だけの横幅いっぱいの一覧) */}
+              <div className="divide-y divide-[var(--color-border)]">
                 {visible.map((entry) => (
                   <WordRow
                     key={entry.word.id}
                     word={entry.word}
                     selectMode={false}
                     selected={false}
-                    metaLine={<WordMetaLine entry={entry} />}
                     onToggleSelect={() => {}}
                     onCycleStatus={(newStatus) => handleCycleStatus(entry, newStatus)}
                     onCycleVocabularyType={() => void handleCycleVocabularyType(entry)}

--- a/src/components/desktop/DesktopAccount.tsx
+++ b/src/components/desktop/DesktopAccount.tsx
@@ -4,7 +4,6 @@ import { useState } from 'react';
 import Link from 'next/link';
 import { Icon } from '@/components/ui/Icon';
 import { DesktopButton, DesktopTopbar } from '@/components/desktop/DesktopChrome';
-import { ReviewLimitPicker } from '@/components/settings/ReviewLimitPicker';
 import { isBillingEnabled } from '@/lib/billing/feature';
 import { useCoins } from '@/hooks/use-coins';
 
@@ -63,9 +62,9 @@ export function DesktopSettingsView({
           <div className="ds-set-group">
             <div className="gh">アカウント</div>
             <div className="ds-set-row">
-              <Link
-                href="/profile"
-                style={{ display: 'flex', alignItems: 'center', gap: 14, flex: 1, minWidth: 0, textDecoration: 'none', color: 'inherit' }}
+              {/* アカウント表示はタップしても遷移させない (表示のみ) */}
+              <div
+                style={{ display: 'flex', alignItems: 'center', gap: 14, flex: 1, minWidth: 0, color: 'inherit' }}
               >
                 {avatarUrl ? (
                   // eslint-disable-next-line @next/next/no-img-element
@@ -85,7 +84,7 @@ export function DesktopSettingsView({
                   <div className="d">{email ?? 'ゲスト'}</div>
                   {accountId && <div className="d mono">@{accountId}</div>}
                 </div>
-              </Link>
+              </div>
               <span className="ds-pro-badge">
                 <Icon name={isPro ? 'bolt' : 'person'} filled style={{ fontSize: 13 }} />
                 {isPro ? 'PRO' : 'FREE'}
@@ -167,26 +166,13 @@ export function DesktopSettingsView({
           </div>
 
           <div className="ds-set-group">
-            <div className="gh">学習</div>
-            <div style={{ padding: '14px 16px' }}>
-              <div style={{ fontSize: 13.5, fontWeight: 700 }}>1日の復習上限</div>
-              <p className="muted" style={{ fontSize: 11.5, lineHeight: 1.7, margin: '4px 0 10px' }}>
-                復習クイズに出す問題数の上限。間違いが多い単語・CEFRが高い単語から優先して選ばれます
-              </p>
-              <ReviewLimitPicker />
-            </div>
-          </div>
-
-          <div className="ds-set-group">
             <div className="gh">カスタマイズ</div>
             <SettingsLink icon="tune" label="通知・パーソナライズ" description="学習リマインダー、例文ジャンル" href="/settings/customize" />
           </div>
 
           <div className="ds-set-group">
             <div className="gh">豆知識</div>
-            <SettingsLink icon="text_fields" label="接頭語（プレフィックス）" description="un- / re- / pre- など、頭に付くパーツの意味と例" href="/tips/prefixes" />
-            <SettingsLink icon="text_fields" label="接尾語（サフィックス）" description="-tion / -ous / -able など、品詞を決めるパーツ" href="/tips/suffixes" />
-            <SettingsLink icon="text_fields" label="接中語（インフィックス）" description="therm-o-meter の -o- など、語根をつなぐパーツ" href="/tips/infixes" />
+            <SettingsLink icon="lightbulb" label="豆知識" description="接頭語・接尾語・接中語のパーツ辞典" href="/tips" />
           </div>
 
           <div className="ds-set-group">

--- a/src/components/desktop/DesktopScan.tsx
+++ b/src/components/desktop/DesktopScan.tsx
@@ -52,7 +52,6 @@ const SCAN_OPTIONS: {
   { key: 'all', label: '単語帳取込', description: '単語帳形式の単語を抽出', icon: 'document_scanner' },
   { key: 'circled', label: '丸囲み', description: 'マークした単語を優先', icon: 'gesture' },
   { key: 'idiom', label: '熟語・イディオム', description: '複数語の表現も候補化', icon: 'link' },
-  { key: 'eiken', label: '英検', description: '級別の頻出語を優先', icon: 'filter_alt', pro: true },
   { key: 'custom', label: 'カスタム', description: '抽出条件を自分で指示', icon: 'edit_note' },
 ];
 

--- a/src/components/home/ScanCapturePanel.tsx
+++ b/src/components/home/ScanCapturePanel.tsx
@@ -51,9 +51,9 @@ const EIKEN_LEVEL_OPTIONS: { value: Exclude<EikenLevel, null>; label: string }[]
 
 type SubOption = ExtractMode;
 
+// 英検モードはUIから非表示（サーバー側・級選択のコードはそのまま残してある）。
 const SUB_OPTIONS: { k: SubOption; label: string; hint: string; pro?: boolean }[] = [
   { k: 'circled', label: '丸囲み',           hint: '手動マークを優先' },
-  { k: 'eiken',  label: '英検',             hint: '級別頻出語を優先', pro: true },
   { k: 'idiom',  label: '熟語・イディオム', hint: '複合語・熟語を抽出' },
   { k: 'all',    label: '単語帳取込',       hint: '単語帳形式の単語を抽出' },
   { k: 'custom', label: 'カスタム',         hint: '抽出条件を自分で指示' },

--- a/src/components/profile/ProfileView.tsx
+++ b/src/components/profile/ProfileView.tsx
@@ -8,6 +8,7 @@ import { ProfileAvatar } from '@/components/profile/ProfileAvatar';
 import { DesktopButton, DesktopTopbar } from '@/components/desktop/DesktopChrome';
 import { SolidPanel } from '@/components/redesign/SolidPage';
 import type { CachedStats } from '@/lib/stats-cache';
+import { usePageScrolled } from '@/hooks/use-page-scrolled';
 
 const HEAT_COLORS = [
   'rgba(26,26,26,0.07)',
@@ -82,6 +83,7 @@ export function ProfileView({
   withBottomNav?: boolean;
 }) {
   const router = useRouter();
+  const pageScrolled = usePageScrolled();
 
   // Prefer returning to the actual previous page (e.g. the group the user came
   // from) when we arrived here via in-app navigation. Fall back to backHref on
@@ -137,8 +139,13 @@ export function ProfileView({
       }`}
     >
       <div className="mx-auto w-full max-w-xl">
-        {/* Top bar */}
-        <div className="flex items-center gap-2 px-[18px] pb-1 pt-1">
+        {/* Top bar: スクロールしても上部に固定する */}
+        <header
+          className={`sticky z-40 flex items-center gap-2 border-b-2 bg-[var(--color-background)]/95 px-[18px] py-1.5 backdrop-blur-md ${
+            pageScrolled ? 'border-[var(--solid-ink)]' : 'border-transparent'
+          }`}
+          style={{ top: 'env(safe-area-inset-top, 0px)' }}
+        >
           {backHref ? (
             <Link
               href={backHref}
@@ -172,7 +179,7 @@ export function ProfileView({
               <Icon name="settings" size={22} />
             </Link>
           )}
-        </div>
+        </header>
 
         {/* Profile header */}
         <div className="px-[18px] pb-[14px] pt-2">

--- a/src/components/project/WordRow.tsx
+++ b/src/components/project/WordRow.tsx
@@ -9,7 +9,7 @@
  * 使えるようにここへ切り出した。
  */
 
-import { useCallback, useEffect, useState, type ReactNode } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { Icon } from '@/components/ui/Icon';
 import { VocabularyTypeButton } from '@/components/project/VocabularyTypeButton';
 import { TranslationDisplay } from '@/components/word/TranslationDisplay';
@@ -112,7 +112,6 @@ export function WordRow({
   selectMode,
   selected,
   tourAnchor = false,
-  metaLine,
   onToggleSelect,
   onCycleStatus,
   onCycleVocabularyType,
@@ -123,11 +122,6 @@ export function WordRow({
   selectMode: boolean;
   selected: boolean;
   tourAnchor?: boolean;
-  /**
-   * 訳の下に足す補足行。単語帳をまたぐ一覧で「どの単語帳の語か」を
-   * 出すために使う。単語帳詳細では渡さない (行の見た目は元のまま)。
-   */
-  metaLine?: ReactNode;
   onToggleSelect: () => void;
   onCycleStatus: (newStatus: WordStatus) => void;
   onCycleVocabularyType: () => void;
@@ -157,7 +151,6 @@ export function WordRow({
                 <TranslationDisplay word={word} compact />
               </span>
             </div>
-            {metaLine}
           </div>
           <VocabularyTypeBadge vocabularyType={word.vocabularyType} />
           <BookmarkBadge active={word.isFavorite} />
@@ -184,7 +177,6 @@ export function WordRow({
               <TranslationDisplay word={word} compact />
             </span>
           </div>
-          {metaLine}
         </button>
 
         <VocabularyTypeButton

--- a/src/components/project/WordStatusBar.tsx
+++ b/src/components/project/WordStatusBar.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+/**
+ * 学習度の内訳バー (習得 / 定着中 / 学習中 / 未学習)。
+ * 単語帳詳細 (/project/[id]) と単語一覧 (/words) で共用する。
+ * カード枠は持たず、置かれた場所の背景の上にそのまま並ぶ。
+ */
+
+export function StackedBar({ total, m, a, l, n }: { total: number; m: number; a: number; l: number; n: number }) {
+  const pctM = total ? (m / total) * 100 : 0;
+  const pctA = total ? (a / total) * 100 : 0;
+  const pctL = total ? (l / total) * 100 : 0;
+  const pctN = total ? (n / total) * 100 : 0;
+
+  return (
+    <div>
+      <div className="flex h-2.5 overflow-hidden rounded-full border-2 border-[var(--solid-ink)] bg-white">
+        <div style={{ width: `${pctM}%`, background: 'var(--color-success)' }} />
+        <div style={{ width: `${pctA}%`, background: '#2563eb' }} />
+        <div style={{ width: `${pctL}%`, background: 'var(--color-warning)' }} />
+        <div style={{ width: `${pctN}%`, background: 'rgba(26,26,26,0.12)' }} />
+      </div>
+      <div className="mt-[7px] flex flex-wrap gap-3.5 font-[var(--font-body)]">
+        <BarDot color="var(--color-success)" label="習得" count={m} />
+        <BarDot color="#2563eb" label="定着中" count={a} />
+        <BarDot color="var(--color-warning)" label="学習中" count={l} />
+        <BarDot color="rgba(26,26,26,0.35)" label="未学習" count={n} />
+      </div>
+    </div>
+  );
+}
+
+export function BarDot({ color, label, count }: { color: string; label: string; count: number }) {
+  return (
+    <span className="inline-flex items-center gap-[5px]">
+      <span className="h-[7px] w-[7px] rounded-[3.5px]" style={{ background: color }} />
+      <span className="text-[11px] font-semibold text-[#4a4a4a]">{label}</span>
+      <span className="font-mono text-[11px] tabular-nums text-[var(--color-muted)]">{count}</span>
+    </span>
+  );
+}

--- a/src/components/ui/StickyPageHeader.tsx
+++ b/src/components/ui/StickyPageHeader.tsx
@@ -1,0 +1,63 @@
+'use client';
+
+/**
+ * スクロールしても画面上部に残るページ内ヘッダ。
+ * 単語帳詳細 (/project/[id]) と同じ挙動で、下線はコンテンツがヘッダの下に
+ * 潜り込んだとき（スクロール中）だけ出す。
+ * アカウント・設定まわりのページで共用する。
+ */
+
+import type { ReactNode } from 'react';
+import { Icon } from '@/components/ui/Icon';
+import { usePageScrolled } from '@/hooks/use-page-scrolled';
+
+export function StickyPageHeader({
+  eyebrow,
+  title,
+  onBack,
+  backLabel = '戻る',
+  right,
+  className = '',
+}: {
+  /** 見出しの上に出していた英字ラベル。見出しの右に小さく並べる。 */
+  eyebrow?: string;
+  title: string;
+  /** 省略すると戻るボタンを出さない。 */
+  onBack?: () => void;
+  backLabel?: string;
+  right?: ReactNode;
+  className?: string;
+}) {
+  const scrolled = usePageScrolled();
+
+  return (
+    <header
+      className={`sticky z-40 flex items-center gap-2.5 border-b-2 bg-[var(--color-background)]/95 px-[18px] py-2.5 backdrop-blur-md ${
+        scrolled ? 'border-[var(--solid-ink)]' : 'border-transparent'
+      } ${className}`}
+      style={{ top: 'env(safe-area-inset-top, 0px)' }}
+    >
+      {onBack && (
+        <button
+          type="button"
+          onClick={onBack}
+          aria-label={backLabel}
+          className="flex h-[38px] w-[38px] shrink-0 items-center justify-center rounded-[19px] border-2 border-[var(--solid-ink)] bg-white text-[var(--solid-ink)] transition-all duration-100 active:translate-x-px active:translate-y-px"
+        >
+          <Icon name="chevron_left" size={20} />
+        </button>
+      )}
+      <div className="flex min-w-0 flex-1 items-baseline gap-2">
+        <span className="truncate font-display text-[19px] font-extrabold leading-none tracking-[-0.02em] text-[var(--solid-ink)]">
+          {title}
+        </span>
+        {eyebrow && (
+          <span className="shrink-0 font-mono text-[10px] font-bold uppercase tracking-[0.08em] text-[var(--color-muted)]">
+            {eyebrow}
+          </span>
+        )}
+      </div>
+      {right}
+    </header>
+  );
+}


### PR DESCRIPTION
## 概要

単語一覧 (`/words`) の見た目を単語帳詳細 (`/project/[id]`) にそろえ、あわせてスキャンモードとアカウント・設定まわりの調整をまとめた。

## 単語一覧 (/words)

- **検索・絞り込み・並べ替えを一列に配置**。並べ替えは `swap_vert` のボタンに端末標準のピッカーを重ねる形にし、デスクトップでは選択中の並び順ラベルも出す。件数表示はヘッダ右端へ移動
- **ページ内ヘッダをスクロールしても上部に固定**。単語帳詳細と同じ sticky パターンで、コンテンツが潜り込んだときだけ下線を出す
- **一覧の枠を単語帳詳細に合わせた**。カード枠をやめ、区切り線だけの横幅いっぱいの一覧に
- **単語の下の補足行 (単語帳名・例文などのマーク) を削除**。これに伴い `WordRow` に足していた `metaLine` を外し、単語帳詳細からの純粋な切り出しに戻した
- **学習度の内訳バーを共通化**。単語帳詳細の `StackedBar` を `src/components/project/WordStatusBar.tsx` に切り出して共用し、単語一覧ではヘッダ直下に枠を持たせず背景の上へ置いた

## スキャン

- **スキャンモードの一覧から英検を非表示**にした (モバイル `ScanCapturePanel` / デスクトップ `DesktopScan`)。級選択のUIとサーバー側の処理はそのまま残してあるので、戻すのは一覧に1行足すだけ

## アカウント・設定

- **ページ内ヘッダを固定**: アカウント (`/profile`)、設定、プロフィール変更、カスタマイズ。共通の `StickyPageHeader` を追加し、単語帳詳細と同じくスクロール中だけ下線を出す
- **豆知識を `/tips` にまとめた**。設定ページには入口を1行置くだけにし、接頭語・接尾語・接中語へのリンクは新設した豆知識トップに格納 (デスクトップ設定も同様)
- **設定ページ最上部のアカウント表示をタップしても遷移しないように**した (モバイル・デスクトップとも表示のみ)
- **1日の復習上限の設定表示を廃止** (モバイル・デスクトップとも)。設定値と復習の選定ロジック自体は残している

## 確認

- `npx tsc --noEmit`: 新規エラーなし
- `npm run lint`: 変更ファイルにエラー・警告なし
- `npm run build`: 成功 (`/tips` を含む)
- `npm test`: 1505 pass / 2 fail — 失敗2件 (`otp.contract`, `words/create`) はこの変更前から落ちている既存の失敗
- `/words` と `/tips` はローカルでダミーデータを入れて描画とスクロール固定を確認。設定・プロフィール系はログイン必須のため実画面確認は未実施
- 切り出した `WordRow` / `StackedBar` は元コードと差分がないことを比較で確認済み (単語帳詳細の見た目は変わらない)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QcMJzd1TxdcQwDZCh79Ezn

---
_Generated by [Claude Code](https://claude.ai/code/session_01QcMJzd1TxdcQwDZCh79Ezn)_