### PR TITLE
単語一覧のヘッダ固定と、フラッシュカードの自動再生の無音を修正

### DIFF
--- a/src/app/words/page.tsx
+++ b/src/app/words/page.tsx
@@ -171,7 +171,7 @@ export default function WordsPage() {
 
   return (
     <div
-      className="relative flex min-h-screen w-full flex-col overflow-x-hidden bg-[var(--color-background)] pb-32 lg:pb-10"
+      className="relative flex min-h-screen w-full flex-col bg-[var(--color-background)] pb-32 lg:pb-10"
       style={{ fontFamily: 'var(--font-body)' }}
     >
       {/* スクロールしても上部に固定されるヘッダー(単語帳詳細と同じパターン)。
@@ -274,7 +274,10 @@ export default function WordsPage() {
           <WordFilterPanel {...panelProps} />
         </aside>
 
-        <div className="min-w-0">
+        {/* 横にはみ出させない。sticky なヘッダ/サイドバーの祖先に overflow を
+            付けると sticky がその要素基準になって効かなくなるので、
+            sticky を含まないこのカラムだけで閉じる。 */}
+        <div className="min-w-0 overflow-x-hidden">
 
           {/* 適用中の条件: 1つずつ外せる */}
           {activeChips.length > 0 && (

--- a/src/lib/speech/tts-player.test.ts
+++ b/src/lib/speech/tts-player.test.ts
@@ -42,9 +42,19 @@ type FakeAudio = ReturnType<typeof createFakeAudio>;
 function playerWith(audio: FakeAudio, fetchImpl?: typeof fetch) {
   return createTtsPlayer({
     createAudio: () => audio as unknown as HTMLAudioElement,
-    fetchImpl: fetchImpl ?? (async () => new Response(null)),
+    fetchImpl: fetchImpl ?? (async () => new Response(null, { status: 200 })),
   });
 }
+
+/** 音声を返さないサーバー (APIキー未設定・未ログインなど)。 */
+function failingFetch(status = 500) {
+  let calls = 0;
+  const impl = (async () => { calls += 1; return new Response('{}', { status }); }) as typeof fetch;
+  return { impl, get calls() { return calls; } };
+}
+
+/** fetch の解決を1周待つ。 */
+const tick = () => new Promise((resolve) => setTimeout(resolve, 0));
 
 test('URLはテキストと言語で決まる (同じ単語なら同じURL = キャッシュが効く)', () => {
   assert.equal(ttsAudioUrl('apple', 'en'), ttsAudioUrl('apple', 'en'));
@@ -60,7 +70,7 @@ test('unlock はユーザー操作の中で1回鳴らして要素を解錠する
   player.unlock();
 
   assert.equal(audio.playCalls, 1);
-  assert.match(audio.src, /^data:audio\/mpeg/);
+  assert.match(audio.src, /silence-loop\.wav$/);
   assert.ok(audio.attributes.includes('playsinline'));
 });
 
@@ -74,9 +84,11 @@ test('要素は使い回す (iOSは操作外で作った要素の再生を拒む
 
   player.unlock();
   const first = player.play('apple', 'en');
+  await tick();
   audio.emit('ended');
   await first;
   const second = player.play('banana', 'en');
+  await tick();
   audio.emit('ended');
   await second;
 
@@ -88,6 +100,7 @@ test('鳴り終わったら played で解決し、リスナーを残さない', 
   const player = playerWith(audio);
 
   const playing = player.play('apple', 'en');
+  await tick();
   assert.match(audio.src, /\/api\/tts\?/);
   audio.emit('ended');
 
@@ -101,6 +114,7 @@ test('再生エラーは unavailable (呼び出し側が読み上げにフォー
   const player = playerWith(audio);
 
   const playing = player.play('apple', 'en');
+  await tick();
   audio.emit('error');
 
   assert.equal(await playing, 'unavailable');
@@ -162,4 +176,34 @@ test('dispose 後は鳴らさない', async () => {
 
   assert.equal(await player.play('apple', 'en'), 'unavailable');
   assert.equal(audio.paused, true);
+});
+
+test('音声が取れない環境では要素に読み込ませず、すぐ読み上げに譲る', async () => {
+  const audio = createFakeAudio();
+  const failing = failingFetch(500);
+  const player = createTtsPlayer({
+    createAudio: () => audio as unknown as HTMLAudioElement,
+    fetchImpl: failing.impl,
+  });
+
+  assert.equal(await player.play('apple', 'en'), 'unavailable');
+  // 鳴らない音源を掴ませない (掴ませると無音のまま待たされる)
+  assert.equal(audio.playCalls, 0);
+  assert.equal(audio.src, '');
+});
+
+test('一度失敗したら以降は取りに行かない (毎カード待たされない)', async () => {
+  const audio = createFakeAudio();
+  const failing = failingFetch(401);
+  const player = createTtsPlayer({
+    createAudio: () => audio as unknown as HTMLAudioElement,
+    fetchImpl: failing.impl,
+  });
+
+  await player.play('apple', 'en');
+  await player.play('banana', 'en');
+  player.prefetch('cherry', 'en');
+  await tick();
+
+  assert.equal(failing.calls, 1);
 });

--- a/src/lib/speech/tts-player.ts
+++ b/src/lib/speech/tts-player.ts
@@ -16,15 +16,17 @@
 
 import type { TtsLang } from '@/lib/speech/cloud-text-to-speech';
 
-/** 解錠用の無音 mp3 (ごく短い)。ユーザー操作の中で一度だけ鳴らす。 */
-const SILENT_MP3 =
-  'data:audio/mpeg;base64,//uQxAAAAAAAAAAAAAAAAAAAAAAAWGluZwAAAA8AAAACAAACcQCA' +
-  'gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgP///////' +
-  '////////////////////////////////////////8AAAAATGF2YzU4LjEzAAAAAAAAAAAAAAAA' +
-  'JAAAAAAAAAAAAnGDdQ2CAAAA';
+/**
+ * 解錠用の無音音源。フラッシュカードが常時鳴らしているものと同じファイルを使う
+ * (手書きの data URI だと壊れた音源を掴ませかねないので、実在のファイルにする)。
+ */
+const SILENT_AUDIO_SRC = '/audio/silence-loop.wav';
 
-/** 1クリップの再生を諦めるまでの時間。ここで詰まると自動再生が止まるので必ず抜ける。 */
-const PLAY_TIMEOUT_MS = 20_000;
+/**
+ * 1クリップの再生を諦めるまでの時間。
+ * ここで詰まると自動再生が丸ごと黙るので、短めに切ってブラウザ読み上げへ渡す。
+ */
+const PLAY_TIMEOUT_MS = 8_000;
 
 export type TtsPlayResult = 'played' | 'unavailable';
 
@@ -56,6 +58,13 @@ export function createTtsPlayer(deps?: TtsPlayerDeps): TtsPlayer {
 
   let audio: HTMLAudioElement | null = null;
   let disposed = false;
+  /**
+   * 音声が使えるか。null = 未確認。
+   * APIキー未設定・未ログイン・上限などで音声が取れない環境では、鳴らない音を
+   * 毎回ロードしにいっても待たされるだけなので、一度失敗したら以降は即あきらめて
+   * ブラウザ読み上げに任せる。
+   */
+  let available: boolean | null = null;
   const prefetched = new Set<string>();
 
   const ensureAudio = (): HTMLAudioElement | null => {
@@ -75,14 +84,32 @@ export function createTtsPlayer(deps?: TtsPlayerDeps): TtsPlayer {
       if (!element) return;
       // 操作の呼び出しスタックの中で一度鳴らしておくと、以降はタイマーからの
       // 再生 (=画面消灯中の次のカード) も許可される。
-      element.src = SILENT_MP3;
+      element.src = SILENT_AUDIO_SRC;
       void element.play().catch(() => {});
     },
 
     async play(text, lang) {
       const trimmed = text?.trim();
+      if (!trimmed || disposed || available === false) return 'unavailable';
+
+      // 先に音声そのものを取りに行く。取れないと分かった時点で引き返せば、
+      // オーディオ要素に鳴らない音を読み込ませずに済む
+      // (要素に失敗した音源を掴ませると、そのぶん無音の待ち時間が生まれる)。
+      const url = ttsAudioUrl(trimmed, lang);
+      try {
+        const response = await fetchImpl(url, { credentials: 'same-origin' });
+        if (!response.ok) {
+          available = false;
+          return 'unavailable';
+        }
+      } catch {
+        available = false;
+        return 'unavailable';
+      }
+      available = true;
+
       const element = ensureAudio();
-      if (!trimmed || !element) return 'unavailable';
+      if (!element) return 'unavailable';
 
       return new Promise<TtsPlayResult>((resolve) => {
         let settled = false;
@@ -108,7 +135,8 @@ export function createTtsPlayer(deps?: TtsPlayerDeps): TtsPlayer {
         // 音源が壊れている・応答が返らない場合でも必ず抜ける。
         timer = setTimeout(() => settle('unavailable'), PLAY_TIMEOUT_MS);
 
-        element.src = ttsAudioUrl(trimmed, lang);
+        // 直前に取得済みなので、ここはHTTPキャッシュから読まれる。
+        element.src = url;
         const started = element.play();
         if (started && typeof started.catch === 'function') {
           started.catch(() => settle('unavailable'));
@@ -118,14 +146,18 @@ export function createTtsPlayer(deps?: TtsPlayerDeps): TtsPlayer {
 
     prefetch(text, lang) {
       const trimmed = text?.trim();
-      if (!trimmed || disposed) return;
+      if (!trimmed || disposed || available === false) return;
       const url = ttsAudioUrl(trimmed, lang);
       if (prefetched.has(url)) return;
       prefetched.add(url);
-      void fetchImpl(url, { credentials: 'same-origin' }).catch(() => {
-        // 取れなくても再生時に取り直せばよい。次の機会のために覚えておかない。
-        prefetched.delete(url);
-      });
+      void fetchImpl(url, { credentials: 'same-origin' })
+        .then((response) => {
+          if (!response.ok) available = false;
+        })
+        .catch(() => {
+          // 取れなくても再生時に取り直せばよい。次の機会のために覚えておかない。
+          prefetched.delete(url);
+        });
     },
 
     stop() {


### PR DESCRIPTION
いずれも直前の変更で入れ込んだ不具合。

単語一覧:
- 横スクロール対策でルートに overflow-x を付けたせいで、ヘッダの sticky が そのルート基準になり固定されなくなっていた。overflow は sticky を含まない 一覧カラムだけに移し、ヘッダは画面上部に固定されるよう戻した (スクロール後のヘッダ位置を実測して確認)

フラッシュカード:
- 読み上げの合成音声が使えない環境 (APIキー未設定・未ログイン・上限) で、 鳴らない音源をオーディオ要素に読み込ませ、イベントが来ないまま最大20秒 待ってから読み上げに落ちていた。カードごとに無音が続くため、実質「音声が 再生されない」状態になっていた
- 再生前に音声を取得し、取れないと分かった時点で要素に触らずブラウザ読み上げへ 渡すようにした。一度失敗したらそのセッションでは以降取りに行かない
- 諦めるまでの上限も 20秒 → 8秒 に短縮
- 解錠用の音源を手書きの data URI から、既存の /audio/silence-loop.wav に変更


Claude-Session: https://claude.ai/code/session_01QcMJzd1TxdcQwDZCh79Ezn