### PR TITLE
対戦UIをコンポーネント分割し、ホームからリールを削除

### DIFF
--- a/src/app/battle/[roomId]/page.tsx
+++ b/src/app/battle/[roomId]/page.tsx
@@ -2,22 +2,38 @@
 
 import { use, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useRouter } from 'next/navigation';
-import Link from 'next/link';
 import { useAuth } from '@/hooks/use-auth';
 import { useBattleRoom } from '@/hooks/use-battle-room';
+import { BattleScreenHeader } from '@/components/battle/BattleScreenHeader';
+import { BattleStatusPanel } from '@/components/battle/BattleStatusPanel';
+import { BattleScoreboard } from '@/components/battle/BattleScoreboard';
+import { BattleTimerBar } from '@/components/battle/BattleTimerBar';
+import { BattlePromptCard } from '@/components/battle/BattlePromptCard';
+import { BattleChoiceList } from '@/components/battle/BattleChoiceList';
+import {
+  BattleRoundFeedback,
+  type BattleRoundOutcome,
+} from '@/components/battle/BattleRoundFeedback';
+import { BattleResultPanel } from '@/components/battle/BattleResultPanel';
+import { BattleButton, BattleLinkButton } from '@/components/battle/BattleButton';
+import { BattleInviteCard } from '@/components/battle/BattleInviteCard';
 import {
   getBattleProgressLabel,
   getBattleResultForViewer,
   getViewerParticipants,
 } from '@/lib/battle/room-state';
-import type { BattleParticipant } from '@/lib/battle/types';
 
-function ScoreBadge({ participant, label }: { participant: BattleParticipant | null; label: string }) {
+function BattleShell({
+  header,
+  children,
+}: {
+  header: React.ReactNode;
+  children: React.ReactNode;
+}) {
   return (
-    <div className="flex-1 text-center">
-      <p className="mb-1 truncate text-xs text-[var(--color-muted)]">{label}</p>
-      <p className="mb-1 truncate text-sm font-semibold">{participant?.displayName ?? '待機中'}</p>
-      <p className="text-3xl font-bold">{participant?.score ?? 0}</p>
+    <div className="relative flex min-h-[100dvh] flex-col bg-[var(--color-background)] font-[var(--font-body)]">
+      {header}
+      {children}
     </div>
   );
 }
@@ -30,7 +46,6 @@ export default function BattleRoomPage({ params }: { params: Promise<{ roomId: s
 
   const {
     room,
-    questions,
     loading,
     error,
     currentQuestion,
@@ -51,7 +66,7 @@ export default function BattleRoomPage({ params }: { params: Promise<{ roomId: s
     [room, userId],
   );
 
-  // The host generates the question set once both seats are filled.
+  // 両席が埋まったらホストが問題セットを生成する。
   useEffect(() => {
     if (!room || !userId) return;
     if (room.status !== 'ready' || !room.guest) return;
@@ -78,151 +93,155 @@ export default function BattleRoomPage({ params }: { params: Promise<{ roomId: s
   }, [leaveBattle, router]);
 
   if (authLoading || loading) {
-    return <main className="p-6 text-center text-[var(--color-muted)]">読み込み中...</main>;
+    return (
+      <BattleShell header={<BattleScreenHeader eyebrow="BATTLE" title="対戦" />}>
+        <BattleStatusPanel spinning title="読み込み中" />
+      </BattleShell>
+    );
   }
 
   if (error || !room || !viewer) {
     return (
-      <main className="mx-auto max-w-md p-6 text-center">
-        <p className="mb-6 text-sm text-[var(--color-muted)]">{error ?? '対戦が見つかりません。'}</p>
-        <Link href="/battle" className="inline-block rounded-xl bg-[var(--color-foreground)] px-6 py-3 font-semibold text-white">
-          対戦トップへ
-        </Link>
-      </main>
+      <BattleShell header={<BattleScreenHeader eyebrow="BATTLE" title="対戦" />}>
+        <BattleStatusPanel
+          icon="error"
+          title="対戦が見つかりません"
+          description={error ?? undefined}
+          actions={<BattleLinkButton href="/battle" icon="arrow_back">対戦トップへ</BattleLinkButton>}
+        />
+      </BattleShell>
     );
   }
 
-  if (room.status === 'finished' || room.status === 'cancelled') {
-    const result = getBattleResultForViewer(room, userId ?? '');
-    const heading =
-      room.status === 'cancelled'
-        ? '対戦は中止されました'
-        : result === 'win' ? '勝ち！' : result === 'lose' ? '負け...' : '引き分け';
+  const finished = room.status === 'finished' || room.status === 'cancelled';
 
+  if (finished) {
     return (
-      <main className="mx-auto flex min-h-[70vh] max-w-md flex-col items-center justify-center p-6 text-center">
-        <h1 className="mb-2 text-3xl font-bold">{heading}</h1>
-        {room.outcome === 'abandoned' && (
-          <p className="mb-6 text-sm text-[var(--color-muted)]">相手が退出しました。</p>
-        )}
-
-        <div className="mb-10 flex w-full items-start gap-4 pt-6">
-          <ScoreBadge participant={viewer.self} label="あなた" />
-          <span className="pt-6 text-2xl font-bold text-[var(--color-muted)]">-</span>
-          <ScoreBadge participant={viewer.opponent} label="相手" />
+      <BattleShell header={<BattleScreenHeader eyebrow="RESULT" title="対戦結果" fallbackHref="/battle" />}>
+        <div className="flex flex-1 flex-col justify-center px-[18px] py-8">
+          <BattleResultPanel
+            result={getBattleResultForViewer(room, userId ?? '')}
+            outcome={room.outcome}
+            cancelled={room.status === 'cancelled'}
+            self={viewer.self}
+            opponent={viewer.opponent}
+          />
+          <div className="mt-8">
+            <BattleLinkButton href="/battle" icon="replay">もう一度対戦する</BattleLinkButton>
+          </div>
         </div>
-
-        <Link href="/battle" className="w-full rounded-xl bg-[var(--color-foreground)] py-4 text-lg font-bold text-white">
-          もう一度対戦する
-        </Link>
-      </main>
+      </BattleShell>
     );
   }
 
-  if (room.status === 'waiting' || room.status === 'ready' || room.status === 'preparing') {
+  if (room.status !== 'in_progress') {
+    const waitingForOpponent = !room.guest;
+
     return (
-      <main className="mx-auto flex min-h-[70vh] max-w-md flex-col items-center justify-center p-6 text-center">
-        <div className="mb-6 h-10 w-10 animate-spin rounded-full border-4 border-[var(--color-surface-secondary)] border-t-[var(--color-foreground)]" />
-        <h1 className="mb-2 text-lg font-bold">
-          {room.guest ? '問題を準備しています...' : '相手を待っています...'}
-        </h1>
-        {room.inviteCode && !room.guest && (
-          <p className="mb-6 font-mono text-3xl font-bold tracking-[0.3em]">{room.inviteCode}</p>
-        )}
-        {startError && <p className="mb-6 text-sm text-red-600">{startError}</p>}
-        <button
-          type="button"
-          onClick={handleLeave}
-          className="rounded-xl border-2 border-[var(--color-foreground)] px-6 py-3 font-semibold"
+      <BattleShell
+        header={
+          <BattleScreenHeader
+            eyebrow={room.mode === 'friend' ? 'FRIEND MATCH' : 'RANDOM MATCH'}
+            title={waitingForOpponent ? '相手を待っています' : '対戦準備中'}
+            onBack={handleLeave}
+          />
+        }
+      >
+        <BattleStatusPanel
+          spinning
+          title={waitingForOpponent ? '相手を待っています' : '問題を準備しています'}
+          description={
+            waitingForOpponent
+              ? 'このコードを相手に伝えてください。'
+              : 'お互いの単語帳から問題を作成しています。'
+          }
+          actions={
+            <BattleButton variant="outline" icon="logout" onClick={handleLeave}>
+              退出する
+            </BattleButton>
+          }
         >
-          退出する
-        </button>
-      </main>
+          {waitingForOpponent && room.inviteCode ? (
+            <BattleInviteCard inviteCode={room.inviteCode} />
+          ) : null}
+          {startError && (
+            <p role="alert" className="mt-4 text-[13px] text-[var(--color-error)]">
+              {startError}
+            </p>
+          )}
+        </BattleStatusPanel>
+      </BattleShell>
     );
   }
 
   const resolved = Boolean(currentQuestion?.resolvedAt);
-  const correctIndex = currentQuestion?.correctIndex ?? null;
-  const wonRound = currentQuestion?.answeredBy && currentQuestion.answeredBy === userId;
-  const secondsLeft = Math.ceil(remainingMs / 1000);
+  const answeredBy = currentQuestion?.answeredBy ?? null;
+
+  const roundOutcome: BattleRoundOutcome = !currentQuestion
+    ? 'live'
+    : resolved
+      ? answeredBy === userId
+        ? 'won'
+        : answeredBy
+          ? 'lost'
+          : hasAnswered
+            ? 'missed'
+            : 'timeout'
+      : hasAnswered
+        ? 'waiting'
+        : 'live';
+
+  const scoredSeat = resolved && answeredBy
+    ? answeredBy === userId ? 'self' : 'opponent'
+    : null;
 
   return (
-    <main className="mx-auto flex min-h-[100dvh] max-w-md flex-col p-6">
-      <header className="mb-6">
-        <div className="mb-4 flex items-start gap-4">
-          <ScoreBadge participant={viewer.self} label="あなた" />
-          <span className="pt-6 text-2xl font-bold text-[var(--color-muted)]">-</span>
-          <ScoreBadge participant={viewer.opponent} label="相手" />
-        </div>
-        <div className="flex items-center justify-between text-xs text-[var(--color-muted)]">
-          <span>{getBattleProgressLabel(room)}</span>
-          <span className={remainingMs < 3000 && !resolved ? 'font-bold text-red-600' : ''}>
-            残り {secondsLeft}秒
-          </span>
-        </div>
-        <div className="mt-2 h-1.5 overflow-hidden rounded-full bg-[var(--color-surface-secondary)]">
-          <div
-            className="h-full bg-[var(--color-foreground)] transition-[width] duration-100 ease-linear"
-            style={{ width: `${Math.max(0, (remainingMs / room.roundDurationMs) * 100)}%` }}
-          />
-        </div>
-      </header>
+    <BattleShell
+      header={
+        <BattleScreenHeader
+          eyebrow={room.mode === 'friend' ? 'FRIEND MATCH' : 'RANDOM MATCH'}
+          title="早押しバトル"
+          onBack={handleLeave}
+        />
+      }
+    >
+      <div className="flex flex-1 flex-col gap-4 px-[18px] pb-8 pt-3">
+        <BattleScoreboard self={viewer.self} opponent={viewer.opponent} scoredSeat={scoredSeat} />
 
-      <section className="mb-8 flex flex-1 flex-col items-center justify-center">
-        <p className="mb-2 text-xs text-[var(--color-muted)]">この単語の意味は？</p>
-        <h1 className="text-center text-4xl font-bold break-words">{currentQuestion?.prompt ?? ''}</h1>
+        <BattleTimerBar
+          remainingMs={remainingMs}
+          totalMs={room.roundDurationMs}
+          progressLabel={getBattleProgressLabel(room)}
+          paused={resolved}
+        />
 
-        {resolved && (
-          <p className="mt-4 text-sm font-semibold">
-            {wonRound ? '正解！ +1' : currentQuestion?.answeredBy ? '相手が正解しました' : '時間切れ'}
-          </p>
+        {currentQuestion ? (
+          <>
+            <BattlePromptCard prompt={currentQuestion.prompt} />
+
+            <BattleRoundFeedback outcome={roundOutcome} answer={currentQuestion.answer} />
+
+            <BattleChoiceList
+              choices={currentQuestion.choices}
+              selectedIndex={selectedChoice}
+              correctIndex={currentQuestion.correctIndex}
+              resolved={resolved}
+              canAnswer={canAnswer}
+              onSelect={(index) => void submitAnswer(index)}
+            />
+          </>
+        ) : (
+          <BattleStatusPanel spinning title="問題を読み込んでいます" />
         )}
-      </section>
 
-      <section className="mb-6 grid gap-3">
-        {(currentQuestion?.choices ?? []).map((choice, index) => {
-          const isCorrect = resolved && correctIndex === index;
-          const isMyWrongPick = resolved && selectedChoice === index && correctIndex !== index;
-
-          return (
-            <button
-              key={`${currentQuestion?.roundIndex}-${index}`}
-              type="button"
-              disabled={!canAnswer}
-              onClick={() => submitAnswer(index)}
-              className={`w-full rounded-xl border-2 p-4 text-left font-semibold transition-colors ${
-                isCorrect
-                  ? 'border-green-600 bg-green-50 text-green-800 dark:bg-green-950/40 dark:text-green-300'
-                  : isMyWrongPick
-                    ? 'border-red-600 bg-red-50 text-red-800 dark:bg-red-950/40 dark:text-red-300'
-                    : selectedChoice === index
-                      ? 'border-[var(--color-foreground)] bg-[var(--color-surface-secondary)]'
-                      : 'border-[var(--color-foreground)]'
-              } ${!canAnswer && !resolved ? 'opacity-60' : ''}`}
-            >
-              {choice}
-            </button>
-          );
-        })}
-      </section>
-
-      {hasAnswered && !resolved && (
-        <p className="mb-4 text-center text-sm text-[var(--color-muted)]">
-          相手の回答を待っています...
-        </p>
-      )}
-
-      <button
-        type="button"
-        onClick={handleLeave}
-        className="mb-2 text-center text-xs text-[var(--color-muted)] underline"
-      >
-        対戦を降参する
-      </button>
-
-      {questions.length === 0 && (
-        <p className="text-center text-xs text-[var(--color-muted)]">問題を読み込んでいます...</p>
-      )}
-    </main>
+        <button
+          type="button"
+          onClick={handleLeave}
+          className="mt-auto pt-4 text-center font-display text-[12px] font-bold text-[var(--color-muted)] underline underline-offset-2"
+        >
+          対戦を降参する
+        </button>
+      </div>
+    </BattleShell>
   );
 }

--- a/src/app/battle/page.tsx
+++ b/src/app/battle/page.tsx
@@ -2,9 +2,17 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useRouter } from 'next/navigation';
-import Link from 'next/link';
+import { Icon } from '@/components/ui/Icon';
 import { useAuth } from '@/hooks/use-auth';
 import { useProjects } from '@/hooks/use-projects';
+import { BattleScreenHeader } from '@/components/battle/BattleScreenHeader';
+import { BattleStatusPanel } from '@/components/battle/BattleStatusPanel';
+import { BattleButton, BattleLinkButton } from '@/components/battle/BattleButton';
+import { BattleInviteCard } from '@/components/battle/BattleInviteCard';
+import {
+  BattleSettingsFields,
+  BattleWordbookField,
+} from '@/components/battle/BattleLobbyForm';
 import {
   BATTLE_DEFAULT_QUESTION_COUNT,
   BATTLE_DEFAULT_ROUND_DURATION_MS,
@@ -15,21 +23,17 @@ import type { BattleRoom } from '@/lib/battle/types';
 
 type LobbyMode = 'idle' | 'matching' | 'hosting';
 
-const QUESTION_COUNT_OPTIONS = [5, 10, 20];
-const ROUND_DURATION_OPTIONS = [
-  { label: '10秒', value: 10_000 },
-  { label: '15秒', value: 15_000 },
-  { label: '20秒', value: 20_000 },
-];
+const QUESTION_COUNT_OPTIONS = [5, 10, 20] as const;
+const ROUND_DURATION_OPTIONS = [10_000, 15_000, 20_000] as const;
 
 export default function BattleLobbyPage() {
   const router = useRouter();
   const { isAuthenticated, isPro, loading: authLoading } = useAuth();
   const { projects, loading: projectsLoading } = useProjects();
 
-  const [projectId, setProjectId] = useState<string>('');
-  const [questionCount, setQuestionCount] = useState(BATTLE_DEFAULT_QUESTION_COUNT);
-  const [roundDurationMs, setRoundDurationMs] = useState(BATTLE_DEFAULT_ROUND_DURATION_MS);
+  const [projectId, setProjectId] = useState('');
+  const [questionCount, setQuestionCount] = useState<number>(BATTLE_DEFAULT_QUESTION_COUNT);
+  const [roundDurationMs, setRoundDurationMs] = useState<number>(BATTLE_DEFAULT_ROUND_DURATION_MS);
   const [mode, setMode] = useState<LobbyMode>('idle');
   const [hostedRoom, setHostedRoom] = useState<BattleRoom | null>(null);
   const [joinCode, setJoinCode] = useState('');
@@ -45,8 +49,8 @@ export default function BattleLobbyPage() {
     }
   }, [projects, projectId]);
 
-  const selectedProject = useMemo(
-    () => projects.find((project) => project.id === projectId) ?? null,
+  const hasProject = useMemo(
+    () => projects.some((project) => project.id === projectId),
     [projects, projectId],
   );
 
@@ -64,7 +68,7 @@ export default function BattleLobbyPage() {
   }, []);
 
   const startRandomMatch = useCallback(async () => {
-    if (!projectId) return;
+    if (!hasProject) return;
     setError(null);
     setBusy(true);
     try {
@@ -84,14 +88,14 @@ export default function BattleLobbyPage() {
     } finally {
       setBusy(false);
     }
-  }, [projectId, questionCount, roundDurationMs, postJson, router]);
+  }, [hasProject, projectId, questionCount, roundDurationMs, postJson, router]);
 
   const cancelRandomMatch = useCallback(async () => {
     setMode('idle');
     await fetch('/api/battle/match', { method: 'DELETE' }).catch(() => {});
   }, []);
 
-  // While queued, poll for the room the server paired us into.
+  // 待機中はサーバーがペアリングしたルームをポーリングで拾う。
   useEffect(() => {
     if (mode !== 'matching') return;
 
@@ -103,7 +107,7 @@ export default function BattleLobbyPage() {
           router.push(`/battle/${payload.roomId}`);
         }
       } catch {
-        // Keep waiting -- a dropped poll is not fatal.
+        // 1回落ちても待機は続ける。
       }
     }, BATTLE_MATCH_POLL_INTERVAL_MS);
 
@@ -111,7 +115,7 @@ export default function BattleLobbyPage() {
   }, [mode, router]);
 
   const createFriendRoom = useCallback(async () => {
-    if (!projectId) return;
+    if (!hasProject) return;
     setError(null);
     setBusy(true);
     try {
@@ -127,9 +131,9 @@ export default function BattleLobbyPage() {
     } finally {
       setBusy(false);
     }
-  }, [projectId, questionCount, roundDurationMs, postJson]);
+  }, [hasProject, projectId, questionCount, roundDurationMs, postJson]);
 
-  // The host waits here until someone joins with the invite code.
+  // ホストは相手がコードで入室するまでここで待つ。
   useEffect(() => {
     if (mode !== 'hosting' || !hostedRoom) return;
 
@@ -137,9 +141,7 @@ export default function BattleLobbyPage() {
       try {
         const response = await fetch(`/api/battle/rooms/${hostedRoom.id}`, { cache: 'no-store' });
         const payload = await response.json().catch(() => null);
-        if (payload?.room?.guest) {
-          router.push(`/battle/${hostedRoom.id}`);
-        }
+        if (payload?.room?.guest) router.push(`/battle/${hostedRoom.id}`);
       } catch {
         // ignore
       }
@@ -149,7 +151,7 @@ export default function BattleLobbyPage() {
   }, [mode, hostedRoom, router]);
 
   const joinFriendRoom = useCallback(async () => {
-    if (!projectId) return;
+    if (!hasProject) return;
     const normalized = normalizeInviteCode(joinCode);
     if (!normalized) {
       setError('招待コードは6文字です。');
@@ -159,207 +161,179 @@ export default function BattleLobbyPage() {
     setError(null);
     setBusy(true);
     try {
-      const payload = await postJson('/api/battle/join', {
-        inviteCode: normalized,
-        projectId,
-      });
+      const payload = await postJson('/api/battle/join', { inviteCode: normalized, projectId });
       router.push(`/battle/${(payload.room as BattleRoom).id}`);
     } catch (err) {
       setError(err instanceof Error ? err.message : '参加に失敗しました。');
     } finally {
       setBusy(false);
     }
-  }, [projectId, joinCode, postJson, router]);
+  }, [hasProject, projectId, joinCode, postJson, router]);
+
+  const shell = (children: React.ReactNode, header?: React.ReactNode) => (
+    <div className="relative flex min-h-screen flex-col bg-[var(--color-background)] pb-[110px] font-[var(--font-body)]">
+      {header ?? <BattleScreenHeader eyebrow="BATTLE" title="単語対戦" fallbackHref="/" />}
+      {children}
+    </div>
+  );
 
   if (authLoading) {
-    return <main className="p-6 text-center text-[var(--color-muted)]">読み込み中...</main>;
+    return shell(<BattleStatusPanel spinning title="読み込み中" />);
   }
 
   if (!isAuthenticated) {
-    return (
-      <main className="mx-auto max-w-md p-6 text-center">
-        <h1 className="mb-3 text-xl font-bold">リアルタイム単語対戦</h1>
-        <p className="mb-6 text-sm text-[var(--color-muted)]">対戦にはログインが必要です。</p>
-        <Link href="/login" className="inline-block rounded-xl bg-[var(--color-foreground)] px-6 py-3 font-semibold text-white">
-          ログイン
-        </Link>
-      </main>
+    return shell(
+      <BattleStatusPanel
+        icon="lock"
+        title="ログインが必要です"
+        description="リアルタイム対戦を遊ぶにはログインしてください。"
+        actions={<BattleLinkButton href="/login" icon="login">ログイン</BattleLinkButton>}
+      />,
     );
   }
 
   if (!isPro) {
-    return (
-      <main className="mx-auto max-w-md p-6 text-center">
-        <h1 className="mb-3 text-xl font-bold">リアルタイム単語対戦</h1>
-        <p className="mb-6 text-sm text-[var(--color-muted)]">
-          リアルタイム対戦はProプラン限定の機能です。コインは消費しません。
-        </p>
-        <Link href="/pricing" className="inline-block rounded-xl bg-[var(--color-foreground)] px-6 py-3 font-semibold text-white">
-          Proプランを見る
-        </Link>
-      </main>
+    return shell(
+      <BattleStatusPanel
+        icon="crown"
+        title="Proプラン限定の機能です"
+        description="リアルタイム対戦はProプラン限定です。対戦でコインは消費しません。"
+        actions={<BattleLinkButton href="/pricing" icon="crown">Proプランを見る</BattleLinkButton>}
+      />,
     );
   }
 
   if (mode === 'matching') {
-    return (
-      <main className="mx-auto flex min-h-[60vh] max-w-md flex-col items-center justify-center p-6 text-center">
-        <div className="mb-6 h-12 w-12 animate-spin rounded-full border-4 border-[var(--color-surface-secondary)] border-t-[var(--color-foreground)]" />
-        <h1 className="mb-2 text-lg font-bold">対戦相手を探しています...</h1>
-        <p className="mb-8 text-sm text-[var(--color-muted)]">
-          見つかり次第、自動で対戦が始まります。
-        </p>
-        <button
-          type="button"
-          onClick={cancelRandomMatch}
-          className="rounded-xl border-2 border-[var(--color-foreground)] px-6 py-3 font-semibold"
-        >
-          キャンセル
-        </button>
-      </main>
+    return shell(
+      <BattleStatusPanel
+        spinning
+        title="対戦相手を探しています"
+        description="見つかり次第、自動で対戦が始まります。"
+        actions={
+          <BattleButton variant="outline" icon="close" onClick={cancelRandomMatch}>
+            キャンセル
+          </BattleButton>
+        }
+      />,
+      <BattleScreenHeader
+        eyebrow="RANDOM MATCH"
+        title="マッチング中"
+        onBack={cancelRandomMatch}
+      />,
     );
   }
 
-  if (mode === 'hosting' && hostedRoom) {
-    return (
-      <main className="mx-auto flex min-h-[60vh] max-w-md flex-col items-center justify-center p-6 text-center">
-        <h1 className="mb-2 text-lg font-bold">招待コード</h1>
-        <p className="mb-6 text-sm text-[var(--color-muted)]">
-          このコードを相手に伝えてください。参加すると自動で始まります。
-        </p>
-        <div className="mb-8 rounded-2xl border-2 border-[var(--color-foreground)] px-8 py-6 font-mono text-4xl font-bold tracking-[0.3em]">
-          {hostedRoom.inviteCode}
+  if (mode === 'hosting' && hostedRoom?.inviteCode) {
+    const leaveHosting = () => {
+      setMode('idle');
+      setHostedRoom(null);
+    };
+
+    return shell(
+      <BattleStatusPanel
+        spinning
+        title="相手を待っています"
+        description="このコードを相手に伝えてください。参加すると自動で始まります。"
+        actions={
+          <BattleButton variant="outline" icon="close" onClick={leaveHosting}>
+            キャンセル
+          </BattleButton>
+        }
+      >
+        <BattleInviteCard inviteCode={hostedRoom.inviteCode} />
+      </BattleStatusPanel>,
+      <BattleScreenHeader eyebrow="FRIEND MATCH" title="招待コード" onBack={leaveHosting} />,
+    );
+  }
+
+  return shell(
+    <div className="px-[18px] pb-8 pt-4">
+      <div className="mb-6 flex items-start gap-3 rounded-[16px] border-2 border-[var(--solid-ink)] bg-[var(--color-accent)] p-4 text-white shadow-[2px_3px_0_var(--solid-ink)]">
+        <Icon name="bolt" size={24} className="mt-0.5 shrink-0" />
+        <div>
+          <p className="font-display text-[15px] font-black leading-tight">早押し4択バトル</p>
+          <p className="mt-1 text-[12px] leading-relaxed opacity-90">
+            先に正解した方が1ポイント。1問につき回答は1人1回だけです。
+          </p>
         </div>
-        <div className="mb-6 h-8 w-8 animate-spin rounded-full border-4 border-[var(--color-surface-secondary)] border-t-[var(--color-foreground)]" />
-        <button
-          type="button"
-          onClick={() => { setMode('idle'); setHostedRoom(null); }}
-          className="rounded-xl border-2 border-[var(--color-foreground)] px-6 py-3 font-semibold"
-        >
-          キャンセル
-        </button>
-      </main>
-    );
-  }
-
-  return (
-    <main className="mx-auto max-w-md p-6">
-      <h1 className="mb-2 text-2xl font-bold">リアルタイム単語対戦</h1>
-      <p className="mb-8 text-sm text-[var(--color-muted)]">
-        早押し4択。お互いの単語帳から出題され、先に正解した方がポイントを取ります。
-      </p>
+      </div>
 
       {error && (
-        <p className="mb-6 rounded-xl bg-red-50 p-3 text-sm text-red-700 dark:bg-red-950/40 dark:text-red-300">
-          {error}
-        </p>
+        <div
+          role="alert"
+          className="mb-5 flex items-start gap-2 rounded-[12px] border-2 border-[var(--color-error)] bg-[var(--color-error-light)] px-3.5 py-3 text-[13px] text-[var(--color-error)]"
+        >
+          <Icon name="error" size={16} className="mt-0.5 shrink-0" />
+          <span>{error}</span>
+        </div>
       )}
 
-      <section className="mb-8">
-        <h2 className="mb-3 text-sm font-bold">使う単語帳</h2>
-        {projectsLoading ? (
-          <p className="text-sm text-[var(--color-muted)]">読み込み中...</p>
-        ) : projects.length === 0 ? (
-          <p className="text-sm text-[var(--color-muted)]">
-            単語帳がありません。先に単語帳を作成してください。
-          </p>
-        ) : (
-          <select
-            value={projectId}
-            onChange={(event) => setProjectId(event.target.value)}
-            className="w-full rounded-xl border-2 border-[var(--color-foreground)] bg-[var(--color-surface)] p-3 font-semibold"
-          >
-            {projects.map((project) => (
-              <option key={project.id} value={project.id}>
-                {project.title}
-              </option>
-            ))}
-          </select>
-        )}
-      </section>
+      <div className="mb-7 grid gap-5">
+        <BattleWordbookField
+          projects={projects}
+          loading={projectsLoading}
+          value={projectId}
+          onChange={setProjectId}
+        />
+        <BattleSettingsFields
+          questionCount={questionCount}
+          onQuestionCountChange={setQuestionCount}
+          questionCountOptions={QUESTION_COUNT_OPTIONS}
+          roundDurationMs={roundDurationMs}
+          onRoundDurationChange={setRoundDurationMs}
+          roundDurationOptions={ROUND_DURATION_OPTIONS}
+        />
+      </div>
 
-      <section className="mb-8 grid grid-cols-2 gap-4">
-        <div>
-          <h2 className="mb-3 text-sm font-bold">問題数</h2>
-          <div className="flex gap-2">
-            {QUESTION_COUNT_OPTIONS.map((option) => (
-              <button
-                key={option}
-                type="button"
-                onClick={() => setQuestionCount(option)}
-                className={`flex-1 rounded-xl border-2 py-2 text-sm font-semibold ${
-                  questionCount === option
-                    ? 'border-[var(--color-foreground)] bg-[var(--color-foreground)] text-white'
-                    : 'border-[var(--color-foreground)]'
-                }`}
-              >
-                {option}
-              </button>
-            ))}
-          </div>
-        </div>
-        <div>
-          <h2 className="mb-3 text-sm font-bold">制限時間</h2>
-          <div className="flex gap-2">
-            {ROUND_DURATION_OPTIONS.map((option) => (
-              <button
-                key={option.value}
-                type="button"
-                onClick={() => setRoundDurationMs(option.value)}
-                className={`flex-1 rounded-xl border-2 py-2 text-sm font-semibold ${
-                  roundDurationMs === option.value
-                    ? 'border-[var(--color-foreground)] bg-[var(--color-foreground)] text-white'
-                    : 'border-[var(--color-foreground)]'
-                }`}
-              >
-                {option.label}
-              </button>
-            ))}
-          </div>
-        </div>
-      </section>
-
-      <button
-        type="button"
+      <BattleButton
+        icon="shuffle"
+        disabled={busy || !hasProject}
         onClick={startRandomMatch}
-        disabled={busy || !selectedProject}
-        className="mb-8 w-full rounded-xl bg-[var(--color-foreground)] py-4 text-lg font-bold text-white disabled:opacity-50"
+        className="mb-7"
       >
         ランダムマッチ
-      </button>
+      </BattleButton>
 
-      <section className="rounded-2xl border-2 border-[var(--color-foreground)] p-5">
-        <h2 className="mb-4 text-sm font-bold">フレンド対戦</h2>
+      <section className="rounded-[16px] border-2 border-[var(--solid-ink)] bg-[var(--color-surface)] p-4 shadow-[2px_3px_0_var(--solid-ink)]">
+        <div className="mb-3.5 flex items-center gap-1.5">
+          <Icon name="group" size={14} className="text-[var(--color-muted)]" />
+          <h2 className="font-mono text-[9px] font-bold uppercase tracking-[0.08em] text-[var(--color-muted)]">
+            フレンド対戦
+          </h2>
+        </div>
 
-        <button
-          type="button"
+        <BattleButton
+          variant="outline"
+          icon="add"
+          disabled={busy || !hasProject}
           onClick={createFriendRoom}
-          disabled={busy || !selectedProject}
-          className="mb-4 w-full rounded-xl border-2 border-[var(--color-foreground)] py-3 font-semibold disabled:opacity-50"
+          className="mb-3.5"
         >
           招待コードを作る
-        </button>
+        </BattleButton>
 
         <div className="flex gap-2">
           <input
             value={joinCode}
             onChange={(event) => setJoinCode(event.target.value.toUpperCase())}
-            placeholder="コードを入力"
+            placeholder="コード"
             maxLength={8}
             inputMode="text"
             autoCapitalize="characters"
-            className="min-w-0 flex-1 rounded-xl border-2 border-[var(--color-foreground)] bg-[var(--color-surface)] p-3 text-center font-mono text-lg font-bold tracking-[0.2em]"
+            autoComplete="off"
+            aria-label="招待コード"
+            className="min-w-0 flex-1 rounded-[12px] border-2 border-[var(--solid-ink)] bg-[var(--color-background)] px-3 py-3 text-center font-display text-[18px] font-black uppercase tracking-[0.2em] text-[var(--solid-ink)] placeholder:text-[13px] placeholder:font-bold placeholder:tracking-normal placeholder:text-[var(--color-muted)]"
           />
           <button
             type="button"
             onClick={joinFriendRoom}
-            disabled={busy || !selectedProject || joinCode.length === 0}
-            className="rounded-xl bg-[var(--color-foreground)] px-5 font-semibold text-white disabled:opacity-50"
+            disabled={busy || !hasProject || joinCode.length === 0}
+            className="shrink-0 rounded-[12px] border-2 border-[var(--solid-ink)] bg-[var(--solid-ink)] px-5 font-display text-[14px] font-bold text-[var(--color-background)] shadow-[2px_3px_0_var(--solid-ink)] transition-all duration-100 active:translate-x-px active:translate-y-px active:shadow-[1px_2px_0_var(--solid-ink)] disabled:opacity-45 disabled:shadow-none"
           >
             参加
           </button>
         </div>
       </section>
-    </main>
+    </div>,
   );
 }

--- a/src/app/home-client.tsx
+++ b/src/app/home-client.tsx
@@ -11,7 +11,6 @@ import { ScanCaptureModal } from '@/components/home/ScanCaptureModal';
 import { CreateWordbookSheet } from '@/components/home/CreateWordbookSheet';
 import { GeneratingProjectCard } from '@/components/project/GeneratingProjectCard';
 import { HomeShortcutGrid } from '@/components/home/HomeShortcutGrid';
-import { HomeReelRail } from '@/components/home/HomeReelRail';
 import { HomeWordSearchSheet } from '@/components/home/HomeWordSearchSheet';
 import { PwaInstallBanner } from '@/components/home/PwaInstallBanner';
 import { ProUpgradeBanner, useProUpgradeBannerDismissed } from '@/components/home/ProUpgradeBanner';
@@ -584,12 +583,8 @@ export function HomeClient() {
   const showUpgradeBanner = isBillingEnabled() && !isPro && !upgradeBannerDismissed;
   // 参加中のグループ（マイ単語帳の下に表示。/shared から移設）
   const { groups: myGroups } = useMyGroups();
-  // ホームのおすすめ（英検級ベースの共有単語帳 + 語源あり単語限定のリール）
-  const {
-    books: recommendedBooks,
-    reels: recommendedReels,
-    loading: recommendationsLoading,
-  } = useHomeRecommendations();
+  // ホームのおすすめ（英検級ベースの共有単語帳）。リールはホームから外した
+  const { books: recommendedBooks } = useHomeRecommendations();
   // 語法問題集（Pro限定）。グループ表示の上に出す
   const { books: grammarBooks } = useHomeGrammarBooks();
   const visibleRecommendedBooks = loading ? [] : recommendedBooks;
@@ -614,8 +609,6 @@ export function HomeClient() {
         goal={{ state: goalState, count: goalCount }}
         grammarBooks={grammarBooks}
         recommendedBooks={visibleRecommendedBooks}
-        recommendedReels={recommendedReels}
-        recommendationsLoading={recommendationsLoading}
         onStartScan={() => setDesktopCreateOpen(true)}
         showUpgrade={showUpgradeBanner}
         onDismissUpgrade={dismissUpgradeBanner}
@@ -777,9 +770,6 @@ export function HomeClient() {
 
       {/* 参加中のグループ（/shared から移設） */}
       <JoinedGroupsSection groups={myGroups} />
-
-      {/* おすすめのリール（語源がある単語限定・単語帳/グループより下に配置） */}
-      <HomeReelRail items={recommendedReels} loading={recommendationsLoading} />
 
       </div>
       <ScanCaptureModal

--- a/src/components/battle/BattleButton.tsx
+++ b/src/components/battle/BattleButton.tsx
@@ -1,0 +1,61 @@
+'use client';
+
+/**
+ * 対戦機能まわりのボタン。アプリ共通の枠線＋ハードシャドウの見た目に揃える。
+ */
+
+import type { ButtonHTMLAttributes, ReactNode } from 'react';
+import Link from 'next/link';
+import { Icon } from '@/components/ui/Icon';
+
+type BattleButtonVariant = 'primary' | 'outline' | 'quiet';
+
+const VARIANT_CLASSES: Record<BattleButtonVariant, string> = {
+  primary:
+    'border-[var(--solid-ink)] bg-[var(--color-accent)] text-white shadow-[2px_3px_0_var(--solid-ink)] active:translate-x-px active:translate-y-px active:shadow-[1px_2px_0_var(--solid-ink)]',
+  outline:
+    'border-[var(--solid-ink)] bg-[var(--color-surface)] text-[var(--solid-ink)] shadow-[2px_3px_0_var(--solid-ink)] active:translate-x-px active:translate-y-px active:shadow-[1px_2px_0_var(--solid-ink)]',
+  quiet:
+    'border-transparent bg-transparent text-[var(--color-muted)] shadow-none',
+};
+
+const BASE_CLASSES =
+  'inline-flex w-full items-center justify-center gap-2 rounded-[14px] border-2 px-5 py-3.5 font-display text-[15px] font-bold transition-all duration-100 disabled:opacity-45 disabled:shadow-none disabled:active:translate-x-0 disabled:active:translate-y-0';
+
+export function BattleButton({
+  variant = 'primary',
+  icon,
+  children,
+  className = '',
+  ...props
+}: ButtonHTMLAttributes<HTMLButtonElement> & {
+  variant?: BattleButtonVariant;
+  icon?: string;
+  children: ReactNode;
+}) {
+  return (
+    <button type="button" className={`${BASE_CLASSES} ${VARIANT_CLASSES[variant]} ${className}`} {...props}>
+      {icon && <Icon name={icon} size={18} className="shrink-0" />}
+      {children}
+    </button>
+  );
+}
+
+export function BattleLinkButton({
+  href,
+  variant = 'primary',
+  icon,
+  children,
+}: {
+  href: string;
+  variant?: BattleButtonVariant;
+  icon?: string;
+  children: ReactNode;
+}) {
+  return (
+    <Link href={href} className={`${BASE_CLASSES} ${VARIANT_CLASSES[variant]} no-underline`}>
+      {icon && <Icon name={icon} size={18} className="shrink-0" />}
+      {children}
+    </Link>
+  );
+}

--- a/src/components/battle/BattleChoiceList.tsx
+++ b/src/components/battle/BattleChoiceList.tsx
@@ -1,0 +1,106 @@
+'use client';
+
+/**
+ * 早押し4択の選択肢。
+ *
+ * 表示状態は5つ:
+ *   idle     … まだ押せる
+ *   picked   … 自分が押した直後（判定待ち）
+ *   correct  … 決着後、正解だった選択肢
+ *   missed   … 決着後、自分が選んで外した選択肢
+ *   locked   … 回答権を失った / 決着済みで無関係な選択肢
+ *
+ * 「押せない理由」は色ではなく主に不透明度で表し、正誤の色（緑・赤）は
+ * 決着後だけに使う。回答前に色が出ると答えが透けるため。
+ */
+
+import { Icon } from '@/components/ui/Icon';
+
+const CHOICE_LABELS = ['A', 'B', 'C', 'D'];
+
+type ChoiceState = 'idle' | 'picked' | 'correct' | 'missed' | 'locked';
+
+function resolveState(options: {
+  index: number;
+  selectedIndex: number | null;
+  correctIndex: number | null;
+  resolved: boolean;
+  canAnswer: boolean;
+}): ChoiceState {
+  const { index, selectedIndex, correctIndex, resolved, canAnswer } = options;
+
+  if (resolved && correctIndex === index) return 'correct';
+  if (resolved && selectedIndex === index) return 'missed';
+  if (resolved) return 'locked';
+  if (selectedIndex === index) return 'picked';
+  return canAnswer ? 'idle' : 'locked';
+}
+
+const STATE_CLASSES: Record<ChoiceState, string> = {
+  idle: 'border-[var(--solid-ink)] bg-[var(--color-surface)] text-[var(--solid-ink)] shadow-[2px_3px_0_var(--solid-ink)] active:translate-x-px active:translate-y-px active:shadow-[1px_2px_0_var(--solid-ink)]',
+  picked:
+    'border-[var(--solid-ink)] bg-[var(--color-surface-secondary)] text-[var(--solid-ink)] shadow-none translate-x-px translate-y-px',
+  correct:
+    'border-[var(--color-accent)] bg-[var(--color-accent)] text-white shadow-[2px_3px_0_var(--solid-ink)]',
+  missed:
+    'border-[var(--color-error)] bg-[var(--color-error-light)] text-[var(--color-error)] shadow-none',
+  locked:
+    'border-[var(--solid-ink)] bg-[var(--color-surface)] text-[var(--solid-ink)] opacity-45 shadow-none',
+};
+
+const BADGE_CLASSES: Record<ChoiceState, string> = {
+  idle: 'border-[var(--solid-ink)] text-[var(--color-muted)]',
+  picked: 'border-[var(--solid-ink)] text-[var(--solid-ink)]',
+  correct: 'border-white/70 text-white',
+  missed: 'border-[var(--color-error)] text-[var(--color-error)]',
+  locked: 'border-[var(--solid-ink)] text-[var(--color-muted)]',
+};
+
+export function BattleChoiceList({
+  choices,
+  selectedIndex,
+  correctIndex,
+  resolved,
+  canAnswer,
+  onSelect,
+}: {
+  choices: string[];
+  selectedIndex: number | null;
+  correctIndex: number | null;
+  resolved: boolean;
+  canAnswer: boolean;
+  onSelect: (index: number) => void;
+}) {
+  return (
+    <ul className="grid gap-2.5">
+      {choices.map((choice, index) => {
+        const state = resolveState({ index, selectedIndex, correctIndex, resolved, canAnswer });
+
+        return (
+          <li key={`${index}-${choice}`}>
+            <button
+              type="button"
+              disabled={!canAnswer}
+              onClick={() => onSelect(index)}
+              aria-label={`選択肢${CHOICE_LABELS[index] ?? index + 1}: ${choice}`}
+              className={`flex w-full items-center gap-3 rounded-[14px] border-2 px-3.5 py-3.5 text-left transition-all duration-100 disabled:cursor-default ${STATE_CLASSES[state]}`}
+            >
+              <span
+                className={`flex h-[26px] w-[26px] shrink-0 items-center justify-center rounded-full border-2 font-mono text-[11px] font-bold ${BADGE_CLASSES[state]}`}
+              >
+                {CHOICE_LABELS[index] ?? index + 1}
+              </span>
+
+              <span className="min-w-0 flex-1 font-display text-[15px] font-bold leading-snug break-words">
+                {choice}
+              </span>
+
+              {state === 'correct' && <Icon name="check_circle" size={20} className="shrink-0" />}
+              {state === 'missed' && <Icon name="cancel" size={20} className="shrink-0" />}
+            </button>
+          </li>
+        );
+      })}
+    </ul>
+  );
+}

--- a/src/components/battle/BattleInviteCard.tsx
+++ b/src/components/battle/BattleInviteCard.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+/**
+ * フレンド対戦の招待コード表示。
+ * コードは口頭でも伝えられるよう1文字ずつ分けて大きく出す。
+ * コピーは navigator.clipboard が無い環境（非 HTTPS など）もあるので握りつぶす。
+ */
+
+import { useCallback, useState } from 'react';
+import { Icon } from '@/components/ui/Icon';
+
+export function BattleInviteCard({ inviteCode }: { inviteCode: string }) {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = useCallback(async () => {
+    try {
+      await navigator.clipboard.writeText(inviteCode);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1600);
+    } catch {
+      // クリップボードが使えない環境では表示されたコードを読んでもらう。
+    }
+  }, [inviteCode]);
+
+  return (
+    <div className="rounded-[16px] border-2 border-[var(--solid-ink)] bg-[var(--color-surface)] p-4 shadow-[2px_3px_0_var(--solid-ink)]">
+      <p className="mb-3 text-center font-mono text-[9px] font-bold uppercase tracking-[0.08em] text-[var(--color-muted)]">
+        Invite Code
+      </p>
+
+      <div className="mb-3 flex justify-center gap-1.5">
+        {inviteCode.split('').map((character, index) => (
+          <span
+            key={`${index}-${character}`}
+            className="flex h-[42px] w-[30px] items-center justify-center rounded-[8px] border-2 border-[var(--solid-ink)] bg-[var(--color-background)] font-display text-[22px] font-black text-[var(--solid-ink)]"
+          >
+            {character}
+          </span>
+        ))}
+      </div>
+
+      <button
+        type="button"
+        onClick={handleCopy}
+        className="flex w-full items-center justify-center gap-1.5 rounded-[10px] py-1.5 font-display text-[12px] font-bold text-[var(--color-muted)] transition-colors active:text-[var(--solid-ink)]"
+      >
+        <Icon name={copied ? 'check' : 'content_copy'} size={14} />
+        {copied ? 'コピーしました' : 'コードをコピー'}
+      </button>
+    </div>
+  );
+}

--- a/src/components/battle/BattleLobbyForm.tsx
+++ b/src/components/battle/BattleLobbyForm.tsx
@@ -1,0 +1,145 @@
+'use client';
+
+/**
+ * ロビーの設定フォーム（使う単語帳・問題数・制限時間）。
+ * 出題は両者の単語帳をマージするので、ここで選ぶのは「自分が持ち込む1冊」。
+ */
+
+import { Icon } from '@/components/ui/Icon';
+import type { Project } from '@/types';
+
+function FieldLabel({ icon, children }: { icon: string; children: string }) {
+  return (
+    <div className="mb-2 flex items-center gap-1.5">
+      <Icon name={icon} size={14} className="text-[var(--color-muted)]" />
+      <h2 className="font-mono text-[9px] font-bold uppercase tracking-[0.08em] text-[var(--color-muted)]">
+        {children}
+      </h2>
+    </div>
+  );
+}
+
+export function BattleChipGroup<T extends number>({
+  options,
+  value,
+  onChange,
+  formatLabel,
+}: {
+  options: readonly T[];
+  value: T;
+  onChange: (next: T) => void;
+  formatLabel: (option: T) => string;
+}) {
+  return (
+    <div className="flex gap-2">
+      {options.map((option) => {
+        const active = option === value;
+        return (
+          <button
+            key={option}
+            type="button"
+            aria-pressed={active}
+            onClick={() => onChange(option)}
+            className={`flex-1 rounded-[12px] border-2 border-[var(--solid-ink)] py-2.5 font-display text-[13px] font-bold transition-all duration-100 ${
+              active
+                ? 'bg-[var(--solid-ink)] text-[var(--color-background)] shadow-none translate-x-px translate-y-px'
+                : 'bg-[var(--color-surface)] text-[var(--solid-ink)] shadow-[2px_3px_0_var(--solid-ink)] active:translate-x-px active:translate-y-px active:shadow-[1px_2px_0_var(--solid-ink)]'
+            }`}
+          >
+            {formatLabel(option)}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+export function BattleWordbookField({
+  projects,
+  loading,
+  value,
+  onChange,
+}: {
+  projects: Project[];
+  loading: boolean;
+  value: string;
+  onChange: (projectId: string) => void;
+}) {
+  return (
+    <section>
+      <FieldLabel icon="menu_book">持ち込む単語帳</FieldLabel>
+
+      {loading ? (
+        <div className="h-[50px] animate-pulse rounded-[12px] border-2 border-[var(--color-border)] bg-[var(--color-surface-secondary)]" />
+      ) : projects.length === 0 ? (
+        <p className="rounded-[12px] border-2 border-dashed border-[var(--solid-ink)] px-4 py-3.5 text-[13px] text-[var(--color-muted)]">
+          単語帳がありません。先に単語帳を作成してください。
+        </p>
+      ) : (
+        <div className="relative">
+          <select
+            value={value}
+            onChange={(event) => onChange(event.target.value)}
+            aria-label="持ち込む単語帳"
+            className="w-full appearance-none rounded-[12px] border-2 border-[var(--solid-ink)] bg-[var(--color-surface)] px-4 py-3.5 pr-11 font-display text-[14px] font-bold text-[var(--solid-ink)] shadow-[2px_3px_0_var(--solid-ink)]"
+          >
+            {projects.map((project) => (
+              <option key={project.id} value={project.id}>
+                {project.title}
+              </option>
+            ))}
+          </select>
+          <Icon
+            name="keyboard_arrow_down"
+            size={20}
+            className="pointer-events-none absolute right-3.5 top-1/2 -translate-y-1/2 text-[var(--solid-ink)]"
+          />
+        </div>
+      )}
+
+      <p className="mt-2 text-[11.5px] leading-relaxed text-[var(--color-muted)]">
+        出題は自分と相手の単語帳を混ぜて作られます。
+      </p>
+    </section>
+  );
+}
+
+export function BattleSettingsFields({
+  questionCount,
+  onQuestionCountChange,
+  questionCountOptions,
+  roundDurationMs,
+  onRoundDurationChange,
+  roundDurationOptions,
+}: {
+  questionCount: number;
+  onQuestionCountChange: (next: number) => void;
+  questionCountOptions: readonly number[];
+  roundDurationMs: number;
+  onRoundDurationChange: (next: number) => void;
+  roundDurationOptions: readonly number[];
+}) {
+  return (
+    <div className="grid grid-cols-2 gap-3.5">
+      <section>
+        <FieldLabel icon="format_list_bulleted">問題数</FieldLabel>
+        <BattleChipGroup
+          options={questionCountOptions}
+          value={questionCount}
+          onChange={onQuestionCountChange}
+          formatLabel={(option) => `${option}`}
+        />
+      </section>
+
+      <section>
+        <FieldLabel icon="timer">制限時間</FieldLabel>
+        <BattleChipGroup
+          options={roundDurationOptions}
+          value={roundDurationMs}
+          onChange={onRoundDurationChange}
+          formatLabel={(option) => `${option / 1000}s`}
+        />
+      </section>
+    </div>
+  );
+}

--- a/src/components/battle/BattlePromptCard.tsx
+++ b/src/components/battle/BattlePromptCard.tsx
@@ -1,0 +1,28 @@
+'use client';
+
+/**
+ * 出題中の英単語カード。
+ * 長い単語や熟語でも折り返して読めるよう、文字サイズを語長で段階的に落とす。
+ */
+
+function promptSizeClass(prompt: string): string {
+  if (prompt.length > 28) return 'text-[24px]';
+  if (prompt.length > 18) return 'text-[30px]';
+  if (prompt.length > 11) return 'text-[36px]';
+  return 'text-[42px]';
+}
+
+export function BattlePromptCard({ prompt }: { prompt: string }) {
+  return (
+    <div className="flex min-h-[132px] flex-col items-center justify-center rounded-[18px] border-2 border-[var(--solid-ink)] bg-[var(--color-surface)] px-5 py-6 shadow-[2px_3px_0_var(--solid-ink)]">
+      <p className="mb-2 font-mono text-[9px] font-bold uppercase tracking-[0.08em] text-[var(--color-muted)]">
+        Meaning?
+      </p>
+      <h1
+        className={`text-center font-display font-black leading-tight tracking-tight text-[var(--solid-ink)] break-words ${promptSizeClass(prompt)}`}
+      >
+        {prompt}
+      </h1>
+    </div>
+  );
+}

--- a/src/components/battle/BattleResultPanel.tsx
+++ b/src/components/battle/BattleResultPanel.tsx
@@ -1,0 +1,76 @@
+'use client';
+
+/**
+ * 対戦結果。勝敗はサーバーが決めた winner_user_id から導出済みのものを受け取る。
+ */
+
+import { Icon } from '@/components/ui/Icon';
+import { BattleScoreboard } from '@/components/battle/BattleScoreboard';
+import type { BattleResultForViewer } from '@/lib/battle/room-state';
+import type { BattleOutcome, BattleParticipant } from '@/lib/battle/types';
+
+const RESULT_STYLES: Record<
+  Exclude<BattleResultForViewer, 'pending'>,
+  { icon: string; heading: string; className: string }
+> = {
+  win: {
+    icon: 'emoji_events',
+    heading: '勝ち！',
+    className: 'border-[var(--color-accent)] bg-[var(--color-accent)] text-white',
+  },
+  lose: {
+    icon: 'sentiment_dissatisfied',
+    heading: '負け...',
+    className: 'border-[var(--solid-ink)] bg-[var(--color-surface)] text-[var(--solid-ink)]',
+  },
+  draw: {
+    icon: 'balance',
+    heading: '引き分け',
+    className: 'border-[var(--solid-ink)] bg-[var(--color-surface)] text-[var(--solid-ink)]',
+  },
+};
+
+export function BattleResultPanel({
+  result,
+  outcome,
+  cancelled,
+  self,
+  opponent,
+}: {
+  result: BattleResultForViewer;
+  outcome: BattleOutcome | null;
+  cancelled: boolean;
+  self: BattleParticipant;
+  opponent: BattleParticipant | null;
+}) {
+  if (cancelled) {
+    return (
+      <div className="flex flex-col items-center gap-6">
+        <div className="flex h-[52px] w-[52px] items-center justify-center rounded-full border-2 border-[var(--solid-ink)] bg-[var(--color-surface)]">
+          <Icon name="close" size={24} />
+        </div>
+        <h1 className="font-display text-[22px] font-black tracking-tight">対戦は中止されました</h1>
+      </div>
+    );
+  }
+
+  const style = RESULT_STYLES[result === 'pending' ? 'draw' : result];
+
+  return (
+    <div className="flex flex-col items-center gap-6">
+      <div
+        className={`flex w-full flex-col items-center gap-2 rounded-[18px] border-2 px-6 py-7 shadow-[2px_3px_0_var(--solid-ink)] ${style.className}`}
+      >
+        <Icon name={style.icon} size={34} />
+        <h1 className="font-display text-[26px] font-black tracking-tight">{style.heading}</h1>
+        {outcome === 'abandoned' && (
+          <p className="text-[12px] opacity-90">相手が退出しました</p>
+        )}
+      </div>
+
+      <div className="w-full">
+        <BattleScoreboard self={self} opponent={opponent} />
+      </div>
+    </div>
+  );
+}

--- a/src/components/battle/BattleRoundFeedback.tsx
+++ b/src/components/battle/BattleRoundFeedback.tsx
@@ -1,0 +1,75 @@
+'use client';
+
+/**
+ * ラウンド決着の一行フィードバック。
+ * 高さを固定して、表示/非表示で選択肢の位置がずれないようにする。
+ */
+
+import { Icon } from '@/components/ui/Icon';
+
+export type BattleRoundOutcome =
+  | 'won'        // 自分が先に正解した
+  | 'lost'       // 相手が先に正解した
+  | 'missed'     // 自分が外して決着した
+  | 'timeout'    // 誰も正解できずに時間切れ
+  | 'waiting'    // 自分は回答済み、相手待ち
+  | 'live';      // まだ回答できる
+
+const OUTCOME_STYLES: Record<
+  Exclude<BattleRoundOutcome, 'live'>,
+  { icon: string; label: string; className: string }
+> = {
+  won: {
+    icon: 'bolt',
+    label: '正解！ +1',
+    className: 'border-[var(--color-accent)] bg-[var(--color-accent)] text-white',
+  },
+  lost: {
+    icon: 'close',
+    label: '相手が先に正解',
+    className: 'border-[var(--solid-ink)] bg-[var(--color-surface)] text-[var(--color-muted)]',
+  },
+  missed: {
+    icon: 'cancel',
+    label: '不正解',
+    className: 'border-[var(--color-error)] bg-[var(--color-error-light)] text-[var(--color-error)]',
+  },
+  timeout: {
+    icon: 'hourglass_bottom',
+    label: '時間切れ',
+    className: 'border-[var(--solid-ink)] bg-[var(--color-surface)] text-[var(--color-muted)]',
+  },
+  waiting: {
+    icon: 'hourglass_top',
+    label: '相手の回答を待っています',
+    className: 'border-[var(--solid-ink)] bg-[var(--color-surface)] text-[var(--color-muted)]',
+  },
+};
+
+export function BattleRoundFeedback({
+  outcome,
+  answer,
+}: {
+  outcome: BattleRoundOutcome;
+  /** 決着後に開示された正解。自分が正解した場合は出さない。 */
+  answer?: string | null;
+}) {
+  if (outcome === 'live') {
+    return <div className="h-[42px]" aria-hidden="true" />;
+  }
+
+  const style = OUTCOME_STYLES[outcome];
+  const showAnswer = Boolean(answer) && outcome !== 'won' && outcome !== 'waiting';
+
+  return (
+    <div
+      role="status"
+      className={`flex h-[42px] items-center justify-center gap-2 rounded-[12px] border-2 px-4 ${style.className}`}
+    >
+      <Icon name={style.icon} size={16} className="shrink-0" />
+      <span className="truncate font-display text-[13px] font-bold">
+        {showAnswer ? `${style.label} · 正解は「${answer}」` : style.label}
+      </span>
+    </div>
+  );
+}

--- a/src/components/battle/BattleScoreboard.tsx
+++ b/src/components/battle/BattleScoreboard.tsx
@@ -1,0 +1,90 @@
+'use client';
+
+/**
+ * 対戦中・結果画面のスコア表示。
+ * 自分は常に左、相手は常に右に固定して、どちらの視点でも読み方が変わらないようにする。
+ */
+
+import { ProfileAvatar } from '@/components/profile/ProfileAvatar';
+import { profileAvatarColor } from '@/components/profile/ProfileView';
+import type { BattleParticipant } from '@/lib/battle/types';
+
+function initialOf(name: string): string {
+  return name.trim().slice(0, 1).toUpperCase() || '?';
+}
+
+function PlayerColumn({
+  participant,
+  label,
+  leading,
+  justScored,
+}: {
+  participant: BattleParticipant | null;
+  label: string;
+  leading: boolean;
+  justScored: boolean;
+}) {
+  const name = participant?.displayName ?? '待機中';
+
+  return (
+    <div className="flex min-w-0 flex-1 flex-col items-center gap-1.5">
+      <ProfileAvatar
+        avatarUrl={participant?.avatarUrl}
+        initial={initialOf(name)}
+        color={profileAvatarColor(participant?.userId ?? name)}
+        size={44}
+        radius={22}
+        className={justScored ? 'animate-pulse' : undefined}
+      />
+      <p className="max-w-full truncate font-display text-[12px] font-bold text-[var(--solid-ink)]">
+        {name}
+      </p>
+      <p className="font-mono text-[8.5px] font-bold uppercase tracking-[0.08em] text-[var(--color-muted)]">
+        {label}
+      </p>
+      <p
+        className={`font-display text-[30px] font-black leading-none tabular-nums transition-colors ${
+          leading ? 'text-[var(--color-accent)]' : 'text-[var(--solid-ink)]'
+        }`}
+      >
+        {participant?.score ?? 0}
+      </p>
+    </div>
+  );
+}
+
+export function BattleScoreboard({
+  self,
+  opponent,
+  /** 直前のラウンドで得点した側。アバターを一瞬強調する。 */
+  scoredSeat = null,
+}: {
+  self: BattleParticipant;
+  opponent: BattleParticipant | null;
+  scoredSeat?: 'self' | 'opponent' | null;
+}) {
+  const selfScore = self.score;
+  const opponentScore = opponent?.score ?? 0;
+
+  return (
+    <div className="flex items-center gap-3 rounded-[16px] border-2 border-[var(--solid-ink)] bg-[var(--color-surface)] px-4 py-3.5 shadow-[2px_3px_0_var(--solid-ink)]">
+      <PlayerColumn
+        participant={self}
+        label="YOU"
+        leading={selfScore > opponentScore}
+        justScored={scoredSeat === 'self'}
+      />
+
+      <div className="shrink-0 font-display text-[13px] font-black tracking-[0.08em] text-[var(--color-muted)]">
+        VS
+      </div>
+
+      <PlayerColumn
+        participant={opponent}
+        label="RIVAL"
+        leading={opponentScore > selfScore}
+        justScored={scoredSeat === 'opponent'}
+      />
+    </div>
+  );
+}

--- a/src/components/battle/BattleScreenHeader.tsx
+++ b/src/components/battle/BattleScreenHeader.tsx
@@ -1,0 +1,86 @@
+'use client';
+
+/**
+ * 対戦画面・ロビー共通の固定ヘッダー。
+ * 単語帳詳細やグループページと同じ sticky パターンで、top はノッチ下端に合わせる
+ * （ノッチ帯は全体共通の StatusBarCover が覆う）。下線はコンテンツがヘッダの下に
+ * 潜り込んだときだけ出す。
+ */
+
+import type { ReactNode } from 'react';
+import { useRouter } from 'next/navigation';
+import { Icon } from '@/components/ui/Icon';
+import { usePageScrolled } from '@/hooks/use-page-scrolled';
+
+export function BattleHeaderButton({
+  children,
+  onClick,
+  'aria-label': ariaLabel,
+}: {
+  children: ReactNode;
+  onClick?: () => void;
+  'aria-label'?: string;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-label={ariaLabel}
+      className="flex h-[38px] w-[38px] shrink-0 items-center justify-center rounded-[19px] border-2 border-[var(--solid-ink)] bg-[var(--color-surface)] text-[var(--solid-ink)] transition-all duration-100 active:translate-x-px active:translate-y-px"
+    >
+      {children}
+    </button>
+  );
+}
+
+export function BattleScreenHeader({
+  eyebrow,
+  title,
+  trailing,
+  onBack,
+  fallbackHref = '/battle',
+}: {
+  eyebrow: string;
+  title: string;
+  trailing?: ReactNode;
+  /** 指定すると戻る前に確認や降参処理を挟める。 */
+  onBack?: () => void;
+  fallbackHref?: string;
+}) {
+  const router = useRouter();
+  const pageScrolled = usePageScrolled();
+
+  const handleBack = () => {
+    if (onBack) {
+      onBack();
+      return;
+    }
+    // 直前の画面に戻す。履歴が無い場合のみ対戦トップへ。
+    if (typeof window !== 'undefined' && window.history.length > 1) router.back();
+    else router.replace(fallbackHref);
+  };
+
+  return (
+    <header
+      className={`sticky z-40 flex items-center gap-2.5 border-b-2 bg-[var(--color-background)]/95 px-[14px] py-2.5 backdrop-blur-md ${
+        pageScrolled ? 'border-[var(--solid-ink)]' : 'border-transparent'
+      }`}
+      style={{ top: 'env(safe-area-inset-top, 0px)' }}
+    >
+      <BattleHeaderButton onClick={handleBack} aria-label="戻る">
+        <Icon name="arrow_back" size={16} />
+      </BattleHeaderButton>
+
+      <div className="min-w-0 flex-1">
+        <div className="font-mono text-[9px] font-bold uppercase tracking-[0.08em] text-[var(--color-muted)]">
+          {eyebrow}
+        </div>
+        <div className="truncate font-display text-[15px] font-extrabold leading-tight text-[var(--solid-ink)]">
+          {title}
+        </div>
+      </div>
+
+      {trailing && <div className="flex shrink-0 items-center gap-2">{trailing}</div>}
+    </header>
+  );
+}

--- a/src/components/battle/BattleStatusPanel.tsx
+++ b/src/components/battle/BattleStatusPanel.tsx
@@ -1,0 +1,64 @@
+'use client';
+
+/**
+ * 読み込み中・待機中・エラーなど「本文がない状態」の共通レイアウト。
+ * ヘッダーは各ページ側が出すので、ここは中央寄せの本文だけを担う。
+ */
+
+import type { ReactNode } from 'react';
+import { Icon } from '@/components/ui/Icon';
+
+export function BattleSpinner({ size = 40 }: { size?: number }) {
+  return (
+    <div
+      className="animate-spin rounded-full border-[3px] border-[var(--color-surface-secondary)] border-t-[var(--solid-ink)]"
+      style={{ width: size, height: size }}
+      role="progressbar"
+      aria-label="読み込み中"
+    />
+  );
+}
+
+export function BattleStatusPanel({
+  icon,
+  spinning = false,
+  title,
+  description,
+  children,
+  actions,
+}: {
+  /** spinning が false のときに出すアイコン。 */
+  icon?: string;
+  spinning?: boolean;
+  title: string;
+  description?: string;
+  /** 招待コードなど、説明文の下に差し込む要素。 */
+  children?: ReactNode;
+  actions?: ReactNode;
+}) {
+  return (
+    <div className="flex flex-1 flex-col items-center justify-center px-6 py-12 text-center">
+      {spinning ? (
+        <BattleSpinner />
+      ) : icon ? (
+        <div className="flex h-[52px] w-[52px] items-center justify-center rounded-full border-2 border-[var(--solid-ink)] bg-[var(--color-surface)]">
+          <Icon name={icon} size={24} className="text-[var(--solid-ink)]" />
+        </div>
+      ) : null}
+
+      <h2 className="mt-5 font-display text-[19px] font-black tracking-tight text-[var(--solid-ink)]">
+        {title}
+      </h2>
+
+      {description && (
+        <p className="mt-2 max-w-[280px] text-[13px] leading-relaxed text-[var(--color-muted)]">
+          {description}
+        </p>
+      )}
+
+      {children && <div className="mt-6 w-full max-w-[320px]">{children}</div>}
+
+      {actions && <div className="mt-8 flex w-full max-w-[320px] flex-col gap-2.5">{actions}</div>}
+    </div>
+  );
+}

--- a/src/components/battle/BattleTimerBar.tsx
+++ b/src/components/battle/BattleTimerBar.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+/**
+ * ラウンドの残り時間バー。
+ * 締切はサーバーが持っているので、ここは remainingMs を描くだけの純表示。
+ */
+
+const BATTLE_TIMER_WARNING_MS = 3_000;
+
+export function BattleTimerBar({
+  remainingMs,
+  totalMs,
+  progressLabel,
+  paused = false,
+}: {
+  remainingMs: number;
+  totalMs: number;
+  /** 「3 / 10」のような進行状況。 */
+  progressLabel: string;
+  /** ラウンド決着後は減り続けないよう止める。 */
+  paused?: boolean;
+}) {
+  const ratio = totalMs > 0 ? Math.max(0, Math.min(1, remainingMs / totalMs)) : 0;
+  const warning = !paused && remainingMs <= BATTLE_TIMER_WARNING_MS;
+  const seconds = Math.ceil(remainingMs / 1000);
+
+  return (
+    <div>
+      <div className="mb-1.5 flex items-baseline justify-between">
+        <span className="font-mono text-[9px] font-bold uppercase tracking-[0.08em] text-[var(--color-muted)]">
+          Q {progressLabel}
+        </span>
+        <span
+          className={`font-mono text-[11px] font-bold tabular-nums ${
+            warning ? 'text-[var(--color-error)]' : 'text-[var(--color-muted)]'
+          }`}
+        >
+          {paused ? '--' : `${seconds}s`}
+        </span>
+      </div>
+
+      <div className="h-2 overflow-hidden rounded-full border-2 border-[var(--solid-ink)] bg-[var(--color-surface)]">
+        <div
+          className={`h-full transition-[width] duration-100 ease-linear ${
+            warning ? 'bg-[var(--color-error)]' : 'bg-[var(--color-accent)]'
+          }`}
+          style={{ width: `${ratio * 100}%` }}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/components/desktop/DesktopHome.tsx
+++ b/src/components/desktop/DesktopHome.tsx
@@ -4,7 +4,7 @@
  * デスクトップホーム。
  * 上部: Spotify 風ショートカットグリッド（TODAY'S GOAL + 保存済み + 単語帳/グループ/おすすめ）
  * 下部: マイ単語帳は従来の本棚タイル（グリッド/リスト切替）。上部グリッドに
- *       載った単語帳は除外して表示する。おすすめの単語帳/リールはシェルフのまま。
+ *       載った単語帳は除外して表示する。おすすめの単語帳はシェルフのまま。
  * 右サイドの学習サイドバー・アップグレードカードはモバイルと違い維持する。
  */
 
@@ -14,7 +14,6 @@ import { Icon } from '@/components/ui/Icon';
 import { DesktopButton, DesktopTopbar } from '@/components/desktop/DesktopChrome';
 import { DesktopWordSearchOverlay } from '@/components/desktop/DesktopWordSearchOverlay';
 import { useAuth } from '@/hooks/use-auth';
-import { DesktopMediaCard, DesktopShelf } from '@/components/desktop/DesktopMediaShelf';
 import { DesktopStudySidebar } from '@/components/desktop/DesktopStudySidebar';
 import { JoinedGroupGrid } from '@/components/groups/JoinedGroupsSection';
 import { DesktopHomeGrammarBooks } from '@/components/home/HomeGrammarBooks';
@@ -29,9 +28,7 @@ import {
   prefetchGroupOverview,
   seedGroupSummary,
 } from '@/lib/shared-projects/group-overview-cache';
-import { prefetchReelFeed } from '@/hooks/use-reel-feed';
-import { seedPinnedReelPreview } from '@/lib/reels/pinned-preview';
-import type { HomeRecommendedBook, HomeReelPreviewItem } from '@/lib/home/recommendations-types';
+import type { HomeRecommendedBook } from '@/lib/home/recommendations-types';
 import type { Project } from '@/types';
 import type { StudyGroupSummary } from '@/lib/shared-projects/types';
 
@@ -77,8 +74,6 @@ export function DesktopHomeView({
   goal,
   grammarBooks = [],
   recommendedBooks = [],
-  recommendedReels = [],
-  recommendationsLoading = false,
   onStartScan,
   showUpgrade = false,
   onDismissUpgrade,
@@ -92,8 +87,6 @@ export function DesktopHomeView({
   goal: DesktopHomeGoal;
   grammarBooks?: GrammarBook[];
   recommendedBooks?: HomeRecommendedBook[];
-  recommendedReels?: HomeReelPreviewItem[];
-  recommendationsLoading?: boolean;
   onStartScan: () => void;
   showUpgrade?: boolean;
   onDismissUpgrade?: () => void;
@@ -320,17 +313,6 @@ export function DesktopHomeView({
             </div>
           )}
 
-          {/* おすすめのリール（語源がある単語限定）。デスクトップで小さくなり
-              すぎないようカード幅を広めに取る */}
-          {(recommendationsLoading || recommendedReels.length > 0) && (
-            <DesktopShelf title="おすすめのリール" seeAllHref="/reels" >
-              {recommendationsLoading && recommendedReels.length === 0
-                ? [0, 1, 2].map((slot) => <DesktopMediaCardSkeleton key={slot} />)
-                : recommendedReels.map((item) => (
-                    <DesktopReelPreviewCard key={item.id} item={item} />
-                  ))}
-            </DesktopShelf>
-          )}
         </div>
 
         {/* 右サイド（モバイルと違い維持） */}
@@ -704,17 +686,6 @@ function DesktopProjectRow({ project }: { project: DesktopHomeProject }) {
   );
 }
 
-function DesktopMediaCardSkeleton() {
-  return (
-    <div className="ds-media-card" style={{ cursor: 'default' }} aria-hidden="true">
-      <div className="art ds-shimmer" style={{ boxShadow: 'none', borderColor: 'var(--color-border)' }} />
-      <div className="meta">
-        <div className="ds-shimmer" style={{ height: 13, borderRadius: 6, width: '80%' }} />
-        <div className="ds-shimmer" style={{ height: 10, borderRadius: 6, width: '55%', marginTop: 6 }} />
-      </div>
-    </div>
-  );
-}
 
 // おすすめの共有単語帳。マイ単語帳と同じ本棚タイル（ds-book）で表示する。
 function DesktopRecommendedBookTile({ book, compact = false }: { book: HomeRecommendedBook; compact?: boolean }) {
@@ -748,71 +719,6 @@ function DesktopRecommendedBookTile({ book, compact = false }: { book: HomeRecom
   );
 }
 
-const REEL_MAX_FORMULA_PARTS = 3;
-
-function DesktopReelPreviewCard({ item }: { item: HomeReelPreviewItem }) {
-  const parts = item.morphology.formula.slice(0, REEL_MAX_FORMULA_PARTS);
-  return (
-    <DesktopMediaCard
-      href={`/reels?pin=${encodeURIComponent(item.id)}`}
-      // クリック時点でフィード取得を先行開始（この単語を先頭に固定）し、
-      // /reels 側で即時表示できるよう表示データもシードする。
-      onClick={() => {
-        prefetchReelFeed(item.id);
-        seedPinnedReelPreview(item);
-      }}
-      artStyle={{ background: `linear-gradient(165deg, ${desktopThumbColor(item.id)} 0%, #1a1a1a 170%)` }}
-      artChildren={
-        <div
-          style={{
-            position: 'absolute',
-            inset: 0,
-            padding: 12,
-            display: 'flex',
-            flexDirection: 'column',
-            justifyContent: 'space-between',
-            textAlign: 'left',
-          }}
-        >
-          <span
-            className="mono"
-            style={{
-              alignSelf: 'flex-start',
-              borderRadius: 999,
-              background: 'rgba(255,255,255,0.2)',
-              padding: '2px 8px',
-              fontSize: 9,
-              fontWeight: 700,
-              letterSpacing: '0.04em',
-            }}
-          >
-            語源
-          </span>
-          <div style={{ minWidth: 0 }}>
-            <div style={{ fontSize: 20, fontWeight: 800, lineHeight: 1.15, wordBreak: 'break-word' }}>
-              {item.english}
-            </div>
-            <div style={{ display: 'flex', flexWrap: 'wrap', alignItems: 'center', gap: 4, marginTop: 8 }}>
-              {parts.map((part, index) => (
-                <span key={`${part.text}-${index}`} style={{ display: 'inline-flex', alignItems: 'center', gap: 4 }}>
-                  {index > 0 && <span style={{ fontSize: 10, fontWeight: 700, color: 'rgba(255,255,255,0.6)' }}>+</span>}
-                  <span
-                    className="mono"
-                    style={{ borderRadius: 6, background: 'rgba(255,255,255,0.2)', padding: '2px 6px', fontSize: 10, fontWeight: 700 }}
-                  >
-                    {part.text}
-                  </span>
-                </span>
-              ))}
-            </div>
-          </div>
-        </div>
-      }
-      title={item.japanese}
-      subtitle={item.bookTitle}
-    />
-  );
-}
 
 /* ============ 右サイド ============ */
 


### PR DESCRIPTION
#502 で入れた対戦機能のフロントエンドを作り直しました。バックエンド（マイグレーション・RPC・APIルート）は変更していません。

## 1. 対戦UIのコンポーネント分割

前回はページファイルに素のタグを直接並べていて、アプリの他画面と見た目が揃っていませんでした。共通のデザイン言語（`border-2 border-[var(--solid-ink)]` + ハードシャドウ、`font-display` の見出し、`font-mono` の大文字マイクロラベル、アクセントの緑）に合わせたコンポーネントへ分解しています。

`src/components/battle/` に追加:

| コンポーネント | 役割 |
| --- | --- |
| `BattleScreenHeader` | 固定ヘッダー。左端に戻る矢印 |
| `BattleScoreboard` | 自分を常に左に固定した対戦スコア |
| `BattleTimerBar` | 残り時間バー（残り3秒で赤） |
| `BattlePromptCard` | 出題単語。語長で文字サイズを段階調整 |
| `BattleChoiceList` | 4択。5状態を持つ |
| `BattleRoundFeedback` | ラウンド決着の一行表示 |
| `BattleStatusPanel` | 読み込み・待機・エラーの共通レイアウト |
| `BattleButton` / `BattleLinkButton` | ボタン3バリアント |
| `BattleInviteCard` | 招待コード（1文字ずつ表示 + コピー） |
| `BattleResultPanel` | 勝敗結果 |
| `BattleLobbyForm` | 単語帳選択・問題数・制限時間のチップ |

ページ側（`/battle`, `/battle/[roomId]`）は状態の組み立てとハンドラだけを持つ形に薄くしました。

### 選択肢の状態設計

`BattleChoiceList` は idle / picked / correct / missed / locked の5状態を持ちます。**正誤の色（緑・赤）は決着後だけに使い、回答前は不透明度のみで押せるかを表しています** — 回答前に色を出すと正解が透けてしまうためです。早押しなので、この区別は見た目の問題ではなく機能の問題になります。

`BattleRoundFeedback` は表示・非表示で選択肢の位置がずれないよう高さを固定しました。押そうとした瞬間にボタンが動くのは早押しでは致命的なので。

## 2. 固定ヘッダー + 戻る矢印

単語帳詳細ページと同じ sticky パターンに合わせました。`top` をノッチ下端（`env(safe-area-inset-top)`）に合わせ、ノッチ帯は全体共通の `StatusBarCover` に任せます。下線はコンテンツがヘッダ下に潜り込んだときだけ `usePageScrolled` で出します。

左端の戻る矢印は履歴があれば `router.back()`、無ければ対戦トップへフォールバックします。対戦中とマッチング中は戻る操作に降参・キューキャンセルを紐づけてあるので、ブラウザバックで幽霊ルームが残りません。

## 3. ホームからリールUIを削除

モバイル（`HomeReelRail`）とデスクトップ（おすすめのリール棚）の両方から削除し、併せて使われなくなった `DesktopReelPreviewCard` / `DesktopMediaCardSkeleton` と関連インポートも片付けました。`useHomeRecommendations` の `books` はおすすめ単語帳で引き続き使うため残しています。`/reels` 自体は削除していません。

## 検証

- `npm run build` — 成功、対戦ルートの出力を確認
- `npm test` — 1468 pass / 2 fail
- `npx tsc --noEmit` — 対戦・ホーム関連はエラーなし
- `npx eslint` — 変更ファイルすべて指摘なし

テストの2件（`otp.contract.test.ts`, `words/create/route.test.ts`）と `tsc` の3件（`grammar/route.security.test.ts`, `translation-targets.test.ts`）は本PRの変更前から `main` に存在するもので、`git stash` した状態で再現することを確認済みです。

## 注意

`20260814100000_create_word_battles.sql` は #502 でマージ済みですが、**本番への適用がまだの場合は適用が必要**です。未適用だと対戦画面はテーブル・RPC不在でエラーになります。

---
_Generated by [Claude Code](https://claude.ai/code/session_01MQGABRKMMaAzdZxAxPXh5K)_