### PR TITLE
グループのトップに今週の上位3人を表示する

### DIFF
--- a/src/app/groups/[groupId]/page.tsx
+++ b/src/app/groups/[groupId]/page.tsx
@@ -18,6 +18,7 @@ import { DesktopButton } from '@/components/desktop/DesktopChrome';
 import { GroupHubTiles, buildGroupHubTiles } from '@/components/groups/GroupHubTiles';
 import { GroupLeaderboard, findViewerRank } from '@/components/groups/GroupLeaderboard';
 import { GroupRoomHeader } from '@/components/groups/GroupRoomHeader';
+import { GroupTopThree } from '@/components/groups/GroupTopThree';
 import { Icon } from '@/components/ui';
 import { useAuth } from '@/hooks/use-auth';
 import { useToast } from '@/components/ui/toast';
@@ -202,7 +203,14 @@ export default function GroupPage() {
           >
             {stateView ?? (group && (
               <>
-                {/* タイルは余白の中央に置く（下端に貼り付けない） */}
+                {/* 上部に今週の上位3人。誰が走っているかを開いた瞬間に見せる。
+                    メンバーは全員0問でも並ぶので、空配列＝まだ読めていない状態。
+                    その間は帯ごと出さない（一瞬「誰も解いていません」が出るため）*/}
+                {leaderboard.length > 0 && (
+                  <GroupTopThree leaderboard={leaderboard} href={`${groupPath}/ranking`} />
+                )}
+
+                {/* タイルは残りの余白の中央に置く（下端に貼り付けない） */}
                 <div className="flex flex-1 items-center">
                   <GroupHubTiles tiles={tiles} />
                 </div>

--- a/src/components/groups/GroupHubTiles.tsx
+++ b/src/components/groups/GroupHubTiles.tsx
@@ -80,7 +80,8 @@ export function buildGroupHubTiles(options: {
 export function GroupHubTiles({ tiles }: { tiles: GroupHubTile[] }) {
   return (
     // 4枚が正方形寄りに収まる高さ。画面が高いときに間延びしないよう上限を切る。
-    <div className="grid h-[min(56dvh,420px)] min-h-[260px] w-full grid-cols-2 grid-rows-2 gap-2.5">
+    // 上にランキングの帯が乗ったぶん、1画面に収まるよう少しだけ低くしている。
+    <div className="grid h-[min(50dvh,400px)] min-h-[240px] w-full grid-cols-2 grid-rows-2 gap-2.5">
       {tiles.map((tile) => {
         const ink = tile.foreground === 'dark';
         // 面の色はテーマで変わらないので、文字色もトークンではなく固定値にする

--- a/src/components/groups/GroupTopThree.tsx
+++ b/src/components/groups/GroupTopThree.tsx
@@ -1,0 +1,107 @@
+'use client';
+
+/**
+ * グループのトップに置く「今週の上位3人」。
+ *
+ * ハブは 2×2 のタイルだけの画面なので、誰が走っているかはランキングページまで
+ * 開かないと分からなかった。ここに表彰台を薄く1枚置いて、開いた瞬間に today's
+ * 競争相手が見えるようにする。
+ *
+ * 全体をランキングページへの1枚のリンクにしている（各アバターを個別のプロフィール
+ * リンクにするとリンクが入れ子になるうえ、狭い帯の中でタップ先が3つに割れて
+ * 押しにくい）。個々のプロフィールへはランキングページから開ける。
+ */
+
+import Link from 'next/link';
+import { ProfileAvatar } from '@/components/profile/ProfileAvatar';
+import { profileAvatarColor } from '@/components/profile/ProfileView';
+import { Icon } from '@/components/ui/Icon';
+import { memberInitial, memberLabel } from '@/app/groups/[groupId]/member-ui';
+import { triggerHaptic } from '@/lib/haptics';
+import type { StudyGroupLeaderboardEntry } from '@/lib/shared-projects/types';
+
+/** GroupLeaderboard の表彰台と同じ配色（金・銀・銅）。 */
+const MEDALS = ['#FFC800', '#C3CDD6', '#E29C57'];
+
+/** 表彰台の並び順。中央が1位になるよう 2 → 1 → 3 で置く。 */
+const PODIUM_ORDER = [1, 0, 2];
+
+export function GroupTopThree({
+  leaderboard,
+  href,
+}: {
+  leaderboard: StudyGroupLeaderboardEntry[];
+  /** ランキングページ。帯ごとここへ飛ぶ。 */
+  href: string;
+}) {
+  const podium = leaderboard.slice(0, 3);
+  // 全員0問の週は順位に意味が無いので、表彰台ではなく誘い文句を出す。
+  const hasRecord = podium.some((entry) => entry.quizCount > 0);
+
+  return (
+    <Link
+      href={href}
+      onClick={() => triggerHaptic()}
+      aria-label="今週のランキングを見る"
+      className="mb-3 block rounded-[16px] border-2 border-[var(--solid-ink)] bg-[var(--color-surface)] px-3 pb-2.5 pt-2 shadow-[2px_3px_0_var(--solid-ink)] transition-all duration-100 active:translate-x-px active:translate-y-px active:shadow-[1px_2px_0_var(--solid-ink)]"
+    >
+      <div className="flex items-center gap-1.5">
+        <Icon name="emoji_events" size={14} className="shrink-0 text-[#F0A500]" />
+        <span className="min-w-0 flex-1 truncate font-mono text-[9.5px] font-bold tracking-[0.06em] text-[var(--color-muted)]">
+          THIS WEEK · 今週のランキング
+        </span>
+        <Icon name="chevron_right" size={15} className="shrink-0 text-[var(--color-muted)]" />
+      </div>
+
+      {hasRecord ? (
+        <div className="mt-1.5 flex items-end justify-center gap-1">
+          {PODIUM_ORDER.map((index) => {
+            const entry = podium[index];
+            if (!entry) return null;
+            return <PodiumSlot key={entry.userId} entry={entry} place={index + 1} />;
+          })}
+        </div>
+      ) : (
+        <p className="py-3 text-center text-[11.5px] font-bold text-[var(--color-muted)]">
+          今週はまだ誰も解いていません。最初の1問を解こう！
+        </p>
+      )}
+    </Link>
+  );
+}
+
+function PodiumSlot({ entry, place }: { entry: StudyGroupLeaderboardEntry; place: number }) {
+  const first = place === 1;
+  const size = first ? 46 : 38;
+
+  return (
+    <div className={`flex min-w-0 flex-1 flex-col items-center ${first ? '' : 'pb-1'}`}>
+      <div className="relative">
+        <ProfileAvatar
+          avatarUrl={entry.avatarUrl}
+          initial={memberInitial(entry)}
+          color={profileAvatarColor(entry.accountId ?? entry.userId)}
+          size={size}
+          radius={size / 2}
+          fontSize={first ? 18 : 15}
+        />
+        <span
+          className="absolute -bottom-0.5 -right-0.5 inline-flex h-[18px] w-[18px] items-center justify-center rounded-full border-2 border-[var(--solid-ink)] font-display text-[10px] font-extrabold text-[var(--solid-ink)]"
+          style={{ backgroundColor: MEDALS[place - 1] }}
+        >
+          {place}
+        </span>
+      </div>
+      <div
+        className={`mt-1 max-w-full truncate text-center text-[10.5px] font-extrabold ${
+          entry.isViewer ? 'text-[var(--color-accent)]' : 'text-[var(--solid-ink)]'
+        }`}
+      >
+        {entry.isViewer ? 'あなた' : memberLabel(entry)}
+      </div>
+      <div className="font-mono text-[10px] font-bold tabular-nums text-[var(--color-muted)]">
+        {entry.quizCount}問
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## 概要

グループのハブ（モバイル）は 2×2 のタイルだけなので、誰が走っているかはランキングページを開くまで分かりませんでした。ヘッダの直下に今週の上位3人の表彰台を薄い帯として置きます。

## 変更点

- `GroupTopThree` を追加し、グループページ上部に表示（金・銀・銅の配色と 2→1→3 の並びは既存の `GroupLeaderboard` と同じ）
- 帯ごとランキングページへのリンクにしている。アバターを個別のプロフィールリンクにするとリンクが入れ子になり、狭い帯の中でタップ先が3つに割れて押しにくいため。個々のプロフィールへはランキングページから開ける
- 全員0問の週は順位に意味が無いので、表彰台ではなく「今週はまだ誰も解いていません」を出す
- メンバーは0問でもランキングに並ぶので、空配列は「まだ取得できていない」状態。その間は帯ごと出さない（一瞬「誰も解いていません」が出るのを避ける）
- 帯が乗ったぶん、ハブのタイルの高さを `min(56dvh,420px)` → `min(50dvh,400px)` に下げ、1画面に収まるようにした

デスクトップは従来どおり右カラムにランキングを出しているので変更していません。

## 確認

- `npm run lint` — 新規のエラーなし
- `npm run build` — 成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bih421w73Fdz42K7yHuLSc


---
_Generated by [Claude Code](https://claude.ai/code/session_01Bih421w73Fdz42K7yHuLSc)_