### PR TITLE
点々スクラバーをカード1枚ごとに振動させ、タップでの送りをやめる

### DIFF
--- a/src/components/quiz/FlashcardScrubber.tsx
+++ b/src/components/quiz/FlashcardScrubber.tsx
@@ -7,7 +7,6 @@ import {
   getScrubDots,
   getScrubIndexFromRatio,
   getScrubRatioFromPosition,
-  getScrubTick,
   type ScrubDotKind,
 } from '@/lib/quiz/flashcard-scrubber';
 import { triggerHaptic } from '@/lib/haptics';
@@ -19,8 +18,8 @@ import { triggerHaptic } from '@/lib/haptics';
  * スワイプ）すると、指の位置に対応するカードへ即座に飛ぶ。押している間ずっと
  * 追従するので、指を滑らせるだけで山札が爆速で流れる。
  *
- * - 短く叩いただけ = 叩いた位置のカードへジャンプ
  * - 長押し / 横スワイプ = スクラブ開始。離すまで指に追従
+ * - 短く叩いただけ = 何も起きない（触れただけで山札が飛ばないように）
  *
  * 点は最大5個。送り幅を決めるのは点ではなく帯（trackRef）の幅全体なので、
  * 何百枚あっても左端から右端まで一振りで流せる。
@@ -115,7 +114,7 @@ export function FlashcardScrubber({
   const startYRef = useRef(0);
   const pendingXRef = useRef<number | null>(null);
   const frameRef = useRef<number | null>(null);
-  const lastTickRef = useRef(getScrubTick(currentIndex, total));
+  const lastIndexRef = useRef(currentIndex);
   const onSeekRef = useRef(onSeek);
   const onScrubbingChangeRef = useRef(onScrubbingChange);
   useEffect(() => { onSeekRef.current = onSeek; }, [onSeek]);
@@ -131,16 +130,19 @@ export function FlashcardScrubber({
     }
   }, []);
 
-  /** 指の x からカードを決めて送る。刻みをまたいだときだけ小さく震わせる。 */
+  /**
+   * 指の x からカードを決めて送る。カードが1枚動くたびに短く震わせて、
+   * 目で追えない速さで流していても「今めくった」手応えが指に残るようにする。
+   * 呼び出し自体が1フレーム1回に間引かれているので、震えの上限も同じ。
+   */
   const applyPosition = useCallback((clientX: number) => {
     const rect = trackRef.current?.getBoundingClientRect();
     if (!rect) return;
     const ratio = getScrubRatioFromPosition(clientX, rect.left, rect.width);
     const index = getScrubIndexFromRatio(ratio, totalRef.current);
-    const tick = getScrubTick(index, totalRef.current);
-    if (tick !== lastTickRef.current) {
-      lastTickRef.current = tick;
-      triggerHaptic(6);
+    if (index !== lastIndexRef.current) {
+      lastIndexRef.current = index;
+      triggerHaptic(5);
     }
     onSeekRef.current(index);
   }, []);
@@ -184,11 +186,10 @@ export function FlashcardScrubber({
   useEffect(() => endScrub, [endScrub]);
 
   // スクラブしていない間は、外からの送り（次へ/自動再生）に合わせて
-  // 振動の基準にしている刻みを追従させる。
-  const currentTick = getScrubTick(currentIndex, total);
+  // 振動の基準にしているカード番号を追従させる。
   useEffect(() => {
-    if (!scrubbingRef.current) lastTickRef.current = currentTick;
-  }, [currentTick]);
+    if (!scrubbingRef.current) lastIndexRef.current = currentIndex;
+  }, [currentIndex]);
 
   const handlePointerDown = (e: React.PointerEvent<HTMLDivElement>) => {
     if (total <= 1 || e.button > 0) return;
@@ -214,20 +215,15 @@ export function FlashcardScrubber({
     else if (dy > SCRUB_MOVE_THRESHOLD_PX * 2) clearHoldTimer();
   };
 
-  const handlePointerUp = (e: React.PointerEvent<HTMLDivElement>) => {
+  const handlePointerUp = () => {
     if (scrubbingRef.current) {
       endScrub();
       return;
     }
-    // 長押しに届かなかった＝タップ。叩いた位置のカードへ飛ぶ。
+    // 長押しに届かずに離した＝ただのタップ。何もしない。
+    // 点はあくまで早送りのための帯で、触れただけでカードが動くと、
+    // 画面下端を持ち直しただけで山札が飛んでしまう。
     clearHoldTimer();
-    if (total <= 1) return;
-    const rect = trackRef.current?.getBoundingClientRect();
-    if (!rect) return;
-    const ratio = getScrubRatioFromPosition(e.clientX, rect.left, rect.width);
-    triggerHaptic();
-    markHintSeen();
-    onSeek(getScrubIndexFromRatio(ratio, total));
   };
 
   if (dots.length <= 1) return null;

--- a/src/lib/quiz/flashcard-scrubber.test.ts
+++ b/src/lib/quiz/flashcard-scrubber.test.ts
@@ -6,7 +6,6 @@ import {
   getScrubDots,
   getScrubIndexFromRatio,
   getScrubRatioFromPosition,
-  getScrubTick,
 } from '@/lib/quiz/flashcard-scrubber';
 
 /** 点の並びを "・" (normal) / "●" (active) / "." (edge) の文字列にして見比べる */
@@ -105,17 +104,4 @@ test('矩形の外へ指が出ても0..1に収める', () => {
 
 test('幅が取れないうちは左端扱い', () => {
   assert.equal(getScrubRatioFromPosition(50, 0, 0), 0);
-});
-
-test('振動の刻みは端から端まででも決まった回数しか変わらない', () => {
-  const total = 500;
-  const ticks = new Set<number>();
-  for (let i = 0; i < total; i += 1) ticks.add(getScrubTick(i, total));
-  assert.equal(ticks.size, 21); // 0..20
-  assert.equal(getScrubTick(0, total), 0);
-  assert.equal(getScrubTick(total - 1, total), 20);
-});
-
-test('カードが1枚しかなければ刻みは動かない', () => {
-  assert.equal(getScrubTick(0, 1), 0);
 });

--- a/src/lib/quiz/flashcard-scrubber.ts
+++ b/src/lib/quiz/flashcard-scrubber.ts
@@ -30,9 +30,6 @@ export const SCRUB_MOVE_THRESHOLD_PX = 8;
 /** 同時に描く点の上限 */
 export const SCRUB_VISIBLE_DOTS = 5;
 
-/** 早送り中に振動させる刻み数。カード1枚ごとに震わせると細かすぎる */
-export const SCRUB_HAPTIC_TICKS = 20;
-
 export type ScrubDotKind =
   /** 今のカード */
   | 'active'
@@ -88,17 +85,4 @@ export function getScrubIndexFromRatio(ratio: number, total: number): number {
 export function getScrubRatioFromPosition(clientX: number, left: number, width: number): number {
   if (!Number.isFinite(clientX) || !Number.isFinite(left) || !(width > 0)) return 0;
   return Math.min(Math.max((clientX - left) / width, 0), 1);
-}
-
-/**
- * 振動の刻み。山札を ticks 等分した何番目にいるかを返す。
- * これが変わったときだけ震わせれば、100枚流しても振動は ticks 回で済む。
- */
-export function getScrubTick(
-  index: number,
-  total: number,
-  ticks: number = SCRUB_HAPTIC_TICKS,
-): number {
-  if (total <= 1 || ticks <= 0) return 0;
-  return Math.round((clampIndex(index, total) / (total - 1)) * ticks);
 }


### PR DESCRIPTION
#518 のフォローアップ。

## 変更

**1. 振動をカード1枚ごとに**

早送り中の振動は「山札を20等分した刻みをまたいだとき」だけだったのを、**カードが1枚動くたび**に変更した。目で追えない速さで流していても、めくった手応えが指に残る。

呼び出し（`applyPosition`）自体が `requestAnimationFrame` で1フレーム1回に間引かれているので、振動の上限も同じ。指を止めて押さえているだけの間は鳴らない。

**2. タップでの送りを削除**

短く叩いた位置へ飛ぶ挙動をなくした。点はあくまで早送りのための帯で、画面下端に触れただけで山札が飛ぶのは事故のもと。カードを送るのは**長押し（220ms）または横スワイプからのスクラブだけ**になる。

**3. 後片付け**

使わなくなった `getScrubTick` / `SCRUB_HAPTIC_TICKS` とそのテストを削除。

## 確認したこと

- `npm test`（スクラバー15件）パス、`npm run build` 成功、lint 追加分の指摘ゼロ
- 実ブラウザ（Chromium / iPhone 13 エミュレーション）で `navigator.vibrate` の呼び出し回数を数えて確認:
  - 75%地点をタップ → `index=0` のまま、振動0回（送りが消えている）
  - 長押し → スクラブ開始、以降ドラッグの1ステップにつき1回振動
  - 指を止めて押さえたまま0.5秒 → 追加の振動なし

---
_Generated by [Claude Code](https://claude.ai/code/session_01TiXmXZdDSTRoumDsdVewAW)_