### PR TITLE
音声クイズの回答をクイズ回数の集計に含める

### DIFF
--- a/src/app/voice-quiz/[projectId]/page.tsx
+++ b/src/app/voice-quiz/[projectId]/page.tsx
@@ -459,11 +459,28 @@ export default function VoiceQuizPage() {
         const newStatus = getStatusAfterAnswer(word.status, correct);
         const srUpdate = calculateNextReview(correct, word);
         const updates = { status: newStatus, ...srUpdate };
+        const becameMastered = word.status !== 'mastered' && newStatus === 'mastered';
         await repository.updateWord(word.id, updates);
         setPool((prev) => prev.map((w) => (w.id === word.id ? { ...w, ...updates } : w)));
+        if (user) {
+          fetch('/api/quiz-sessions/events', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+              wordId: word.id,
+              projectId,
+              english: word.english,
+              japanese: word.japanese,
+              becameMastered,
+              isCorrect: correct,
+            }),
+          }).catch((error) => {
+            console.warn('Failed to record quiz session event:', error);
+          });
+        }
       } catch {}
     },
-    [projectId, repository],
+    [projectId, repository, user],
   );
 
   /** 1回の試行の結果を受けて、再挑戦させるか問題を確定するかを決める。 */


### PR DESCRIPTION
## Summary
- 音声クイズ（`/voice-quiz/[projectId]`）の回答完了時に、通常クイズと同じ `/api/quiz-sessions/events` へのPOSTを追加
- これまで音声クイズの回答は `recordCorrectAnswer`/`recordWrongAnswer`（ホーム画面の今日のクイズ回数用のlocalStorage集計）にしか記録されておらず、グループのクイズ回数リーダーボード（`answer_count` をサーバー側で集計）には反映されていなかった
- 通常クイズ画面（`src/app/quiz/[projectId]/page.tsx`）と同じペイロード（wordId, projectId, english, japanese, becameMastered, isCorrect）・同じタイミング（`repository.updateWord` 成功後）で送信するよう揃えた

## Test plan
- [ ] 音声認識APIエラー時（`apiErrored`）は送信されないこと（既存の `recordCorrectAnswer`/`recordWrongAnswer` と同じガード条件）を確認
- [ ] ログインユーザーが音声クイズに回答した際、`quiz_sessions/events` 経由でグループのクイズ回数が増えることを確認
- [ ] 未ログイン時は送信されないこと（`user` チェック）を確認


---
_Generated by [Claude Code](https://claude.ai/code/session_0132zXXX1KCfKj1HyRDeCAFW)_