### PR TITLE
バインダーに音読チャレンジを通し、スキャンの語をpassive既定にし、バインダーの並びを整える

### DIFF
--- a/src/app/api/scan-jobs/process/route.contract.test.ts
+++ b/src/app/api/scan-jobs/process/route.contract.test.ts
@@ -916,6 +916,7 @@ test('server_cloud new project completion keeps project insert, words insert, an
       custom_sections: [],
       morphology: null,
       derived_words: null,
+      vocabulary_type: 'passive',
     },
   ]);
 

--- a/src/app/api/words/create/route.test.ts
+++ b/src/app/api/words/create/route.test.ts
@@ -244,7 +244,8 @@ test('words/create inserts raw words, returns resolved lexicon entries, and enqu
   assert.equal(fakeClient.insertedRows[0]?.['lexicon_entry_id'], preservedLexiconEntryId);
   assert.equal(fakeClient.insertedRows[0]?.['english'], 'book');
   assert.equal(fakeClient.insertedRows[0]?.['word_order_quiz'], null);
-  assert.equal(fakeClient.insertedRows[1]?.['vocabulary_type'], null);
+  // 未指定の語は passive で入る (スキャンで拾った語の既定値)
+  assert.equal(fakeClient.insertedRows[1]?.['vocabulary_type'], 'passive');
   assert.equal(fakeClient.insertedRows[1]?.['english'], 'compose');
   assert.deepEqual(
     fakeClient.translationRows.map((row) => ({

--- a/src/app/api/words/create/route.ts
+++ b/src/app/api/words/create/route.ts
@@ -13,6 +13,7 @@ import { mapWordFromRow, type WordRow } from '../../../../../shared/db';
 import { getDefaultSpacedRepetitionFields } from '@/lib/spaced-repetition';
 import { getSupabaseAdmin } from '@/lib/supabase/admin';
 import { prefillWordOrderQuizzesForWords } from '@/lib/scan/word-order-prefill';
+import { DEFAULT_SCANNED_VOCABULARY_TYPE } from '@/lib/vocabulary-type';
 import {
   buildWordTranslationInsertRows,
   normalizeWordForTranslationPersistence,
@@ -229,7 +230,7 @@ export async function handleWordsCreatePost(request: NextRequest, deps?: WordsCr
         english: word.english,
         japanese: word.japanese,
         japanese_source: word.japaneseSource ?? null,
-        vocabulary_type: word.vocabularyType ?? 'passive',
+        vocabulary_type: word.vocabularyType ?? DEFAULT_SCANNED_VOCABULARY_TYPE,
         lexicon_entry_id: word.lexiconEntryId ?? null,
         lexicon_sense_id: word.lexiconSenseId ?? null,
         distractors: word.distractors,

--- a/src/app/binder/[name]/page.tsx
+++ b/src/app/binder/[name]/page.tsx
@@ -170,9 +170,11 @@ export default function BinderDetailPage({ params }: { params: Promise<{ name: s
         </Link>
       </header>
 
-      {/* バインダー全体の学習度。単語帳詳細と同じ内訳バーを使う */}
+      {/* バインダー全体の学習度。ヘッダと地続きに見せたいので、上と左右の枠は持たず
+          下の境界線だけを画面幅いっぱいに引く (-mx で端まで抜く)。
+          固定はせず、スクロールすればヘッダだけが残る。 */}
       {hasWords && (
-        <section className="mt-3.5 rounded-[14px] border-2 border-[var(--solid-ink)] bg-white p-3.5">
+        <section className="-mx-[18px] border-b-2 border-[var(--solid-ink)] px-[18px] pb-3.5 pt-1.5 lg:-mx-8 lg:px-8">
           <div className="mb-2 flex items-baseline justify-between">
             <span className="font-mono text-[9.5px] font-bold tracking-[0.06em] text-[var(--color-muted)]">
               BINDER PROGRESS
@@ -191,20 +193,22 @@ export default function BinderDetailPage({ params }: { params: Promise<{ name: s
         </section>
       )}
 
-      <div className="pt-3.5">
+      <div>
         {loading ? (
           <div className="flex items-center justify-center py-16 text-[var(--color-muted)]">
             <Icon name="progress_activity" size={20} className="animate-spin" />
             <span className="ml-2 text-sm">読み込み中...</span>
           </div>
         ) : inBinder.length === 0 ? (
-          <div className="rounded-xl border-2 border-[var(--solid-ink)] bg-white p-5 text-center">
+          <div className="mt-3.5 rounded-xl border-2 border-[var(--solid-ink)] bg-white p-5 text-center">
             <p className="m-0 text-[13px] leading-[1.8] text-[var(--solid-ink)]">
               このバインダーにはまだ単語帳がありません。「単語帳を追加」から入れましょう。
             </p>
           </div>
         ) : (
-          <div className="flex flex-col gap-2.5">
+          /* 1冊ずつ枠で囲わず、上下の境界線だけで区切る音楽アプリ風の並び。
+             線は画面幅いっぱいに引きたいので、行も -mx で端まで抜く */
+          <div className="-mx-[18px] divide-y divide-[var(--color-border)] border-b border-[var(--color-border)] lg:-mx-8">
             {inBinder.map((project) => (
               <BinderProjectRow
                 key={project.id}
@@ -345,7 +349,7 @@ function BinderProjectRow({
     : 0;
 
   return (
-    <div className="relative flex items-center gap-3 rounded-[14px] border-2 border-[var(--solid-ink)] bg-white p-[13px]">
+    <div className="relative flex items-center gap-3 px-[18px] py-3 lg:px-8">
       <Link href={`/project/${project.id}`} className="flex min-w-0 flex-1 items-center gap-3 no-underline">
         <span
           className="flex h-[44px] w-[44px] shrink-0 items-center justify-center rounded-[10px] border-2 border-[var(--solid-ink)] bg-cover bg-center font-display text-[18px] font-extrabold text-white"
@@ -389,7 +393,8 @@ function BinderProjectRow({
             aria-label="メニューを閉じる"
             onClick={() => setMenuOpen(false)}
           />
-          <div className="absolute right-[13px] top-[54px] z-[71] w-[190px] overflow-hidden rounded-[14px] border-2 border-[var(--solid-ink)] bg-white shadow-[2px_3px_0_var(--solid-ink)]">
+          {/* 行の高さは進捗バーの有無で変わるので、下端を基準に置く */}
+          <div className="absolute right-[18px] top-full z-[71] w-[190px] overflow-hidden rounded-[14px] border-2 border-[var(--solid-ink)] bg-white shadow-[2px_3px_0_var(--solid-ink)] lg:right-8">
             <button
               type="button"
               onClick={() => { setMenuOpen(false); onRemove(); }}

--- a/src/app/quiz/[projectId]/page.tsx
+++ b/src/app/quiz/[projectId]/page.tsx
@@ -466,12 +466,6 @@ export default function QuizPage() {
   const returnPath = searchParams.get('from');
   const reviewMode = searchParams.get('review') === '1';
   const learnMode = searchParams.get('learn') === '1';
-  /**
-   * 音読チャレンジに送れない出題か。
-   * 音読側は単語帳を1冊だけ読み込む作りで、`all` や復習・今日の学習のような
-   * 横断出題を扱えない。ここが true のときはクイズ形式の選択を適用しない。
-   */
-  const voiceQuizUnavailable = projectId === 'all' || reviewMode || learnMode;
   const wrongMode = searchParams.get('wrong') === '1';
   const favoritesMode = searchParams.get('favorites') === '1';
   const reminderMode = searchParams.get('reminder') === '1';
@@ -483,6 +477,13 @@ export default function QuizPage() {
    * 単語帳を前提にした副作用 (リモート同期・語彙タイプの取り込み) は止める。
    */
   const binderName = projectId === 'all' ? searchParams.get('binder') : null;
+  /**
+   * 音読チャレンジに送れない出題か。
+   * 音読側が読めるのは単語帳1冊かバインダー1つぶんで、復習・今日の学習や
+   * 「すべての単語帳」のような横断出題は扱えない。ここが true のときは
+   * クイズ形式の選択を適用しない。
+   */
+  const voiceQuizUnavailable = (projectId === 'all' && !binderName) || reviewMode || learnMode;
   const [questionCount, setQuestionCount] = useState<number | null>(() => {
     if (!countFromUrl) return DEFAULT_QUESTION_COUNT;
     const parsed = Number.parseInt(countFromUrl, 10);
@@ -622,6 +623,7 @@ export default function QuizPage() {
     const parsedInput = Number.parseInt(inputCount, 10);
     const count = Number.isFinite(parsedInput) && parsedInput > 0 ? parsedInput : questionCount;
     if (count && count > 0) params.set('count', String(count));
+    if (binderName) params.set('binder', binderName);
     if (returnPath) params.set('from', returnPath);
     const query = params.toString();
     const href = `/voice-quiz/${projectId}${query ? `?${query}` : ''}`;
@@ -629,7 +631,7 @@ export default function QuizPage() {
     // 自動送りは replace。push にすると「戻る」でここへ戻され、また送られて堂々巡りになる。
     if (options?.replace) router.replace(href);
     else router.push(href);
-  }, [inputCount, questionCount, returnPath, router, projectId]);
+  }, [inputCount, questionCount, returnPath, router, projectId, binderName]);
 
   // 端末の選択を読む。未選択ならクイズの前に選択画面を出す。
   useEffect(() => {

--- a/src/app/voice-quiz/[projectId]/page.tsx
+++ b/src/app/voice-quiz/[projectId]/page.tsx
@@ -9,6 +9,7 @@ import { QuizModeChooser } from '@/components/quiz';
 import { readQuizMode, writeQuizMode, type QuizMode } from '@/lib/quiz/quiz-mode-preference';
 import { voiceQuizBatch } from '@/lib/quiz/voice-quiz-batch';
 import { getRepository } from '@/lib/db';
+import { getWordsByProjectMap } from '@/lib/projects/load-helpers';
 import { cn, recordCorrectAnswer, recordWrongAnswer, recordActivity, getGuestUserId } from '@/lib/utils';
 import { calculateNextReview, getStatusAfterAnswer, sortWordsByPriority } from '@/lib/spaced-repetition';
 import { playAnswerFeedbackSound } from '@/lib/audio/answer-feedback';
@@ -152,6 +153,12 @@ export default function VoiceQuizPage() {
   const searchParams = useSearchParams();
   const projectId = params.projectId as string;
   const returnPath = searchParams.get('from');
+  /**
+   * バインダー横断の出題。`/voice-quiz/all?binder=<バインダー名>` で、そのバインダーに
+   * 入っている単語帳の語をひとつの山にして出す。1冊ぶんの出題ではないので、
+   * 単語帳を前提にした記録先 (projectId) は語ごとのものに切り替える。
+   */
+  const binderName = projectId === 'all' ? searchParams.get('binder') : null;
   // 通常クイズから引き継いだ出題数。モード選択はURLだけで表現し、保存はしない。
   const requestedCount = resolveVoiceQuizCount(searchParams.get('count'));
   const { subscription, loading: authLoading, user } = useAuth();
@@ -161,16 +168,18 @@ export default function VoiceQuizPage() {
   const repository = useMemo(() => getRepository(subscriptionStatus, wasPro), [subscriptionStatus, wasPro]);
 
   const backToProject = useCallback(() => {
-    router.replace(returnPath || `/project/${projectId}`);
-  }, [router, returnPath, projectId]);
+    const fallback = binderName ? `/binder/${encodeURIComponent(binderName)}` : `/project/${projectId}`;
+    router.replace(returnPath || fallback);
+  }, [router, returnPath, projectId, binderName]);
 
-  /** 通常クイズへ戻す。出題数はそのまま引き継ぐ。 */
+  /** 通常クイズへ戻す。出題数とバインダーの指定はそのまま引き継ぐ。 */
   const goToNormalQuiz = useCallback(() => {
     writeQuizMode('normal');
     const params = new URLSearchParams({ count: String(requestedCount) });
+    if (binderName) params.set('binder', binderName);
     if (returnPath) params.set('from', returnPath);
     router.replace(`/quiz/${projectId}?${params.toString()}`);
-  }, [router, projectId, returnPath, requestedCount]);
+  }, [router, projectId, binderName, returnPath, requestedCount]);
 
   // 端末の選択を読む。未選択ならクイズの前に選択画面を出す。
   useEffect(() => {
@@ -353,22 +362,35 @@ export default function VoiceQuizPage() {
     const load = async () => {
       try {
         const ownerUserId = user ? user.id : getGuestUserId();
-        // 音読チャレンジは単語帳1冊ぶんしか出題できない。横断出題の入口
-        // (/voice-quiz/all や復習・今日の学習) を踏んだら、行き止まりにせず
-        // 四択へ渡す。ここで backToProject に落とすと、クイズが始まらないまま
-        // ホームへ戻されたように見える。
-        if (projectId === 'all') {
+        let loaded: Word[];
+
+        if (binderName) {
+          // バインダーに入っている単語帳をまとめてひとつの山にする
+          const projects = await repository.getProjects(ownerUserId);
+          const ids = projects
+            .filter((p) => (p.binder?.trim() ?? '') === binderName)
+            .map((p) => p.id);
+          if (ids.length === 0) {
+            backToProject();
+            return;
+          }
+          const wordsByProject = await getWordsByProjectMap(repository, ids);
+          loaded = ids.flatMap((id) => wordsByProject[id] ?? []);
+        } else if (projectId === 'all') {
+          // 音読チャレンジはバインダー以外の横断出題 (復習・今日の学習・すべての
+          // 単語帳) を扱えない。行き止まりにせず四択へ渡す。ここで backToProject に
+          // 落とすと、クイズが始まらないままホームへ戻されたように見える。
           goToNormalQuiz();
           return;
+        } else {
+          const project = await repository.getProject(projectId);
+          if (!project || project.userId !== ownerUserId) {
+            backToProject();
+            return;
+          }
+          loaded = await repository.getWords(projectId);
         }
 
-        const project = await repository.getProject(projectId);
-        if (!project || project.userId !== ownerUserId) {
-          backToProject();
-          return;
-        }
-
-        let loaded = await repository.getWords(projectId);
         const unmastered = loaded.filter((w) => w.status !== 'mastered');
         if (unmastered.length > 0) {
           loaded = unmastered;
@@ -389,7 +411,7 @@ export default function VoiceQuizPage() {
     };
 
     load();
-  }, [authLoading, projectId, repository, user, backToProject, goToNormalQuiz]);
+  }, [authLoading, projectId, binderName, repository, user, backToProject, goToNormalQuiz]);
 
   /** 1問を確定させる。以降この問題では再挑戦しない。 */
   const finishQuestion = useCallback(
@@ -418,11 +440,15 @@ export default function VoiceQuizPage() {
       // 音声認識が落ちたぶんは、間違えたことにしない。答えを聞き取れなかった
       // だけで、答えられなかったわけではない —— 記録すると復習の間隔まで
       // 縮み、上限に達した日は解いた10問ぶんの成績と学習状態が丸ごと壊れる。
+      // バインダー横断のときの projectId は `all` という擬似IDなので、
+      // 記録先はその語が実際に属する単語帳にする
+      const recordProjectId = binderName ? word.projectId : projectId;
+
       if (!apiErrored) {
         if (correct) {
           recordCorrectAnswer(false);
         } else {
-          recordWrongAnswer(word.id, word.english, word.japanese, projectId, word.distractors);
+          recordWrongAnswer(word.id, word.english, word.japanese, recordProjectId, word.distractors);
         }
         recordActivity();
       }
@@ -468,7 +494,7 @@ export default function VoiceQuizPage() {
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({
               wordId: word.id,
-              projectId,
+              projectId: recordProjectId,
               english: word.english,
               japanese: word.japanese,
               becameMastered,
@@ -480,7 +506,7 @@ export default function VoiceQuizPage() {
         }
       } catch {}
     },
-    [projectId, repository, user],
+    [projectId, binderName, repository, user],
   );
 
   /** 1回の試行の結果を受けて、再挑戦させるか問題を確定するかを決める。 */

--- a/src/lib/db/local-repository.ts
+++ b/src/lib/db/local-repository.ts
@@ -4,6 +4,7 @@ import type { LexiconEntry, Project, Word, WordRepository, Collection, Collectio
 import { getDefaultSpacedRepetitionFields } from '@/lib/spaced-repetition';
 import { normalizeSourceLabels } from '../../../shared/source-labels';
 import { normalizeWordForTranslationPersistence } from '@/lib/words/translation-persistence';
+import { DEFAULT_SCANNED_VOCABULARY_TYPE } from '@/lib/vocabulary-type';
 
 // Local implementation of WordRepository using Dexie (IndexedDB)
 // Used for Free tier users - data stays on device
@@ -83,7 +84,7 @@ export class LocalWordRepository implements WordRepository {
       createdAt: now,
       isFavorite: false,
       status: 'new' as const,
-      vocabularyType: word.vocabularyType ?? ('passive' as const),
+      vocabularyType: word.vocabularyType ?? DEFAULT_SCANNED_VOCABULARY_TYPE,
     }));
 
     await db.words.bulkAdd(newWords);

--- a/src/lib/scan/server-cloud-persistence.contract.test.ts
+++ b/src/lib/scan/server-cloud-persistence.contract.test.ts
@@ -99,6 +99,7 @@ test('buildServerCloudWordsInsertPayload fixes the words insert shape', () => {
       custom_sections: [],
       morphology: null,
       derived_words: null,
+      vocabulary_type: 'passive',
     },
     {
       project_id: 'project-123',
@@ -116,6 +117,7 @@ test('buildServerCloudWordsInsertPayload fixes the words insert shape', () => {
       custom_sections: [],
       morphology: null,
       derived_words: null,
+      vocabulary_type: 'passive',
     },
   ]);
   assert.equal(Object.hasOwn(payload[1] ?? {}, 'part_of_speech_tags'), true);
@@ -239,6 +241,7 @@ test('stripSourceModesFromServerCloudWordsInsertPayload removes only source_mode
       custom_sections: [],
       morphology: null,
       derived_words: null,
+      vocabulary_type: 'passive',
     },
   ]);
 });

--- a/src/lib/scan/server-cloud-persistence.ts
+++ b/src/lib/scan/server-cloud-persistence.ts
@@ -1,6 +1,7 @@
 import { mergeSourceLabels } from '../../../shared/source-labels';
 import type { ExtractMode } from '@/lib/scan/mode-provider';
-import type { CustomSection, WordDerivedWords, WordMorphology } from '@/types';
+import type { CustomSection, VocabularyType, WordDerivedWords, WordMorphology } from '@/types';
+import { DEFAULT_SCANNED_VOCABULARY_TYPE } from '@/lib/vocabulary-type';
 
 export interface ServerCloudProjectInsertParams {
   userId: string;
@@ -50,6 +51,7 @@ export interface ServerCloudWordInsertPayload {
   custom_sections: CustomSection[];
   morphology: WordMorphology | null;
   derived_words: WordDerivedWords | null;
+  vocabulary_type: VocabularyType;
 }
 
 type MaybePostgrestColumnError = {
@@ -129,6 +131,10 @@ export function buildServerCloudWordsInsertPayload(
     custom_sections: word.customSections ?? [],
     morphology: word.morphology ?? null,
     derived_words: word.derivedWords ?? null,
+    // スキャンで拾った語は「見て分かればいい語」から始める。ここを NULL のまま
+    // 挿すと、ローカル保存 (local-repository) 経由の語だけ passive になって
+    // 端末とバックグラウンドスキャンで既定値が食い違う。
+    vocabulary_type: DEFAULT_SCANNED_VOCABULARY_TYPE,
   }));
 }
 
@@ -221,6 +227,7 @@ export function stripServerCloudWordsInsertPayloadForCompat(
       pronunciation: word.pronunciation,
       part_of_speech_tags: word.part_of_speech_tags,
       custom_sections: word.custom_sections,
+      vocabulary_type: word.vocabulary_type,
     };
 
     if (!options.omitLexiconSenseId) {

--- a/src/lib/vocabulary-type.ts
+++ b/src/lib/vocabulary-type.ts
@@ -1,5 +1,15 @@
 import type { VocabularyType } from '@/types';
 
+/**
+ * スキャンで取り込んだ語の既定の語彙モード。
+ *
+ * 拾ったばかりの語はまず「見て分かればいい語 (passive)」から始めて、
+ * 自分で使えるようにしたい語だけ手で active に上げてもらう。
+ * ローカル保存 (`local-repository`)・`/api/words/create`・バックグラウンド
+ * スキャンの直挿し (`server-cloud-persistence`) の3経路で同じ値を使う。
+ */
+export const DEFAULT_SCANNED_VOCABULARY_TYPE: VocabularyType = 'passive';
+
 export function getNextVocabularyType(
   current: VocabularyType | null | undefined,
 ): VocabularyType | null {


### PR DESCRIPTION
## 1. 音読チャレンジのバインダー対応

`/voice-quiz/all?binder=<バインダー名>` で、バインダーに入っている単語帳をまとめてひとつの山にして出題します。

これまで `voiceQuizUnavailable` は `projectId === 'all'` を一律で弾いていました。音読側が単語帳を1冊しか読めなかったためです。バインダー指定があるときだけ通すようにし、復習・今日の学習・「すべての単語帳」は今まで通り四択へ渡します（音読側はこれらを扱えないので、行き止まりにせず `goToNormalQuiz()` へ流す既存の作りをそのまま残しています）。

- 語の読み込みは既存の `getWordsByProjectMap` を再利用
- 四択 ⇄ 音読の往復と「戻る」の行き先で `binder` を引き継ぐ
- 回答の記録先（誤答記録・`quiz-sessions/events`）は `all` という擬似IDではなく、その語が属する単語帳にする

## 2. スキャンで追加した単語を passive 既定に

調べたところ、経路によって既定値が食い違っていました。

| 経路 | これまで |
|---|---|
| 端末保存 `local-repository.createWords` | `passive` |
| `/api/words/create` | `passive` |
| **バックグラウンドスキャン `/api/scan-jobs/process` の直挿し** | **未指定 → NULL** |

`words.vocabulary_type` 列に `DEFAULT` が無いため、バックグラウンドスキャン（iOS の scan-jobs 経路）で入った語だけ「未設定」になっていました。`buildServerCloudWordsInsertPayload` で `vocabulary_type` を渡すようにしています。

あわせて、互換フォールバック `stripServerCloudWordsInsertPayloadForCompat` が行を明示的に組み直しており、そのままだと `vocabulary_type` を落としてしまうので、常に残す列に加えました（列欠落のフォールバックが1回でも走ると NULL に戻る）。

3経路で同じ値を使うよう `DEFAULT_SCANNED_VOCABULARY_TYPE` に集約しています。

なお `src/app/api/words/create/route.test.ts` は **main の時点で既に落ちていた**テストです（`vocabulary_type` が `null` である前提のまま、実装だけ `passive` に変わっていた）。今回 `passive` を意図した既定値として確定させたので、テスト側を実装に合わせました。

## 3. バインダーの並び

- 進捗バーの上・左右の枠を外し、**下の境界線だけを画面幅いっぱい**に引いてヘッダと地続きに見せます。固定はしないので、下にスクロールすれば従来どおりヘッダだけが残ります
- 単語帳を1冊ずつ枠で囲うのをやめ、**上下の境界線だけ**で区切る並びにしました
- 行の「...」メニューは、進捗バーの有無で行の高さが変わるため `top-full`（行の下端基準）に変更

## テスト

- `npm run lint` — 変更ファイルに新規エラーなし（残る5件は `gcp-budget-guard/` の既存エラー）
- `npm test` — 1596/1597 pass。残る失敗1件（`otp.contract.test.ts`）は main でも落ちる既存のもの。`words/create` の失敗は今回解消
- `npx tsc --noEmit` — 変更ファイルにエラーなし
- `npm run build` — 成功

## 手動確認のポイント

- バインダーの「クイズを始める」→ クイズ形式で音読チャレンジを選び、複数単語帳の語が混ざって出題されること。終了後にバインダーへ戻ること
- 「すべての単語帳」「復習」「今日の学習」で音読チャレンジが従来どおり出ないこと
- iOS のバックグラウンドスキャンで取り込んだ語が Passive（P バッジ）になっていること

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NxgQSXFoUGdkrJ1QmG7fdf

---
_Generated by [Claude Code](https://claude.ai/code/session_01NxgQSXFoUGdkrJ1QmG7fdf)_