### PR TITLE
バインダーの進捗バーと単語帳の間の境界線を外し、…ボタンの丸枠をやめる

### DIFF
--- a/src/app/binder/[name]/page.tsx
+++ b/src/app/binder/[name]/page.tsx
@@ -170,11 +170,10 @@ export default function BinderDetailPage({ params }: { params: Promise<{ name: s
         </Link>
       </header>
 
-      {/* バインダー全体の学習度。ヘッダと地続きに見せたいので、上と左右の枠は持たず
-          下の境界線だけを画面幅いっぱいに引く (-mx で端まで抜く)。
+      {/* バインダー全体の学習度。ヘッダと地続きに見せたいので枠は持たない。
           固定はせず、スクロールすればヘッダだけが残る。 */}
       {hasWords && (
-        <section className="-mx-[18px] border-b-2 border-[var(--solid-ink)] px-[18px] pb-3.5 pt-1.5 lg:-mx-8 lg:px-8">
+        <section className="pb-3.5 pt-1.5">
           <div className="mb-2 flex items-baseline justify-between">
             <span className="font-mono text-[9.5px] font-bold tracking-[0.06em] text-[var(--color-muted)]">
               BINDER PROGRESS
@@ -381,9 +380,9 @@ function BinderProjectRow({
         onClick={() => setMenuOpen(true)}
         disabled={disabled}
         aria-label={`「${project.title}」のメニュー`}
-        className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full border-2 border-[var(--solid-ink)] bg-white text-[var(--solid-ink)] transition-all duration-100 active:translate-x-px active:translate-y-px disabled:opacity-50"
+        className="flex h-9 w-9 shrink-0 items-center justify-center text-[var(--solid-ink)] transition-opacity duration-100 active:opacity-60 disabled:opacity-50"
       >
-        <Icon name="more_horiz" size={17} />
+        <Icon name="more_horiz" size={20} />
       </button>
       {menuOpen && (
         <>


### PR DESCRIPTION
#523 のフォローアップ。バインダー詳細 (`/binder/[name]`) の見た目を2点直します。

## 進捗バーと単語帳の間の境界線を外す

進捗バーの下に引いていた全幅の境界線をやめ、ヘッダから単語帳まで線なしで繋がるようにしました。線が無くなったので、境界線を端まで抜くための `-mx` / `px` の打ち消しも不要になり、素の余白に戻しています。

単語帳どうしの区切り線（`divide-y`）はそのままです。

## 「...」ボタンの丸枠をやめる

単語帳の右端の「...」から丸い枠と白地を外し、アイコンだけにしました。1冊ずつ枠で囲わない並びに合わせています。枠が無くなって見た目が小さくなるぶん、アイコンは 17 → 20 に上げ、押したときのフィードバックは枠のずれではなく不透明度に変えています。タップ範囲は 36px のまま変えていません。

## テスト

- `npx eslint src/app/binder` — エラーなし
- `npm run build` — 成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NxgQSXFoUGdkrJ1QmG7fdf

---
_Generated by [Claude Code](https://claude.ai/code/session_01NxgQSXFoUGdkrJ1QmG7fdf)_