### PR TITLE
単語帳の一覧で訳を英語の右に置き、複数語義を縦に積む

### DIFF
--- a/src/app/project/[id]/page.tsx
+++ b/src/app/project/[id]/page.tsx
@@ -1612,6 +1612,7 @@ export default function ProjectPage() {
                 selectMode={selectMode}
                 selected={selected}
                 hideMeaning={redSheet}
+                splitMeaning
                 tourAnchor={index === 0 && wordPage === 0}
                 onToggleSelect={() => handleToggleSelectWord(word)}
                 onCycleStatus={(newStatus) => handleCycleStatus(word.id, newStatus)}
@@ -2129,16 +2130,22 @@ function RecommendedWordsSection({
                 {word.english.charAt(0).toUpperCase()}
               </div>
               <div className="min-w-0 flex-1">
-                <div className="truncate font-display text-[15px] font-bold text-[var(--solid-ink)]">
-                  {word.english}
+                {/* 一覧と同じく、訳は英語の下ではなく右のカラムに仕切りを挟んで並べる。
+                    出典の単語帳名だけは右カラムに入れると訳を潰すので下の行に落とす */}
+                <div className="flex items-center gap-2">
+                  <div className="min-w-0 shrink-0 basis-[46%] truncate font-display text-[15px] font-bold text-[var(--solid-ink)]">
+                    {word.english}
+                  </div>
+                  <span aria-hidden className="w-px shrink-0 self-stretch bg-[var(--color-border)]" />
+                  <div className="flex min-w-0 flex-1 items-baseline gap-1 text-[11px] text-[var(--color-muted)]">
+                    {pos && <span className="shrink-0 font-mono text-[9px]">{posShort(pos)}</span>}
+                    <span className="block min-w-0">
+                      <TranslationDisplay word={word} compact stacked />
+                    </span>
+                  </div>
                 </div>
-                <div className="mt-px flex items-center gap-1 text-[11px] text-[var(--color-muted)]">
-                  {pos && <span className="shrink-0 font-mono text-[9px]">{posShort(pos)}</span>}
-                  <span className="truncate">
-                    <TranslationDisplay word={word} compact />
-                  </span>
-                  <span className="shrink-0">·</span>
-                  <span className="max-w-[96px] truncate">{suggestion.sourceProjectTitle}</span>
+                <div className="mt-px truncate text-[11px] text-[var(--color-muted)]">
+                  {suggestion.sourceProjectTitle}
                 </div>
               </div>
               <button

--- a/src/app/project/[id]/page.tsx
+++ b/src/app/project/[id]/page.tsx
@@ -2122,30 +2122,33 @@ function RecommendedWordsSection({
           const adding = addingIds.has(word.id);
           const pos = word.partOfSpeechTags?.[0] ?? null;
           return (
-            <div key={word.id} className="flex items-center gap-2.5 py-2.5">
+            <div key={word.id} className="flex items-stretch gap-2.5 py-2.5">
               <div
-                className="flex h-10 w-10 shrink-0 items-center justify-center rounded-[9px] border-2 border-[var(--solid-ink)] font-display text-[16px] font-extrabold text-white"
+                className="flex h-10 w-10 shrink-0 self-center items-center justify-center rounded-[9px] border-2 border-[var(--solid-ink)] font-display text-[16px] font-extrabold text-white"
                 style={{ backgroundColor: thumbColor(word.id) }}
               >
                 {word.english.charAt(0).toUpperCase()}
               </div>
-              <div className="min-w-0 flex-1">
-                {/* 一覧と同じく、訳は英語の下ではなく右のカラムに仕切りを挟んで並べる。
-                    出典の単語帳名だけは右カラムに入れると訳を潰すので下の行に落とす */}
-                <div className="flex items-center gap-2">
-                  <div className="min-w-0 shrink-0 basis-[46%] truncate font-display text-[15px] font-bold text-[var(--solid-ink)]">
+              {/* 一覧と同じく、訳は英語の下ではなく右のカラムに仕切りを挟んで並べる。
+                  仕切りは行の上下いっぱい (py-2.5 の外) まで貫通させる。
+                  出典の単語帳名だけは訳と横に並べると潰れるので、右カラムの下に置く */}
+              <div className="flex min-w-0 flex-1 items-stretch gap-2">
+                <div className="flex min-w-0 shrink-0 basis-[46%] items-center">
+                  <span className="truncate font-display text-[15px] font-bold text-[var(--solid-ink)]">
                     {word.english}
-                  </div>
-                  <span aria-hidden className="w-px shrink-0 self-stretch bg-[var(--color-border)]" />
-                  <div className="flex min-w-0 flex-1 items-baseline gap-1 text-[11px] text-[var(--color-muted)]">
+                  </span>
+                </div>
+                <span aria-hidden className="-my-2.5 w-px shrink-0 self-stretch bg-[var(--color-border)]" />
+                <div className="flex min-w-0 flex-1 flex-col justify-center">
+                  <div className="flex min-w-0 items-baseline gap-1 text-[11px] text-[var(--color-muted)]">
                     {pos && <span className="shrink-0 font-mono text-[9px]">{posShort(pos)}</span>}
                     <span className="block min-w-0">
                       <TranslationDisplay word={word} compact stacked maxLines={1} />
                     </span>
                   </div>
-                </div>
-                <div className="mt-px truncate text-[11px] text-[var(--color-muted)]">
-                  {suggestion.sourceProjectTitle}
+                  <div className="mt-px truncate text-[11px] text-[var(--color-muted)]">
+                    {suggestion.sourceProjectTitle}
+                  </div>
                 </div>
               </div>
               <button
@@ -2153,7 +2156,7 @@ function RecommendedWordsSection({
                 onClick={() => onAdd(suggestion)}
                 disabled={adding}
                 aria-label={`「${word.english}」をこの単語帳に追加`}
-                className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full border-2 border-[var(--solid-ink)] bg-white text-[var(--solid-ink)] transition-all duration-100 active:translate-x-px active:translate-y-px disabled:opacity-50"
+                className="flex h-8 w-8 shrink-0 self-center items-center justify-center rounded-full border-2 border-[var(--solid-ink)] bg-white text-[var(--solid-ink)] transition-all duration-100 active:translate-x-px active:translate-y-px disabled:opacity-50"
               >
                 <Icon
                   name={adding ? 'progress_activity' : 'add'}

--- a/src/app/project/[id]/page.tsx
+++ b/src/app/project/[id]/page.tsx
@@ -2140,7 +2140,7 @@ function RecommendedWordsSection({
                   <div className="flex min-w-0 flex-1 items-baseline gap-1 text-[11px] text-[var(--color-muted)]">
                     {pos && <span className="shrink-0 font-mono text-[9px]">{posShort(pos)}</span>}
                     <span className="block min-w-0">
-                      <TranslationDisplay word={word} compact stacked />
+                      <TranslationDisplay word={word} compact stacked maxLines={1} />
                     </span>
                   </div>
                 </div>

--- a/src/components/desktop/DesktopProjectDetail.tsx
+++ b/src/components/desktop/DesktopProjectDetail.tsx
@@ -42,6 +42,9 @@ const DAY_MS = 24 * 60 * 60 * 1000;
 
 const DESKTOP_WORDS_PER_PAGE = 10;
 
+/** 英単語列と日本語訳列の間の仕切り。ds-table は他画面でも使うのでこの表だけに当てる。 */
+const JA_COL_DIVIDER: CSSProperties = { borderLeft: '1px solid var(--color-border)' };
+
 function vocabularyTypeSortRank(value: Word['vocabularyType']): number {
   if (value === 'active') return 0;
   if (value === 'passive') return 1;
@@ -467,7 +470,7 @@ export function DesktopProjectDetailView({
                   </th>
                   <th style={{ width: 70 }}>品詞</th>
                   {hiddenCols.has('ja') ? null : (
-                    <th>
+                    <th style={JA_COL_DIVIDER}>
                       日本語
                       <span
                         role="button"
@@ -527,8 +530,8 @@ export function DesktopProjectDetailView({
                     </td>
                     <td className="pos">{desktopPosLabel(word.partOfSpeechTags)}</td>
                     {hiddenCols.has('ja') ? null : (
-                      <td className="ja">
-                        <TranslationDisplay word={word} compact />
+                      <td className="ja" style={JA_COL_DIVIDER}>
+                        <TranslationDisplay word={word} compact stacked />
                       </td>
                     )}
                     <td style={{ textAlign: 'center' }}>

--- a/src/components/desktop/DesktopProjectDetail.tsx
+++ b/src/components/desktop/DesktopProjectDetail.tsx
@@ -531,7 +531,7 @@ export function DesktopProjectDetailView({
                     <td className="pos">{desktopPosLabel(word.partOfSpeechTags)}</td>
                     {hiddenCols.has('ja') ? null : (
                       <td className="ja" style={JA_COL_DIVIDER}>
-                        <TranslationDisplay word={word} compact stacked />
+                        <TranslationDisplay word={word} compact stacked maxLines={2} />
                       </td>
                     )}
                     <td style={{ textAlign: 'center' }}>

--- a/src/components/home/WordList.tsx
+++ b/src/components/home/WordList.tsx
@@ -184,20 +184,25 @@ function WordItem({
   }
 
   return (
-    <div className="px-1 py-3 flex items-center gap-2">
+    /* 縦の余白を行ではなく各カラムに持たせているのは、訳との間の仕切りを行の上下
+       いっぱいまで貫通させるため。横スクロール枠は縦をクリップするので、余白が枠の
+       外にあると仕切りが余白まで届かない。 */
+    <div className="px-1 flex items-stretch gap-2">
       {onStatusChange && (
-        <NotionCheckbox wordId={word.id} status={word.status} onStatusChange={onStatusChange} />
+        <span className="flex shrink-0 items-center py-3">
+          <NotionCheckbox wordId={word.id} status={word.status} onStatusChange={onStatusChange} />
+        </span>
       )}
       <div
         ref={scrollRef}
         className="flex-1 min-w-0 overflow-x-auto overflow-y-hidden"
         style={{ scrollbarWidth: 'thin' }}
       >
-        <div className="w-max max-w-none">
+        <div className="flex min-h-full w-max max-w-none flex-col py-3">
           {/* 訳は英語の下ではなく右に置き、間に縦の仕切りを入れる。
               見出し語側に最小幅を持たせているのは、行ごとに仕切りが揃うようにするため
               (この列は横スクロールするので、幅は割合ではなく最小幅で決める) */}
-          <div className="flex items-center gap-2">
+          <div className="flex flex-1 items-center gap-2">
             <div className="flex min-w-[7.5rem] items-center gap-1.5">
               <span className="font-semibold text-[var(--color-foreground)] whitespace-nowrap">{word.english}</span>
               {word.isFavorite && (
@@ -210,7 +215,7 @@ function WordItem({
                 />
               )}
             </div>
-            <span aria-hidden className="w-px shrink-0 self-stretch bg-[var(--color-border)]" />
+            <span aria-hidden className="-my-3 w-px shrink-0 self-stretch bg-[var(--color-border)]" />
             <p className="text-sm text-[var(--color-muted)] whitespace-nowrap" title={formatJapaneseForDisplay(word)}>
               <TranslationDisplay word={word} compact stacked maxLines={2} />
             </p>
@@ -220,7 +225,7 @@ function WordItem({
           )}
         </div>
       </div>
-      <div className="flex items-center gap-1">
+      <div className="flex items-center gap-1 py-3">
         {onCycleVocabularyType && (
           <VocabularyTypeButton
             vocabularyType={word.vocabularyType}

--- a/src/components/home/WordList.tsx
+++ b/src/components/home/WordList.tsx
@@ -212,7 +212,7 @@ function WordItem({
             </div>
             <span aria-hidden className="w-px shrink-0 self-stretch bg-[var(--color-border)]" />
             <p className="text-sm text-[var(--color-muted)] whitespace-nowrap" title={formatJapaneseForDisplay(word)}>
-              <TranslationDisplay word={word} compact stacked />
+              <TranslationDisplay word={word} compact stacked maxLines={2} />
             </p>
           </div>
           {showProjectName && word.projectTitle && (

--- a/src/components/home/WordList.tsx
+++ b/src/components/home/WordList.tsx
@@ -194,21 +194,27 @@ function WordItem({
         style={{ scrollbarWidth: 'thin' }}
       >
         <div className="w-max max-w-none">
-          <div className="flex items-center gap-1.5">
-            <span className="font-semibold text-[var(--color-foreground)] whitespace-nowrap">{word.english}</span>
-            {word.isFavorite && (
-              <Icon
-                name="flag"
-                size={14}
-                filled
-                className="text-[var(--color-warning)] shrink-0"
-                aria-label="苦手マーク"
-              />
-            )}
+          {/* 訳は英語の下ではなく右に置き、間に縦の仕切りを入れる。
+              見出し語側に最小幅を持たせているのは、行ごとに仕切りが揃うようにするため
+              (この列は横スクロールするので、幅は割合ではなく最小幅で決める) */}
+          <div className="flex items-center gap-2">
+            <div className="flex min-w-[7.5rem] items-center gap-1.5">
+              <span className="font-semibold text-[var(--color-foreground)] whitespace-nowrap">{word.english}</span>
+              {word.isFavorite && (
+                <Icon
+                  name="flag"
+                  size={14}
+                  filled
+                  className="text-[var(--color-warning)] shrink-0"
+                  aria-label="苦手マーク"
+                />
+              )}
+            </div>
+            <span aria-hidden className="w-px shrink-0 self-stretch bg-[var(--color-border)]" />
+            <p className="text-sm text-[var(--color-muted)] whitespace-nowrap" title={formatJapaneseForDisplay(word)}>
+              <TranslationDisplay word={word} compact stacked />
+            </p>
           </div>
-          <p className="text-sm text-[var(--color-muted)] whitespace-nowrap" title={formatJapaneseForDisplay(word)}>
-            <TranslationDisplay word={word} compact />
-          </p>
           {showProjectName && word.projectTitle && (
             <p className="text-xs text-[var(--color-primary)] mt-1 whitespace-nowrap">{word.projectTitle}</p>
           )}

--- a/src/components/project/WordRow.tsx
+++ b/src/components/project/WordRow.tsx
@@ -119,11 +119,14 @@ function MaskedTranslation({
   word,
   hidden,
   interactive,
+  stacked = false,
 }: {
   word: Word;
   hidden: boolean;
   /** 赤い部分をタップして1行だけ表に戻せるか。選択モードでは行全体がボタンなので無効。 */
   interactive: boolean;
+  /** 複数語義を1語義1行で縦に積む (収まらない語義はその行だけ `...` で省略)。 */
+  stacked?: boolean;
 }) {
   const [revealed, setRevealed] = useState(false);
 
@@ -135,13 +138,18 @@ function MaskedTranslation({
     setRevealed(false);
   }
 
-  const content = <TranslationDisplay word={word} compact />;
+  const content = <TranslationDisplay word={word} compact stacked={stacked} />;
+
+  // 縦積みのときは語義ごとに `...` を出すので、ラッパ側では1行に潰さない。
+  // flex-1 で伸ばさず内容幅のままにしているのは、赤シートのベタが訳のない余白まで
+  // 広がらないようにするため (狭いときは flex の縮小で効いて各行が `...` になる)。
+  const boxClass = stacked ? 'block min-w-0' : 'truncate';
 
   if (!hidden || revealed) {
-    return <span className="truncate">{content}</span>;
+    return <span className={boxClass}>{content}</span>;
   }
 
-  const maskClass = 'truncate select-none rounded-[4px] bg-[#e0483f] text-transparent';
+  const maskClass = `${boxClass} select-none rounded-[4px] bg-[#e0483f] text-transparent`;
 
   if (!interactive) {
     return (
@@ -190,6 +198,57 @@ function WrongCountBadge({ count }: { count: number }) {
   );
 }
 
+/**
+ * 行の本文 (見出し語 + 訳)。
+ *
+ * `splitMeaning` を立てると、訳を英語の下ではなく右のカラムに置き、間に縦の仕切りを
+ * 入れる (単語帳詳細 /project/[id] のレイアウト)。見出し語側の幅を割合で固定して
+ * いるのは、行ごとに仕切りの位置がずれると一覧が表に見えなくなるため。
+ */
+function WordRowText({
+  word,
+  pos,
+  wrongCount,
+  hideMeaning,
+  interactive,
+  splitMeaning,
+}: {
+  word: Word;
+  pos: string | null;
+  wrongCount: number;
+  hideMeaning: boolean;
+  interactive: boolean;
+  splitMeaning: boolean;
+}) {
+  const english = (
+    <div className="truncate font-display text-[15px] font-bold text-[var(--solid-ink)]">{word.english}</div>
+  );
+  const meaning = (
+    <>
+      {pos && <span className="shrink-0 font-mono text-[9px]">{posShort(pos)}</span>}
+      <MaskedTranslation word={word} hidden={hideMeaning} interactive={interactive} stacked={splitMeaning} />
+      <WrongCountBadge count={wrongCount} />
+    </>
+  );
+
+  if (!splitMeaning) {
+    return (
+      <>
+        {english}
+        <div className="mt-px flex items-center gap-1 text-[11px] text-[var(--color-muted)]">{meaning}</div>
+      </>
+    );
+  }
+
+  return (
+    <div className="flex items-center gap-2">
+      <div className="min-w-0 shrink-0 basis-[46%]">{english}</div>
+      <span aria-hidden className="w-px shrink-0 self-stretch bg-[var(--color-border)]" />
+      <div className="flex min-w-0 flex-1 items-baseline gap-1 text-[11px] text-[var(--color-muted)]">{meaning}</div>
+    </div>
+  );
+}
+
 export function WordRow({
   word,
   selectMode,
@@ -197,6 +256,7 @@ export function WordRow({
   tourAnchor = false,
   wrongCount = 0,
   hideMeaning = false,
+  splitMeaning = false,
   onToggleSelect,
   onCycleStatus,
   onCycleVocabularyType,
@@ -211,6 +271,8 @@ export function WordRow({
   wrongCount?: number;
   /** 赤シート。true の間は訳を赤いベタで覆う (行タップで1行だけ表に戻せる)。 */
   hideMeaning?: boolean;
+  /** 訳を英語の下ではなく右のカラムに出し、間に仕切りを引く。 */
+  splitMeaning?: boolean;
   onToggleSelect: () => void;
   onCycleStatus: (newStatus: WordStatus) => void;
   onCycleVocabularyType: () => void;
@@ -233,12 +295,14 @@ export function WordRow({
         <div className="flex items-center gap-2.5">
           <SelectCheckbox checked={selected} size={26} />
           <div className="min-w-0 flex-1">
-            <div className="truncate font-display text-[15px] font-bold text-[var(--solid-ink)]">{word.english}</div>
-            <div className="mt-px flex items-center gap-1 text-[11px] text-[var(--color-muted)]">
-              {pos && <span className="shrink-0 font-mono text-[9px]">{posShort(pos)}</span>}
-              <MaskedTranslation word={word} hidden={hideMeaning} interactive={false} />
-              <WrongCountBadge count={wrongCount} />
-            </div>
+            <WordRowText
+              word={word}
+              pos={pos}
+              wrongCount={wrongCount}
+              hideMeaning={hideMeaning}
+              interactive={false}
+              splitMeaning={splitMeaning}
+            />
           </div>
           <VocabularyTypeBadge vocabularyType={word.vocabularyType} />
           <BookmarkBadge active={word.isFavorite} />
@@ -258,12 +322,14 @@ export function WordRow({
         />
 
         <button type="button" onClick={onSelect} className="min-w-0 flex-1 text-left">
-          <div className="truncate font-display text-[15px] font-bold text-[var(--solid-ink)]">{word.english}</div>
-          <div className="mt-px flex items-center gap-1 text-[11px] text-[var(--color-muted)]">
-            {pos && <span className="shrink-0 font-mono text-[9px]">{posShort(pos)}</span>}
-            <MaskedTranslation word={word} hidden={hideMeaning} interactive />
-            <WrongCountBadge count={wrongCount} />
-          </div>
+          <WordRowText
+            word={word}
+            pos={pos}
+            wrongCount={wrongCount}
+            hideMeaning={hideMeaning}
+            interactive
+            splitMeaning={splitMeaning}
+          />
         </button>
 
         <VocabularyTypeButton

--- a/src/components/project/WordRow.tsx
+++ b/src/components/project/WordRow.tsx
@@ -242,10 +242,14 @@ function WordRowText({
     );
   }
 
+  // 仕切りは行の上下いっぱい (px-1 py-2.5 の padding の外) まで貫通させる。
+  // 呼び出し側が親を self-stretch で行の高さまで伸ばしてあるので、ここは
+  // self-stretch + `-my-2.5` (= 行の py-2.5) で padding の分だけはみ出させる。
+  // マージンボックスは行の高さのままなので、行が伸びることはない。
   return (
-    <div className="flex items-center gap-2">
+    <div className="flex min-w-0 flex-1 items-center gap-2">
       <div className="min-w-0 shrink-0 basis-[46%]">{english}</div>
-      <span aria-hidden className="w-px shrink-0 self-stretch bg-[var(--color-border)]" />
+      <span aria-hidden className="-my-2.5 w-px shrink-0 self-stretch bg-[var(--color-border)]" />
       <div className="flex min-w-0 flex-1 items-baseline gap-1 text-[11px] text-[var(--color-muted)]">{meaning}</div>
     </div>
   );
@@ -296,7 +300,7 @@ export function WordRow({
       >
         <div className="flex items-center gap-2.5">
           <SelectCheckbox checked={selected} size={26} />
-          <div className="min-w-0 flex-1">
+          <div className={`min-w-0 flex-1${splitMeaning ? ' flex self-stretch overflow-visible' : ''}`}>
             <WordRowText
               word={word}
               pos={pos}
@@ -323,7 +327,11 @@ export function WordRow({
           className={tourAnchor ? 'tour-anchor-word-status' : undefined}
         />
 
-        <button type="button" onClick={onSelect} className="min-w-0 flex-1 text-left">
+        <button
+          type="button"
+          onClick={onSelect}
+          className={`min-w-0 flex-1 text-left${splitMeaning ? ' flex self-stretch overflow-visible' : ''}`}
+        >
           <WordRowText
             word={word}
             pos={pos}

--- a/src/components/project/WordRow.tsx
+++ b/src/components/project/WordRow.tsx
@@ -138,7 +138,9 @@ function MaskedTranslation({
     setRevealed(false);
   }
 
-  const content = <TranslationDisplay word={word} compact stacked={stacked} />;
+  // 2行までなのは、行の高さを決めているステータスの3マス (42px) に収まる行数だから。
+  // 3行にすると一覧の行が伸びてしまう。あふれた語義は末尾の `...` で示す。
+  const content = <TranslationDisplay word={word} compact stacked={stacked} maxLines={2} />;
 
   // 縦積みのときは語義ごとに `...` を出すので、ラッパ側では1行に潰さない。
   // flex-1 で伸ばさず内容幅のままにしているのは、赤シートのベタが訳のない余白まで

--- a/src/components/word/TranslationDisplay.tsx
+++ b/src/components/word/TranslationDisplay.tsx
@@ -11,6 +11,12 @@ type TranslationDisplayProps = {
    * 幅に収まらない語義はその行だけ `...` で省略する (折り返して行が増えない)。
    */
   stacked?: boolean;
+  /**
+   * `stacked` のとき縦に積む行数の上限。行が増えて一覧の行の高さが変わらないよう、
+   * 呼び出し側で「元の高さに収まる行数」を渡す。あふれた語義は最終行の末尾の
+   * `...` で示す (全語義は単語詳細で見られる)。
+   */
+  maxLines?: number;
 };
 
 export function TranslationDisplay({
@@ -19,6 +25,7 @@ export function TranslationDisplay({
   itemClassName = '',
   compact = false,
   stacked = false,
+  maxLines,
 }: TranslationDisplayProps) {
   const translations = getDisplayTranslations(word);
   if (translations.length === 0) return null;
@@ -31,13 +38,23 @@ export function TranslationDisplay({
     );
   }
 
+  // 行数上限を超えた語義は畳んで、最終行の末尾に `...` を出す。
+  const visible = stacked && maxLines && maxLines > 0 ? translations.slice(0, maxLines) : translations;
+  const hasHiddenTranslations = visible.length < translations.length;
+
+  // 行送りを詰めているのは、縦積みにしても一覧の行の高さが変わらないようにするため。
   const listClassName = stacked
-    ? 'flex min-w-0 flex-col items-stretch gap-y-0.5'
+    ? 'flex min-w-0 flex-col items-stretch gap-y-px leading-[1.35]'
     : 'inline-flex flex-wrap items-baseline gap-x-2 gap-y-0.5';
 
   return (
-    <span className={`${listClassName} ${className}`.trim()}>
-      {translations.map((translation) => (
+    <span
+      className={`${listClassName} ${className}`.trim()}
+      title={hasHiddenTranslations
+        ? translations.map((translation) => `${translation.label}${translation.text}`).join(' ')
+        : undefined}
+    >
+      {visible.map((translation, index) => (
         <span
           key={`${translation.label}-${translation.text}`}
           className={`${stacked ? 'flex min-w-0' : 'inline-flex'} items-baseline gap-0.5 ${itemClassName}`.trim()}
@@ -48,6 +65,9 @@ export function TranslationDisplay({
             {translation.label}
           </span>
           <span className={stacked ? 'truncate' : undefined}>{translation.text}</span>
+          {hasHiddenTranslations && index === visible.length - 1 && (
+            <span className="shrink-0" aria-label={`ほか${translations.length - visible.length}語義`}>...</span>
+          )}
         </span>
       ))}
     </span>

--- a/src/components/word/TranslationDisplay.tsx
+++ b/src/components/word/TranslationDisplay.tsx
@@ -6,6 +6,11 @@ type TranslationDisplayProps = {
   className?: string;
   itemClassName?: string;
   compact?: boolean;
+  /**
+   * 複数語義を横並びではなく1語義1行で縦に積む。
+   * 幅に収まらない語義はその行だけ `...` で省略する (折り返して行が増えない)。
+   */
+  stacked?: boolean;
 };
 
 export function TranslationDisplay({
@@ -13,29 +18,36 @@ export function TranslationDisplay({
   className = '',
   itemClassName = '',
   compact = false,
+  stacked = false,
 }: TranslationDisplayProps) {
   const translations = getDisplayTranslations(word);
   if (translations.length === 0) return null;
 
   if (translations.length === 1) {
     return (
-      <span className={className} title={translations[0].text}>
+      <span className={`${stacked ? 'block truncate' : ''} ${className}`.trim()} title={translations[0].text}>
         {translations[0].text}
       </span>
     );
   }
 
+  const listClassName = stacked
+    ? 'flex min-w-0 flex-col items-stretch gap-y-0.5'
+    : 'inline-flex flex-wrap items-baseline gap-x-2 gap-y-0.5';
+
   return (
-    <span className={`inline-flex flex-wrap items-baseline gap-x-2 gap-y-0.5 ${className}`.trim()}>
+    <span className={`${listClassName} ${className}`.trim()}>
       {translations.map((translation) => (
         <span
           key={`${translation.label}-${translation.text}`}
-          className={`inline-flex items-baseline gap-0.5 ${itemClassName}`.trim()}
+          className={`${stacked ? 'flex min-w-0' : 'inline-flex'} items-baseline gap-0.5 ${itemClassName}`.trim()}
           style={{ opacity: translation.opacity }}
           title={`${translation.label} ${translation.text}`}
         >
-          <span className={compact ? 'text-[0.85em]' : 'text-[0.8em]'}>{translation.label}</span>
-          <span>{translation.text}</span>
+          <span className={`${compact ? 'text-[0.85em]' : 'text-[0.8em]'}${stacked ? ' shrink-0' : ''}`}>
+            {translation.label}
+          </span>
+          <span className={stacked ? 'truncate' : undefined}>{translation.text}</span>
         </span>
       ))}
     </span>


### PR DESCRIPTION
## 変更内容

`/project/*` の単語一覧で、日本語訳を**英語の下ではなく右のカラム**に移し、間に縦の仕切りを入れました。あわせて、複数語義は横並びをやめて**1語義1行の縦積み**にし、幅に収まらない語義はその行だけ `...` で省略します（折り返して行数が増えないようにしています）。

### 対象

| 画面 | 変更 |
|---|---|
| `/project/[id]` モバイル一覧 | `WordRow` に `splitMeaning` を追加して左右2カラム + 仕切りに。訳は縦積み |
| `/project/[id]` デスクトップ表 | 元から別カラムなので、英単語側と日本語列の間に仕切りを追加。訳は縦積み |
| `/project/[id]/words` | 左右2カラム + 仕切り。訳は縦積み |
| `/project/[id]` の「おすすめの単語」 | 同じ左右2カラムに。出典の単語帳名だけは右カラムに入れると訳を潰すので下の行へ |

### 実装メモ

- `TranslationDisplay` に `stacked` を足した **opt-in** なので、クイズ・フラッシュカード・共有ページなど他の画面の訳の見た目は変わりません。
- `WordRow` は単語帳をまたぐ `/words` と共用なので、左右分割は `splitMeaning` を渡した `/project/[id]` だけに効きます（`/words` は従来どおり縦2段）。
- 見出し語側の幅は割合固定（46%）にしています。行ごとに仕切りの位置がずれると一覧が表に見えなくなるためです。
- 赤シート（`hideMeaning`）は縦積みでもブロックごと覆います。ベタが訳のない余白まで広がらないよう、訳の箱は `flex-1` で伸ばさず内容幅のままにしています。
- デスクトップ表の仕切りは `ds-table` が他画面と共用のため、この表だけにインラインで当てています。

### 確認

- `npm run lint` — 既存の警告のみ（エラー5件は `gcp-budget-guard/*.js` の既存分、本変更とは無関係）
- `npm test` — 1602 pass / 1 fail（`otp.contract.test.ts` の1件は変更前の `main` でも失敗する既存の失敗）
- `npx tsc --noEmit` — 変更ファイルにエラーなし
- `npm run build` — 成功
- ビルド済みCSSを使ってヘッドレスChromiumで行のレイアウトを目視確認（1語義／複数語義／長い訳の省略／赤シート）


---
_Generated by [Claude Code](https://claude.ai/code/session_012bVSZjjfUQtDxS8dYbfeJr)_