### PR TITLE
単語コピー後にコピー先の単語帳を開けるようにする

### DIFF
--- a/src/app/project/[id]/page.tsx
+++ b/src/app/project/[id]/page.tsx
@@ -669,6 +669,13 @@ export default function ProjectPage() {
       showToast({
         message: `${targets.length}語を「${targetProject?.title ?? '単語帳'}」にコピーしました`,
         type: 'success',
+        // コピーしただけだと結果を確かめに行く導線が無いので、その場で
+        // コピー先の単語帳を開けるようにする（タップする間だけ表示を延ばす）。
+        action: {
+          label: '開く',
+          onClick: () => router.push(`/project/${targetProjectId}`),
+        },
+        duration: 6000,
       });
       setBulkImportModalOpen(false);
       setSelectedWordIds(new Set());

--- a/src/app/share/[shareId]/page.tsx
+++ b/src/app/share/[shareId]/page.tsx
@@ -505,7 +505,12 @@ export default function SharedDetailPage() {
       const skipped = targetWords.length - newWords.length;
 
       if (newWords.length === 0) {
-        showToast({ message: `「${target.title}」には既に登録済みです`, type: 'warning' });
+        showToast({
+          message: `「${target.title}」には既に登録済みです`,
+          type: 'warning',
+          action: { label: '開く', onClick: () => router.push(`/project/${target.id}`) },
+          duration: 6000,
+        });
         return;
       }
 
@@ -530,6 +535,13 @@ export default function SharedDetailPage() {
           ? `「${target.title}」に${newWords.length}語を追加しました（${skipped}語は登録済み）`
           : `「${target.title}」に${newWords.length}語を追加しました`,
         type: 'success',
+        // 単語帳まるごとの取り込みには「追加済み — 単語帳を開く」があるのに、
+        // 単語だけ足したときは追加先へ行く導線が無かったのでここで開けるようにする。
+        action: {
+          label: '開く',
+          onClick: () => router.push(`/project/${target.id}`),
+        },
+        duration: 6000,
       });
       setBookPickerOpen(false);
       setBookPickerWords([]);

--- a/src/components/ui/toast.tsx
+++ b/src/components/ui/toast.tsx
@@ -68,13 +68,15 @@ export function ToastProvider({ children }: { children: ReactNode }) {
           >
             <span className="text-sm flex-1">{toast.message}</span>
 
+            {/* 文字色はトーストの地色に合わせる（warning は明るい地に黒文字なので、
+                白固定にするとアクションだけ読めなくなる）。 */}
             {toast.action && (
               <button
                 onClick={() => {
                   toast.action?.onClick();
                   hideToast(toast.id);
                 }}
-                className="flex items-center gap-1 text-sm font-medium text-white/90 hover:text-white shrink-0"
+                className="flex items-center gap-1 text-sm font-bold text-current opacity-90 hover:opacity-100 shrink-0"
               >
                 {toast.action.label}
                 <Icon name="chevron_right" size={16} />


### PR DESCRIPTION
単語を別の単語帳へコピーしたとき、これまでは「コピーしました」と報告する
だけで、コピー先を確認しに行く導線がなかった。ホームまで戻って単語帳を
探し直す必要があったので、成功トーストに「開く」を追加して、その場で
コピー先を開けるようにする。

- 単語帳詳細の一括コピー (ImportToProjectModal 経由) の成功トースト
- 共有単語帳から既存の単語帳へ単語を追加したときの成功トースト (単語帳まるごとの取り込みには「追加済み — 単語帳を開く」が既にあり、 単語だけ追加した場合にだけ導線が欠けていた)
- 追加先に全部登録済みで実際には何も追加されなかったときも、確認できる ようにトーストから開けるようにする

タップの猶予として、これらのトーストは表示時間を 6 秒にした。あわせて
トーストのアクションの文字色を地色依存 (text-current) に変更した。white
固定のままだと warning トースト (明るい地に黒文字) でアクションだけ
読めなくなるため。


Claude-Session: https://claude.ai/code/session_012tAKXQhYjrLVDgxgcR9n64